### PR TITLE
RFP: Add endpoint url config for AWS

### DIFF
--- a/dvc/config.py
+++ b/dvc/config.py
@@ -76,6 +76,7 @@ class Config(object):
     SECTION_AWS = 'aws'
     SECTION_AWS_STORAGEPATH = 'storagepath'
     SECTION_AWS_CREDENTIALPATH = 'credentialpath'
+    SECTION_AWS_ENDPOINT_URL = 'endpointurl'
     SECTION_AWS_REGION = 'region'
     SECTION_AWS_PROFILE = 'profile'
     SECTION_AWS_SCHEMA = {
@@ -83,6 +84,7 @@ class Config(object):
         schema.Optional(SECTION_AWS_REGION): str,
         schema.Optional(SECTION_AWS_PROFILE, default='default'): str,
         schema.Optional(SECTION_AWS_CREDENTIALPATH, default = ''): str,
+        schema.Optional(SECTION_AWS_ENDPOINT_URL, default=None): str,
     }
 
     # backward compatibility
@@ -111,6 +113,7 @@ class Config(object):
         schema.Optional(SECTION_AWS_REGION): str,
         schema.Optional(SECTION_AWS_PROFILE, default='default'): str,
         schema.Optional(SECTION_AWS_CREDENTIALPATH, default = ''): str,
+        schema.Optional(SECTION_AWS_ENDPOINT_URL, default=None): str,
         schema.Optional(SECTION_GCP_PROJECTNAME): str,
         schema.Optional(SECTION_CACHE_TYPE): SECTION_CACHE_TYPE_SCHEMA,
         schema.Optional(SECTION_REMOTE_USER): str,

--- a/dvc/remote/s3.py
+++ b/dvc/remote/s3.py
@@ -45,6 +45,7 @@ class RemoteS3(RemoteBase):
         self.region = config.get(Config.SECTION_AWS_REGION, None)
         self.profile = config.get(Config.SECTION_AWS_PROFILE, None)
         self.credentialpath = config.get(Config.SECTION_AWS_CREDENTIALPATH, None)
+        self.endpoint_url = config.get(Config.SECTION_AWS_ENDPOINT_URL, None)
 
     @property
     def bucket(self):
@@ -56,7 +57,7 @@ class RemoteS3(RemoteBase):
 
     @property
     def s3(self):
-        return boto3.resource('s3')
+        return boto3.resource('s3', endpoint_url=self.endpoint_url)
 
     def get_etag(self, bucket, key):
         try:


### PR DESCRIPTION
Add config for `endpoint_url` on initializing `boto3` client. 

This allows us to use AWS-compatible cloud storage (e.g. OpenStack).
See also [boto3's reference](https://boto3.readthedocs.io/en/latest/reference/core/session.html#boto3.session.Session.resource).