### PR TITLE
Log computed stage MD5 in verbose mode

### DIFF
--- a/dvc/stage.py
+++ b/dvc/stage.py
@@ -556,9 +556,9 @@ class Stage(object):
         # NOTE: excluding parameters that don't affect the state of the
         # pipeline. Not excluding `OutputLOCAL.PARAM_CACHE`, because if
         # it has changed, we might not have that output in our cache.
-        return dict_md5(
-            d, exclude=[self.PARAM_LOCKED, OutputLOCAL.PARAM_METRIC]
-        )
+        m = dict_md5(d, exclude=[self.PARAM_LOCKED, OutputLOCAL.PARAM_METRIC])
+        logger.debug("Computed stage '{}' md5: '{}'".format(self.relpath, m))
+        return m
 
     def save(self):
         for dep in self.deps:

--- a/tests/unit/stage.py
+++ b/tests/unit/stage.py
@@ -5,7 +5,7 @@ from dvc.stage import Stage
 
 class TestStageChecksum(TestCase):
     def test(self):
-        stage = Stage(None)
+        stage = Stage(None, "path")
         outs = [{"path": "a", "md5": "123456789"}]
         deps = [{"path": "b", "md5": "987654321"}]
         d = {"md5": "123456", "cmd": "mycmd", "outs": outs, "deps": deps}


### PR DESCRIPTION
Sometimes it is handy to manually update the stage MD5 checksum after some non-breaking changes were made (e.g. renaming an output file). Logging the computed md5 hash in verbose mode can help experienced users to fix this problem.