### PR TITLE
logger: Remove deprecation warning reported by pytest

### DIFF
--- a/dvc/logger.py
+++ b/dvc/logger.py
@@ -142,7 +142,7 @@ class Logger(object):
 
     @classmethod
     def warn(cls, msg, exc=None):
-        cls._with_exc(cls.logger().warn, cls.warning_prefix() + msg, exc=exc)
+        cls._with_exc(cls.logger().warning, cls.warning_prefix() + msg, exc=exc)
 
     @classmethod
     def debug(cls, msg, exc=None):

--- a/dvc/logger.py
+++ b/dvc/logger.py
@@ -142,11 +142,15 @@ class Logger(object):
 
     @classmethod
     def warn(cls, msg, exc=None):
-        cls._with_exc(cls.logger().warning, cls.warning_prefix() + msg, exc=exc)
+        cls._with_exc(cls.logger().warning,
+                      cls.warning_prefix() + msg,
+                      exc=exc)
 
     @classmethod
     def debug(cls, msg, exc=None):
-        cls._with_exc(cls.logger().debug, cls.debug_prefix() + msg, exc=exc)
+        cls._with_exc(cls.logger().debug,
+                      cls.debug_prefix() + msg,
+                      exc=exc)
 
     @staticmethod
     def info(msg):


### PR DESCRIPTION
dvc/logger.py:113: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead