### PR TITLE
dvc: retain formatting and comments in .dvc files

### DIFF
--- a/dvc/command/tag.py
+++ b/dvc/command/tag.py
@@ -1,5 +1,7 @@
-import yaml
 import logging
+
+from ruamel.yaml import YAML
+from ruamel.yaml.compat import StringIO
 
 from dvc.exceptions import DvcException
 from dvc.command.base import CmdBase, fix_subparsers, append_doc_link
@@ -50,11 +52,19 @@ class CmdTagList(CmdBase):
                     recursive=self.args.recursive,
                 )
                 if tags:
-                    logger.info(yaml.dump(tags, default_flow_style=False))
+                    logger.info(to_yaml_string(tags))
             except DvcException:
                 logger.exception("failed list tags")
                 return 1
         return 0
+
+
+def to_yaml_string(data, **kw):
+    stream = StringIO()
+    yaml = YAML()
+    yaml.default_flow_style = False
+    yaml.dump(data, stream)
+    return stream.getvalue()
 
 
 def add_parser(subparsers, parent_parser):

--- a/dvc/command/tag.py
+++ b/dvc/command/tag.py
@@ -1,8 +1,6 @@
 import logging
 
-from ruamel.yaml import YAML
-from ruamel.yaml.compat import StringIO
-
+from dvc.utils import to_yaml_string
 from dvc.exceptions import DvcException
 from dvc.command.base import CmdBase, fix_subparsers, append_doc_link
 
@@ -57,14 +55,6 @@ class CmdTagList(CmdBase):
                 logger.exception("failed list tags")
                 return 1
         return 0
-
-
-def to_yaml_string(data, **kw):
-    stream = StringIO()
-    yaml = YAML()
-    yaml.default_flow_style = False
-    yaml.dump(data, stream)
-    return stream.getvalue()
 
 
 def add_parser(subparsers, parent_parser):

--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -214,11 +214,12 @@ class NoMetricsError(DvcException):
 
 
 class StageFileCorruptedError(DvcException):
-    def __init__(self, path):
+    def __init__(self, path, cause=None):
         path = os.path.relpath(path)
         super(StageFileCorruptedError, self).__init__(
             "unable to read stage file: {} "
-            "YAML file structure is corrupted".format(path)
+            "YAML file structure is corrupted".format(path),
+            cause=cause,
         )
 
 

--- a/dvc/repo/metrics/show.py
+++ b/dvc/repo/metrics/show.py
@@ -234,10 +234,14 @@ def _read_metrics(self, metrics, branch):
                 branch=branch,
             )
         else:
-            fd = self.tree.open(out.path)
-            metric = _read_metric(
-                fd, typ=typ, xpath=xpath, rel_path=out.rel_path, branch=branch
-            )
+            with self.tree.open(out.path) as fd:
+                metric = _read_metric(
+                    fd,
+                    typ=typ,
+                    xpath=xpath,
+                    rel_path=out.rel_path,
+                    branch=branch,
+                )
 
         if not metric:
             continue

--- a/dvc/stage.py
+++ b/dvc/stage.py
@@ -15,7 +15,7 @@ import dvc.prompt as prompt
 import dvc.dependency as dependency
 import dvc.output as output
 from dvc.exceptions import DvcException
-from dvc.utils import dict_md5, fix_env, load_stage_file_fobj, dump_stage_file
+from dvc.utils import dict_md5, fix_env, load_stage_file_fd, dump_stage_file
 from dvc.utils.collections import apply_diff
 
 
@@ -568,7 +568,8 @@ class Stage(object):
         Stage._check_dvc_filename(fname)
         Stage._check_isfile(repo, fname)
 
-        d = load_stage_file_fobj(repo.tree.open(fname), fname)
+        with repo.tree.open(fname) as fd:
+            d = load_stage_file_fd(fd, fname)
         # Making a deepcopy since the original structure
         # looses keys in deps and outs load
         state = copy.deepcopy(d)

--- a/dvc/stage.py
+++ b/dvc/stage.py
@@ -15,7 +15,7 @@ import dvc.prompt as prompt
 import dvc.dependency as dependency
 import dvc.output as output
 from dvc.exceptions import DvcException
-from dvc.utils import dict_md5, fix_env, load_stage_file_fd, dump_stage_file
+from dvc.utils import dict_md5, fix_env, load_stage_fd, dump_stage_file
 from dvc.utils.collections import apply_diff
 
 
@@ -569,7 +569,7 @@ class Stage(object):
         Stage._check_isfile(repo, fname)
 
         with repo.tree.open(fname) as fd:
-            d = load_stage_file_fd(fd, fname)
+            d = load_stage_fd(fd, fname)
         # Making a deepcopy since the original structure
         # looses keys in deps and outs load
         state = copy.deepcopy(d)

--- a/dvc/stage.py
+++ b/dvc/stage.py
@@ -15,8 +15,9 @@ import dvc.prompt as prompt
 import dvc.dependency as dependency
 import dvc.output as output
 from dvc.exceptions import DvcException
-from dvc.utils import dict_md5, fix_env, load_stage_fd, dump_stage_file
+from dvc.utils import dict_md5, fix_env
 from dvc.utils.collections import apply_diff
+from dvc.utils.stage import load_stage_fd, dump_stage_file
 
 
 logger = logging.getLogger(__name__)

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -2,7 +2,6 @@
 
 from __future__ import unicode_literals
 
-import yaml
 from dvc.utils.compat import str, builtin_str, open, cast_bytes_py2
 
 import os
@@ -19,7 +18,8 @@ import colorama
 import re
 import logging
 
-from yaml.scanner import ScannerError
+from ruamel.yaml.error import YAMLError
+from ruamel.yaml import YAML
 
 
 logger = logging.getLogger(__name__)
@@ -252,9 +252,17 @@ def load_stage_file_fobj(fobj, path):
     from dvc.exceptions import StageFileCorruptedError
 
     try:
-        return yaml.safe_load(fobj) or {}
-    except ScannerError:
+        yaml = YAML()
+        return yaml.load(fobj) or {}
+    except YAMLError:
         raise StageFileCorruptedError(path)
+
+
+def dump_stage_file(path, data):
+    with open(path, "w") as fd:
+        yaml = YAML()
+        yaml.default_flow_style = False
+        yaml.dump(data, fd)
 
 
 def dvc_walk(

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-from dvc.utils.compat import str, builtin_str, open, cast_bytes_py2
+from dvc.utils.compat import str, builtin_str, open, cast_bytes_py2, StringIO
 
 import os
 import sys
@@ -263,6 +263,18 @@ def dump_stage_file(path, data):
         yaml = YAML()
         yaml.default_flow_style = False
         yaml.dump(data, fd)
+
+
+def from_yaml_string(s):
+    return YAML().load(StringIO(s))
+
+
+def to_yaml_string(data):
+    stream = StringIO()
+    yaml = YAML()
+    yaml.default_flow_style = False
+    yaml.dump(data, stream)
+    return stream.getvalue()
 
 
 def dvc_walk(

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -244,22 +244,22 @@ def current_timestamp():
 
 
 def load_stage_file(path):
-    with open(path, "r") as fd:
+    with open(path, "r", encoding="utf-8") as fd:
         return load_stage_file_fd(fd, path)
 
 
-def load_stage_file_fd(fobj, path):
+def load_stage_file_fd(fd, path):
     from dvc.exceptions import StageFileCorruptedError
 
     try:
         yaml = YAML()
-        return yaml.load(fobj) or {}
+        return yaml.load(fd) or {}
     except YAMLError:
         raise StageFileCorruptedError(path)
 
 
 def dump_stage_file(path, data):
-    with open(path, "w") as fd:
+    with open(path, "w", encoding="utf-8") as fd:
         yaml = YAML()
         yaml.default_flow_style = False
         yaml.dump(data, fd)

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -18,7 +18,6 @@ import colorama
 import re
 import logging
 
-from ruamel.yaml.error import YAMLError
 from ruamel.yaml import YAML
 
 
@@ -241,28 +240,6 @@ def tmp_fname(fname):
 
 def current_timestamp():
     return int(nanotime.timestamp(time.time()))
-
-
-def load_stage_file(path):
-    with open(path, "r", encoding="utf-8") as fd:
-        return load_stage_fd(fd, path)
-
-
-def load_stage_fd(fd, path):
-    from dvc.exceptions import StageFileCorruptedError
-
-    try:
-        yaml = YAML()
-        return yaml.load(fd) or {}
-    except YAMLError as exc:
-        raise StageFileCorruptedError(path, cause=exc)
-
-
-def dump_stage_file(path, data):
-    with open(path, "w", encoding="utf-8") as fd:
-        yaml = YAML()
-        yaml.default_flow_style = False
-        yaml.dump(data, fd)
 
 
 def from_yaml_string(s):

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -244,11 +244,11 @@ def current_timestamp():
 
 
 def load_stage_file(path):
-    with open(path, "r") as fobj:
-        return load_stage_file_fobj(fobj, path)
+    with open(path, "r") as fd:
+        return load_stage_file_fd(fd, path)
 
 
-def load_stage_file_fobj(fobj, path):
+def load_stage_file_fd(fobj, path):
     from dvc.exceptions import StageFileCorruptedError
 
     try:

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -245,17 +245,17 @@ def current_timestamp():
 
 def load_stage_file(path):
     with open(path, "r", encoding="utf-8") as fd:
-        return load_stage_file_fd(fd, path)
+        return load_stage_fd(fd, path)
 
 
-def load_stage_file_fd(fd, path):
+def load_stage_fd(fd, path):
     from dvc.exceptions import StageFileCorruptedError
 
     try:
         yaml = YAML()
         return yaml.load(fd) or {}
-    except YAMLError:
-        raise StageFileCorruptedError(path)
+    except YAMLError as exc:
+        raise StageFileCorruptedError(path, cause=exc)
 
 
 def dump_stage_file(path, data):

--- a/dvc/utils/collections.py
+++ b/dvc/utils/collections.py
@@ -1,6 +1,46 @@
 from __future__ import unicode_literals
+from collections.abc import Mapping
 
 
 # just simple check for Nones and emtpy strings
 def compact(args):
     return list(filter(bool, args))
+
+
+def apply_diff(src, dest):
+    """Recursively apply changes from stc to dest"""
+    Seq = (list, tuple)
+    Container = (Mapping, list, tuple)
+
+    def is_same_type(a, b):
+        return any(
+            isinstance(a, t) and isinstance(b, t)
+            for t in [str, Mapping, Seq, bool]
+        )
+
+    if isinstance(src, Mapping) and isinstance(dest, Mapping):
+        for key, value in src.items():
+            if isinstance(value, Container) and is_same_type(
+                value, dest.get(key)
+            ):
+                apply_diff(value, dest[key])
+            elif key not in dest or value != dest[key]:
+                dest[key] = value
+        for key in set(dest) - set(src):
+            del dest[key]
+    elif isinstance(src, Seq) and isinstance(dest, Seq):
+        if len(src) != len(dest):
+            dest[:] = src
+        else:
+            for i, value in enumerate(src):
+                if isinstance(value, Container) and is_same_type(
+                    value, dest[i]
+                ):
+                    apply_diff(value, dest[i])
+                elif value != dest[i]:
+                    dest[i] = value
+    else:
+        raise ValueError(
+            "Can't apply diff from %s to %s"
+            % (src.__class__.__name__, dest.__class__.__name__)
+        )

--- a/dvc/utils/collections.py
+++ b/dvc/utils/collections.py
@@ -1,5 +1,9 @@
-from __future__ import unicode_literals
-from collections.abc import Mapping
+from __future__ import absolute_import, unicode_literals
+
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 
 # just simple check for Nones and emtpy strings

--- a/dvc/utils/collections.py
+++ b/dvc/utils/collections.py
@@ -40,7 +40,7 @@ def apply_diff(src, dest):
                 elif value != dest[i]:
                     dest[i] = value
     else:
-        raise ValueError(
+        raise AssertionError(
             "Can't apply diff from {} to {}".format(
                 src.__class__.__name__, dest.__class__.__name__
             )

--- a/dvc/utils/collections.py
+++ b/dvc/utils/collections.py
@@ -1,9 +1,5 @@
 from __future__ import absolute_import, unicode_literals
-
-try:
-    from collections.abc import Mapping
-except ImportError:
-    from collections import Mapping
+from dvc.utils.compat import Mapping
 
 
 # just simple check for Nones and emtpy strings
@@ -45,6 +41,7 @@ def apply_diff(src, dest):
                     dest[i] = value
     else:
         raise ValueError(
-            "Can't apply diff from %s to %s"
-            % (src.__class__.__name__, dest.__class__.__name__)
+            "Can't apply diff from {} to {}".format(
+                src.__class__.__name__, dest.__class__.__name__
+            )
         )

--- a/dvc/utils/compat.py
+++ b/dvc/utils/compat.py
@@ -98,6 +98,7 @@ if is_py2:
     from SimpleHTTPServer import SimpleHTTPRequestHandler  # noqa: F401
     import ConfigParser  # noqa: F401
     from io import open  # noqa: F401
+    from pathlib2 import Path  # noqa: F401
 
     builtin_str = str  # noqa: F821
     bytes = str  # noqa: F821
@@ -110,6 +111,7 @@ if is_py2:
     makedirs = _makedirs
 
 elif is_py3:
+    from pathlib import Path  # noqa: F401
     from os import makedirs  # noqa: F401
     from urllib.parse import urlparse, urljoin  # noqa: F401
     from io import StringIO, BytesIO  # noqa: F401

--- a/dvc/utils/compat.py
+++ b/dvc/utils/compat.py
@@ -92,8 +92,6 @@ def _makedirs(name, mode=0o777, exist_ok=False):
 
 if is_py2:
     from urlparse import urlparse, urljoin  # noqa: F401
-    from StringIO import StringIO  # noqa: F401
-    from io import BytesIO  # noqa: F401
     from BaseHTTPServer import HTTPServer  # noqa: F401
     from SimpleHTTPServer import SimpleHTTPRequestHandler  # noqa: F401
     import ConfigParser  # noqa: F401
@@ -109,6 +107,24 @@ if is_py2:
     input = raw_input  # noqa: F821
     cast_bytes_py2 = cast_bytes
     makedirs = _makedirs
+
+    import StringIO
+    import io
+
+    class StringIO(StringIO.StringIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            self.close()
+
+    class BytesIO(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            self.close()
+
 
 elif is_py3:
     from pathlib import Path  # noqa: F401

--- a/dvc/utils/compat.py
+++ b/dvc/utils/compat.py
@@ -1,4 +1,5 @@
 """Handle import compatibility between Python 2 and Python 3"""
+from __future__ import absolute_import
 
 import sys
 import os
@@ -97,6 +98,7 @@ if is_py2:
     import ConfigParser  # noqa: F401
     from io import open  # noqa: F401
     from pathlib2 import Path  # noqa: F401
+    from collections import Mapping  # noqa: F401
 
     builtin_str = str  # noqa: F821
     bytes = str  # noqa: F821
@@ -136,6 +138,7 @@ elif is_py3:
         SimpleHTTPRequestHandler,  # noqa: F401
     )  # noqa: F401
     import configparser as ConfigParser  # noqa: F401
+    from collections.abc import Mapping  # noqa: F401
 
     builtin_str = str  # noqa: F821
     str = str  # noqa: F821

--- a/dvc/utils/stage.py
+++ b/dvc/utils/stage.py
@@ -1,0 +1,26 @@
+from dvc.utils.compat import open
+
+from ruamel.yaml.error import YAMLError
+from ruamel.yaml import YAML
+
+from dvc.exceptions import StageFileCorruptedError
+
+
+def load_stage_file(path):
+    with open(path, "r", encoding="utf-8") as fd:
+        return load_stage_fd(fd, path)
+
+
+def load_stage_fd(fd, path):
+    try:
+        yaml = YAML()
+        return yaml.load(fd) or {}
+    except YAMLError as exc:
+        raise StageFileCorruptedError(path, cause=exc)
+
+
+def dump_stage_file(path, data):
+    with open(path, "w", encoding="utf-8") as fd:
+        yaml = YAML()
+        yaml.default_flow_style = False
+        yaml.dump(data, fd)

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ inflect>=2.1.0
 humanize>=0.5.1
 dulwich>=0.19.11
 ruamel.yaml>=0.15.91
+pathlib2==2.3.3; python_version == "2.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ PyInstaller==3.3.1
 colorama>=0.3.9
 configobj>=5.0.6
 networkx>=2.1
-pyyaml>=3.12
 gitpython>=2.1.8
 setuptools>=34.0.0
 nanotime>=0.5.2
@@ -29,3 +28,4 @@ treelib>=1.5.5
 inflect>=2.1.0
 humanize>=0.5.1
 dulwich>=0.19.11
+ruamel.yaml>=0.15.91

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
         "azure": azure,
         "ssh": ssh,
         # NOTE: https://github.com/inveniosoftware/troubleshooting/issues/1
-        ':python_version=="2.7"': ["futures"],
+        ':python_version=="2.7"': ["futures", "pathlib2"],
     },
     keywords="data science, data version control, machine learning",
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ install_requires = [
     "colorama>=0.3.9",
     "configobj>=5.0.6",
     "networkx>=2.1",
-    "pyyaml>=3.12",
     "gitpython>=2.1.8",
     "setuptools>=34.0.0",
     "nanotime>=0.5.2",
@@ -59,6 +58,7 @@ install_requires = [
     "inflect>=2.1.0",
     "humanize>=0.5.1",
     "dulwich>=0.19.11",
+    "ruamel.yaml==0.15.91",
 ]
 
 # Extra dependencies for remote integrations

--- a/tests/basic_env.py
+++ b/tests/basic_env.py
@@ -98,7 +98,6 @@ class TestDirFixture(object):
 
     def tearDown(self):
         self._popd()
-        # TODO: delete dir here
 
 
 class TestGitFixture(TestDirFixture):
@@ -147,7 +146,6 @@ class TestDvcFixture(TestGitFixture):
         logger.setLevel("DEBUG")
 
 
-# TODO: refactor? Looks like this one is only used once
 class TestDvcGitInitializedFixture(TestDvcFixture):
     def __init__(self, root_dir=None):
         super(TestDvcGitInitializedFixture, self).__init__(root_dir)
@@ -157,7 +155,6 @@ class TestDvcGitInitializedFixture(TestDvcFixture):
         self.git.init()
 
 
-# TODO: refactor? Looks like this one is only used once too
 class TestDvcDataFileFixture(TestDvcGitInitializedFixture):
     DATA_DVC_FILE = "data.dvc"
     DATA_DIR_DVC_FILE = "data_sub_dir.dvc"

--- a/tests/basic_env.py
+++ b/tests/basic_env.py
@@ -98,6 +98,7 @@ class TestDirFixture(object):
 
     def tearDown(self):
         self._popd()
+        # TODO: delete dir here
 
 
 class TestGitFixture(TestDirFixture):
@@ -146,6 +147,7 @@ class TestDvcFixture(TestGitFixture):
         logger.setLevel("DEBUG")
 
 
+# TODO: refactor? Looks like this one is only used once
 class TestDvcGitInitializedFixture(TestDvcFixture):
     def __init__(self, root_dir=None):
         super(TestDvcGitInitializedFixture, self).__init__(root_dir)
@@ -155,6 +157,7 @@ class TestDvcGitInitializedFixture(TestDvcFixture):
         self.git.init()
 
 
+# TODO: refactor? Looks like this one is only used once too
 class TestDvcDataFileFixture(TestDvcGitInitializedFixture):
     DATA_DVC_FILE = "data.dvc"
     DATA_DIR_DVC_FILE = "data_sub_dir.dvc"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,50 @@
+import pytest
+from git import Repo
+from git.exc import GitCommandNotFound
+
+from dvc.repo import Repo as DvcRepo
+from .basic_env import TestDirFixture, logger
+
+
+@pytest.fixture(autouse=True)
+def debug():
+    logger.setLevel("DEBUG")
+
+
+# Wrap class like fixture as pytest-like one to avoid code duplication
+@pytest.fixture
+def repo_dir():
+    old_fixture = TestDirFixture()
+    old_fixture.setUp()
+    try:
+        yield old_fixture
+    finally:
+        old_fixture.tearDown()
+
+
+@pytest.fixture
+def git(repo_dir):
+    # NOTE: handles EAGAIN error on BSD systems (osx in our case).
+    # Otherwise when running tests you might get this exception:
+    #
+    #    GitCommandNotFound: Cmd('git') not found due to:
+    #        OSError('[Errno 35] Resource temporarily unavailable')
+    retries = 5
+    while retries:
+        try:
+            git = Repo.init()
+        except GitCommandNotFound:
+            retries -= 1
+            continue
+        break
+
+    git.index.add([repo_dir.CODE])
+    git.index.commit("add code")
+    return git
+
+
+@pytest.fixture
+def dvc(repo_dir, git):
+    dvc = DvcRepo.init(repo_dir._root_dir)
+    dvc.scm.commit("init dvc")
+    return dvc

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,8 @@ def repo_dir():
         old_fixture.tearDown()
 
 
+# NOTE: this duplicates code from GitFixture,
+#       would fix itself once class-based fixtures are removed
 @pytest.fixture
 def git(repo_dir):
     # NOTE: handles EAGAIN error on BSD systems (osx in our case).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ def repo_dir():
 
 
 # NOTE: this duplicates code from GitFixture,
-#       would fix itself once class-based fixtures are removed
+# would fix itself once class-based fixtures are removed
 @pytest.fixture
 def git(repo_dir):
     # NOTE: handles EAGAIN error on BSD systems (osx in our case).

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -12,7 +12,8 @@ from dvc.system import System
 from mock import patch
 
 from dvc.main import main
-from dvc.utils import file_md5, load_stage_file
+from dvc.utils import file_md5
+from dvc.utils.stage import load_stage_file
 from dvc.stage import Stage
 from dvc.exceptions import DvcException, RecursiveAddingWhileUsingFilename
 from dvc.output.base import OutputAlreadyTrackedError

--- a/tests/func/test_checkout.py
+++ b/tests/func/test_checkout.py
@@ -11,7 +11,8 @@ from dvc.main import main
 from dvc import progress
 from dvc.repo import Repo as DvcRepo
 from dvc.system import System
-from dvc.utils import walk_files, load_stage_file, dump_stage_file
+from dvc.utils import walk_files
+from dvc.utils.stage import load_stage_file, dump_stage_file
 from tests.basic_env import TestDvc
 from tests.func.test_repro import TestRepro
 from dvc.stage import Stage, StageFileBadNameError, StageFileDoesNotExistError

--- a/tests/func/test_checkout.py
+++ b/tests/func/test_checkout.py
@@ -2,7 +2,6 @@ import os
 import sys
 import re
 
-import yaml
 import shutil
 import filecmp
 import collections
@@ -12,7 +11,7 @@ from dvc.main import main
 from dvc import progress
 from dvc.repo import Repo as DvcRepo
 from dvc.system import System
-from dvc.utils import walk_files, load_stage_file
+from dvc.utils import walk_files, load_stage_file, dump_stage_file
 from tests.basic_env import TestDvc
 from tests.func.test_repro import TestRepro
 from dvc.stage import Stage, StageFileBadNameError, StageFileDoesNotExistError
@@ -298,14 +297,10 @@ class TestGitIgnoreWhenCheckout(CheckoutBase):
 
 class TestCheckoutMissingMd5InStageFile(TestRepro):
     def test(self):
-        with open(self.file1_stage, "r") as fd:
-            d = yaml.load(fd)
-
+        d = load_stage_file(self.file1_stage)
         del d[Stage.PARAM_OUTS][0][RemoteLOCAL.PARAM_CHECKSUM]
         del d[Stage.PARAM_DEPS][0][RemoteLOCAL.PARAM_CHECKSUM]
-
-        with open(self.file1_stage, "w") as fd:
-            yaml.dump(d, fd)
+        dump_stage_file(self.file1_stage, d)
 
         self.dvc.checkout(force=True)
 

--- a/tests/func/test_commit.py
+++ b/tests/func/test_commit.py
@@ -1,5 +1,4 @@
-import yaml
-from dvc.utils import load_stage_file
+from dvc.utils import load_stage_file, dump_stage_file
 
 from tests.basic_env import TestDvc
 from dvc.stage import StageCommitError
@@ -78,10 +77,8 @@ class TestCommitChangedMd5(TestDvc):
         stage = stages[0]
 
         st = load_stage_file(stage.path)
-
         st["md5"] = "1111111111"
-        with open(stage.path, "w") as fobj:
-            yaml.safe_dump(st, fobj, default_flow_style=False)
+        dump_stage_file(stage.path, st)
 
         with self.assertRaises(StageCommitError):
             self.dvc.commit(stage.path)

--- a/tests/func/test_commit.py
+++ b/tests/func/test_commit.py
@@ -1,4 +1,4 @@
-from dvc.utils import load_stage_file, dump_stage_file
+from dvc.utils.stage import load_stage_file, dump_stage_file
 
 from tests.basic_env import TestDvc
 from dvc.stage import StageCommitError

--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -26,7 +26,8 @@ from dvc.data_cloud import (
     RemoteHTTP,
 )
 from dvc.remote.base import STATUS_OK, STATUS_NEW, STATUS_DELETED
-from dvc.utils import file_md5, load_stage_file, dump_stage_file
+from dvc.utils import file_md5
+from dvc.utils.stage import load_stage_file, dump_stage_file
 
 from tests.basic_env import TestDvc
 from tests.utils import spy

--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -641,7 +641,6 @@ class TestWarnOnOutdatedStage(TestDvc):
 
             assert expected_warning in self._caplog.text
 
-    # ASK: why?
     def test(self):
         self._test()
 

--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -6,7 +6,6 @@ import uuid
 import shutil
 import getpass
 import platform
-import yaml
 import copy
 import logging
 
@@ -27,7 +26,7 @@ from dvc.data_cloud import (
     RemoteHTTP,
 )
 from dvc.remote.base import STATUS_OK, STATUS_NEW, STATUS_DELETED
-from dvc.utils import file_md5, load_stage_file
+from dvc.utils import file_md5, load_stage_file, dump_stage_file
 
 from tests.basic_env import TestDvc
 from tests.utils import spy
@@ -629,8 +628,7 @@ class TestWarnOnOutdatedStage(TestDvc):
         stage_file_path = stage.relpath
         content = load_stage_file(stage_file_path)
         del content["outs"][0]["md5"]
-        with open(stage_file_path, "w") as stage_file:
-            yaml.dump(content, stage_file)
+        dump_stage_file(stage_file_path, content)
 
         with self._caplog.at_level(logging.WARNING, logger="dvc"):
             self._caplog.clear()
@@ -643,6 +641,7 @@ class TestWarnOnOutdatedStage(TestDvc):
 
             assert expected_warning in self._caplog.text
 
+    # ASK: why?
     def test(self):
         self._test()
 

--- a/tests/func/test_move.py
+++ b/tests/func/test_move.py
@@ -3,7 +3,7 @@ import os
 from dvc.main import main
 from dvc.exceptions import DvcException, MoveNotDataSourceError
 from dvc.stage import Stage
-from dvc.utils import load_stage_file
+from dvc.utils.stage import load_stage_file
 
 from tests.basic_env import TestDvc
 from tests.func.test_repro import TestRepro

--- a/tests/func/test_repro.py
+++ b/tests/func/test_repro.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from dvc.utils.compat import str, Path
 
 import os

--- a/tests/func/test_repro.py
+++ b/tests/func/test_repro.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from dvc.utils.compat import str, Path
+from dvc.utils.compat import str, urljoin, Path
 
 import os
 import re
@@ -18,8 +18,8 @@ import pytest
 
 from dvc.main import main
 from dvc.repo import Repo as DvcRepo
-from dvc.utils import file_md5, load_stage_file, dump_stage_file
-from dvc.utils.compat import urljoin
+from dvc.utils import file_md5
+from dvc.utils.stage import load_stage_file, dump_stage_file
 from dvc.remote.local import RemoteLOCAL
 from dvc.stage import Stage, StageFileDoesNotExistError
 from dvc.system import System

--- a/tests/func/test_repro.py
+++ b/tests/func/test_repro.py
@@ -1370,9 +1370,6 @@ class TestShouldDisplayMetricsOnReproWithMetricsOption(TestDvc):
         self.assertIn(expected_metrics_display, self._caplog.text)
 
 
-# Pytest style tests
-
-
 @pytest.fixture
 def foo_copy(repo_dir, dvc):
     stages = dvc.add(repo_dir.FOO)

--- a/tests/func/test_run.py
+++ b/tests/func/test_run.py
@@ -5,7 +5,6 @@ import mock
 import shutil
 import filecmp
 import subprocess
-import yaml
 
 from dvc.main import main
 from dvc.output import OutputBase
@@ -615,15 +614,13 @@ class TestCmdRunWorkingDirectory(TestDvc):
         stage = self.dvc.run(
             cmd="echo test > {}".format(self.FOO), outs=[self.FOO], wdir="."
         )
-        with open(stage.relpath, "r") as fobj:
-            d = yaml.safe_load(fobj)
+        d = load_stage_file(stage.relpath)
         self.assertEqual(d[Stage.PARAM_WDIR], ".")
 
         stage = self.dvc.run(
             cmd="echo test > {}".format(self.BAR), outs=[self.BAR]
         )
-        with open(stage.relpath, "r") as fobj:
-            d = yaml.safe_load(fobj)
+        d = load_stage_file(stage.relpath)
         self.assertEqual(d[Stage.PARAM_WDIR], ".")
 
     def test_fname_changes_path_and_wdir(self):
@@ -640,8 +637,7 @@ class TestCmdRunWorkingDirectory(TestDvc):
         )
 
         # Check that it is dumped properly (relative to fname)
-        with open(stage.relpath, "r") as fobj:
-            d = yaml.safe_load(fobj)
+        d = load_stage_file(stage.relpath)
         self.assertEqual(d[Stage.PARAM_WDIR], "..")
 
     def test_cwd_is_ignored(self):

--- a/tests/func/test_run.py
+++ b/tests/func/test_run.py
@@ -9,7 +9,8 @@ import subprocess
 from dvc.main import main
 from dvc.output import OutputBase
 from dvc.repo import Repo as DvcRepo
-from dvc.utils import file_md5, load_stage_file
+from dvc.utils import file_md5
+from dvc.utils.stage import load_stage_file
 from dvc.system import System
 from dvc.stage import Stage, StagePathNotFoundError, StagePathNotDirectoryError
 from dvc.stage import StageFileBadNameError, MissingDep

--- a/tests/func/test_stage.py
+++ b/tests/func/test_stage.py
@@ -1,4 +1,3 @@
-import yaml
 import tempfile
 import os
 
@@ -6,7 +5,7 @@ from dvc.main import main
 from dvc.output.local import OutputLOCAL
 from dvc.remote.local import RemoteLOCAL
 from dvc.stage import Stage, StageFileFormatError
-from dvc.utils import load_stage_file
+from dvc.utils import load_stage_file, dump_stage_file
 
 from tests.basic_env import TestDvc
 
@@ -74,8 +73,6 @@ class TestSchemaDepsOuts(TestSchema):
 
 class TestReload(TestDvc):
     def test(self):
-        import yaml
-
         stages = self.dvc.add(self.FOO)
         self.assertEqual(len(stages), 1)
         stage = stages[0]
@@ -86,9 +83,7 @@ class TestReload(TestDvc):
         # NOTE: checking that reloaded stage didn't change its checksum
         md5 = "11111111111111111111111111111111"
         d[stage.PARAM_MD5] = md5
-
-        with open(stage.relpath, "w") as fobj:
-            yaml.safe_dump(d, fobj, default_flow_style=False)
+        dump_stage_file(stage.relpath, d)
 
         stage = Stage.load(self.dvc, stage.relpath)
         self.assertTrue(stage is not None)
@@ -109,16 +104,13 @@ class TestDefaultWorkingDirectory(TestDvc):
         d = stage.dumpd()
         self.assertEqual(d[stage.PARAM_WDIR], ".")
 
-        with open(stage.relpath, "r") as fobj:
-            d = yaml.safe_load(fobj)
+        d = load_stage_file(stage.relpath)
         self.assertEqual(d[stage.PARAM_WDIR], ".")
 
         del d[stage.PARAM_WDIR]
-        with open(stage.relpath, "w") as fobj:
-            yaml.safe_dump(d, fobj, default_flow_style=False)
+        dump_stage_file(stage.relpath, d)
 
-        with open(stage.relpath, "r") as fobj:
-            d = yaml.safe_load(fobj)
+        d = load_stage_file(stage.relpath)
         self.assertIsNone(d.get(stage.PARAM_WDIR))
 
         with self.dvc.state:

--- a/tests/func/test_stage.py
+++ b/tests/func/test_stage.py
@@ -5,7 +5,7 @@ from dvc.main import main
 from dvc.output.local import OutputLOCAL
 from dvc.remote.local import RemoteLOCAL
 from dvc.stage import Stage, StageFileFormatError
-from dvc.utils import load_stage_file, dump_stage_file
+from dvc.utils.stage import load_stage_file, dump_stage_file
 
 from tests.basic_env import TestDvc
 

--- a/tests/func/test_stage.py
+++ b/tests/func/test_stage.py
@@ -157,3 +157,13 @@ class TestExternalRemoteResolution(TestDvc):
         assert main(["import", "remote://storage/file", "movie.txt"]) == 0
 
         assert os.path.exists("movie.txt")
+
+
+def test_md5_ignores_comments(repo_dir, dvc):
+    stage, = dvc.add("foo")
+
+    with open(stage.path, "a") as f:
+        f.write("# End comment\n")
+
+    new_stage = Stage.load(dvc, stage.path)
+    assert not new_stage.changed_md5()

--- a/tests/func/test_tag.py
+++ b/tests/func/test_tag.py
@@ -4,6 +4,7 @@ import filecmp
 import logging
 
 from dvc.main import main
+from dvc.utils import from_yaml_string
 
 from tests.basic_env import TestDvc
 
@@ -64,20 +65,19 @@ class TestTagAll(TestDvc):
         ret = main(["tag", "list"])
         self.assertEqual(ret, 0)
 
-        expected = (
-            "bar.dvc:\n"
-            "  bar:\n"
-            "    v1:\n"
-            "      md5: 8978c98bb5a48c2fb5f2c4c905768afa\n"
-            "foo.dvc:\n"
-            "  foo:\n"
-            "    v1:\n"
-            "      md5: acbd18db4cc2f85cedef654fccc4a4d8\n"
-        )
+        expected = {
+            "foo.dvc": {
+                "foo": {"v1": {"md5": "acbd18db4cc2f85cedef654fccc4a4d8"}}
+            },
+            "bar.dvc": {
+                "bar": {"v1": {"md5": "8978c98bb5a48c2fb5f2c4c905768afa"}}
+            },
+        }
 
         stdout = "\n".join(record.message for record in self._caplog.records)
+        received = from_yaml_string(stdout)
 
-        assert expected == stdout
+        assert expected == received
 
         ret = main(["tag", "remove", "v1"])
         self.assertEqual(ret, 0)

--- a/tests/unit/utils/test_collections.py
+++ b/tests/unit/utils/test_collections.py
@@ -1,0 +1,49 @@
+from dvc.utils.collections import apply_diff
+
+
+class MyDict(dict):
+    pass
+
+
+class MyInt(int):
+    pass
+
+
+def test_apply_diff_is_inplace():
+    dest = MyDict()
+    dest.attr = 42
+    apply_diff({}, dest)
+
+    assert type(dest) is MyDict, "Preserves class"
+    assert dest.attr == 42, "Preserves custom attrs"
+
+
+def test_apply_diff_mapping():
+    src = {"a": 1}
+    dest = {"b": 2}
+    apply_diff(src, dest)
+    assert dest == src, "Adds and removes keys"
+
+    src = {"a": 1}
+    dest = {"a": MyInt(1)}
+    apply_diff(src, dest)
+    assert type(dest["a"]) is MyInt, "Does not replace equals"
+
+    src = {"d": {"a": 1}}
+    inner = {}
+    dest = {"d": inner}
+    apply_diff(src, dest)
+    assert dest["d"] is inner, "Updates inner dicts"
+
+
+def test_apply_diff_seq():
+    src = [1]
+    dest = [MyInt(1)]
+    apply_diff(src, dest)
+    assert type(dest[0]) is MyInt, "Does not replace equals"
+
+    src = {"l": [1]}
+    inner = []
+    dest = {"l": inner}
+    apply_diff(src, dest)
+    assert dest["l"] is inner, "Updates inner lists"

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,4 +1,3 @@
-import yaml
 import os
 
 from dvc.scm import Git
@@ -20,11 +19,6 @@ def spy(method_to_decorate):
 def get_gitignore_content():
     with open(Git.GITIGNORE, "r") as gitignore:
         return gitignore.read().splitlines()
-
-
-def load_stage_file(path):
-    with open(path, "r") as fobj:
-        return yaml.safe_load(fobj)
 
 
 @contextmanager


### PR DESCRIPTION
This PR does several things:
- ensures comments and custom string layout in stage files are retained in the load/dump cycle.
- replaces `PyYAML` with `ruamel.yaml`
- fixes broken abstraction of saving/loading dvc files directly via yaml lib, mostly in tests. Now `load_stage_file()` and `dump_stage_file()` is used everywhere.
- adds pytest like fixtures to write functional tests with test dir 
- ensures utf-8 is always used in stage files regardless of OS default encoding
- ensures stage files are always properly closed 

**NOTE:** This does not include support for custom fields in stage files. That would go in separate PR.