### PR TITLE
Add integration tests for Azure Remote

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,6 +15,8 @@ environment:
     secure: 96fJ3r2i2GohbXHwnSs5N4EplQ7q8YmLpPWM0AC+f4s=
   CODECOV_TOKEN:
     secure: XN4jRtmGE5Bqg8pPZkwNs7kn3UEI73Rkldqc0MGsQISZBm5TNJZOPofDMc1QnUsf
+  AZURE_STORAGE_CONTAINER_NAME: appveyor-tests
+  AZURE_STORAGE_CONNECTION_STRING: DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;
 
   matrix:
 
@@ -44,6 +46,9 @@ environment:
 #      PYTHON_ARCH: "64"
 
 install:
+  - ps: Install-Product node
+  - npm install -g azurite
+  - ps: $AzuriteProcess = Start-Process azurite-blob -PassThru
   - cinst wget
   - cinst awscli
   - cinst gcloudsdk
@@ -70,6 +75,9 @@ after_test:
   - if "%APPVEYOR_PULL_REQUEST_NUMBER%"=="" codecov
   - if "%APPVEYOR_REPO_TAG%"=="true" python -m dvc pull
   - if "%APPVEYOR_REPO_TAG%"=="true" .\scripts\build_windows.cmd
+
+on_finish:
+  - ps: Stop-Process $AzuriteProcess
 
 artifacts:
   - path: dvc*.exe

--- a/dvc/remote/azure.py
+++ b/dvc/remote/azure.py
@@ -137,19 +137,16 @@ class RemoteAzure(RemoteBase):
         } for md5 in md5s]
 
     def exists(self, path_infos):
-        # TODO: check whether per-key exists() is faster than listing all
-        # objects altogether.
-        ret = []
+        keys = {blob.name
+                for blob in self.blob_service.list_blobs(self.bucket)}
 
+        ret = []
         for path_info in path_infos:
             if path_info['scheme'] != self.scheme:
                 raise NotImplementedError
 
-            bucket = path_info['bucket']
             key = path_info['key']
-
-            exists = self.blob_service.exists(bucket, key)
-            ret.append(exists)
+            ret.append(key in keys)
 
         return ret
 

--- a/dvc/remote/azure.py
+++ b/dvc/remote/azure.py
@@ -29,7 +29,7 @@ class Callback(object):
 class RemoteAzure(RemoteBase):
     scheme = 'azure'
     REGEX = (r'^azure://'
-             r'(ContainerName=(?P<container_name>[^;]+);)?'
+             r'(ContainerName=(?P<container_name>[^;]+);?)?'
              r'(?P<connection_string>.+)?$')
     REQUIRES = {'azure-storage-blob': BlockBlobService}
     PARAM_ETAG = 'etag'

--- a/dvc/remote/azure.py
+++ b/dvc/remote/azure.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 import re
 import time
@@ -36,7 +37,7 @@ class RemoteAzure(RemoteBase):
     COPY_POLL_SECONDS = 5
 
     def __init__(self, project, config):
-        super().__init__(project, config)
+        super(RemoteAzure, self).__init__(project, config)
         self.project = project
 
         url = config.get(Config.SECTION_REMOTE_URL)

--- a/scripts/ci/before_install.sh
+++ b/scripts/ci/before_install.sh
@@ -17,3 +17,10 @@ ssh-keyscan 0.0.0.0 >> ~/.ssh/known_hosts
 ssh 0.0.0.0 ls &> /dev/null
 ssh 127.0.0.1 ls &> /dev/null
 ssh localhost ls &> /dev/null
+
+scriptdir="$(dirname $0)"
+
+if [ -n "$TRAVIS_OS_NAME" ] && [ "$TRAVIS_OS_NAME" != "osx" ]; then
+  bash "$scriptdir/install_azurite.sh"
+  source ~/.bashrc
+fi

--- a/scripts/ci/install_azurite.sh
+++ b/scripts/ci/install_azurite.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# install docker
+export DEBIAN_FRONTEND=noninteractive
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+sudo apt-get update
+sudo apt-get install -y docker-ce
+
+# run azurite
+sudo docker run --restart always -e executable=blob -p 10000:10000 --tmpfs /opt/azurite/folder -d arafato/azurite:2.6.5
+
+# save secrets
+echo "export AZURE_STORAGE_CONTAINER_NAME='travis-tests'" >> ~/.bashrc
+echo "export AZURE_STORAGE_CONNECTION_STRING='DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;'" >> ~/.bashrc

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -7,4 +7,4 @@ os.chdir(REPO_ROOT)
 os.putenv('PATH', '{}:{}'.format(os.path.join(REPO_ROOT, 'bin'), os.getenv('PATH')))
 os.putenv('DVC_HOME', REPO_ROOT)
 
-check_call('nosetests  --processes=-1 --process-timeout=200 --cover-inclusive --cover-erase --cover-package=dvc --with-coverage', shell=True)
+check_call('nosetests -v --processes=-1 --process-timeout=200 --cover-inclusive --cover-erase --cover-package=dvc --with-coverage', shell=True)

--- a/tests/test_data_cloud.py
+++ b/tests/test_data_cloud.py
@@ -59,7 +59,8 @@ def _should_test_azure():
     elif os.getenv("DVC_TEST_AZURE") == "false":
         return False
 
-    return os.getenv("AZURE_STORAGE_CONTAINER") and os.getenv("AZURE_STORAGE_CONNECTION_STRING")
+    return (os.getenv("AZURE_STORAGE_CONTAINER_NAME")
+            and os.getenv("AZURE_STORAGE_CONNECTION_STRING"))
 
 
 def _should_test_ssh():

--- a/tests/test_data_cloud.py
+++ b/tests/test_data_cloud.py
@@ -1,5 +1,6 @@
 from subprocess import CalledProcessError
 from subprocess import check_output
+from unittest import SkipTest
 import os
 import time
 import uuid
@@ -172,15 +173,22 @@ class TestDataCloud(TestDvc):
 
 
 class TestDataCloudBase(TestDvc):
+    def _get_cloud_class(self):
+        return None
+
     def _should_test(self):
         return False
 
     def _get_url(self):
-        return None
+        return ''
+
+    def _ensure_should_run(self):
+        if not self._should_test():
+            raise SkipTest('Test {} is disabled'
+                           .format(self.__class__.__name__))
 
     def _setup_cloud(self):
-        if not self._should_test():
-            return
+        self._ensure_should_run()
 
         repo = self._get_url()
 
@@ -254,8 +262,8 @@ class TestDataCloudBase(TestDvc):
         self.assertTrue((md5_dir, STATUS_OK) in status_dir)
 
     def test(self):
-        if self._should_test():
-            self._test_cloud()
+        self._ensure_should_run()
+        self._test_cloud()
 
 
 class TestRemoteS3(TestDataCloudBase):

--- a/tests/test_data_cloud.py
+++ b/tests/test_data_cloud.py
@@ -155,6 +155,7 @@ class TestDataCloud(TestDvc):
 
         for scheme, cl in [('s3://', RemoteS3),
                            ('gs://', RemoteGS),
+                           ('azure://ContainerName=', RemoteAzure),
                            ('ssh://user@localhost:/', RemoteSSH),
                            (tempfile.mkdtemp(), RemoteLOCAL)]:
 

--- a/tests/test_data_cloud.py
+++ b/tests/test_data_cloud.py
@@ -10,7 +10,8 @@ import platform
 
 from dvc.main import main
 from dvc.config import Config, ConfigError
-from dvc.data_cloud import DataCloud, RemoteS3, RemoteGS, RemoteAzure, RemoteLOCAL, RemoteSSH, RemoteHDFS
+from dvc.data_cloud import (DataCloud, RemoteS3, RemoteGS, RemoteAzure,
+                            RemoteLOCAL, RemoteSSH, RemoteHDFS)
 from dvc.remote.base import STATUS_OK, STATUS_NEW, STATUS_DELETED
 
 from tests.basic_env import TestDvc
@@ -104,11 +105,15 @@ def get_local_url():
 
 
 def get_ssh_url():
-    return 'ssh://{}@127.0.0.1:{}'.format(getpass.getuser(), get_local_storagepath())
+    return 'ssh://{}@127.0.0.1:{}'.format(
+        getpass.getuser(),
+        get_local_storagepath())
 
 
 def get_hdfs_url():
-    return 'hdfs://{}@127.0.0.1{}'.format(getpass.getuser(), get_local_storagepath())
+    return 'hdfs://{}@127.0.0.1{}'.format(
+        getpass.getuser(),
+        get_local_storagepath())
 
 
 def get_aws_storagepath():
@@ -152,13 +157,16 @@ class TestDataCloud(TestDvc):
                            ('gs://', RemoteGS),
                            ('ssh://user@localhost:/', RemoteSSH),
                            (tempfile.mkdtemp(), RemoteLOCAL)]:
-            config[TEST_SECTION][Config.SECTION_REMOTE_URL] = scheme + str(uuid.uuid4())
+
+            remote_url = scheme + str(uuid.uuid4())
+            config[TEST_SECTION][Config.SECTION_REMOTE_URL] = remote_url
             self._test_cloud(config, cl)
 
     def test_unsupported(self):
-        with self.assertRaises(ConfigError) as cx:
+        with self.assertRaises(ConfigError):
+            remote_url = 'notsupportedscheme://a/b'
             config = TEST_CONFIG
-            config[TEST_SECTION][Config.SECTION_REMOTE_URL] = 'notsupportedscheme://a/b'
+            config[TEST_SECTION][Config.SECTION_REMOTE_URL] = remote_url
             DataCloud(self.dvc, config=config)
 
 
@@ -344,7 +352,7 @@ class TestDataCloudCLIBase(TestDvc):
         stage_dir = self.dvc.add(self.DATA_DIR)
         cache_dir = stage_dir.outs[0].cache
 
-        #FIXME check status output
+        # FIXME check status output
         sleep()
         self.main(['status', '-c'] + args)
 


### PR DESCRIPTION
This is a follow-up to https://github.com/iterative/dvc/pull/868.

The main change of this pull request is to set up the Azure Storage emulator [Azurite](https://github.com/Azure/Azurite) on the Travis CI machine via Docker and runs the Azure integration tests against the emulator (fcd0e34). An example of a successful build with this configuration on Travis can be found [here](https://travis-ci.org/CatalystCode/dvc/builds/402397620).

The pull request also contains a number of related functional fixes:
- Make the Azure remote compatible with Python 2 (8a32292).
- Switch the exists implementation of the Azure remote to the same list-then-check logic as S3 (a438f77).
- Make the Azure environment variables consistent between test and prod (581132b).
- Add the Azure remote to an additional test suite (fcbc6d1).

Additionally, the pull request also includes some related refactoring:
- Fix lint warnings in the data cloud tests file (1b1ca68).
- Replace `os.system` and make should-run cloud test checks more robust (9724bd9).
- Mark non-executed cloud tests explicitly as skipped (97dfc88).
- Increase test runner verbosity (7897dd8).
