### PR TITLE
updater: don't use io.open when working with json

### DIFF
--- a/dvc/updater.py
+++ b/dvc/updater.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from dvc.utils.compat import str, open
+from dvc.utils.compat import str
 
 import sys
 import os

--- a/tests/unit/updater.py
+++ b/tests/unit/updater.py
@@ -1,0 +1,39 @@
+import os
+import json
+import mock
+
+from dvc import VERSION
+from tests.basic_env import TestDvc
+
+
+class MockResponse(object):
+    def __init__(self, json_data, status_code):
+        self.json_data = json_data
+        self.status_code = status_code
+
+    def json(self):
+        return self.json_data
+
+
+def mocked_requests_get(*args, **kwargs):
+    class MockResponse:
+        def __init__(self, json_data, status_code):
+            self.json_data = json_data
+            self.status_code = status_code
+
+        def json(self):
+            return self.json_data
+
+    return MockResponse({"version": VERSION}, 200)
+
+
+class TestUpdater(TestDvc):
+    @mock.patch("requests.get", side_effect=mocked_requests_get)
+    def test_fetch(self, mock_get):
+        self.assertFalse(os.path.exists(self.dvc.updater.updater_file))
+        self.dvc.updater.fetch(detach=False)
+        mock_get.assert_called_once()
+        self.assertTrue(os.path.isfile(self.dvc.updater.updater_file))
+        with open(self.dvc.updater.updater_file, "r") as fobj:
+            info = json.load(fobj)
+        self.assertEqual(info["version"], VERSION)


### PR DESCRIPTION
Otherwise we get this on python2:
```
======================================================================
ERROR: test_fetch (tests.unit.updater.TestUpdater)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/efiop/.pyenv/versions/2.7.15/envs/2.7.15-dvc/local/lib/
python2.7/site-packages/mock/mock.py", line 1305, in patched
    return func(*args, **keywargs)
  File "/home/efiop/git/dvc/tests/unit/updater.py", line 34, in test_fetch
    self.dvc.updater.fetch(detach=False)
  File "/home/efiop/git/dvc/dvc/updater.py", line 77, in fetch
    self._with_lock(self._get_latest_version, "fetching")
  File "/home/efiop/git/dvc/dvc/updater.py", line 39, in _with_lock
    func()
  File "/home/efiop/git/dvc/dvc/updater.py", line 91, in _get_latest_version
    json.dump(convert_to_unicode(info), fobj)
  File "/usr/lib/python2.7/json/__init__.py", line 190, in dump
    fp.write(chunk)
TypeError: write() argument 1 must be unicode, not str
-------------------- >> begin captured logging << --------------------
```

Signed-off-by: Ruslan Kuprieiev <ruslan@iterative.ai>