### PR TITLE
metrics: shows formatted multiline metrics

### DIFF
--- a/dvc/command/metrics.py
+++ b/dvc/command/metrics.py
@@ -6,12 +6,26 @@ from dvc.command.base import CmdBase, fix_subparsers
 
 
 def show_metrics(metrics, all_branches=False, all_tags=False):
+    """
+    Args:
+        metrics (list): Where each element is either a `list`
+            if an xpath was specified, otherwise a `str`
+    """
     for branch, val in metrics.items():
         if all_branches or all_tags:
-            logger.info("{}:".format(branch))
+            logger.info("{branch}:".format(branch=branch))
 
         for fname, metric in val.items():
-            logger.info("\t{}: {}".format(fname, metric))
+            lines = metric if type(metric) is list else metric.splitlines()
+
+            if len(lines) > 1:
+                logger.info("\t{fname}:".format(fname=fname))
+
+                for line in lines:
+                    logger.info("\t\t{content}".format(content=line))
+
+            else:
+                logger.info("\t{}: {}".format(fname, metric))
 
 
 class CmdMetricsShow(CmdBase):


### PR DESCRIPTION
Close #1716

----

How things should look like:
```
❯ dvc metrics show
	metrics.tsv:
		value_mse   deviation_mse   data_set
		0.421601    0.173461        train
		0.67528     0.289545        testing
		0.671502    0.297848        validation
	metrics.csv:
		value_mse   deviation_mse   data_set
		0.421601    0.173461        train
		0.67528     0.289545        testing
		0.671502    0.297848        validation
	metrics.txt:
		ROC_AUC:   0.64
		KS:        78.9999999996
		F_SCORE:   77
	metrics.json:
		{
		   "deviation_mse": [
		      "0.173461",
		      "0.289545",
		      "0.297848"
		   ],
		   "data_set": [
		      "train",
		      "testing",
		      "validation"
		   ],
		   "value_mse": [
		      "0.421601",
		      "0.67528",
		      "0.671502"
		   ]
		}
```