### PR TITLE
stage: remove outs upon import

### DIFF
--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -758,7 +758,7 @@ class RemoteLOCAL(RemoteBase):
             copyfile(
                 path,
                 tmp,
-                name="Unprotecting :{}".format(os.path.relpath(path)),
+                name="Unprotecting '{}'".format(os.path.relpath(path)),
             )
             remove(path)
             os.rename(tmp, path)

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -755,7 +755,11 @@ class RemoteLOCAL(RemoteBase):
             # would get only the part of file. So, at first, the file should be
             # copied with the temporary name, and then original file should be
             # replaced by new.
-            copyfile(path, tmp)
+            copyfile(
+                path,
+                tmp,
+                name="Unprotecting :{}".format(os.path.relpath(path)),
+            )
             remove(path)
             os.rename(tmp, path)
 

--- a/dvc/stage.py
+++ b/dvc/stage.py
@@ -730,7 +730,7 @@ class Stage(object):
             raise StageCmdFailedError(self)
 
     def run(self, dry=False, resume=False, no_commit=False, force=False):
-        if self.cmd and not self.locked and not dry:
+        if (self.cmd or self.is_import) and not self.locked and not dry:
             self.remove_outs(ignore_remove=False, force=False)
 
         if self.locked:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -864,7 +864,7 @@ class TestShouldRaiseOnOverlappingOutputPaths(TestDvc):
 class TestRerunWithSameOutputs(TestDvc):
     def _read_content_only(self, path):
         with open(path, "r") as fobj:
-            return [line.rstrip() for line in fobj.readlines()]
+            return [line.rstrip() for line in fobj]
 
     @property
     def _outs_command(self):


### PR DESCRIPTION
Related to:
https://github.com/iterative/dvc/commit/bf68fbffec0954c9b39af993c43518970bad89ab#r32942088

minor fixes:
- progress bar for unprotect
- iterating over file lines in test