### PR TITLE
Fix _find_root in base.py

### DIFF
--- a/dvc/command/base.py
+++ b/dvc/command/base.py
@@ -24,10 +24,12 @@ class CmdBase(object):
         from dvc.project import Project
 
         root = os.getcwd()
-        while not os.path.ismount(root):
+        while True:
             dvc_dir = os.path.join(root, Project.DVC_DIR)
             if os.path.isdir(dvc_dir):
                 return root
+            if os.path.ismount(root):
+                break
             root = os.path.dirname(root)
         msg = "Not a dvc repository (checked up to mount point {})"
         raise DvcException(msg.format(root))


### PR DESCRIPTION
The original _find_root does not check whether the mount point itself has a .dvc folder. This causes a problem when I mount the dvc repository as a volume inside a docker container.