### PR TITLE
dvc: add progress bar when hashing a large dir

### DIFF
--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -126,6 +126,16 @@ class Progress(object):
             self.refresh()
         self._lock.release()
 
+    def __call__(self, seq, name="", total=None):
+        if total is None:
+            total = len(seq)
+
+        self.update_target(name, 0, total)
+        for done, item in enumerate(seq, start=1):
+            yield item
+            self.update_target(name, done, total)
+        self.finish_target(name)
+
 
 class ProgressCallback(object):
     def __init__(self, total):

--- a/tests/func/test_remote.py
+++ b/tests/func/test_remote.py
@@ -1,5 +1,6 @@
 import os
 import configobj
+from mock import patch
 
 from dvc.main import main
 from dvc.command.remote import CmdRemoteAdd
@@ -169,3 +170,16 @@ class TestRemoteShouldHandleUppercaseRemoteName(TestDvc):
 
         ret = main(["push", "-r", self.upper_case_remote_name])
         self.assertEqual(ret, 0)
+
+
+def test_large_dir_progress(repo_dir, dvc):
+    from dvc.utils import LARGE_DIR_SIZE
+    from dvc.progress import progress
+
+    # Create a "large dir"
+    for i in range(LARGE_DIR_SIZE + 1):
+        repo_dir.create(os.path.join("gen", "{}.txt".format(i)), str(i))
+
+    with patch.object(progress, "update_target") as update_target:
+        dvc.add("gen")
+        assert update_target.called


### PR DESCRIPTION
Added an easier way to show progress bar over for loops as part of this. 

BTW, why don't you use [tqdm](https://github.com/tqdm/tqdm)?