### PR TITLE
remote local: Check value before using it in `self.changed_cache`

### DIFF
--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -326,10 +326,11 @@ class RemoteLOCAL(RemoteBase):
             entry_checksum_info = {self.PARAM_MD5: m}
 
             if self.changed(entry_info, entry_checksum_info):
-                if force or self._already_cached(p):
-                    remove(p)
-                else:
-                    self._safe_remove(p)
+                if os.path.exists(p):
+                    if force or self._already_cached(p):
+                        remove(p)
+                    else:
+                        self._safe_remove(p)
 
                 self.link(c, p)
 
@@ -345,6 +346,9 @@ class RemoteLOCAL(RemoteBase):
 
     def _already_cached(self, path):
         current_md5 = self.state.update(path)
+
+        if not current_md5:
+            return False
 
         return not self.changed_cache(current_md5)
 

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -359,3 +359,16 @@ class TestCheckoutWithDeps(TestRepro):
 
         self.assertTrue(os.path.exists(self.FOO))
         self.assertTrue(os.path.exists(self.file1))
+
+
+class TestCheckoutDirectory(TestRepro):
+    def test(self):
+        stage = self.dvc.add(self.DATA_DIR)[0]
+
+        shutil.rmtree(self.DATA_DIR)
+        self.assertFalse(os.path.exists(self.DATA_DIR))
+
+        ret = main(['checkout', stage.path])
+        self.assertEqual(ret, 0)
+
+        self.assertTrue(os.path.exists(self.DATA_DIR))


### PR DESCRIPTION
Fix #1376