### PR TITLE
add: don't try to save cached stages

### DIFF
--- a/dvc/project.py
+++ b/dvc/project.py
@@ -229,7 +229,8 @@ class Project(object):
         self._check_dag(self.stages() + stages)
 
         for stage in stages:
-            stage.dump()
+            if stage is not None:
+                stage.dump()
 
         self._remind_to_git_add()
 

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -188,3 +188,19 @@ class TestCmdAdd(TestDvc):
 
         ret = main(["add", "non-existing-file"])
         self.assertNotEqual(ret, 0)
+
+
+class TestDoubleAddUnchanged(TestDvc):
+    def test_file(self):
+        ret = main(["add", self.FOO])
+        self.assertEqual(ret, 0)
+
+        ret = main(["add", self.FOO])
+        self.assertEqual(ret, 0)
+
+    def test_dir(self):
+        ret = main(["add", self.DATA_DIR])
+        self.assertEqual(ret, 0)
+
+        ret = main(["add", self.DATA_DIR])
+        self.assertEqual(ret, 0)


### PR DESCRIPTION
Cached stages are already saved, so there is no need to try to save them
once again.

Fixes #1581

Signed-off-by: Ruslan Kuprieiev <ruslan@iterative.ai>