### PR TITLE
cli: fix overwriting remotes in `dvc remote add`

### DIFF
--- a/dvc/command/remote.py
+++ b/dvc/command/remote.py
@@ -8,14 +8,9 @@ import dvc.logger as logger
 from dvc.command.base import append_doc_link, fix_subparsers
 from dvc.command.config import CmdConfig
 from dvc.config import Config
-from dvc.exceptions import ConfirmRemoveError, DvcException
 
 
 class CmdRemoteAdd(CmdConfig):
-    def _prevent_config_overwriting(self, section):
-        if (section in self.configobj.keys()) and not self.args.force:
-            raise ConfirmRemoveError(section)
-
     @staticmethod
     def resolve_path(path, config_file):
         """Resolve path relative to config file location.
@@ -44,11 +39,12 @@ class CmdRemoteAdd(CmdConfig):
             )
 
         section = Config.SECTION_REMOTE_FMT.format(self.args.name)
-
-        try:
-            self._prevent_config_overwriting(section)
-        except DvcException as exc:
-            logger.error(exc)
+        if (section in self.configobj.keys()) and not self.args.force:
+            logger.error(
+                "Remote with name {} already exists. "
+                "Use -f (--force) to overwrite remote "
+                "with new value".format(self.args.name)
+            )
             return 1
 
         ret = self._set(section, Config.SECTION_REMOTE_URL, self.args.url)

--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -179,8 +179,8 @@ class CyclicGraphError(DvcException):
 class ConfirmRemoveError(DvcException):
     def __init__(self, path):
         super(ConfirmRemoveError, self).__init__(
-            "unable to remove or overwrite '{}' without a confirmation "
-            "from the user. Use '-f' to force.".format(path)
+            "unable to remove '{}' without a confirmation from the user. Use "
+            "'-f' to force.".format(path)
         )
 
 

--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -179,8 +179,8 @@ class CyclicGraphError(DvcException):
 class ConfirmRemoveError(DvcException):
     def __init__(self, path):
         super(ConfirmRemoveError, self).__init__(
-            "unable to remove '{}' without a confirmation from the user. Use "
-            "'-f' to force.".format(path)
+            "unable to remove or overwrite '{}' without a confirmation "
+            "from the user. Use '-f' to force.".format(path)
         )
 
 

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -60,7 +60,7 @@ class TestRemote(TestDvc):
     def test_overwrite(self):
         remote_name = "a"
         remote_url = "s3://bucket/name"
-        main(["remote", "add", remote_name, remote_url])
+        self.assertEqual(main(["remote", "add", remote_name, remote_url]), 0)
         self.assertEqual(main(["remote", "add", remote_name, remote_url]), 1)
         self.assertEqual(
             main(["remote", "add", "-f", remote_name, remote_url]), 0

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -57,6 +57,15 @@ class TestRemote(TestDvc):
         config = configobj.ConfigObj(self.dvc.config.config_file)
         self.assertEqual(config['remote "mylocal"']["url"], rel)
 
+    def test_overwrite(self):
+        remote_name = "a"
+        remote_url = "s3://bucket/name"
+        main(["remote", "add", remote_name, remote_url])
+        self.assertEqual(main(["remote", "add", remote_name, remote_url]), 1)
+        self.assertEqual(
+            main(["remote", "add", "-f", remote_name, remote_url]), 0
+        )
+
 
 class TestRemoteRemoveDefault(TestDvc):
     def test(self):


### PR DESCRIPTION
Now, `dvc remote add` requires user confirmation in case of overwriting of an already existing remote.

Fixes #1760 

Looks like:
```bash
$ dvc remote list
dvc	s3://dvc-share/dvc/
$ dvc remote add dvc s3://something/new
Error: unable to remove or overwrite 'remote "dvc"' without a confirmation from the user. Use '-f' to force. - unable to remove or overwrite 'remote "dvc"' without a confirmation from the user. Use '-f' to force.

Having any troubles? Hit us up at https://dvc.org/support, we are always happy to help!

$ dvc remote add -f dvc s3://something/new
$ dvc remote list
dvc	s3://something/new
```