### PR TITLE
logger: don not log without a message

### DIFF
--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -48,7 +48,7 @@ class CmdRepro(CmdBase):
                     metrics = self.repo.metrics.show()
                     show_metrics(metrics)
             except DvcException:
-                logger.exception()
+                logger.exception("")
                 ret = 1
                 break
 


### PR DESCRIPTION
This was the only instance I found that was not passing a message to the logger.

```bash
rg -t py "logger\.\w+\(\)"
```

Close #1858