### PR TITLE
test: fix tests being dependent on log level and abandon default DEBUG level

### DIFF
--- a/dvc/main.py
+++ b/dvc/main.py
@@ -24,6 +24,7 @@ def main(argv=None):
     args = None
     cmd = None
 
+    outerLogLevel = logger.level
     try:
         args = parse_args(argv)
 
@@ -46,6 +47,8 @@ def main(argv=None):
     except Exception:  # pylint: disable=broad-except
         logger.exception("unexpected error")
         ret = 255
+    finally:
+        logger.setLevel(outerLogLevel)
 
     Analytics().send_cmd(cmd, args, ret)
 

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -18,7 +18,7 @@ else:
     params = " ".join(sys.argv[1:])
 
 cmd = (
-    "py.test -v -n=4 --timeout=600 --timeout_method=thread --cov=dvc "
-    "{params} ".format(params=params)
+    "py.test -v -n=4 --timeout=600 --timeout_method=thread --log-level=debug"
+    " --cov=dvc {params} ".format(params=params)
 )
 check_call(cmd, shell=True)

--- a/tests/basic_env.py
+++ b/tests/basic_env.py
@@ -163,7 +163,6 @@ class TestDvcFixture(TestGitFixture):
         super(TestDvcFixture, self).setUp()
         self.dvc = DvcRepo.init(self._root_dir)
         self.dvc.scm.commit("init dvc")
-        logger.setLevel("DEBUG")
 
     def tearDown(self):
         self.dvc.scm.git.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,8 +11,16 @@ from .basic_env import TestDirFixture
 
 
 @pytest.fixture(autouse=True)
-def debug(caplog):
-    with caplog.at_level("DEBUG", logger="dvc"):
+def reset_loglevel(request, caplog):
+    """
+    Use it to ensure log level at the start of each test
+    regardless of dvc.logger.setup(), Repo configs or whatever.
+    """
+    level = request.config.getoption("--log-level")
+    if level:
+        with caplog.at_level(level.upper(), logger="dvc"):
+            yield
+    else:
         yield
 
 


### PR DESCRIPTION
This is part of #1888.