### PR TITLE
Replace yield_fixture()

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,14 +69,14 @@ user = "user"
 key_path = os.path.join(here, "{0}.key".format(user))
 
 
-@pytest.yield_fixture()
+@pytest.fixture
 def ssh_server():
     users = {user: key_path}
     with mockssh.Server(users) as s:
         yield s
 
 
-@pytest.yield_fixture()
+@pytest.fixture
 def ssh(ssh_server):
     yield SSHConnection(
         ssh_server.host,


### PR DESCRIPTION
Because yield_fixture() is deprecated since pytest 3.0 [1]. It is
not recommend to use the decorator instead of fixture().

[1] https://docs.pytest.org/en/latest/yieldfixture.html