### PR TITLE
config: Replace expanded user home dir with "~"

### DIFF
--- a/dvc/command/config.py
+++ b/dvc/command/config.py
@@ -78,6 +78,9 @@ class CmdConfig(CmdBase):
         elif self.args.value is None:
             return self._show(section, opt)
         else:
+            home_dir = os.path.expanduser("~")
+            self.args.value = self.args.value.replace(home_dir, "~")
+
             return self._set(section, opt, self.args.value)
 
 

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -57,6 +57,18 @@ class TestRemote(TestDvc):
         config = configobj.ConfigObj(self.dvc.config.config_file)
         self.assertEqual(config['remote "mylocal"']["url"], rel)
 
+    def test_home_directory_path(self):
+        ret = main(["remote", "add", "ssh", "ssh://127.0.0.1:/path/to/dir"])
+        self.assertEqual(ret, 0)
+
+        keyfile_path = os.path.expanduser("~/.ssh/id_rsa")
+
+        ret = main(["remote", "modify", "ssh", "keyfile", keyfile_path])
+        self.assertEqual(ret, 0)
+
+        config = configobj.ConfigObj(self.dvc.config.config_file)
+        self.assertEqual(config['remote "ssh"']["keyfile"], "~/.ssh/id_rsa")
+
 
 class TestRemoteRemoveDefault(TestDvc):
     def test(self):


### PR DESCRIPTION
Fix #1608