### PR TITLE
 Check if each SSH checksum exists individually.

### DIFF
--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -132,7 +132,7 @@ class RemoteSSH(RemoteBase):
                     for checksum in checksums
                     if ssh.file_exists(self.checksum_to_path(checksum))
                 ]
-        # Fallback to listing all files if we have many checksums
+        # Fallback to listing all files for many checksums
         return super(RemoteSSH, self).cache_exists(checksums)
 
     def download(

--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -129,7 +129,11 @@ class RemoteSSH(RemoteBase):
         # Check each checksum individually if we have less then defined number of checksums
         if len(checksums) < self.CHECK_EXIST_LIST_ALL_FILE_THRESHOLD:
             with self.ssh(**self.path_info) as ssh:
-                return [checksum for checksum in checksums if ssh.file_exists(self.checksum_to_path(checksum))]
+                return [
+                    checksum
+                    for checksum in checksums
+                    if ssh.file_exists(self.checksum_to_path(checksum))
+                ]
         # Fallback to listing all files if we have many checksums
         return super(RemoteSSH, self).cache_exists(checksums)
 

--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -2,8 +2,6 @@ from __future__ import unicode_literals
 
 import getpass
 
-import os
-
 try:
     import paramiko
 except ImportError:
@@ -126,7 +124,7 @@ class RemoteSSH(RemoteBase):
             ssh.remove(path_info["path"])
 
     def cache_exists(self, checksums):
-        # Check each checksum individually if we have less then defined number of checksums
+        # Check each checksum if we have less then defined num of checksums
         if len(checksums) < self.CHECK_EXIST_LIST_ALL_FILE_THRESHOLD:
             with self.ssh(**self.path_info) as ssh:
                 return [

--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -129,7 +129,7 @@ class RemoteSSH(RemoteBase):
         # Check each checksum individually if we have less then defined number of checksums
         if len(checksums) < self.CHECK_EXIST_LIST_ALL_FILE_THRESHOLD:
             with self.ssh(**self.path_info) as ssh:
-                return [checksum for checksum in checksums if ssh.file_exists(os.path.join(self.prefix, checksum))]
+                return [checksum for checksum in checksums if ssh.file_exists(self.checksum_to_path(checksum))]
         # Fallback to listing all files if we have many checksums
         return super(RemoteSSH, self).cache_exists(checksums)
 


### PR DESCRIPTION
For a few checksums, it is much faster to check each SSH file individually, especially on machines with shared filesystems. I suggest this heuristic approach that will check each checksum individually for < 50 checksums and fallbacks to listing all files for >= 50 checksums.

In my case, listing the whole SSH cache directory takes up to several minutes. 