### PR TITLE
Travis CI: Flake8 spots some missing imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,12 @@ before_install:
     fi
 install:
   - bash ./scripts/ci/install.sh
+  - pip install flake8
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
   - bash ./scripts/ci/script.sh
 deploy:


### PR DESCRIPTION
flake8 testing of https://github.com/iterative/dvc on Python 3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./dvc/scm.py:86:16: F821 undefined name 'InvalidGitRepositoryError'
        except InvalidGitRepositoryError:
               ^
./dvc/command/destroy.py:16:36: F821 undefined name 'err'
                raise DvcException(err)
                                   ^
./dvc/remote/gs.py:63:19: F821 undefined name 'DvcException'
            raise DvcException('{} doesn\'t exist in the cloud'.format(from_info['key']))
                  ^
3     F821 undefined name 'err'
3
```