### PR TITLE
dvc: meta in stage

### DIFF
--- a/dvc/stage.py
+++ b/dvc/stage.py
@@ -125,6 +125,7 @@ class Stage(object):
     PARAM_DEPS = "deps"
     PARAM_OUTS = "outs"
     PARAM_LOCKED = "locked"
+    PARAM_META = "meta"
 
     SCHEMA = {
         Optional(PARAM_MD5): Or(str, None),
@@ -133,6 +134,7 @@ class Stage(object):
         Optional(PARAM_DEPS): Or(And(list, Schema([dependency.SCHEMA])), None),
         Optional(PARAM_OUTS): Or(And(list, Schema([output.SCHEMA])), None),
         Optional(PARAM_LOCKED): bool,
+        Optional(PARAM_META): object,
     }
 
     TAG_REGEX = r"^(?P<path>.*)@(?P<tag>[^\\/@:]*)$"
@@ -612,6 +614,7 @@ class Stage(object):
                 Stage.PARAM_LOCKED: self.locked,
                 Stage.PARAM_DEPS: [d.dumpd() for d in self.deps],
                 Stage.PARAM_OUTS: [o.dumpd() for o in self.outs],
+                Stage.PARAM_META: self._state.get("meta"),
             }.items()
             if value
         }

--- a/tests/func/test_stage.py
+++ b/tests/func/test_stage.py
@@ -167,3 +167,19 @@ def test_md5_ignores_comments(repo_dir, dvc):
 
     new_stage = Stage.load(dvc, stage.path)
     assert not new_stage.changed_md5()
+
+
+def test_meta_is_preserved(dvc):
+    stage, = dvc.add("foo")
+
+    # Add meta to stage file
+    data = load_stage_file(stage.path)
+    data["meta"] = {"custom_key": 42}
+    dump_stage_file(stage.path, data)
+
+    # Loading and dumping to test that it works and meta is retained
+    new_stage = Stage.load(dvc, stage.path)
+    new_stage.dump()
+
+    new_data = load_stage_file(stage.path)
+    assert new_data["meta"] == data["meta"]


### PR DESCRIPTION
Add `meta` key to stage files to store arbitrary user data.

This is second part of #1799.
This should be merged after #1885.

