### PR TITLE
Suppress outputs in tests

### DIFF
--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -20,6 +20,7 @@ else:
 cmd = (
     "nosetests -v --processes=-1 --process-timeout=500 --cover-inclusive "
     "--cover-erase --cover-package=dvc --with-coverage --with-flaky "
+    "--logging-clear-handlers "
     "{scope} ".format(scope=scope)
 )
 check_call(cmd, shell=True)

--- a/tests/test_data_cloud.py
+++ b/tests/test_data_cloud.py
@@ -11,6 +11,7 @@ import copy
 
 from dvc.state import State
 from mock import patch
+from tests.utils.logger import MockLoggerHandlers
 
 import dvc.logger as logger
 from dvc.utils.compat import str
@@ -637,15 +638,16 @@ class TestWarnOnOutdatedStage(TestDvc):
         with open(stage_file_path, "w") as stage_file:
             yaml.dump(content, stage_file)
 
-        logger.logger.handlers[0].stream = StringIO()
-        self.main(["status", "-c"])
-        self.assertIn(
-            "Warning: Output 'bar'(Stage: 'bar.dvc') is "
-            "missing version info. Cache for it will not be "
-            "collected. Use dvc repro to get your pipeline up to "
-            "date.",
-            logger.logger.handlers[0].stream.getvalue(),
-        )
+        with MockLoggerHandlers(logger.logger):
+            logger.logger.handlers[0].stream = StringIO()
+            self.main(["status", "-c"])
+            self.assertIn(
+                "Warning: Output 'bar'(Stage: 'bar.dvc') is "
+                "missing version info. Cache for it will not be "
+                "collected. Use dvc repro to get your pipeline up to "
+                "date.",
+                logger.logger.handlers[0].stream.getvalue(),
+            )
 
     def test(self):
         self.color_patch.start()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -14,6 +14,10 @@ class TestLogger(TestCase):
     color_patch = patch.object(logger, "colorize", new=lambda x, color="": x)
 
     def setUp(self):
+        logger.logger.handlers = [
+            logger.logging.StreamHandler(),
+            logger.logging.StreamHandler(),
+        ]
         logger.logger.handlers[0].stream = StringIO()
         logger.logger.handlers[1].stream = StringIO()
         logger.set_default_level()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -8,6 +8,7 @@ from tests.basic_env import TestDvc
 
 import dvc.logger as logger
 from dvc.utils.compat import StringIO
+from tests.utils.logger import MockLoggerHandlers
 
 
 class TestMetrics(TestDvc):
@@ -357,25 +358,26 @@ class TestMetricsCLI(TestMetrics):
         ret = main(["add", "metric.unknown"])
         self.assertEqual(ret, 0)
 
-        logger.logger.handlers[1].stream = StringIO()
-        ret = main(["metrics", "add", "metric.unknown", "-t", "unknown"])
-        self.assertEqual(ret, 1)
-        self.assertIn(
-            "failed to add metric file 'metric.unknown' - metric type 'unknown'"
-            " is not supported, must be one of [raw, json, csv, tsv, hcsv, htsv]",
-            logger.logger.handlers[1].stream.getvalue(),
-        )
+        with MockLoggerHandlers(logger.logger):
+            logger.logger.handlers[1].stream = StringIO()
+            ret = main(["metrics", "add", "metric.unknown", "-t", "unknown"])
+            self.assertEqual(ret, 1)
+            self.assertIn(
+                "failed to add metric file 'metric.unknown' - metric type 'unknown'"
+                " is not supported, must be one of [raw, json, csv, tsv, hcsv, htsv]",
+                logger.logger.handlers[1].stream.getvalue(),
+            )
 
-        ret = main(["metrics", "add", "metric.unknown", "-t", "raw"])
-        self.assertEqual(ret, 0)
+            ret = main(["metrics", "add", "metric.unknown", "-t", "raw"])
+            self.assertEqual(ret, 0)
 
-        logger.logger.handlers[0].stream = StringIO()
-        ret = main(["metrics", "show", "metric.unknown"])
-        self.assertEqual(ret, 0)
-        self.assertIn(
-            "\tmetric.unknown: unknown",
-            logger.logger.handlers[0].stream.getvalue(),
-        )
+            logger.logger.handlers[0].stream = StringIO()
+            ret = main(["metrics", "show", "metric.unknown"])
+            self.assertEqual(ret, 0)
+            self.assertIn(
+                "\tmetric.unknown: unknown",
+                logger.logger.handlers[0].stream.getvalue(),
+            )
 
     def test_wrong_type_modify(self):
         with open("metric.unknown", "w+") as fd:
@@ -385,25 +387,28 @@ class TestMetricsCLI(TestMetrics):
         ret = main(["run", "-m", "metric.unknown"])
         self.assertEqual(ret, 0)
 
-        logger.logger.handlers[1].stream = StringIO()
-        ret = main(["metrics", "modify", "metric.unknown", "-t", "unknown"])
-        self.assertEqual(ret, 1)
-        self.assertIn(
-            "failed to modify metric file settings - metric type 'unknown'"
-            " is not supported, must be one of [raw, json, csv, tsv, hcsv, htsv]",
-            logger.logger.handlers[1].stream.getvalue(),
-        )
+        with MockLoggerHandlers(logger.logger):
+            logger.logger.handlers[1].stream = StringIO()
+            ret = main(
+                ["metrics", "modify", "metric.unknown", "-t", "unknown"]
+            )
+            self.assertEqual(ret, 1)
+            self.assertIn(
+                "failed to modify metric file settings - metric type 'unknown'"
+                " is not supported, must be one of [raw, json, csv, tsv, hcsv, htsv]",
+                logger.logger.handlers[1].stream.getvalue(),
+            )
 
-        ret = main(["metrics", "modify", "metric.unknown", "-t", "CSV"])
-        self.assertEqual(ret, 0)
+            ret = main(["metrics", "modify", "metric.unknown", "-t", "CSV"])
+            self.assertEqual(ret, 0)
 
-        logger.logger.handlers[0].stream = StringIO()
-        ret = main(["metrics", "show", "metric.unknown"])
-        self.assertEqual(ret, 0)
-        self.assertIn(
-            "\tmetric.unknown: unknown",
-            logger.logger.handlers[0].stream.getvalue(),
-        )
+            logger.logger.handlers[0].stream = StringIO()
+            ret = main(["metrics", "show", "metric.unknown"])
+            self.assertEqual(ret, 0)
+            self.assertIn(
+                "\tmetric.unknown: unknown",
+                logger.logger.handlers[0].stream.getvalue(),
+            )
 
     def test_wrong_type_show(self):
         with open("metric.unknown", "w+") as fd:
@@ -413,15 +418,24 @@ class TestMetricsCLI(TestMetrics):
         ret = main(["run", "-m", "metric.unknown"])
         self.assertEqual(ret, 0)
 
-        logger.logger.handlers[0].stream = StringIO()
-        ret = main(
-            ["metrics", "show", "metric.unknown", "-t", "unknown", "-x", "0,0"]
-        )
-        self.assertEqual(ret, 0)
-        self.assertIn(
-            "\tmetric.unknown: unknown",
-            logger.logger.handlers[0].stream.getvalue(),
-        )
+        with MockLoggerHandlers(logger.logger):
+            logger.logger.handlers[0].stream = StringIO()
+            ret = main(
+                [
+                    "metrics",
+                    "show",
+                    "metric.unknown",
+                    "-t",
+                    "unknown",
+                    "-x",
+                    "0,0",
+                ]
+            )
+            self.assertEqual(ret, 0)
+            self.assertIn(
+                "\tmetric.unknown: unknown",
+                logger.logger.handlers[0].stream.getvalue(),
+            )
 
 
 class TestNoMetrics(TestDvc):

--- a/tests/utils/httpd.py
+++ b/tests/utils/httpd.py
@@ -1,6 +1,5 @@
 import hashlib
 import os
-import socket
 import threading
 
 from dvc.utils.compat import HTTPServer, SimpleHTTPRequestHandler

--- a/tests/utils/logger.py
+++ b/tests/utils/logger.py
@@ -1,0 +1,20 @@
+import logging
+
+
+class MockLoggerHandlers(object):
+    def __init__(self, l, num=2):
+        self._logger = l
+        self._handlers = l.handlers
+        self._num = num
+
+    def __enter__(self):
+        self._logger.handlers = [
+            logging.FileHandler("tmp{}.log".format(i))
+            for i in range(self._num)
+        ]
+        return self
+
+    def __exit__(self, exc_type=None, exc_val=None, exc_tb=None):
+        for h in self._logger.handlers:
+            h.close()
+        self._logger.handlers = self._handlers


### PR DESCRIPTION
Fixes the outputs issue from #1598

Kudos to @mroutis for pointing to `--logging-clear-handlers` option.