### PR TITLE
stage: don't exclude md5s for deps/outs

### DIFF
--- a/dvc/stage.py
+++ b/dvc/stage.py
@@ -465,11 +465,14 @@ class Stage(object):
 
         d = self.dumpd()
 
+        # NOTE: removing md5 manually in order to not affect md5s in deps/outs
+        if self.PARAM_MD5 in d.keys():
+            del d[self.PARAM_MD5]
+
         # NOTE: excluding parameters that don't affect the state of the
         # pipeline. Not excluding `OutputLOCAL.PARAM_CACHE`, because if
         # it has changed, we might not have that output in our cache.
-        return dict_md5(d, exclude=[self.PARAM_MD5,
-                                    self.PARAM_LOCKED,
+        return dict_md5(d, exclude=[self.PARAM_LOCKED,
                                     OutputLOCAL.PARAM_METRIC])
 
     def save(self):

--- a/tests/unit/stage.py
+++ b/tests/unit/stage.py
@@ -1,0 +1,19 @@
+import mock
+from unittest import TestCase
+
+from dvc.stage import Stage
+
+
+class TestStageChecksum(TestCase):
+    def test(self):
+        stage = Stage(None)
+        outs = [{'path': 'a', 'md5': '123456789'}]
+        deps = [{'path': 'b', 'md5': '987654321'}]
+        d = {'md5': '123456',
+             'cmd': 'mycmd',
+             'outs': outs,
+             'deps': deps}
+
+        with mock.patch.object(stage, 'dumpd', return_value=d):
+            self.assertEqual(stage._compute_md5(),
+                             'e9521a22111493406ea64a88cda63e0b')


### PR DESCRIPTION
A regression from #1508 , that wasn't caught because we didn't have a test for this earlier. Now we do :slightly_smiling_face: 

Currently, md5 for the stage file itself is incompatible with the one produced in earlier versions of dvc, causing unnecessary `dvc repro`s, since it marks stages as changed.

Signed-off-by: Ruslan Kuprieiev <ruslan@iterative.ai>