### PR TITLE
ssh: walk_files error description

### DIFF
--- a/dvc/remote/ssh/connection.py
+++ b/dvc/remote/ssh/connection.py
@@ -128,7 +128,17 @@ class SSHConnection:
 
         self._sftp_connect()
 
-        for entry in self._sftp.listdir_attr(directory):
+        try:
+            dir_entries = self._sftp.listdir_attr(directory)
+        except IOError as exc:
+            raise DvcException(
+                "couldn't get the '{}' remote directory files list".format(
+                    directory
+                ),
+                cause=exc,
+            )
+
+        for entry in dir_entries:
             path = posixpath.join(directory, entry.filename)
 
             if S_ISLNK(entry.st_mode):


### PR DESCRIPTION
Currently SSH remote leaves the user with uninformative "No such file" error on e.g. `dvc push` when remote directory doesn't exist. This PR adds a description to such errors.