### PR TITLE
Fix the probable performance issue in Repo.stages

### DIFF
--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -383,17 +383,6 @@ class Repo(object):
                     outs.append(out.path + out.sep)
                 stages.append(stage)
 
-            def filter_dirs(dname, root=root):
-                path = os.path.join(root, dname)
-                if path in (self.dvc_dir, self.scm.dir):
-                    return False
-                for out in outs:
-                    if path == os.path.normpath(out) or path.startswith(out):
-                        return False
-                return True
-
-            dirs[:] = list(filter(filter_dirs, dirs))
-
         if check_dag:
             self.check_dag(stages)
 


### PR DESCRIPTION
The dirs variable is unused, but there is a complex loop to compute it. It should be removed.