### PR TITLE
Fix bottlenecks related to large number of files.

### DIFF
--- a/dvc/binary_file_extensions.py
+++ b/dvc/binary_file_extensions.py
@@ -1,0 +1,51 @@
+# source: https://github.com/sindresorhus/binary-extensions
+# 
+# MIT License
+# 
+# Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+BINARY_FILE_EXTENSIONS = [
+    "3ds", "3g2", "3gp", "7z", "a", "aac", "adp", "ai", "aif", "aiff", "alz",
+    "ape", "apk", "ar", "arj", "asf", "au", "avi", "bak", "baml", "bh", "bin",
+    "bk", "bmp", "btif", "bz2", "bzip2", "cab", "caf", "cgm", "class", "cmx",
+    "cpio", "cr2", "csv", "cur", "dat", "dcm", "deb", "dex", "djvu", "dll",
+    "dmg", "dng", "doc", "docm", "docx", "dot", "dotm", "dra", "DS_Store",
+    "dsk", "dts", "dtshd", "dvb", "dwg", "dxf", "ecelp4800", "ecelp7470",
+    "ecelp9600", "egg", "eol", "eot", "epub", "exe", "f4v", "fbs", "fh", "fla",
+    "flac", "fli", "flv", "fpx", "fst", "fvt", "g3", "gif", "graffle", "gz",
+    "gzip", "h261", "h263", "h264", "icns", "ico", "ief", "img", "ipa", "iso",
+    "jar", "jpeg", "jpg", "jpgv", "jpm", "jxr", "key", "ktx", "lha", "lib",
+    "lvp", "lz", "lzh", "lzma", "lzo", "m3u", "m4a", "m4v", "mar", "mdi", "mht",
+    "mid", "midi", "mj2", "mka", "mkv", "mmr", "mng", "mobi", "mov", "movie",
+    "mp3", "mp4", "mp4a", "mpeg", "mpg", "mpga", "mxu", "nef", "npx", "numbers",
+    "o", "oga", "ogg", "ogv", "otf", "pages", "pbm", "pcx", "pdb", "pdf", "pea",
+    "pgm", "pic", "png", "pnm", "pot", "potm", "potx", "ppa", "ppam", "ppm",
+    "pps", "ppsm", "ppsx", "ppt", "pptm", "pptx", "psd", "pya", "pyc", "pyo",
+    "pyv", "qt", "rar", "ras", "raw", "resources", "rgb", "rip", "rlc", "rmf",
+    "rmvb", "rtf", "rz", "s3m", "s7z", "scpt", "sgi", "shar", "sil", "sketch",
+    "slk", "smv", "so", "sub", "swf", "tar", "tbz", "tbz2", "tga", "tgz",
+    "thmx", "tif", "tiff", "tlz", "ttc", "ttf", "txz", "udf", "uvh", "uvi",
+    "uvm", "uvp", "uvs", "uvu", "viv", "vob", "war", "wav", "wax", "wbmp",
+    "wdp", "weba", "webm", "webp", "whl", "wim", "wm", "wma", "wmv", "wmx",
+    "woff", "woff2", "wvx", "xbm", "xif", "xla", "xlam", "xls", "xlsb", "xlsm",
+    "xlsx", "xlt", "xltm", "xltx", "xm", "xmind", "xpi", "xpm", "xwd", "xz",
+    "z", "zip", "zipx",
+]

--- a/dvc/state.py
+++ b/dvc/state.py
@@ -187,7 +187,7 @@ class LinkState(State):
         super(LinkState, self).__init__(dvc_dir)
         self.root_dir = root_dir
 
-    def update(self, path):
+    def update(self, path, dump=True):
         if not os.path.exists(path):
             return
 
@@ -195,11 +195,12 @@ class LinkState(State):
         inode = self.inode(path)
 
         with self._lock:
-            with self._lock_file:
-                state = LinkStateEntry(inode, mtime)
-                d = state.dumpd()
-                self._db[os.path.relpath(path, self.root_dir)] = d
-                self.dump()
+            state = LinkStateEntry(inode, mtime)
+            d = state.dumpd()
+            self._db[os.path.relpath(path, self.root_dir)] = d
+            if dump:
+                with self._lock_file:
+                    self.dump()
 
     def _do_remove_all(self):
         for p, s in self._db.items():

--- a/dvc/utils.py
+++ b/dvc/utils.py
@@ -13,6 +13,7 @@ from multiprocessing.pool import ThreadPool
 
 from dvc.progress import progress
 from dvc.logger import Logger
+from dvc.binary_file_extensions import BINARY_FILE_EXTENSIONS
 
 
 LOCAL_CHUNK_SIZE = 1024*1024
@@ -26,7 +27,13 @@ def file_md5(fname):
     """ get the (md5 hexdigest, md5 digest) of a file """
     if os.path.exists(fname):
         hash_md5 = hashlib.md5()
-        binary = is_binary(fname)
+        # when dealing with large collections of binary files, the is_binary
+        # call becomes a bottleneck, here we first check the extension to
+        # avoid this bottleneck when possible:
+        if fname.split('.')[-1] in BINARY_FILE_EXTENSIONS:
+            binary = True
+        else:
+            binary = is_binary(fname)
 
         if binary:
             mode = "rb"


### PR DESCRIPTION
There are 2 bottlenecks:
 - LinkState.update repeatedly saves a large json blob, which generates O(n^2) disk I/O cost where n is number of files being added
 - binaryornot.check.is_binary is slow for large number of small files. This change fixes it in case of binary files - checks extension first and if it is binary, don't call the is_binary function.