### PR TITLE
config: allow cross-referenced remotes

### DIFF
--- a/dvc/command/remote.py
+++ b/dvc/command/remote.py
@@ -36,7 +36,7 @@ class CmdRemoteAdd(CmdConfig):
         from dvc.remote import _get, RemoteLOCAL
 
         remote = _get({Config.SECTION_REMOTE_URL: self.args.url})
-        if remote == RemoteLOCAL:
+        if remote == RemoteLOCAL and not self.args.url.startswith("remote://"):
             self.args.url = self.resolve_path(
                 self.args.url, self.configobj.filename
             )

--- a/dvc/config.py
+++ b/dvc/config.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-from dvc.utils.compat import str, open
+from dvc.utils.compat import str, open, urlparse
 
 import os
 import errno
@@ -483,6 +483,56 @@ class Config(object):  # pylint: disable=too-many-instance-attributes
             except Exception as exc:
                 msg = "failed to write config '{}'".format(conf.filename)
                 raise ConfigError(msg, exc)
+
+    def get_remote_settings(self, name):
+        import posixpath
+
+        """
+        Args:
+            name (str): The name of the remote that we want to retrieve
+
+        Returns:
+            dict: The content beneath the given remote name.
+
+        Example:
+            >>> config = {'remote "server"': {'url': 'ssh://localhost/'}}
+            >>> get_remote_settings("server")
+            {'url': 'ssh://localhost/'}
+        """
+        settings = self.config[self.SECTION_REMOTE_FMT.format(name)]
+        parsed = urlparse(settings["url"])
+
+        # Support for cross referenced remotes.
+        # This will merge the settings, giving priority to the outer reference.
+        # For example, having:
+        #
+        #       dvc remote add server ssh://localhost
+        #       dvc remote modify server user root
+        #       dvc remote modify server ask_password true
+        #
+        #       dvc remote add images remote://server/tmp/pictures
+        #       dvc remote modify images user alice
+        #       dvc remote modify images ask_password false
+        #       dvc remote modify images password asdf1234
+        #
+        # Results on a config dictionary like:
+        #
+        #       {
+        #           "url": "ssh://localhost/tmp/pictures",
+        #           "user": "alice",
+        #           "password": "asdf1234",
+        #           "ask_password": False,
+        #       }
+        #
+        if parsed.scheme == "remote":
+            reference = self.get_remote_settings(parsed.netloc)
+            url = posixpath.join(reference["url"], parsed.path.lstrip("/"))
+            merged = reference.copy()
+            merged.update(settings)
+            merged["url"] = url
+            return merged
+
+        return settings
 
     @staticmethod
     def unset(config, section, opt=None):

--- a/dvc/dependency/__init__.py
+++ b/dvc/dependency/__init__.py
@@ -2,9 +2,6 @@ from __future__ import unicode_literals
 
 import schema
 
-from dvc.config import Config
-from dvc.utils.compat import urlparse
-
 import dvc.output as output
 from dvc.output.base import OutputBase
 from dvc.dependency.s3 import DependencyS3
@@ -46,11 +43,13 @@ del SCHEMA[schema.Optional(OutputBase.PARAM_METRIC)]
 
 
 def _get(stage, p, info):
+    from dvc.utils.compat import urlparse
+
     parsed = urlparse(p)
+
     if parsed.scheme == "remote":
-        name = Config.SECTION_REMOTE_FMT.format(parsed.netloc)
-        sect = stage.repo.config.config[name]
-        remote = Remote(stage.repo, sect)
+        settings = stage.repo.config.get_remote_settings(parsed.netloc)
+        remote = Remote(stage.repo, settings)
         return DEP_MAP[remote.scheme](stage, p, info, remote=remote)
 
     for d in DEPS:

--- a/dvc/output/__init__.py
+++ b/dvc/output/__init__.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 import schema
 
-from dvc.config import Config
 from dvc.utils.compat import urlparse, str
 
 from dvc.output.base import OutputBase
@@ -59,10 +58,10 @@ SCHEMA[schema.Optional(OutputBase.PARAM_PERSIST)] = bool
 
 def _get(stage, p, info, cache, metric, persist=False, tags=None):
     parsed = urlparse(p)
+
     if parsed.scheme == "remote":
-        name = Config.SECTION_REMOTE_FMT.format(parsed.netloc)
-        sect = stage.repo.config.config[name]
-        remote = Remote(stage.repo, sect)
+        settings = stage.repo.config.get_remote_settings(parsed.netloc)
+        remote = Remote(stage.repo, settings)
         return OUTS_MAP[remote.scheme](
             stage,
             p,

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -70,6 +70,15 @@ class TestExternalCacheDir(TestDvc):
         self.assertFalse(os.path.exists(".dvc/cache"))
         self.assertNotEqual(len(os.listdir(cache_dir)), 0)
 
+    def test_remote_references(self):
+        assert main(["remote", "add", "storage", "ssh://localhost"]) == 0
+        assert main(["remote", "add", "cache", "remote://storage/tmp"]) == 0
+        assert main(["config", "cache.ssh", "cache"]) == 0
+
+        self.dvc.__init__()
+
+        assert self.dvc.cache.ssh.url == "ssh://localhost/tmp"
+
 
 class TestSharedCacheDir(TestDir):
     def test(self):

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -66,6 +66,14 @@ class TestRemote(TestDvc):
             main(["remote", "add", "-f", remote_name, remote_url]), 0
         )
 
+    def test_referencing_other_remotes(self):
+        assert main(["remote", "add", "foo", "ssh://localhost/"]) == 0
+        assert main(["remote", "add", "bar", "remote://foo/dvc-storage"]) == 0
+
+        config = configobj.ConfigObj(self.dvc.config.config_file)
+
+        assert config['remote "bar"']["url"] == "remote://foo/dvc-storage"
+
 
 class TestRemoteRemoveDefault(TestDvc):
     def test(self):


### PR DESCRIPTION
**Test scenario**:
```bash
# Get your SSH daemon up and running
sudo systemctl start sshd

# Initialize the DVC repository with some remotes
dvc init --no-scm --force
dvc remote add ssh ssh://localhost
dvc remote modify ssh ask_password true
dvc remote add text-files remote://ssh/tmp/text-files
dvc remote add dvc-storage remote://ssh/tmp/dvc-storage
dvc config cache.ssh dvc-storage
mkdir -p /tmp/{text-files,dvc-storage}

# Test cross-referenced remote dependencies
echo "hello" > /tmp/text-files/hello
dvc import remote://text-files/hello
test -f hello

# Test cross-referenced remote outputs with cache
dvc run -o remote://text-files/derp 'echo "derp" > /tmp/text-files/derp'
test -f /tmp/text-files/derp
test -f /tmp/dvc-storage/b2/c3e317682929a3255a5e6433ccc5be
```

----

Close #1614