### PR TITLE
py2: raise OSErrors on makedirs

### DIFF
--- a/dvc/utils/compat.py
+++ b/dvc/utils/compat.py
@@ -14,9 +14,6 @@ is_py2 = _ver[0] == 2
 #: Python 3.x?
 is_py3 = _ver[0] == 3
 
-# NOTE: cast_bytes_py2 is taken from https://github.com/ipython/ipython_genutils
-# NOTE _makedirs is taken from https://github.com/python/cpython/blob/3ce3dea60646d8a5a1c952469a2eb65f937875b3/Lib/os.py#L196-L226
-
 # simplified version of ipython_genutils/encoding.py
 DEFAULT_ENCODING = sys.getdefaultencoding()
 
@@ -30,12 +27,14 @@ def encode(u, encoding=None):
     return u.encode(encoding, "replace")
 
 
+# NOTE: cast_bytes_py2 is taken from https://github.com/ipython/ipython_genutils
 def cast_bytes(s, encoding=None):
     if not isinstance(s, bytes):
         return encode(s, encoding)
     return s
 
 
+# NOTE _makedirs is taken from https://github.com/python/cpython/blob/3ce3dea60646d8a5a1c952469a2eb65f937875b3/Lib/os.py#L196-L226
 def _makedirs(name, mode=0o777, exist_ok=False):
     head, tail = os.path.split(name)
     if not tail:
@@ -44,8 +43,8 @@ def _makedirs(name, mode=0o777, exist_ok=False):
         try:
             _makedirs(head, exist_ok=exist_ok)
         except OSError as e:
-            if e.errno == errno.EEXIST:
-                pass
+            if e.errno != errno.EEXIST:
+                raise e
         cdir = os.curdir
         if isinstance(tail, bytes):
             cdir = bytes(os.curdir, "ASCII")

--- a/dvc/utils/compat.py
+++ b/dvc/utils/compat.py
@@ -44,7 +44,7 @@ def _makedirs(name, mode=0o777, exist_ok=False):
             _makedirs(head, exist_ok=exist_ok)
         except OSError as e:
             if e.errno != errno.EEXIST:
-                raise e
+                raise
         cdir = os.curdir
         if isinstance(tail, bytes):
             cdir = bytes(os.curdir, "ASCII")


### PR DESCRIPTION
With this commit, `makedirs` will behave as expected:
```python
>>> makedirs('/system32/system32', exist_ok=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "dvc/utils/compat.py", line 49, in _makedirs
    raise e
OSError: [Errno 13] Permission denied: '/system32'
```

Kudos to @shcheklein for pointing that out in a review: https://github.com/iterative/dvc/pull/1637#issuecomment-465249883 (great catch, btw.)