### PR TITLE
logger: optimize calls

### DIFF
--- a/dvc/analytics.py
+++ b/dvc/analytics.py
@@ -3,7 +3,7 @@ import json
 import errno
 
 from dvc import VERSION
-from dvc.logger import Logger
+from dvc.logger import logger
 
 
 class Analytics(object):
@@ -75,7 +75,7 @@ class Analytics(object):
                 info = json.load(fobj)
                 return info[self.PARAM_USER_ID]
             except json.JSONDecodeError as exc:
-                Logger.debug("Failed to load user_id: {}".format(exc))
+                logger.debug("Failed to load user_id: {}".format(exc))
                 return None
 
     def _get_user_id(self):
@@ -89,7 +89,7 @@ class Analytics(object):
                 return user_id
         except LockError:
             msg = "Failed to acquire '{}'"
-            Logger.debug(msg.format(self.user_id_file_lock.lock_file))
+            logger.debug(msg.format(self.user_id_file_lock.lock_file))
 
     def _collect_windows(self):
         import sys
@@ -194,7 +194,7 @@ class Analytics(object):
 
         core = config._config.get(Config.SECTION_CORE, {})
         enabled = core.get(Config.SECTION_CORE_ANALYTICS, True)
-        Logger.debug("Analytics is {}abled."
+        logger.debug("Analytics is {}abled."
                      .format('en' if enabled else 'dis'))
         return enabled
 
@@ -217,9 +217,9 @@ class Analytics(object):
 
         self.collect()
 
-        Logger.debug("Sending analytics: {}".format(self.info))
+        logger.debug("Sending analytics: {}".format(self.info))
 
         try:
             requests.post(self.URL, json=self.info, timeout=self.TIMEOUT_POST)
         except requests.exceptions.RequestException as exc:
-            Logger.debug("Failed to send analytics: {}".format(str(exc)))
+            logger.debug("Failed to send analytics: {}".format(str(exc)))

--- a/dvc/cli.py
+++ b/dvc/cli.py
@@ -28,7 +28,7 @@ from dvc.command.lock import CmdLock, CmdUnlock
 from dvc.command.pipeline import CmdPipelineShow, CmdPipelineList
 from dvc.command.daemon import CmdDaemonUpdater, CmdDaemonAnalytics
 from dvc.exceptions import DvcParserError
-from dvc.logger import Logger
+from dvc.logger import logger
 from dvc import VERSION
 
 
@@ -44,7 +44,7 @@ def _fix_subparsers(subparsers):
 
 class DvcParser(argparse.ArgumentParser):
     def error(self, message):
-        sys.stderr.write('{}: {}\n'.format(Logger.error_prefix(), message))
+        sys.stderr.write('{}: {}\n'.format(logger.error_prefix(), message))
         self.print_help()
         raise DvcParserError()
 

--- a/dvc/command/add.py
+++ b/dvc/command/add.py
@@ -1,6 +1,6 @@
 from dvc.exceptions import DvcException
 from dvc.command.base import CmdBase
-from dvc.logger import Logger
+from dvc.logger import logger
 
 
 class CmdAdd(CmdBase):
@@ -9,6 +9,6 @@ class CmdAdd(CmdBase):
             try:
                 self.project.add(target, recursive=self.args.recursive)
             except DvcException as ex:
-                Logger.error('Failed to add \'{}\''.format(target), ex)
+                logger.error('Failed to add \'{}\''.format(target), ex)
                 return 1
         return 0

--- a/dvc/command/base.py
+++ b/dvc/command/base.py
@@ -1,4 +1,4 @@
-from dvc.logger import Logger
+from dvc.logger import logger
 
 
 class CmdBase(object):
@@ -13,10 +13,10 @@ class CmdBase(object):
     @staticmethod
     def _set_loglevel(args):
         if args.quiet:
-            Logger.be_quiet()
+            logger.be_quiet()
 
         elif args.verbose:
-            Logger.be_verbose()
+            logger.be_verbose()
 
     def run_cmd(self):
         from dvc.lock import LockError
@@ -25,7 +25,7 @@ class CmdBase(object):
             with self.project.lock:
                 return self.run()
         except LockError as ex:
-            Logger.error('Failed to lock before running a command', ex)
+            logger.error('Failed to lock before running a command', ex)
             return 1
 
     # Abstract methods that have to be implemented by any inheritance class

--- a/dvc/command/config.py
+++ b/dvc/command/config.py
@@ -1,7 +1,7 @@
 import os
 
 from dvc.command.base import CmdBase
-from dvc.logger import Logger
+from dvc.logger import logger
 from dvc.config import Config
 from dvc.exceptions import DvcException
 
@@ -44,7 +44,7 @@ class CmdConfig(CmdBase):
             self.config.unset(configobj, section, opt)
             self.config.save(configobj)
         except DvcException as exc:
-            Logger.error("Failed to unset '{}'".format(self.args.name), exc)
+            logger.error("Failed to unset '{}'".format(self.args.name), exc)
             return 1
         return 0
 
@@ -52,7 +52,7 @@ class CmdConfig(CmdBase):
         try:
             self.config.show(self.configobj, section, opt)
         except DvcException as exc:
-            Logger.error("Failed to show '{}'".format(self.args.name), exc)
+            logger.error("Failed to show '{}'".format(self.args.name), exc)
             return 1
         return 0
 
@@ -61,7 +61,7 @@ class CmdConfig(CmdBase):
             self.config.set(self.configobj, section, opt, value)
             self.config.save(self.configobj)
         except DvcException as exc:
-            Logger.error("Failed to set '{}.{}' to '{}'".format(section,
+            logger.error("Failed to set '{}.{}' to '{}'".format(section,
                                                                 opt,
                                                                 value),
                          exc)

--- a/dvc/command/imp.py
+++ b/dvc/command/imp.py
@@ -7,7 +7,7 @@ except ImportError:
 
 from dvc.exceptions import DvcException
 from dvc.command.base import CmdBase
-from dvc.logger import Logger
+from dvc.logger import logger
 
 
 class CmdImport(CmdBase):
@@ -21,6 +21,6 @@ class CmdImport(CmdBase):
 
             self.project.imp(self.args.url, out)
         except DvcException as ex:
-            Logger.error('Failed to import {}'.format(self.args.url), ex)
+            logger.error('Failed to import {}'.format(self.args.url), ex)
             return 1
         return 0

--- a/dvc/command/init.py
+++ b/dvc/command/init.py
@@ -1,4 +1,4 @@
-from dvc.logger import Logger
+from dvc.logger import logger
 
 
 class CmdInit(object):
@@ -14,6 +14,6 @@ class CmdInit(object):
                                         force=self.args.force)
             self.config = self.project.config
         except InitError as e:
-            Logger.error('Failed to initiate dvc', e)
+            logger.error('Failed to initiate dvc', e)
             return 1
         return 0

--- a/dvc/command/install.py
+++ b/dvc/command/install.py
@@ -1,4 +1,4 @@
-from dvc.logger import Logger
+from dvc.logger import logger
 from dvc.command.base import CmdBase
 
 
@@ -7,6 +7,6 @@ class CmdInstall(CmdBase):
         try:
             self.project.install()
         except Exception as e:
-            Logger.error('Failed to install dvc hooks', e)
+            logger.error('Failed to install dvc hooks', e)
             return 1
         return 0

--- a/dvc/command/remote.py
+++ b/dvc/command/remote.py
@@ -2,7 +2,7 @@ import re
 
 from dvc.config import Config
 from dvc.command.config import CmdConfig
-from dvc.logger import Logger
+from dvc.logger import logger
 
 
 class CmdRemoteAdd(CmdConfig):
@@ -14,7 +14,7 @@ class CmdRemoteAdd(CmdConfig):
 
         if self.args.default:
             msg = 'Setting \'{}\' as a default remote.'.format(self.args.name)
-            Logger.info(msg)
+            logger.info(msg)
             ret = self._set(Config.SECTION_CORE,
                             Config.SECTION_CORE_REMOTE,
                             self.args.name)
@@ -70,5 +70,5 @@ class CmdRemoteList(CmdConfig):
                 name = r.group('name')
                 url = self.configobj[section].get(Config.SECTION_REMOTE_URL,
                                                   '')
-                Logger.info('{}\t{}'.format(name, url))
+                logger.info('{}\t{}'.format(name, url))
         return 0

--- a/dvc/command/remove.py
+++ b/dvc/command/remove.py
@@ -1,6 +1,6 @@
 from dvc.exceptions import DvcException
 from dvc.command.base import CmdBase
-from dvc.logger import Logger
+from dvc.logger import logger
 
 
 class CmdRemove(CmdBase):
@@ -32,6 +32,6 @@ class CmdRemove(CmdBase):
                 outs_only = self._is_outs_only(target)
                 self.project.remove(target, outs_only=outs_only)
             except DvcException as ex:
-                Logger.error('Failed to remove {}'.format(target), ex)
+                logger.error('Failed to remove {}'.format(target), ex)
                 return 1
         return 0

--- a/dvc/config.py
+++ b/dvc/config.py
@@ -6,7 +6,7 @@ import errno
 import configobj
 from schema import Schema, Optional, And, Use, Regex
 
-from dvc.logger import Logger
+from dvc.logger import logger
 from dvc.exceptions import DvcException
 
 
@@ -295,7 +295,7 @@ class Config(object):
                 continue
 
             try:
-                Logger.debug("Writing '{}'.".format(conf.filename))
+                logger.debug("Writing '{}'.".format(conf.filename))
                 dname = os.path.dirname(os.path.abspath(conf.filename))
                 try:
                     os.makedirs(dname)
@@ -337,7 +337,7 @@ class Config(object):
             raise ConfigError("Option '{}.{}' doesn't exist".format(section,
                                                                     opt))
 
-        Logger.info(config[section][opt])
+        logger.info(config[section][opt])
 
     @staticmethod
     def _merge(first, second):

--- a/dvc/daemon.py
+++ b/dvc/daemon.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from subprocess import Popen
-from dvc.logger import Logger
+from dvc.logger import logger
 
 
 class Daemon(object):  # pragma: no cover
@@ -20,7 +20,7 @@ class Daemon(object):  # pragma: no cover
             if pid > 0:
                 return
         except OSError as exc:
-            Logger.error("Failed at first fork", exc)
+            logger.error("Failed at first fork", exc)
             sys.exit(1)
 
         os.setsid()
@@ -31,7 +31,7 @@ class Daemon(object):  # pragma: no cover
             if pid > 0:
                 sys.exit(0)
         except OSError as exc:
-            Logger.error("Failed at second fork", exc)
+            logger.error("Failed at second fork", exc)
             sys.exit(1)
 
         sys.stdin.close()
@@ -50,7 +50,7 @@ class Daemon(object):  # pragma: no cover
             cmd += ['-m', 'dvc']
         cmd += ['daemon', '-q'] + args
 
-        Logger.debug("Trying to spawn '{}'".format(cmd))
+        logger.debug("Trying to spawn '{}'".format(cmd))
 
         if os.name == 'nt':
             self._spawn_windows(cmd)
@@ -59,4 +59,4 @@ class Daemon(object):  # pragma: no cover
         else:
             raise NotImplementedError
 
-        Logger.debug("Spawned '{}'".format(cmd))
+        logger.debug("Spawned '{}'".format(cmd))

--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -1,4 +1,4 @@
-from dvc.logger import Logger
+from dvc.logger import logger
 from dvc.config import Config, ConfigError
 
 from dvc.remote.s3 import RemoteS3
@@ -36,7 +36,7 @@ class DataCloud(object):
         if self._core.get(Config.SECTION_CORE_CLOUD, None):
             # backward compatibility
             msg = 'Using obsoleted config format. Consider updating.'
-            Logger.warn(msg)
+            logger.warn(msg)
             return self._init_compat()
 
         return None
@@ -87,7 +87,7 @@ class DataCloud(object):
     def _init_cloud(self, cloud_config, cloud_type):
         global_storage_path = self._core.get(Config.SECTION_CORE_STORAGEPATH)
         if global_storage_path:
-            Logger.warn('Using obsoleted config format. Consider updating.')
+            logger.warn('Using obsoleted config format. Consider updating.')
 
         cloud = cloud_type(self.project, cloud_config)
         return cloud

--- a/dvc/dependency/local.py
+++ b/dvc/dependency/local.py
@@ -8,7 +8,6 @@ except ImportError:
 from dvc.dependency.base import DependencyBase
 from dvc.dependency.base import DependencyDoesNotExistError
 from dvc.dependency.base import DependencyIsNotFileOrDirError
-from dvc.logger import Logger
 from dvc.remote.local import RemoteLOCAL
 
 
@@ -73,7 +72,8 @@ class DependencyLOCAL(DependencyBase):
 
         if (os.path.isfile(self.path) and os.path.getsize(self.path) == 0) or \
            (os.path.isdir(self.path) and len(os.listdir(self.path)) == 0):
-            Logger.warn("File/directory '{}' is empty.".format(self.rel_path))
+            msg = "File/directory '{}' is empty.".format(self.rel_path)
+            self.project.logger.warn(msg)
 
         self.info = self.remote.save_info(self.path_info)
 

--- a/dvc/main.py
+++ b/dvc/main.py
@@ -1,4 +1,4 @@
-from dvc.logger import Logger
+from dvc.logger import logger
 from dvc.cli import parse_args
 from dvc.command.base import CmdBase
 from dvc.analytics import Analytics
@@ -6,8 +6,6 @@ from dvc.exceptions import NotDvcProjectError, DvcParserError
 
 
 def main(argv=None):
-    Logger.init()
-
     args = None
     cmd = None
     try:
@@ -21,15 +19,15 @@ def main(argv=None):
 
         ret = cmd.run_cmd()
     except KeyboardInterrupt as ex:
-        Logger.error("Interrupted by the user", ex)
+        logger.error("Interrupted by the user", ex)
         ret = 252
     except NotDvcProjectError as ex:
-        Logger.error("", ex)
+        logger.error("", ex)
         ret = 253
     except DvcParserError:
         ret = 254
     except Exception as ex:
-        Logger.error('Unexpected error', ex)
+        logger.error('Unexpected error', ex)
         ret = 255
 
     Analytics().send_cmd(cmd, args, ret)

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -86,9 +86,9 @@ class Progress(object):
         return num + bar + percent + target_name
 
     def _print(self, *args, **kwargs):
-        from dvc.logger import Logger
+        from dvc.logger import logger
 
-        if Logger.is_quiet():
+        if logger.is_quiet():
             return
 
         print(*args, **kwargs)

--- a/dvc/project.py
+++ b/dvc/project.py
@@ -21,7 +21,7 @@ class Project(object):
     DVC_DIR = '.dvc'
 
     def __init__(self, root_dir=None):
-        from dvc.logger import Logger
+        from dvc.logger import logger
         from dvc.config import Config
         from dvc.state import State
         from dvc.lock import Lock
@@ -45,7 +45,8 @@ class Project(object):
         self.state = State(self, self.config._config)
 
         core = self.config._config[Config.SECTION_CORE]
-        self.logger = Logger(core.get(Config.SECTION_CORE_LOGLEVEL, None))
+        self.logger = logger
+        self.logger.set_level(core.get(Config.SECTION_CORE_LOGLEVEL, None))
 
         self.cache = Cache(self)
         self.cloud = DataCloud(self, config=self.config._config)
@@ -106,7 +107,7 @@ class Project(object):
         import shutil
         from dvc.scm import SCM, Base
         from dvc.config import Config
-        from dvc.logger import Logger
+        from dvc.logger import logger
 
         root_dir = os.path.abspath(root_dir)
         dvc_dir = os.path.join(root_dir, Project.DVC_DIR)
@@ -130,9 +131,9 @@ class Project(object):
         if scm.ignore_file():
             scm.add([os.path.join(dvc_dir, scm.ignore_file())])
 
-        Logger.info('\nYou can now commit the changes to git.')
+        logger.info('\nYou can now commit the changes to git.')
 
-        Logger.info(
+        logger.info(
             "\n"
             "{yellow}What's next?{nc}\n"
             "{yellow}------------{nc}\n"

--- a/dvc/remote/azure.py
+++ b/dvc/remote/azure.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     BlockBlobService = None
 
-from dvc.logger import Logger
+from dvc.logger import logger
 from dvc.progress import progress
 from dvc.config import Config
 from dvc.remote.base import RemoteBase
@@ -129,7 +129,7 @@ class RemoteAzure(RemoteBase):
         if path_info['scheme'] != self.scheme:
             raise NotImplementedError
 
-        Logger.debug('Removing azure://{}/{}'.format(path_info['bucket'],
+        logger.debug('Removing azure://{}/{}'.format(path_info['bucket'],
                                                      path_info['key']))
 
         self.blob_service.delete_blob(path_info['bucket'], path_info['key'])
@@ -177,7 +177,7 @@ class RemoteAzure(RemoteBase):
             bucket = to_info['bucket']
             key = to_info['key']
 
-            Logger.debug("Uploading '{}' to '{}/{}'".format(
+            logger.debug("Uploading '{}' to '{}/{}'".format(
                 from_info['path'], bucket, key))
 
             if not name:
@@ -190,7 +190,7 @@ class RemoteAzure(RemoteBase):
                     bucket, key, from_info['path'], progress_callback=cb)
             except Exception as ex:
                 msg = "Failed to upload '{}'".format(from_info['path'])
-                Logger.warn(msg, ex)
+                logger.warn(msg, ex)
             else:
                 progress.finish_target(name)
 
@@ -211,7 +211,7 @@ class RemoteAzure(RemoteBase):
             bucket = from_info['bucket']
             key = from_info['key']
 
-            Logger.debug("Downloading '{}/{}' to '{}'".format(
+            logger.debug("Downloading '{}/{}' to '{}'".format(
                 bucket, key, to_info['path']))
 
             tmp_file = self.tmp_file(to_info['path'])
@@ -227,7 +227,7 @@ class RemoteAzure(RemoteBase):
                     bucket, key, tmp_file, progress_callback=cb)
             except Exception as exc:
                 msg = "Failed to download '{}/{}'".format(bucket, key)
-                Logger.warn(msg, exc)
+                logger.warn(msg, exc)
             else:
                 os.rename(tmp_file, to_info['path'])
 

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -4,7 +4,7 @@ import errno
 from multiprocessing import cpu_count
 
 from dvc.config import Config
-from dvc.logger import Logger
+from dvc.logger import logger
 from dvc.exceptions import DvcException
 
 
@@ -69,7 +69,7 @@ class RemoteBase(object):
                   "are still seeing this message, please report it to us " \
                   "using https://github.com/iterative/dvc/issues. Thank you!"
             msg = msg.format(url, missing, " ".join(missing), cls.scheme)
-            Logger.warn(msg)
+            logger.warn(msg)
 
         return url_ok and deps_ok
 

--- a/dvc/remote/gs.py
+++ b/dvc/remote/gs.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     from urllib.parse import urlparse
 
-from dvc.logger import Logger
+from dvc.logger import logger
 from dvc.remote.base import RemoteBase
 from dvc.remote.local import RemoteLOCAL
 from dvc.config import Config
@@ -84,7 +84,7 @@ class RemoteGS(RemoteBase):
         if {self.PARAM_MD5: md5} != self.save_info(cache):
             if self.exists([cache])[0]:
                 msg = 'Corrupted cache file {}'
-                Logger.warn(msg.format(self.to_string(cache)))
+                logger.warn(msg.format(self.to_string(cache)))
                 self.remove(cache)
             return True
 
@@ -138,22 +138,22 @@ class RemoteGS(RemoteBase):
 
         if not self.changed(path_info, checksum_info):
             msg = "Data '{}' didn't change."
-            Logger.info(msg.format(self.to_string(path_info)))
+            logger.info(msg.format(self.to_string(path_info)))
             return
 
         if self.changed_cache(md5):
             msg = "Cache '{}' not found. File '{}' won't be created."
-            Logger.warn(msg.format(md5, self.to_string(path_info)))
+            logger.warn(msg.format(md5, self.to_string(path_info)))
             return
 
         if self.exists([path_info])[0]:
             msg = "Data '{}' exists. Removing before checkout."
-            Logger.warn(msg.format(self.to_string(path_info)))
+            logger.warn(msg.format(self.to_string(path_info)))
             self.remove(path_info)
             return
 
         msg = "Checking out '{}' with cache '{}'."
-        Logger.info(msg.format(self.to_string(path_info), md5))
+        logger.info(msg.format(self.to_string(path_info), md5))
 
         key = posixpath.join(self.prefix, md5[0:2], md5[2:])
         from_info = {'scheme': 'gs', 'bucket': self.bucket, 'key': key}
@@ -164,7 +164,7 @@ class RemoteGS(RemoteBase):
         if path_info['scheme'] != 'gs':
             raise NotImplementedError
 
-        Logger.debug("Removing gs://{}/{}".format(path_info['bucket'],
+        logger.debug("Removing gs://{}/{}".format(path_info['bucket'],
                                                   path_info['key']))
 
         blob = self.gs.bucket(path_info['bucket']).get_blob(path_info['key'])
@@ -213,7 +213,7 @@ class RemoteGS(RemoteBase):
             if from_info['scheme'] != 'local':
                 raise NotImplementedError
 
-            Logger.debug("Uploading '{}' to '{}/{}'".format(from_info['path'],
+            logger.debug("Uploading '{}' to '{}/{}'".format(from_info['path'],
                                                             to_info['bucket'],
                                                             to_info['key']))
 
@@ -228,7 +228,7 @@ class RemoteGS(RemoteBase):
                 blob.upload_from_filename(from_info['path'])
             except Exception as exc:
                 msg = "Failed to upload '{}' to '{}/{}'"
-                Logger.warn(msg.format(from_info['path'],
+                logger.warn(msg.format(from_info['path'],
                                        to_info['bucket'],
                                        to_info['key']), exc)
                 continue
@@ -258,7 +258,7 @@ class RemoteGS(RemoteBase):
             msg = "Downloading '{}/{}' to '{}'".format(from_info['bucket'],
                                                        from_info['key'],
                                                        to_info['path'])
-            Logger.debug(msg)
+            logger.debug(msg)
 
             tmp_file = self.tmp_file(to_info['path'])
             if not name:
@@ -277,7 +277,7 @@ class RemoteGS(RemoteBase):
                 blob.download_to_filename(tmp_file)
             except Exception as exc:
                 msg = "Failed to download '{}/{}' to '{}'"
-                Logger.warn(msg.format(from_info['bucket'],
+                logger.warn(msg.format(from_info['bucket'],
                                        from_info['key'],
                                        to_info['path']), exc)
                 continue

--- a/dvc/remote/hdfs.py
+++ b/dvc/remote/hdfs.py
@@ -7,7 +7,7 @@ from subprocess import Popen, PIPE
 from dvc.config import Config
 from dvc.remote.base import RemoteBase, RemoteBaseCmdError
 from dvc.remote.local import RemoteLOCAL
-from dvc.logger import Logger
+from dvc.logger import logger
 from dvc.utils import fix_env
 
 
@@ -95,7 +95,7 @@ class RemoteHDFS(RemoteBase):
         if {self.PARAM_CHECKSUM: checksum} != self.save_info(cache):
             if self.exists([cache])[0]:
                 msg = 'Corrupted cache file {}'
-                Logger.warn(msg.format(self.to_string(cache)))
+                logger.warn(msg.format(self.to_string(cache)))
                 self.remove(cache)
             return True
 
@@ -140,22 +140,22 @@ class RemoteHDFS(RemoteBase):
 
         if not self.changed(path_info, checksum_info):
             msg = "Data '{}' didn't change."
-            Logger.info(msg.format(self.to_string(path_info)))
+            logger.info(msg.format(self.to_string(path_info)))
             return
 
         if self.changed_cache(checksum):
             msg = "Cache '{}' not found. File '{}' won't be created."
-            Logger.warn(msg.format(checksum, self.to_string(path_info)))
+            logger.warn(msg.format(checksum, self.to_string(path_info)))
             return
 
         if self.exists([path_info])[0]:
             msg = "Data '{}' exists. Removing before checkout."
-            Logger.warn(msg.format(self.to_string(path_info)))
+            logger.warn(msg.format(self.to_string(path_info)))
             self.remove(path_info)
             return
 
         msg = "Checking out '{}' with cache '{}'."
-        Logger.info(msg.format(self.to_string(path_info), checksum))
+        logger.info(msg.format(self.to_string(path_info), checksum))
 
         src = path_info.copy()
         src['url'] = posixpath.join(self.url, checksum[0:2], checksum[2:])
@@ -168,7 +168,7 @@ class RemoteHDFS(RemoteBase):
 
         assert path_info.get('url')
 
-        Logger.debug('Removing {}'.format(path_info['url']))
+        logger.debug('Removing {}'.format(path_info['url']))
 
         self.rm(path_info)
 

--- a/dvc/remote/http.py
+++ b/dvc/remote/http.py
@@ -3,7 +3,7 @@ import threading
 import requests
 import posixpath
 
-from dvc.logger import Logger
+from dvc.logger import logger
 from dvc.progress import progress
 from dvc.exceptions import DvcException
 from dvc.config import Config
@@ -54,7 +54,7 @@ class RemoteHTTP(RemoteBase):
 
             msg = "Downloading '{}' to '{}'".format(from_info['url'],
                                                     to_info['path'])
-            Logger.debug(msg)
+            logger.debug(msg)
 
             tmp_file = self.tmp_file(to_info['path'])
             if not name:
@@ -73,7 +73,7 @@ class RemoteHTTP(RemoteBase):
                 self._download_to(from_info['url'], tmp_file, callback=cb)
             except Exception as exc:
                 msg = "Failed to download '{}'".format(from_info['url'])
-                Logger.warn(msg, exc)
+                logger.warn(msg, exc)
                 continue
 
             os.rename(tmp_file, to_info['path'])

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -133,11 +133,7 @@ class RemoteLOCAL(RemoteBase):
         if os.path.getsize(cache) == 0:
             open(path, 'w+').close()
 
-            msg = "Created empty file: {} -> {}".format(
-                os.path.relpath(cache),
-                os.path.relpath(path),
-            )
-
+            msg = "Created empty file: {} -> {}".format(cache, path)
             Logger.debug(msg)
             return
 
@@ -151,10 +147,7 @@ class RemoteLOCAL(RemoteBase):
 
                 msg = "Created {}'{}': {} -> {}".format(
                     'protected ' if self.protected else '',
-                    self.cache_types[0],
-                    os.path.relpath(cache),
-                    os.path.relpath(path)
-                )
+                    self.cache_types[0], cache, path)
 
                 Logger.debug(msg)
                 return

--- a/dvc/remote/s3.py
+++ b/dvc/remote/s3.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     from urllib.parse import urlparse
 
-from dvc.logger import Logger
+from dvc.logger import logger
 from dvc.progress import progress
 from dvc.config import Config
 from dvc.remote.base import RemoteBase
@@ -144,7 +144,7 @@ class RemoteS3(RemoteBase):
         if {self.PARAM_ETAG: etag} != self.save_info(cache):
             if self.exists([cache])[0]:
                 msg = 'Corrupted cache file {}'
-                Logger.warn(msg.format(self.to_string(cache)))
+                logger.warn(msg.format(self.to_string(cache)))
                 self.remove(cache)
             return True
 
@@ -160,22 +160,22 @@ class RemoteS3(RemoteBase):
 
         if not self.changed(path_info, checksum_info):
             msg = "Data '{}' didn't change."
-            Logger.info(msg.format(self.to_string(path_info)))
+            logger.info(msg.format(self.to_string(path_info)))
             return
 
         if self.changed_cache(etag):
             msg = "Cache '{}' not found. File '{}' won't be created."
-            Logger.warn(msg.format(etag, self.to_string(path_info)))
+            logger.warn(msg.format(etag, self.to_string(path_info)))
             return
 
         if self.exists([path_info])[0]:
             msg = "Data '{}' exists. Removing before checkout."
-            Logger.warn(msg.format(self.to_string(path_info)))
+            logger.warn(msg.format(self.to_string(path_info)))
             self.remove(path_info)
             return
 
         msg = "Checking out '{}' with cache '{}'."
-        Logger.info(msg.format(self.to_string(path_info), etag))
+        logger.info(msg.format(self.to_string(path_info), etag))
 
         key = posixpath.join(self.prefix, etag[0:2], etag[2:])
         from_info = {'scheme': 's3', 'bucket': self.bucket, 'key': key}
@@ -186,7 +186,7 @@ class RemoteS3(RemoteBase):
         if path_info['scheme'] != 's3':
             raise NotImplementedError
 
-        Logger.debug('Removing s3://{}/{}'.format(path_info['bucket'],
+        logger.debug('Removing s3://{}/{}'.format(path_info['bucket'],
                                                   path_info['key']))
 
         self.s3.delete_object(Bucket=path_info['bucket'],
@@ -256,7 +256,7 @@ class RemoteS3(RemoteBase):
             if from_info['scheme'] != 'local':
                 raise NotImplementedError
 
-            Logger.debug("Uploading '{}' to '{}/{}'".format(from_info['path'],
+            logger.debug("Uploading '{}' to '{}/{}'".format(from_info['path'],
                                                             to_info['bucket'],
                                                             to_info['key']))
 
@@ -273,7 +273,7 @@ class RemoteS3(RemoteBase):
                                Callback=cb)
             except Exception as exc:
                 msg = "Failed to upload '{}'".format(from_info['path'])
-                Logger.warn(msg, exc)
+                logger.warn(msg, exc)
                 continue
 
             progress.finish_target(name)
@@ -301,7 +301,7 @@ class RemoteS3(RemoteBase):
             msg = "Downloading '{}/{}' to '{}'".format(from_info['bucket'],
                                                        from_info['key'],
                                                        to_info['path'])
-            Logger.debug(msg)
+            logger.debug(msg)
 
             tmp_file = self.tmp_file(to_info['path'])
             if not name:
@@ -325,7 +325,7 @@ class RemoteS3(RemoteBase):
             except Exception as exc:
                 msg = "Failed to download '{}/{}'".format(from_info['bucket'],
                                                           from_info['key'])
-                Logger.warn(msg, exc)
+                logger.warn(msg, exc)
                 continue
 
             os.rename(tmp_file, to_info['path'])

--- a/dvc/remote/ssh.py
+++ b/dvc/remote/ssh.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     paramiko = None
 
-from dvc.logger import Logger
+from dvc.logger import logger
 from dvc.progress import progress
 from dvc.remote.base import RemoteBase, RemoteBaseCmdError
 from dvc.remote.local import RemoteLOCAL
@@ -26,7 +26,7 @@ def sizeof_fmt(num, suffix='B'):
 
 def percent_cb(name, complete, total):
     """ Callback for updating target progress """
-    Logger.debug('{}: {} transferred out of {}'.format(name,
+    logger.debug('{}: {} transferred out of {}'.format(name,
                                                        sizeof_fmt(complete),
                                                        sizeof_fmt(total)))
     progress.update_target(name, complete, total)
@@ -83,7 +83,7 @@ class RemoteSSH(RemoteBase):
     def ssh(self, host=None, user=None, port=None):
         msg = "Establishing ssh connection with '{}' " \
               "through port '{}' as user '{}'"
-        Logger.debug(msg.format(host, port, user))
+        logger.debug(msg.format(host, port, user))
 
         ssh = paramiko.SSHClient()
 
@@ -245,7 +245,7 @@ class RemoteSSH(RemoteBase):
         if {self.PARAM_MD5: md5} != self.save_info(cache):
             if self.exists([cache])[0]:
                 msg = 'Corrupted cache file {}'
-                Logger.warn(msg.format(self.to_string(cache)))
+                logger.warn(msg.format(self.to_string(cache)))
                 self.remove(cache)
             return True
 
@@ -286,22 +286,22 @@ class RemoteSSH(RemoteBase):
 
         if not self.changed(path_info, checksum_info):
             msg = "Data '{}' didn't change."
-            Logger.info(msg.format(self.to_string(path_info)))
+            logger.info(msg.format(self.to_string(path_info)))
             return
 
         if self.changed_cache(md5):
             msg = "Cache '{}' not found. File '{}' won't be created."
-            Logger.warn(msg.format(md5, self.to_string(path_info)))
+            logger.warn(msg.format(md5, self.to_string(path_info)))
             return
 
         if self.exists([path_info])[0]:
             msg = "Data '{}' exists. Removing before checkout."
-            Logger.warn(msg.format(self.to_string(path_info)))
+            logger.warn(msg.format(self.to_string(path_info)))
             self.remove(path_info)
             return
 
         msg = "Checking out '{}' with cache '{}'."
-        Logger.info(msg.format(self.to_string(path_info), md5))
+        logger.info(msg.format(self.to_string(path_info), md5))
 
         src = path_info.copy()
         src['path'] = posixpath.join(self.prefix, md5[0:2], md5[2:])
@@ -312,7 +312,7 @@ class RemoteSSH(RemoteBase):
         if path_info['scheme'] != 'ssh':
             raise NotImplementedError
 
-        Logger.debug('Removing ssh://{}@{}/{}'.format(path_info['user'],
+        logger.debug('Removing ssh://{}@{}/{}'.format(path_info['user'],
                                                       path_info['host'],
                                                       path_info['path']))
 
@@ -350,7 +350,7 @@ class RemoteSSH(RemoteBase):
             msg = "Downloading '{}/{}' to '{}'".format(from_info['host'],
                                                        from_info['path'],
                                                        to_info['path'])
-            Logger.debug(msg)
+            logger.debug(msg)
 
             if not name:
                 name = os.path.basename(to_info['path'])
@@ -363,7 +363,7 @@ class RemoteSSH(RemoteBase):
                                     callback=create_cb(name))
             except Exception as exc:
                 msg = "Failed to download '{}/{}' to '{}'"
-                Logger.warn(msg.format(from_info['host'],
+                logger.warn(msg.format(from_info['host'],
                                        from_info['path'],
                                        to_info['path']), exc)
                 continue
@@ -388,7 +388,7 @@ class RemoteSSH(RemoteBase):
             if from_info['scheme'] != 'local':
                 raise NotImplementedError
 
-            Logger.debug("Uploading '{}' to '{}/{}'".format(from_info['path'],
+            logger.debug("Uploading '{}' to '{}/{}'".format(from_info['path'],
                                                             to_info['host'],
                                                             to_info['path']))
 
@@ -404,7 +404,7 @@ class RemoteSSH(RemoteBase):
                          callback=create_cb(name))
             except Exception as exc:
                 msg = "Failed to upload '{}' to '{}/{}'"
-                Logger.warn(msg.format(from_info['path'],
+                logger.warn(msg.format(from_info['path'],
                                        to_info['host'],
                                        to_info['path'], exc))
                 continue

--- a/dvc/scm.py
+++ b/dvc/scm.py
@@ -1,7 +1,7 @@
 import os
 
 from dvc.exceptions import DvcException
-from dvc.logger import Logger
+from dvc.logger import logger
 from dvc.utils import fix_env
 
 
@@ -173,7 +173,7 @@ class Git(Base):
 
         msg = "Adding '{}' to '{}'.".format(os.path.relpath(path),
                                             os.path.relpath(gitignore))
-        Logger.info(msg)
+        logger.info(msg)
 
         content = entry
         if len(ignore_list) > 0:
@@ -212,7 +212,7 @@ class Git(Base):
             msg += 'manually using \'git add\'. '
             msg += 'See \'https://github.com/iterative/dvc/issues/610\' '
             msg += 'for more details.'
-            Logger.error(msg.format(str(paths)), exc)
+            logger.error(msg.format(str(paths)), exc)
 
     def commit(self, msg):
         self.repo.index.commit(msg)

--- a/dvc/stage.py
+++ b/dvc/stage.py
@@ -7,7 +7,7 @@ from schema import Schema, SchemaError, Optional, Or, And
 import dvc.dependency as dependency
 import dvc.output as output
 from dvc.exceptions import DvcException
-from dvc.logger import Logger
+from dvc.logger import logger
 from dvc.utils import dict_md5, fix_env
 
 
@@ -205,7 +205,7 @@ class Stage(object):
             msg = "Stage '{}' didn't change.".format(self.relpath)
             color = 'green'
 
-        log(Logger.colorize(msg, color))
+        log(logger.colorize(msg, color))
 
         return ret
 
@@ -386,7 +386,7 @@ class Stage(object):
 
         if os.path.exists(path):
             if not ignore_build_cache and stage.is_cached():
-                Logger.info('Stage is cached, skipping.')
+                logger.info('Stage is cached, skipping.')
                 return None
 
             msg = "'{}' already exists. Do you wish to run the command and " \
@@ -408,7 +408,7 @@ class Stage(object):
     def _check_dvc_file(fname):
         sname = fname + Stage.STAGE_FILE_SUFFIX
         if Stage.is_stage_file(sname):
-            Logger.info("Do you mean '{}'?".format(sname))
+            logger.info("Do you mean '{}'?".format(sname))
 
     @staticmethod
     def load(project, fname):
@@ -451,7 +451,7 @@ class Stage(object):
         self._check_dvc_filename(fname)
 
         msg = "Saving information to '{}'.".format(os.path.relpath(fname))
-        Logger.info(msg)
+        logger.info(msg)
 
         with open(fname, 'w') as fd:
             yaml.safe_dump(self.dumpd(), fd, default_flow_style=False)

--- a/dvc/state.py
+++ b/dvc/state.py
@@ -7,7 +7,7 @@ from dvc.config import Config
 from dvc.system import System
 from dvc.utils import file_md5, remove
 from dvc.exceptions import DvcException
-from dvc.logger import Logger
+from dvc.logger import logger
 
 
 class StateDuplicateError(DvcException):
@@ -88,7 +88,7 @@ class State(object):
         actual = self.update(path)
 
         msg = "File '{}', md5 '{}', actual '{}'"
-        Logger.debug(msg.format(path, md5, actual))
+        logger.debug(msg.format(path, md5, actual))
 
         if not md5 or not actual:
             return True
@@ -96,12 +96,12 @@ class State(object):
         return actual.split('.')[0] != md5.split('.')[0]
 
     def _execute(self, cmd):
-        Logger.debug(cmd)
+        logger.debug(cmd)
         return self.c.execute(cmd)
 
     def _fetchall(self):
         ret = self.c.fetchall()
-        Logger.debug("fetched: {}".format(ret))
+        logger.debug("fetched: {}".format(ret))
         return ret
 
     def _to_sqlite(self, n):
@@ -263,7 +263,7 @@ class State(object):
 
     @staticmethod
     def inode(path):
-        Logger.debug('Path {} inode {}'.format(path, System.inode(path)))
+        logger.debug('Path {} inode {}'.format(path, System.inode(path)))
         return System.inode(path)
 
     def _do_update(self, path):
@@ -299,7 +299,7 @@ class State(object):
             i = self._from_sqlite(i)
             assert i == inode
             msg = "Inode '{}', mtime '{}', actual mtime '{}'."
-            Logger.debug(msg.format(i, m, mtime))
+            logger.debug(msg.format(i, m, mtime))
             if mtime != m:
                 md5, info = self._collect(path)
                 cmd = 'UPDATE {} SET ' \
@@ -362,7 +362,7 @@ class State(object):
             mtime = self.mtime(path)
 
             if i == inode and m == mtime:
-                Logger.debug('Removing \'{}\' as unused link.'.format(path))
+                logger.debug('Removing \'{}\' as unused link.'.format(path))
                 remove(path)
                 unused.append(p)
 

--- a/dvc/updater.py
+++ b/dvc/updater.py
@@ -6,7 +6,7 @@ import colorama
 
 from dvc import VERSION_BASE
 from dvc.lock import Lock, LockError
-from dvc.logger import Logger
+from dvc.logger import logger
 from dvc.utils import is_binary
 
 
@@ -27,7 +27,7 @@ class Updater(object):  # pragma: no cover
         ctime = os.path.getmtime(self.updater_file)
         outdated = (time.time() - ctime >= self.TIMEOUT)
         if outdated:
-            Logger.debug("'{}' is outdated(".format(self.updater_file))
+            logger.debug("'{}' is outdated(".format(self.updater_file))
         return outdated
 
     def _with_lock(self, func, action):
@@ -36,7 +36,7 @@ class Updater(object):  # pragma: no cover
                 func()
         except LockError:
             msg = "Failed to acquire '{}' before {} updates"
-            Logger.debug(msg.format(self.lock.lock_file, action))
+            logger.debug(msg.format(self.lock.lock_file, action))
 
     def check(self):
         if os.getenv('CI') or os.getenv('DVC_TEST'):
@@ -57,7 +57,7 @@ class Updater(object):  # pragma: no cover
                 self.latest = info['version']
             except Exception as exc:
                 msg = "'{}' is not a valid json: {}"
-                Logger.debug(msg.format(self.updater_file, exc))
+                logger.debug(msg.format(self.updater_file, exc))
                 self.fetch()
                 return
 
@@ -81,7 +81,7 @@ class Updater(object):  # pragma: no cover
             info = r.json()
         except requests.exceptions.RequestException as exc:
             msg = "Failed to retrieve latest version: {}"
-            Logger.debug(msg.format(exc))
+            logger.debug(msg.format(exc))
             return
 
         with open(self.updater_file, 'w+') as fobj:
@@ -113,7 +113,7 @@ class Updater(object):  # pragma: no cover
                  latest=self.latest)
 
         if sys.stdout.isatty():
-            Logger.box(message, border_color='yellow')
+            logger.box(message, border_color='yellow')
 
     def _get_update_instructions(self):
         instructions = {

--- a/dvc/utils.py
+++ b/dvc/utils.py
@@ -11,7 +11,7 @@ import hashlib
 
 from dvc.progress import progress
 from dvc.istextfile import istextfile
-from dvc.logger import Logger
+from dvc.logger import logger
 
 
 LOCAL_CHUNK_SIZE = 1024*1024
@@ -33,7 +33,7 @@ def file_md5(fname):
         if size >= LARGE_FILE_SIZE:
             bar = True
             msg = "Computing md5 for a large file {}. This is only done once."
-            Logger.info(msg.format(os.path.relpath(fname)))
+            logger.info(msg.format(os.path.relpath(fname)))
             name = os.path.relpath(fname)
             total = 0
 
@@ -143,7 +143,7 @@ def remove(path):
     if not os.path.exists(path):
         return
 
-    Logger.debug(u'Removing \'{}\''.format(os.path.relpath(path)))
+    logger.debug(u'Removing \'{}\''.format(os.path.relpath(path)))
 
     def _chmod(func, p, excinfo):
         perm = os.stat(p).st_mode


### PR DESCRIPTION
In scenarios with millions of files, late shortcutting of
debug msgs results in a massive overhead. In order to avoid
that, just shortcut logger messages ASAP if verbose mode
is not enabled.

Related https://github.com/iterative/dvc/issues/1340