### PR TITLE
state: use json.dumps() instead of dump()

### DIFF
--- a/dvc/state.py
+++ b/dvc/state.py
@@ -93,8 +93,9 @@ class State(object):
             return
 
         with SignalHandler():
+            j = json.dumps(self._db)
             with open(self.state_file, 'w+') as fd:
-                json.dump(self._db, fd)
+                fd.write(j)
 
     def dump(self):
         with self._lock:


### PR DESCRIPTION
This is actually 10 times faster, because everything is stored in the
memory.

Signed-off-by: Ruslan Kuprieiev <ruslan@iterative.ai>