### PR TITLE
remote: adds support for s3.list_objects

### DIFF
--- a/dvc/config.py
+++ b/dvc/config.py
@@ -193,6 +193,7 @@ class Config(object):  # pylint: disable=too-many-instance-attributes
     SECTION_AWS_STORAGEPATH = "storagepath"
     SECTION_AWS_CREDENTIALPATH = "credentialpath"
     SECTION_AWS_ENDPOINT_URL = "endpointurl"
+    SECTION_AWS_LIST_OBJECTS = "listobjects"
     SECTION_AWS_REGION = "region"
     SECTION_AWS_PROFILE = "profile"
     SECTION_AWS_USE_SSL = "use_ssl"
@@ -202,6 +203,9 @@ class Config(object):  # pylint: disable=too-many-instance-attributes
         Optional(SECTION_AWS_PROFILE): str,
         Optional(SECTION_AWS_CREDENTIALPATH): str,
         Optional(SECTION_AWS_ENDPOINT_URL): str,
+        Optional(SECTION_AWS_LIST_OBJECTS, default=False): And(
+            str, is_bool, Use(to_bool)
+        ),
         Optional(SECTION_AWS_USE_SSL, default=True): And(
             str, is_bool, Use(to_bool)
         ),
@@ -239,6 +243,9 @@ class Config(object):  # pylint: disable=too-many-instance-attributes
         Optional(SECTION_AWS_PROFILE): str,
         Optional(SECTION_AWS_CREDENTIALPATH): str,
         Optional(SECTION_AWS_ENDPOINT_URL): str,
+        Optional(SECTION_AWS_LIST_OBJECTS, default=False): And(
+            str, is_bool, Use(to_bool)
+        ),
         Optional(SECTION_AWS_USE_SSL, default=True): And(
             str, is_bool, Use(to_bool)
         ),


### PR DESCRIPTION
Optionally use list_objects, useful for ceph and other s3 emulators
fixes: #1476 

Note:  difficulties locating a useful test to extend for this use case?
