### PR TITLE
Add python_requires and version classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
         ':python_version=="2.7"': ["futures"],
     },
     keywords="data science, data version control, machine learning",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Programming Language :: Python :: 2",

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,12 @@ setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,


### PR DESCRIPTION
`python_requires` helps pip install the right version of the library for the user's running Python.

Explicit version classifiers makes it on PyPI what versions are supported.

This is especially useful after dropping Python 2.7 (https://github.com/iterative/dvc/issues/1818) and also useful now.

---

Python 3.4 reached EOL on 2019-03-16, perhaps drop that now?

https://en.wikipedia.org/wiki/CPython#Version_history

Here's the pip installs for dvc from PyPI for March 2019:

| category | percent | downloads |
|----------|--------:|----------:|
|      3.6 |  42.39% |     3,621 |
|      3.5 |  20.21% |     1,726 |
|      2.7 |  17.51% |     1,496 |
|      3.7 |  11.33% |       968 |
| null     |   8.49% |       725 |
|      3.4 |   0.06% |         5 |
|      2.6 |   0.01% |         1 |
| Total    |         |     8,542 |

Source: `pypistats python_minor dvc --last-month # pip install pypistats`