### PR TITLE
dvc: optimize imports

### DIFF
--- a/dvc/command/remote.py
+++ b/dvc/command/remote.py
@@ -6,7 +6,6 @@ import re
 import dvc.logger as logger
 from dvc.command.base import fix_subparsers
 from dvc.config import Config
-from dvc.remote import _get, RemoteLOCAL
 from dvc.command.config import CmdConfig
 
 
@@ -30,6 +29,8 @@ class CmdRemoteAdd(CmdConfig):
         return os.path.relpath(path, os.path.dirname(config_file))
 
     def run(self):
+        from dvc.remote import _get, RemoteLOCAL
+
         remote = _get({Config.SECTION_REMOTE_URL: self.args.url})
         if remote == RemoteLOCAL:
             self.args.url = self.resolve_path(

--- a/dvc/repo/checkout.py
+++ b/dvc/repo/checkout.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 import dvc.logger as logger
-from dvc.stage import StageFileDoesNotExistError, StageFileBadNameError
 from dvc.exceptions import DvcException
 
 
@@ -14,6 +13,8 @@ def _cleanup_unused_links(self, all_stages):
 
 
 def checkout(self, target=None, with_deps=False, force=False, recursive=False):
+    from dvc.stage import StageFileDoesNotExistError, StageFileBadNameError
+
     if target and not recursive:
         all_stages = self.active_stages()
         try:

--- a/dvc/repo/imp.py
+++ b/dvc/repo/imp.py
@@ -1,7 +1,6 @@
-from dvc.stage import Stage
-
-
 def imp(self, url, out, resume=False):
+    from dvc.stage import Stage
+
     stage = Stage.create(repo=self, cmd=None, deps=[url], outs=[out])
 
     if stage is None:

--- a/dvc/repo/status.py
+++ b/dvc/repo/status.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 import dvc.logger as logger
-import dvc.remote.base as cloud
 
 
 def _local_status(self, target=None, with_deps=False):
@@ -36,6 +35,8 @@ def _cloud_status(
     with_deps=False,
     all_tags=False,
 ):
+    import dvc.remote.base as cloud
+
     used = self.used_cache(
         target,
         all_branches=all_branches,


### PR DESCRIPTION
Currently `dvc` takes ~0.7sec to finish. After this patch: 0.17sec.
Profiling has been done using:

    python -X importtime -m dvc 2> log.log
    tuna log.log

Caugth by https://travis-ci.com/iterative/dvc-test .

Signed-off-by: Ruslan Kuprieiev <ruslan@iterative.ai>