### PR TITLE
data cloud: lowercase remote name to match config values

### DIFF
--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -58,7 +58,7 @@ class DataCloud(object):
         return None
 
     def _init_remote(self, remote):
-        section = Config.SECTION_REMOTE_FMT.format(remote)
+        section = Config.SECTION_REMOTE_FMT.format(remote).lower()
         cloud_config = self._config.get(section, None)
         if not cloud_config:
             msg = "can't find remote section '{}' in config"

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -6,6 +6,7 @@ from dvc.command.remote import CmdRemoteAdd
 from dvc.config import Config
 
 from tests.basic_env import TestDvc
+from tests.test_data_cloud import get_local_storagepath
 
 
 class TestRemote(TestDvc):
@@ -136,3 +137,18 @@ class TestRemoteDefault(TestDvc):
         else:
             default = None
         self.assertEqual(default, None)
+
+
+class TestRemoteShouldHandleUppercaseRemoteName(TestDvc):
+    upper_case_remote_name = "UPPERCASEREMOTE"
+
+    def test(self):
+        remote_url = get_local_storagepath()
+        ret = main(["remote", "add", self.upper_case_remote_name, remote_url])
+        self.assertEqual(ret, 0)
+
+        ret = main(["add", self.FOO])
+        self.assertEqual(ret, 0)
+
+        ret = main(["push", "-r", self.upper_case_remote_name])
+        self.assertEqual(ret, 0)


### PR DESCRIPTION
Fixes #1574 