### PR TITLE
dvc: add -d|--default option for `dvc remote add`

### DIFF
--- a/dvc/cli.py
+++ b/dvc/cli.py
@@ -332,6 +332,11 @@ def parse_args(argv=None):
                         action='store_true',
                         default=False,
                         help='Use local config')
+    remote_add_parser.add_argument('-d',
+                        '--default',
+                        action='store_true',
+                        default=False,
+                        help='Set as default remote')
     remote_add_parser.set_defaults(func=CmdRemoteAdd)
 
 

--- a/dvc/command/remote.py
+++ b/dvc/command/remote.py
@@ -8,8 +8,15 @@ from dvc.logger import Logger
 class CmdRemoteAdd(CmdConfig):
     def run(self):
         section = Config.SECTION_REMOTE_FMT.format(self.args.name)
-        return self.set(section, Config.SECTION_REMOTE_URL, self.args.url)
+        ret = self.set(section, Config.SECTION_REMOTE_URL, self.args.url)
+        if ret != 0:
+            return ret
 
+        if self.args.default:
+            Logger.info('Setting \'{}\' as a default remote.'.format(self.args.name))
+            ret = self.set(Config.SECTION_CORE, Config.SECTION_CORE_REMOTE, self.args.name)
+
+        return ret
 
 class CmdRemoteRemove(CmdConfig):
     def run(self):

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -11,7 +11,7 @@ class TestRemote(TestDvc):
         self.assertNotEqual(main(['remote', 'remove', remotes[0]]), 0)
 
         for r in remotes:
-            self.assertEqual(main(['remote', 'add', r, 's3://bucket/name']), 0)
+            self.assertEqual(main(['remote', 'add', '--default', r, 's3://bucket/name']), 0)
 
         self.assertEqual(main(['remote', 'list']), 0)
 


### PR DESCRIPTION
Fixes #783

Signed-off-by: Ruslan Kuprieiev <kupruser@gmail.com>