### PR TITLE
Cached metrics

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,9 @@ repos:
     rev: stable
     hooks:
     - id: black
-      language_version: python3.6
+      language_version: python3
 -   repo: https://gitlab.com/pycqa/flake8
     rev: master
     hooks:
     - id: flake8
-      language_version: python3.6
+      language_version: python3

--- a/dvc/command/run.py
+++ b/dvc/command/run.py
@@ -91,15 +91,15 @@ def add_parser(subparsers, parent_parser):
         "--outs",
         action="append",
         default=[],
-        help="Declare output data file or data directory.",
+        help="Declare output file or directory.",
     )
     run_parser.add_argument(
         "-O",
         "--outs-no-cache",
         action="append",
         default=[],
-        help="Declare output data file or directory "
-        "(sync to Git, not DVC cache).",
+        help="Declare output file or directory "
+        "(do not put into DVC cache).",
     )
     run_parser.add_argument(
         "-m",
@@ -113,7 +113,8 @@ def add_parser(subparsers, parent_parser):
         "--metrics-no-cache",
         action="append",
         default=[],
-        help="Declare output metric file or " "directory (not cached by DVC).",
+        help="Declare output metric file or directory "
+        "(do not put into DVC cache).",
     )
     run_parser.add_argument(
         "-f",

--- a/dvc/command/run.py
+++ b/dvc/command/run.py
@@ -31,6 +31,7 @@ class CmdRun(CmdBase):
                 cmd=self._parsed_cmd(),
                 outs=self.args.outs,
                 outs_no_cache=self.args.outs_no_cache,
+                metrics=self.args.metrics,
                 metrics_no_cache=self.args.metrics_no_cache,
                 deps=self.args.deps,
                 fname=self.args.file,
@@ -95,8 +96,15 @@ def add_parser(subparsers, parent_parser):
         "--outs-no-cache",
         action="append",
         default=[],
-        help="Declare output regular file or directory "
+        help="Declare output data file or directory "
         "(sync to Git, not DVC cache).",
+    )
+    run_parser.add_argument(
+        "-m",
+        "--metrics",
+        action="append",
+        default=[],
+        help="Declare output metric file or directory.",
     )
     run_parser.add_argument(
         "-M",

--- a/dvc/command/run.py
+++ b/dvc/command/run.py
@@ -17,12 +17,14 @@ class CmdRun(CmdBase):
                 self.args.deps,
                 self.args.outs,
                 self.args.outs_no_cache,
+                self.args.metrics,
+                self.args.metrics_no_cache,
                 self.args.command,
             ]
         ):  # pragma: no cover
             logger.error(
                 "too few arguments. Specify at least one: '-d', "
-                "'-o', '-O', 'command'."
+                "'-o', '-O', '-m', '-M', 'command'."
             )
             return 1
 

--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -11,7 +11,7 @@ class DvcException(Exception):
     """Base class for all dvc exceptions.
 
     Args:
-        msg (str): message for this exception.
+        msg (unicode): message for this exception.
         cause (Exception): optional cause exception.
     """
 
@@ -33,7 +33,7 @@ class OutputDuplicationError(DvcException):
     stage.
 
     Args:
-        output (str): path to the file/directory.
+        output (unicode): path to the file/directory.
         stages (list): list of paths to stages.
     """
 

--- a/dvc/logger.py
+++ b/dvc/logger.py
@@ -262,7 +262,9 @@ def _description(message, exception):
     elif message:
         description = "{message}"
     else:
-        raise DvcException('Unexpected error - either exception or message must be provided')
+        raise DvcException(
+            "Unexpected error - either exception or message must be provided"
+        )
 
     return description.format(message=message, exception=exception)
 

--- a/dvc/logger.py
+++ b/dvc/logger.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 
+from dvc.exceptions import DvcException
 from dvc.utils.compat import str
 
 import re
@@ -63,8 +64,8 @@ def box(message, border_color=None):
     """Prints a message in a box.
 
     Args:
-        message (str): message to print.
-        border_color (str): name of a color to outline the box with.
+        message (unicode): message to print.
+        border_color (unicode): name of a color to outline the box with.
     """
     lines = message.split("\n")
     max_width = max(_visual_width(line) for line in lines)
@@ -230,13 +231,13 @@ def _walk_exc(exc):
             tb_list.insert(0, str(exc.cause_tb))
         exc = exc.cause
 
-    return (exc_list, tb_list)
+    return exc_list, tb_list
 
 
 def _parse_exc():
     exc = sys.exc_info()[1]
     if not exc:
-        return (None, "")
+        return None, ""
 
     exc_list, tb_list = _walk_exc(exc)
 
@@ -250,7 +251,7 @@ def _parse_exc():
     else:
         stack_trace = ""
 
-    return (exception, stack_trace)
+    return exception, stack_trace
 
 
 def _description(message, exception):
@@ -260,6 +261,8 @@ def _description(message, exception):
         description = "{exception}"
     elif message:
         description = "{message}"
+    else:
+        raise DvcException('Unexpected error - either exception or message must be provided')
 
     return description.format(message=message, exception=exception)
 

--- a/dvc/logger.py
+++ b/dvc/logger.py
@@ -237,7 +237,7 @@ def _walk_exc(exc):
 def _parse_exc():
     exc = sys.exc_info()[1]
     if not exc:
-        return None, ""
+        return (None, "")
 
     exc_list, tb_list = _walk_exc(exc)
 
@@ -251,7 +251,7 @@ def _parse_exc():
     else:
         stack_trace = ""
 
-    return exception, stack_trace
+    return (exception, stack_trace)
 
 
 def _description(message, exception):

--- a/dvc/project.py
+++ b/dvc/project.py
@@ -1154,7 +1154,7 @@ class Project(object):
                     if os.path.isdir(path):
                         logger.warning(
                             "Path '{path}' is a directory. "
-                            "Consider runnig with '-R'.".format(path=path)
+                            "Consider running with '-R'.".format(path=path)
                         )
                         return {}
 
@@ -1202,7 +1202,7 @@ class Project(object):
             return res
 
         if path:
-            msg = "file '{}' does not exist".format(path)
+            msg = "file '{}' does not exist or malformed".format(path)
         else:
             msg = (
                 "no metric files in this repository."

--- a/dvc/prompt.py
+++ b/dvc/prompt.py
@@ -36,7 +36,7 @@ def confirm(statement):
     """Ask the user for confirmation about the specified statement.
 
     Args:
-        statement (str): statement to ask the user confirmation about.
+        statement (unicode): statement to ask the user confirmation about.
 
     Returns:
         bool: whether or not specified statement was confirmed.

--- a/dvc/stage.py
+++ b/dvc/stage.py
@@ -375,7 +375,9 @@ class Stage(object):
         stage = Stage(project=project, cwd=cwd, cmd=cmd, locked=locked)
 
         stage.outs = output.loads_from(stage, outs, use_cache=True)
-        stage.outs = output.loads_from(stage, metrics, use_cache=True, metric=True)
+        stage.outs += output.loads_from(
+            stage, metrics, use_cache=True, metric=True
+        )
         stage.outs += output.loads_from(stage, outs_no_cache, use_cache=False)
         stage.outs += output.loads_from(
             stage, metrics_no_cache, use_cache=False, metric=True

--- a/dvc/stage.py
+++ b/dvc/stage.py
@@ -551,8 +551,8 @@ class Stage(object):
     def _check_circular_dependency(self):
         from dvc.exceptions import CircularDependencyError
 
-        circular_dependencies = set(f.path for f in self.deps) & set(
-            f.path for f in self.outs
+        circular_dependencies = set(d.path for d in self.deps) & set(
+            o.path for o in self.outs
         )
 
         if circular_dependencies:
@@ -562,11 +562,11 @@ class Stage(object):
         from dvc.exceptions import ArgumentDuplicationError
         from collections import Counter
 
-        count = Counter(f.path for f in self.deps + self.outs)
+        path_counts = Counter(edge.path for edge in self.deps + self.outs)
 
-        for f, occurrence in count.items():
+        for path, occurrence in path_counts.items():
             if occurrence > 1:
-                raise ArgumentDuplicationError(f)
+                raise ArgumentDuplicationError(path)
 
     def _run(self):
         self._check_missing_deps()

--- a/dvc/stage.py
+++ b/dvc/stage.py
@@ -286,10 +286,10 @@ class Stage(object):
     @classmethod
     def _stage_fname_cwd(cls, fname, cwd, outs, add):
         if fname and cwd:
-            return fname, cwd
+            return (fname, cwd)
 
         if not outs:
-            return cls.STAGE_FILE, cwd if cwd else os.getcwd()
+            return (cls.STAGE_FILE, cwd if cwd else os.getcwd())
 
         out = outs[0]
         if out.scheme == "local":
@@ -303,7 +303,7 @@ class Stage(object):
         if not cwd or (add and out.is_local):
             cwd = path.dirname(out.path)
 
-        return fname, cwd
+        return (fname, cwd)
 
     @staticmethod
     def _check_inside_project(project, cwd):

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -1,5 +1,7 @@
 import os
+import sys
 from subprocess import check_call
+
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 os.chdir(REPO_ROOT)
@@ -10,8 +12,14 @@ os.putenv(
 os.putenv("DVC_HOME", REPO_ROOT)
 os.putenv("DVC_TEST", "true")
 
+if len(sys.argv) == 1:
+    scope = "--all-modules"
+else:
+    scope = " ".join(sys.argv[1:])
+
 cmd = (
     "nosetests -v --processes=-1 --process-timeout=500 --cover-inclusive "
-    "--cover-erase --cover-package=dvc --with-coverage --all-modules --with-flaky"
+    "--cover-erase --cover-package=dvc --with-coverage --with-flaky "
+    "{scope} ".format(scope=scope)
 )
 check_call(cmd, shell=True)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -378,12 +378,6 @@ class TestCachedMetrics(TestDvc):
         self.dvc.scm.checkout(branch)
         self.dvc.checkout(force=True)
 
-        print(
-            'print(json.dumps({{"metrics": "{branch}"}})\n'.format(
-                branch=branch
-            )
-        )
-
         with open("code.py", "w+") as fobj:
             fobj.write("import sys\n")
             fobj.write("import os\n")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -378,10 +378,26 @@ class TestCachedMetrics(TestDvc):
         self.dvc.scm.checkout(branch)
         self.dvc.checkout(force=True)
 
-        content = json.dumps({"metrics": branch})
+        print(
+            'print(json.dumps({{"metrics": "{branch}"}})\n'.format(
+                branch=branch
+            )
+        )
+
+        with open("code.py", "w+") as fobj:
+            fobj.write("import sys\n")
+            fobj.write("import os\n")
+            fobj.write("import json\n")
+            fobj.write(
+                'print(json.dumps({{"metrics": "{branch}"}}))\n'.format(
+                    branch=branch
+                )
+            )
+
         stage = self.dvc.run(
+            deps=["code.py"],
             metrics=["metrics.json"],
-            cmd="echo '{content}' > metrics.json".format(content=content),
+            cmd="python code.py metrics.json > metrics.json",
         )
         self.assertIsNotNone(stage)
         self.assertEqual(stage.relpath, "metrics.json.dvc")

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -532,18 +532,14 @@ class TestCmdRunOverwrite(TestDvc):
 
 class TestCmdRunCliMetrics(TestDvc):
     def test_cached(self):
-        ret = main(
-            ["run", "-m", "metrics.txt", "echo -n 'test' > metrics.txt"]
-        )
+        ret = main(["run", "-m", "metrics.txt", "echo 'test' > metrics.txt"])
         self.assertEqual(ret, 0)
-        self.assertEqual(open("metrics.txt", "r").read(), "test")
+        self.assertEqual(open("metrics.txt", "r").read().rstrip(), "test")
 
     def test_not_cached(self):
-        ret = main(
-            ["run", "-M", "metrics.txt", "echo -n 'test' > metrics.txt"]
-        )
+        ret = main(["run", "-M", "metrics.txt", "echo 'test' > metrics.txt"])
         self.assertEqual(ret, 0)
-        self.assertEqual(open("metrics.txt", "r").read(), "test")
+        self.assertEqual(open("metrics.txt", "r").read().rstrip(), "test")
 
 
 class TestRunDeterministicBase(TestDvc):

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -50,7 +50,7 @@ class TestRun(TestDvc):
         self.assertTrue(stage.path, fname)
 
         with self.assertRaises(OutputDuplicationError):
-            stage = self.dvc.run(
+            self.dvc.run(
                 cmd=cmd,
                 deps=deps,
                 outs=outs,
@@ -528,6 +528,22 @@ class TestCmdRunOverwrite(TestDvc):
 
         # NOTE: check that dvcfile was overwritten
         self.assertNotEqual(stage_mtime, os.path.getmtime("out.dvc"))
+
+
+class TestCmdRunCliMetrics(TestDvc):
+    def test_cached(self):
+        ret = main(
+            ["run", "-m", "metrics.txt", "echo -n 'test' > metrics.txt"]
+        )
+        self.assertEqual(ret, 0)
+        self.assertEqual(open("metrics.txt", "r").read(), "test")
+
+    def test_not_cached(self):
+        ret = main(
+            ["run", "-M", "metrics.txt", "echo -n 'test' > metrics.txt"]
+        )
+        self.assertEqual(ret, 0)
+        self.assertEqual(open("metrics.txt", "r").read(), "test")
 
 
 class TestRunDeterministicBase(TestDvc):

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -532,12 +532,12 @@ class TestCmdRunOverwrite(TestDvc):
 
 class TestCmdRunCliMetrics(TestDvc):
     def test_cached(self):
-        ret = main(["run", "-m", "metrics.txt", "echo 'test' > metrics.txt"])
+        ret = main(["run", "-m", "metrics.txt", "echo test > metrics.txt"])
         self.assertEqual(ret, 0)
         self.assertEqual(open("metrics.txt", "r").read().rstrip(), "test")
 
     def test_not_cached(self):
-        ret = main(["run", "-M", "metrics.txt", "echo 'test' > metrics.txt"])
+        ret = main(["run", "-M", "metrics.txt", "echo test > metrics.txt"])
         self.assertEqual(ret, 0)
         self.assertEqual(open("metrics.txt", "r").read().rstrip(), "test")
 


### PR DESCRIPTION
* Fixes https://github.com/iterative/dvc/issues/1590
* Adds ability to run a specific test from a scope:

```
python -m tests tests/test_run.py:TestCmdRunCliMetrics
```

or 

```
python -m tests tests/test_run.py:TestCmdRunCliMetrics:test_not_cached
```
 
* Fixes some warnings from PyCharm's linter
* Fixes a few error messages and edge case tests
