### PR TITLE
gc: support used cache collection for several repositories using the same remote storage

### DIFF
--- a/dvc/cli.py
+++ b/dvc/cli.py
@@ -591,6 +591,13 @@ def parse_args(argv=None):
                         type=int,
                         default=None,
                         help='Number of jobs to run simultaneously.')
+    gc_parser.add_argument(
+                        '-p',
+                        '--projects',
+                        type=str,
+                        nargs='*',
+                        default=None,
+                        help='Collect garbage for all given projects.')
     gc_parser.set_defaults(func=CmdGC)
 
     # Config

--- a/dvc/command/gc.py
+++ b/dvc/command/gc.py
@@ -1,3 +1,5 @@
+import os
+
 from dvc.command.base import CmdBase
 
 
@@ -5,13 +7,21 @@ class CmdGC(CmdBase):
     def run(self):
         msg = 'This will remove all cache except the cache that is used in '
         if not self.args.all_branches and not self.args.all_tags:
-            msg += 'the current git branch.'
+            msg += 'the current git branch'
         elif self.args.all_branches and not self.args.all_tags:
-            msg += 'all git branches.'
+            msg += 'all git branches'
         elif not self.args.all_branches and self.args.all_tags:
-            msg += 'all git tags.'
+            msg += 'all git tags'
         else:
-            msg += 'all git branches and all git tags.'
+            msg += 'all git branches and all git tags'
+
+        if self.args.projects is not None and len(self.args.projects) > 0:
+            msg += ' of the current and the following projects:'
+
+            for project_path in self.args.projects:
+                msg += '\n  - %s' % os.path.abspath(project_path)
+        else:
+            msg += ' of the current project.'
 
         self.project.logger.warn(msg)
 
@@ -24,5 +34,6 @@ class CmdGC(CmdBase):
                         cloud=self.args.cloud,
                         remote=self.args.remote,
                         force=self.args.force,
-                        jobs=self.args.jobs)
+                        jobs=self.args.jobs,
+                        projects=self.args.projects)
         return 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -129,6 +129,20 @@ class TestGC(TestDvc):
         self.assertIsInstance(args.func(args), CmdGC)
 
 
+class TestGCMultipleProjects(TestDvc):
+    def test(self):
+        args = parse_args([
+            'gc',
+            '-p',
+            '/tmp/asdf',
+            '/tmp/xyz'
+        ])
+
+        self.assertIsInstance(args.func(args), CmdGC)
+
+        self.assertEqual(args.projects, ['/tmp/asdf', '/tmp/xyz'])
+
+
 class TestConfig(TestDvc):
     def test(self):
         name = 'param'


### PR DESCRIPTION
Adds an optional ``projects`` argument to the ``Project.gc()`` method. Expects a list of paths to other dvc-projects. If any paths are given, used cache is collected from all of them.

The ``gc`` cli has an optional ``-p`` argument, where multiple paths can be passed.

Fixes #1300