### PR TITLE
hdfs output files: fix import error when using hdfs output files on w…

### DIFF
--- a/dvc/system.py
+++ b/dvc/system.py
@@ -112,8 +112,8 @@ class System(object):
     @staticmethod
     def getdirinfo(path):
         import ctypes
-        from ctypes import c_void_p, c_wchar_p, Structure, WinError
-        from ctypes.wintypes import DWORD, HANDLE, POINTER, BOOL
+        from ctypes import c_void_p, c_wchar_p, Structure, WinError, POINTER
+        from ctypes.wintypes import DWORD, HANDLE, BOOL
 
         FILE_FLAG_BACKUP_SEMANTICS = 0x02000000
         FILE_SHARE_READ = 0x00000001


### PR DESCRIPTION
…indows

When output files are located on hdfs an import error has been raised.

Fixes #1215