### PR TITLE
dvc: ignore cryptography's warnings

### DIFF
--- a/dvc/__init__.py
+++ b/dvc/__init__.py
@@ -80,3 +80,18 @@ VERSION = __version__
 # we can simply ignore them so that they don't show up when you are using dvc.
 warnings.filterwarnings("ignore", message="numpy.dtype size changed")
 warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
+
+# Ignore paramiko's warning: https://github.com/paramiko/paramiko/issues/1386.
+# This only affects paramiko 2.4.2 and should be fixed in the next version.
+# Cryptography developers decided that it is a brilliant idea not to inherit
+# from DeprecationWarning [1] because it is invisible by default, and decided
+# to spam everyone instead. So it is their fault and not paramiko's.
+#
+# [1] https://github.com/pyca/cryptography/blob/2.6.1/src/cryptography/
+#     utils.py#L14
+try:
+    from cryptography.utils import CryptographyDeprecationWarning
+
+    warnings.simplefilter("ignore", CryptographyDeprecationWarning)
+except ImportError:
+    pass


### PR DESCRIPTION
Ignore paramiko's warning: https://github.com/paramiko/paramiko/issues/1386.
This only affects paramiko 2.4.2 and should be fixed in the next version.
Cryptography developers decided that it is a brilliant idea not to inherit
from DeprecationWarning https://github.com/pyca/cryptography/blob/2.6.1/src/cryptography/utils.py#L14  because it is invisible by default, and decided
to spam everyone instead. So it is their fault and not paramiko's.

Signed-off-by: Ruslan Kuprieiev <kupruser@gmail.com>