### PR TITLE
[WIP] remote: cache_exists performance

### DIFF
--- a/dvc/cache.py
+++ b/dvc/cache.py
@@ -42,7 +42,7 @@ class Cache(object):
                 Config.SECTION_CACHE_PROTECTED: protected,
             }
 
-        self._local = Remote(repo, sect)
+        self._local = Remote(repo, sect, "cache")
 
         self._s3 = self._get_remote(config, Config.SECTION_CACHE_S3)
         self._gs = self._get_remote(config, Config.SECTION_CACHE_GS)
@@ -89,4 +89,4 @@ class Cache(object):
 
         name = Config.SECTION_REMOTE_FMT.format(remote)
         sect = self.repo.config.config[name]
-        return Remote(self.repo, sect)
+        return Remote(self.repo, sect, name)

--- a/dvc/config.py
+++ b/dvc/config.py
@@ -132,14 +132,16 @@ class Config(object):  # pylint: disable=too-many-instance-attributes
     CONFIG = "config"
     CONFIG_LOCAL = "config.local"
 
+    BOOL = And(str, is_bool, Use(to_bool))
+
     SECTION_CORE = "core"
     SECTION_CORE_LOGLEVEL = "loglevel"
     SECTION_CORE_LOGLEVEL_SCHEMA = And(Use(str.lower), supported_loglevel)
     SECTION_CORE_REMOTE = "remote"
-    SECTION_CORE_INTERACTIVE_SCHEMA = And(str, is_bool, Use(to_bool))
+    SECTION_CORE_INTERACTIVE_SCHEMA = BOOL
     SECTION_CORE_INTERACTIVE = "interactive"
     SECTION_CORE_ANALYTICS = "analytics"
-    SECTION_CORE_ANALYTICS_SCHEMA = And(str, is_bool, Use(to_bool))
+    SECTION_CORE_ANALYTICS_SCHEMA = BOOL
 
     SECTION_CACHE = "cache"
     SECTION_CACHE_DIR = "dir"
@@ -161,9 +163,7 @@ class Config(object):  # pylint: disable=too-many-instance-attributes
         Optional(SECTION_CACHE_AZURE): str,
         Optional(SECTION_CACHE_DIR): str,
         Optional(SECTION_CACHE_TYPE, default=None): SECTION_CACHE_TYPE_SCHEMA,
-        Optional(SECTION_CACHE_PROTECTED, default=False): And(
-            str, is_bool, Use(to_bool)
-        ),
+        Optional(SECTION_CACHE_PROTECTED, default=False): BOOL,
         Optional(PRIVATE_CWD): str,
     }
 
@@ -203,12 +203,8 @@ class Config(object):  # pylint: disable=too-many-instance-attributes
         Optional(SECTION_AWS_PROFILE): str,
         Optional(SECTION_AWS_CREDENTIALPATH): str,
         Optional(SECTION_AWS_ENDPOINT_URL): str,
-        Optional(SECTION_AWS_LIST_OBJECTS, default=False): And(
-            str, is_bool, Use(to_bool)
-        ),
-        Optional(SECTION_AWS_USE_SSL, default=True): And(
-            str, is_bool, Use(to_bool)
-        ),
+        Optional(SECTION_AWS_LIST_OBJECTS, default=False): BOOL,
+        Optional(SECTION_AWS_USE_SSL, default=True): BOOL,
     }
 
     # backward compatibility
@@ -237,31 +233,27 @@ class Config(object):  # pylint: disable=too-many-instance-attributes
     SECTION_REMOTE_TIMEOUT = "timeout"
     SECTION_REMOTE_PASSWORD = "password"
     SECTION_REMOTE_ASK_PASSWORD = "ask_password"
+    SECTION_REMOTE_NO_TRAVERSE = "no_traverse"
     SECTION_REMOTE_SCHEMA = {
         SECTION_REMOTE_URL: str,
         Optional(SECTION_AWS_REGION): str,
         Optional(SECTION_AWS_PROFILE): str,
         Optional(SECTION_AWS_CREDENTIALPATH): str,
         Optional(SECTION_AWS_ENDPOINT_URL): str,
-        Optional(SECTION_AWS_LIST_OBJECTS, default=False): And(
-            str, is_bool, Use(to_bool)
-        ),
-        Optional(SECTION_AWS_USE_SSL, default=True): And(
-            str, is_bool, Use(to_bool)
-        ),
+        Optional(SECTION_AWS_LIST_OBJECTS, default=False): BOOL,
+        Optional(SECTION_AWS_USE_SSL, default=True): BOOL,
         Optional(SECTION_GCP_PROJECTNAME): str,
         Optional(SECTION_CACHE_TYPE): SECTION_CACHE_TYPE_SCHEMA,
-        Optional(SECTION_CACHE_PROTECTED, default=False): And(
-            str, is_bool, Use(to_bool)
-        ),
+        Optional(SECTION_CACHE_PROTECTED, default=False): BOOL,
         Optional(SECTION_REMOTE_USER): str,
         Optional(SECTION_REMOTE_PORT): Use(int),
         Optional(SECTION_REMOTE_KEY_FILE): str,
         Optional(SECTION_REMOTE_TIMEOUT): Use(int),
         Optional(SECTION_REMOTE_PASSWORD): str,
-        Optional(SECTION_REMOTE_ASK_PASSWORD): And(str, is_bool, Use(to_bool)),
+        Optional(SECTION_REMOTE_ASK_PASSWORD): BOOL,
         Optional(SECTION_AZURE_CONNECTION_STRING): str,
         Optional(PRIVATE_CWD): str,
+        Optional(SECTION_REMOTE_NO_TRAVERSE, default=True): BOOL,
     }
 
     SECTION_STATE = "state"

--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -64,7 +64,7 @@ class DataCloud(object):
             msg = "can't find remote section '{}' in config"
             raise ConfigError(msg.format(section))
 
-        return Remote(self.repo, cloud_config)
+        return Remote(self.repo, cloud_config, section)
 
     def _init_compat(self):
         name = self._core.get(Config.SECTION_CORE_CLOUD, "").strip().lower()

--- a/dvc/dependency/__init__.py
+++ b/dvc/dependency/__init__.py
@@ -50,7 +50,7 @@ def _get(stage, p, info):
     if parsed.scheme == "remote":
         name = Config.SECTION_REMOTE_FMT.format(parsed.netloc)
         sect = stage.repo.config.config[name]
-        remote = Remote(stage.repo, sect)
+        remote = Remote(stage.repo, sect, name)
         return DEP_MAP[remote.scheme](stage, p, info, remote=remote)
 
     for d in DEPS:

--- a/dvc/output/__init__.py
+++ b/dvc/output/__init__.py
@@ -62,7 +62,7 @@ def _get(stage, p, info, cache, metric, persist=False, tags=None):
     if parsed.scheme == "remote":
         name = Config.SECTION_REMOTE_FMT.format(parsed.netloc)
         sect = stage.repo.config.config[name]
-        remote = Remote(stage.repo, sect)
+        remote = Remote(stage.repo, sect, name)
         return OUTS_MAP[remote.scheme](
             stage,
             p,

--- a/dvc/output/base.py
+++ b/dvc/output/base.py
@@ -67,7 +67,7 @@ class OutputBase(object):
         self.repo = stage.repo
         self.url = path
         self.info = info
-        self.remote = remote or self.REMOTE(self.repo, {})
+        self.remote = remote or self.REMOTE(self.repo, {}, "output")
         self.use_cache = False if self.IS_DEPENDENCY else cache
         self.metric = False if self.IS_DEPENDENCY else metric
         self.persist = persist

--- a/dvc/remote/__init__.py
+++ b/dvc/remote/__init__.py
@@ -27,5 +27,5 @@ def _get(config):
     return RemoteLOCAL
 
 
-def Remote(repo, config):
-    return _get(config)(repo, config)
+def Remote(repo, config, name):
+    return _get(config)(repo, config, name)

--- a/dvc/remote/azure.py
+++ b/dvc/remote/azure.py
@@ -38,8 +38,8 @@ class RemoteAzure(RemoteBase):
     PARAM_CHECKSUM = "etag"
     COPY_POLL_SECONDS = 5
 
-    def __init__(self, repo, config):
-        super(RemoteAzure, self).__init__(repo, config)
+    def __init__(self, repo, config, name):
+        super(RemoteAzure, self).__init__(repo, config, name)
 
         self.url = config.get(Config.SECTION_REMOTE_URL, "azure://")
         match = re.match(self.REGEX, self.url)  # backward compatibility

--- a/dvc/remote/gs.py
+++ b/dvc/remote/gs.py
@@ -22,8 +22,8 @@ class RemoteGS(RemoteBase):
     REQUIRES = {"google.cloud.storage": storage}
     PARAM_CHECKSUM = "md5"
 
-    def __init__(self, repo, config):
-        super(RemoteGS, self).__init__(repo, config)
+    def __init__(self, repo, config, name):
+        super(RemoteGS, self).__init__(repo, config, name)
         storagepath = "gs://"
         storagepath += config.get(Config.SECTION_AWS_STORAGEPATH, "/")
         storagepath.lstrip("/")

--- a/dvc/remote/hdfs.py
+++ b/dvc/remote/hdfs.py
@@ -17,8 +17,8 @@ class RemoteHDFS(RemoteBase):
     REGEX = r"^hdfs://((?P<user>.*)@)?.*$"
     PARAM_CHECKSUM = "checksum"
 
-    def __init__(self, repo, config):
-        super(RemoteHDFS, self).__init__(repo, config)
+    def __init__(self, repo, config, name):
+        super(RemoteHDFS, self).__init__(repo, config, name)
         self.url = config.get(Config.SECTION_REMOTE_URL, "/")
         self.prefix = self.url
         self.user = self.group("user")

--- a/dvc/remote/http.py
+++ b/dvc/remote/http.py
@@ -33,8 +33,8 @@ class RemoteHTTP(RemoteBase):
     CHUNK_SIZE = 2 ** 16
     PARAM_CHECKSUM = "etag"
 
-    def __init__(self, repo, config):
-        super(RemoteHTTP, self).__init__(repo, config)
+    def __init__(self, repo, config, name):
+        super(RemoteHTTP, self).__init__(repo, config, name)
         self.cache_dir = config.get(Config.SECTION_REMOTE_URL)
         self.url = self.cache_dir
         self.path_info = {"scheme": "http"}
@@ -98,13 +98,17 @@ class RemoteHTTP(RemoteBase):
         assert path_info["scheme"] in ["http", "https"]
         return bool(self._request("HEAD", path_info.get("path")))
 
-    def cache_exists(self, md5s):
-        assert isinstance(md5s, list)
+    @property
+    def no_traverse(self):
+        return True
+
+    def _cache_exists(self, checksums):
+        assert isinstance(checksums, list)
 
         def func(md5):
             return bool(self._request("HEAD", self.checksum_to_path(md5)))
 
-        return list(filter(func, md5s))
+        return list(filter(func, checksums))
 
     def save_info(self, path_info):
         if path_info["scheme"] not in ["http", "https"]:

--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -29,8 +29,8 @@ class RemoteSSH(RemoteBase):
     DEFAULT_PORT = 22
     TIMEOUT = 1800
 
-    def __init__(self, repo, config):
-        super(RemoteSSH, self).__init__(repo, config)
+    def __init__(self, repo, config, name):
+        super(RemoteSSH, self).__init__(repo, config, name)
         self.url = config.get(Config.SECTION_REMOTE_URL, "ssh://")
 
         parsed = urlparse(self.url)
@@ -196,3 +196,13 @@ class RemoteSSH(RemoteBase):
     def list_cache_paths(self):
         with self.ssh(**self.path_info) as ssh:
             return list(ssh.walk_files(self.prefix))
+
+    def _cache_exists(self, checksums):
+        results = []
+        with self.ssh(**self.path_info) as conn:
+            for checksum in checksums:
+                if conn.file_exists(
+                    self.checksum_to_path_info(checksum)["path"]
+                ):
+                    results.append(checksum)
+        return results

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -14,6 +14,7 @@ import shutil
 import hashlib
 import nanotime
 import time
+import threading
 
 from yaml.scanner import ScannerError
 
@@ -249,3 +250,16 @@ def walk_files(directory):
     for root, _, files in os.walk(str(directory)):
         for f in files:
             yield os.path.join(root, f)
+
+
+class threadsafe_iterator(object):
+    def __init__(self, it):
+        self.it = iter(it)
+        self.lock = threading.Lock()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        with self.lock:
+            return next(self.it)

--- a/tests/unit/remote/ssh/test_ssh.py
+++ b/tests/unit/remote/ssh/test_ssh.py
@@ -9,18 +9,18 @@ class TestRemoteSSH(TestCase):
     def test_user(self):
         url = "ssh://127.0.0.1:/path/to/dir"
         config = {"url": url}
-        remote = RemoteSSH(None, config)
+        remote = RemoteSSH(None, config, "test")
         self.assertEqual(remote.user, getpass.getuser())
 
         user = "test1"
         url = "ssh://{}@127.0.0.1:/path/to/dir".format(user)
         config = {"url": url}
-        remote = RemoteSSH(None, config)
+        remote = RemoteSSH(None, config, "test")
         self.assertEqual(remote.user, user)
 
         user = "test2"
         config["user"] = user
-        remote = RemoteSSH(None, config)
+        remote = RemoteSSH(None, config, "test")
         self.assertEqual(remote.user, user)
 
     def test_url(self):
@@ -33,7 +33,7 @@ class TestRemoteSSH(TestCase):
         url = "ssh://{}@{}:{}{}".format(user, host, port, path)
         config = {"url": url}
 
-        remote = RemoteSSH(None, config)
+        remote = RemoteSSH(None, config, "test")
 
         self.assertEqual(remote.user, user)
         self.assertEqual(remote.host, host)
@@ -44,7 +44,7 @@ class TestRemoteSSH(TestCase):
         url = "ssh://{}@{}:{}".format(user, host, path)
         config = {"url": url}
 
-        remote = RemoteSSH(None, config)
+        remote = RemoteSSH(None, config, "test")
 
         self.assertEqual(remote.user, user)
         self.assertEqual(remote.host, host)
@@ -53,22 +53,22 @@ class TestRemoteSSH(TestCase):
 
     def test_no_path(self):
         config = {"url": "ssh://127.0.0.1"}
-        remote = RemoteSSH(None, config)
+        remote = RemoteSSH(None, config, "test")
         self.assertEqual(remote.prefix, "/")
 
     def test_port(self):
         url = "ssh://127.0.0.1/path/to/dir"
         config = {"url": url}
-        remote = RemoteSSH(None, config)
+        remote = RemoteSSH(None, config, "test")
         self.assertEqual(remote.port, remote.DEFAULT_PORT)
 
         port = 1234
         url = "ssh://127.0.0.1:{}/path/to/dir".format(port)
         config = {"url": url}
-        remote = RemoteSSH(None, config)
+        remote = RemoteSSH(None, config, "test")
         self.assertEqual(remote.port, port)
 
         port = 4321
         config["port"] = port
-        remote = RemoteSSH(None, config)
+        remote = RemoteSSH(None, config, "test")
         self.assertEqual(remote.port, port)

--- a/tests/unit/remote/test_azure.py
+++ b/tests/unit/remote/test_azure.py
@@ -20,7 +20,7 @@ class TestRemoteAzure(TestCase):
             connection_string=self.connection_string,
         )
         config = {"url": url}
-        remote = RemoteAzure(None, config)
+        remote = RemoteAzure(None, config, "name")
         self.assertEqual(remote.url, url)
         self.assertEqual(remote.prefix, "")
         self.assertEqual(remote.bucket, self.container_name)
@@ -30,7 +30,7 @@ class TestRemoteAzure(TestCase):
         prefix = "some/prefix"
         url = "azure://{}/{}".format(self.container_name, prefix)
         config = {"url": url, "connection_string": self.connection_string}
-        remote = RemoteAzure(None, config)
+        remote = RemoteAzure(None, config, "name")
         self.assertEqual(remote.url, url)
         self.assertEqual(remote.prefix, prefix)
         self.assertEqual(remote.bucket, self.container_name)

--- a/tests/unit/remote/test_gs.py
+++ b/tests/unit/remote/test_gs.py
@@ -17,7 +17,7 @@ class TestRemoteGS(TestCase):
     }
 
     def test_init(self):
-        remote = RemoteGS(None, self.CONFIG)
+        remote = RemoteGS(None, self.CONFIG, "test")
         self.assertEqual(remote.url, self.URL)
         self.assertEqual(remote.prefix, self.PREFIX)
         self.assertEqual(remote.bucket, self.BUCKET)
@@ -26,7 +26,7 @@ class TestRemoteGS(TestCase):
 
     @mock.patch("google.cloud.storage.Client.from_service_account_json")
     def test_gs(self, mock_client):
-        remote = RemoteGS(None, self.CONFIG)
+        remote = RemoteGS(None, self.CONFIG, "test")
         self.assertTrue(remote.credentialpath)
         remote.gs()
         mock_client.assert_called_once_with(self.CREDENTIALPATH)
@@ -35,6 +35,6 @@ class TestRemoteGS(TestCase):
     def test_gs_no_credspath(self, mock_client):
         config = self.CONFIG.copy()
         del config["credentialpath"]
-        remote = RemoteGS(None, config)
+        remote = RemoteGS(None, config, "test")
         remote.gs()
         mock_client.assert_called_with(self.PROJECT)


### PR DESCRIPTION
This pull-request implements an ability to check the remote files existence with iteration over local cache files names instead of fetching the whole remote files list. It adds the `no_traversal` config option to the remote config block, which is needed to be switched on to enable this behavior.

It also adds the progress bar which display:
- case `no_traversal = false` (original behavior): the amount of files to be checked which have been found during the iteration over the `remote.all()` remote files list
- case `no_traversal = true`: count of checked files

TODO:
* [ ] recheck and complete the implementations for every remote type
* [ ] write tests for cache_exists

Fix #1762 