### PR TITLE
checkout: handle EOFError when running in a git hook

### DIFF
--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -148,3 +148,11 @@ class CyclicGraphError(DvcException):
             "{stages}".format(stages=stages)
         )
         super(CyclicGraphError, self).__init__(msg)
+
+
+class ConfirmRemoveError(DvcException):
+    def __init__(self, path):
+        super(ConfirmRemoveError, self).__init__(
+            "unable to remove '{}' without a confirmation from the user. Use "
+            "'-f' to force.".format(path)
+        )

--- a/dvc/prompt.py
+++ b/dvc/prompt.py
@@ -14,7 +14,10 @@ def _ask(prompt, limited_to=None):
         return None
 
     while True:
-        answer = input(prompt + " ").lower()
+        try:
+            answer = input(prompt + " ").lower()
+        except EOFError:
+            return None
 
         if not limited_to:
             return answer

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -11,7 +11,7 @@ from multiprocessing import cpu_count
 import dvc.prompt as prompt
 import dvc.logger as logger
 from dvc.config import Config
-from dvc.exceptions import DvcException
+from dvc.exceptions import DvcException, ConfirmRemoveError
 
 
 STATUS_OK = 1
@@ -296,10 +296,7 @@ class RemoteBase(object):
             )
 
             if not prompt.confirm(msg):
-                raise DvcException(
-                    "unable to remove '{}' without a confirmation"
-                    " from the user. Use '-f' to force.".format(str(path_info))
-                )
+                raise ConfirmRemoveError(str(path_info))
 
         self.remove(path_info)
 

--- a/tests/unit/prompt.py
+++ b/tests/unit/prompt.py
@@ -1,0 +1,14 @@
+import mock
+from unittest import TestCase
+
+from dvc.prompt import confirm
+
+
+class TestConfirm(TestCase):
+    @mock.patch("sys.stdout.isatty", return_value=True)
+    @mock.patch("dvc.prompt.input", side_effect=EOFError)
+    def test_eof(self, mock_input, mock_isatty):
+        ret = confirm("message")
+        mock_isatty.assert_called()
+        mock_input.assert_called()
+        self.assertFalse(ret)


### PR DESCRIPTION
This bug was reported by @AlJohri  on (Al) discord. When using `dvc checkout` in a git post-checkout hook(installed with `dvc install`), dvc would throw an error when it coudn't receive a confirmation for modified directory removal:

```
$ git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
Data '{'scheme': 'local', 'path': '/Users/atul/Development/taxonomy-analysis2/experiments/ovr_svm_tfidf_ne_np/ml_model_parameter_search'}' didn't change.
...
....
Checking out '{'scheme': 'local', 'path': '/Users/atul/Development/taxonomy-analysis2/experiments/ovr_svm_tfidf_unigrams_bigrams/rule_model_parameter_search'}' with cache '4bb62290664603eb8095ccf29659bc04.dir'.
Linking directory 'experiments/ovr_svm_tfidf_unigrams_bigrams/rule_model_parameter_search'.
file '{'scheme': 'local', 'path': '/Users/atul/Development/taxonomy-analysis2/experiments/ovr_svm_tfidf_unigrams_bigrams/rule_model_parameter_search/level_1/results.json'}' is going to be removed. Are you sure you want to proceed? [y/n] Error: unexpected error - EOF when reading a line

Having any troubles? Hit us up at https://dvc.org/support, we are always happy to help!
```

We already have isatty() check in place, but it seems that git hooks are called in an interactive mode, but with stdin closed, so we need to catch EOFError ourselves.

Signed-off-by: Ruslan Kuprieiev <ruslan@iterative.ai>