### PR TITLE
run: use quotes to wrap arguments with spaces in them

### DIFF
--- a/dvc/command/run.py
+++ b/dvc/command/run.py
@@ -3,12 +3,28 @@ from dvc.exceptions import DvcException
 
 
 class CmdRun(CmdBase):
+    def _joined_cmd(self):
+        if len(self.args.command) == 0:
+            return ''
+
+        if len(self.args.command) == 1:
+            return self.args.command[0]
+
+        cmd = ''
+        for chunk in self.args.command:
+            if len(chunk.split()) != 1:
+                fmt = ' "{}"'
+            else:
+                fmt = ' {}'
+            cmd += fmt.format(chunk)
+        return cmd
+
     def run(self):
         try:
             if self.args.yes:
                 self.project.prompt.default = True
 
-            self.project.run(cmd=' '.join(self.args.command),
+            self.project.run(cmd=self._joined_cmd(),
                              outs=self.args.outs,
                              outs_no_cache=self.args.outs_no_cache,
                              metrics_no_cache=self.args.metrics_no_cache,

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -156,3 +156,20 @@ class TestCmdRun(TestDvc):
         ret = main(['run',
                     'non-existing-command'])
         self.assertNotEqual(ret, 0)
+
+    def test_run_args_with_spaces(self):
+        with open(self.CODE, 'w') as fobj:
+            fobj.write("import sys\nopen(sys.argv[1], 'w+').write(sys.argv[2])")
+
+        arg = 'arg1 arg2'
+        log = 'log'
+        ret = main(['run',
+                    'python',
+                    self.CODE,
+                    log,
+                    'arg1 arg2'])
+
+        self.assertEqual(ret, 0)
+
+        with open(log, 'r') as fobj:
+            self.assertEqual(fobj.read(), arg)


### PR DESCRIPTION
Fixes #1372

Signed-off-by: Ruslan Kuprieiev <ruslan@iterative.ai>