### PR TITLE
scm: Added preliminary mercurial support

### DIFF
--- a/dvc/stage.py
+++ b/dvc/stage.py
@@ -365,7 +365,7 @@ class Stage(object):
         with open(fname, 'w') as fd:
             yaml.safe_dump(self.dumpd(), fd, default_flow_style=False)
 
-        self.project._files_to_git_add.append(os.path.relpath(fname))
+        self.project._files_to_scm_add.append(os.path.relpath(fname))
 
     def save(self):
         for dep in self.deps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ configobj>=5.0.6
 networkx>=2.1
 pyyaml>=3.12
 gitpython>=2.1.8
+python-hglib==2.6.1
 setuptools>=34.0.0
 nanotime>=0.5.2
 pyasn1>=0.4.1

--- a/tests/basic_env.py
+++ b/tests/basic_env.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import tempfile
 from git import Repo
+import hglib
 from unittest import TestCase
 
 from dvc.project import Project
@@ -69,6 +70,12 @@ class TestGitSubmodule(TestGit):
         self.git.create_submodule(subrepo_path, subrepo_path, subrepo.git_dir)
         self._pushd(subrepo_path)
 
+class TestMercurial(TestDir):
+    def setUp(self):
+        super(TestMercurial, self).setUp()
+        self.hg = hglib.init(os.curdir).open()
+        self.hg.add(self.CODE)
+        self.hg.commit('add code')
 
 class TestDvc(TestGit):
     def setUp(self):

--- a/tests/test_scm.py
+++ b/tests/test_scm.py
@@ -1,10 +1,12 @@
 import os
 
 from git import Repo
+import hglib
 
-from dvc.scm import SCM, Base, Git
+from dvc.scm import SCM, Base, Git, Mercurial
 
-from tests.basic_env import TestDir, TestGit, TestGitSubmodule
+from tests.basic_env import (TestDir, TestGit, TestGitSubmodule,
+                             TestMercurial)
 
 
 class TestSCM(TestDir):
@@ -14,6 +16,10 @@ class TestSCM(TestDir):
     def test_git(self):
         Repo.init(os.curdir)
         self.assertIsInstance(SCM(self._root_dir), Git)
+    
+    def test_hg(self):
+        hglib.init(os.curdir)
+        self.assertIsInstance(SCM(self._root_dir), Mercurial)
 
 
 class TestSCMGit(TestGit):
@@ -39,6 +45,16 @@ class TestSCMGitSubmodule(TestGitSubmodule):
         G.add(['foo'])
         G.commit('add')
         self.assertTrue('foo' in self.git.git.ls_files())
+
+class TestSCMMercurial(TestMercurial):
+    def test_is_repo(self):
+        self.assertTrue(Mercurial.is_repo(os.curdir))
+
+    def test_commit(self):
+        hg = Mercurial(self._root_dir)
+        hg.add(['foo'])
+        hg.commit('add')
+        self.assertTrue('foo' in [fname for (_, _, _, _, fname) in self.hg.manifest()])
 
 
 class TestIgnore(TestGit):


### PR DESCRIPTION
Added preliminary support for using dvc with a mercurial repository
instead of a git one. Changes include:
- Added a new Mercurial class in scm.py that implements the Base class
- Added python-hglib as a dependency, comparable to gitpython
- Changed various logging messages to reflect multi-vcs support, and
  in some cases brought this reporting under the purview of the
  particular scm subclass

Note that in rare cases where both a mercurial and git repo are
found in the same repo, a current limitation implies it will always
choose to use git.

This commit includes a shake at supporting installing mercurial
post-update hooks, but they are not well covered the test suite
and will likely need further work. Mercurial handles hooks all
from one file, so it requires additional intelligence to check
whether the hook is already installed.

Fixes # #945