### PR TITLE
logger: use exception instead of error

### DIFF
--- a/dvc/remote/http.py
+++ b/dvc/remote/http.py
@@ -90,7 +90,7 @@ class RemoteHTTP(RemoteBase):
 
             except Exception:
                 msg = "failed to download '{}'".format(from_info["path"])
-                logger.error(msg)
+                logger.exception(msg)
                 continue
 
             if not no_progress_bar:

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -272,7 +272,7 @@ class RemoteLOCAL(RemoteBase):
                 d = json.load(fd)
         except Exception:
             msg = "Failed to load dir cache '{}'"
-            logger.error(msg.format(os.path.relpath(path)))
+            logger.exception(msg.format(os.path.relpath(path)))
             return []
 
         if not isinstance(d, list):
@@ -511,7 +511,7 @@ class RemoteLOCAL(RemoteBase):
                 copyfile(from_info["path"], tmp_file, name=name)
                 os.rename(tmp_file, to_info["path"])
             except Exception:
-                logger.error(
+                logger.exception(
                     "failed to upload '{}' to '{}'".format(
                         from_info["path"], to_info["path"]
                     )
@@ -555,7 +555,7 @@ class RemoteLOCAL(RemoteBase):
 
                 move(tmp_file, to_info["path"])
             except Exception:
-                logger.error(
+                logger.exception(
                     "failed to download '{}' to '{}'".format(
                         from_info["path"], to_info["path"]
                     )

--- a/dvc/remote/s3.py
+++ b/dvc/remote/s3.py
@@ -188,7 +188,7 @@ class RemoteS3(RemoteBase):
                 )
             except Exception:
                 msg = "failed to upload '{}'".format(from_info["path"])
-                logger.error(msg)
+                logger.exception(msg)
                 continue
 
             progress.finish_target(name)
@@ -246,7 +246,7 @@ class RemoteS3(RemoteBase):
                 msg = "failed to download '{}/{}'".format(
                     from_info["bucket"], from_info["path"]
                 )
-                logger.error(msg)
+                logger.exception(msg)
                 continue
 
             move(tmp_file, to_info["path"])

--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -160,7 +160,7 @@ class RemoteSSH(RemoteBase):
                     from_info["path"], to_info["path"], progress_title=name
                 )
             except Exception:
-                logger.error(
+                logger.exception(
                     "failed to download '{host}/{path}' to '{dest}'".format(
                         host=from_info["host"],
                         path=from_info["path"],


### PR DESCRIPTION
The problem was happening because `logger.error` doesn't include any
`exc_info`, and the `parse_exc` logic was previously to rely on the log
record's `exc_info` instead of the global stack trace.

There's still use cases when you want to just `log` an error without
printing the stack trace, those are left untouched.
You can search for them with: `grep -R 'logger.error' dvc/`

---

Fix #1869