### PR TITLE
dvc: exclude `persist` when computing md5 for the stage

### DIFF
--- a/dvc/stage.py
+++ b/dvc/stage.py
@@ -621,7 +621,7 @@ class Stage(object):
         self.repo.scm.track_file(os.path.relpath(fname))
 
     def _compute_md5(self):
-        from dvc.output.local import OutputLOCAL
+        from dvc.output.base import OutputBase
 
         d = self.dumpd()
 
@@ -643,8 +643,9 @@ class Stage(object):
             d,
             exclude=[
                 self.PARAM_LOCKED,
-                OutputLOCAL.PARAM_METRIC,
-                OutputLOCAL.PARAM_TAGS,
+                OutputBase.PARAM_METRIC,
+                OutputBase.PARAM_TAGS,
+                OutputBase.PARAM_PERSIST,
             ],
         )
         logger.debug("Computed stage '{}' md5: '{}'".format(self.relpath, m))

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -39,6 +39,7 @@ class TestAdd(TestDvc):
         self.assertEqual(len(stage.deps), 0)
         self.assertEqual(stage.cmd, None)
         self.assertEqual(stage.outs[0].info["md5"], md5)
+        self.assertEqual(stage.md5, "ee343f2482f53efffc109be83cc976ac")
 
     def test_unicode(self):
         fname = "\xe1"


### PR DESCRIPTION
Fixes #1828

Signed-off-by: Ruslan Kuprieiev <ruslan@iterative.ai>