### PR TITLE
add: check if output is local when generating stage name

### DIFF
--- a/dvc/output/base.py
+++ b/dvc/output/base.py
@@ -92,10 +92,8 @@ class OutputBase(object):
         return self.url
 
     @property
-    def is_local(self):
-        raise DvcException(
-            "is local is not supported for {}".format(self.scheme)
-        )
+    def is_in_repo(self):
+        return False
 
     def assign_to_stage_file(self, target_repo):
         raise DvcException(
@@ -235,11 +233,11 @@ class OutputBase(object):
         if self.scheme != "local":
             return
 
-        if ignore_remove and self.use_cache and self.is_local:
+        if ignore_remove and self.use_cache and self.is_in_repo:
             self.repo.scm.ignore_remove(self.path)
 
     def move(self, out):
-        if self.scheme == "local" and self.use_cache and self.is_local:
+        if self.scheme == "local" and self.use_cache and self.is_in_repo:
             self.repo.scm.ignore_remove(self.path)
 
         self.remote.move(self.path_info, out.path_info)
@@ -248,7 +246,7 @@ class OutputBase(object):
         self.save()
         self.commit()
 
-        if self.scheme == "local" and self.use_cache and self.is_local:
+        if self.scheme == "local" and self.use_cache and self.is_in_repo:
             self.repo.scm.ignore(self.path)
 
     def get_files_number(self):

--- a/dvc/output/local.py
+++ b/dvc/output/local.py
@@ -54,7 +54,7 @@ class OutputLOCAL(OutputBase):
         return self.rel_path
 
     @property
-    def is_local(self):
+    def is_in_repo(self):
         return urlparse(self.url).scheme != "remote" and not os.path.isabs(
             self.url
         )
@@ -92,7 +92,7 @@ class OutputLOCAL(OutputBase):
 
     def dumpd(self):
         ret = super(OutputLOCAL, self).dumpd()
-        if self.is_local:
+        if self.is_in_repo:
             path = self.remote.unixpath(
                 os.path.relpath(self.path, self.stage.wdir)
             )
@@ -146,7 +146,7 @@ class OutputLOCAL(OutputBase):
             logger.info(msg.format(self.rel_path))
             return
 
-        if self.is_local:
+        if self.is_in_repo:
             if self.repo.scm.is_tracked(self.path):
                 raise OutputAlreadyTrackedError(self.rel_path)
 

--- a/dvc/stage.py
+++ b/dvc/stage.py
@@ -339,7 +339,7 @@ class Stage(object):
     def _expand_to_path_on_add_local(add, fname, out, path_handler):
         if (
             add
-            and out.is_local
+            and out.is_in_repo
             and not contains_symlink_up_to(out.path, out.repo.root_dir)
         ):
             fname = path_handler.join(path_handler.dirname(out.path), fname)

--- a/tests/unit/test_stage.py
+++ b/tests/unit/test_stage.py
@@ -1,6 +1,10 @@
-import mock
-from unittest import TestCase
+import os
+
 from dvc.stage import Stage
+
+import mock
+import pytest
+from unittest import TestCase
 
 
 class TestStageChecksum(TestCase):
@@ -62,3 +66,12 @@ class TestPathConversion(TestCase):
 
         stage.wdir = ntpath.join("..", "..")
         self.assertEqual(stage.dumpd()["wdir"], "../..")
+
+
+@pytest.mark.parametrize("add", [True, False])
+def test_expand_to_path_on_add_local(add):
+    out = mock.Mock()
+    out.is_in_repo = False
+    path = "path"
+    fname = Stage._expand_to_path_on_add_local(add, path, out, os.path)
+    assert fname == path


### PR DESCRIPTION
When adding a remote file with

```
$ dvc add s3://bucket/path
```

it results in

```
Error: failed to add file - is local is not supported for s3
```

Signed-off-by: Ruslan Kuprieiev <ruslan@iterative.ai>