### PR TITLE
test: never run updater nor analytics in tests

### DIFF
--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -10,12 +10,8 @@ os.putenv(
     "PATH", "{}:{}".format(os.path.join(REPO_ROOT, "bin"), os.getenv("PATH"))
 )
 os.putenv("DVC_HOME", REPO_ROOT)
-os.putenv("DVC_TEST", "true")
 
-if len(sys.argv) == 1:
-    params = ""
-else:
-    params = " ".join(sys.argv[1:])
+params = " ".join(sys.argv[1:])
 
 cmd = (
     "py.test -v -n=4 --timeout=600 --timeout_method=thread --cov=dvc "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,14 @@ import os
 from git import Repo
 from git.exc import GitCommandNotFound
 
+from dvc.utils.compat import cast_bytes_py2
 from dvc.remote.ssh.connection import SSHConnection
 from dvc.repo import Repo as DvcRepo
 from .basic_env import TestDirFixture
+
+
+# Prevent updater and analytics from running their processes
+os.environ[cast_bytes_py2("DVC_TEST")] = cast_bytes_py2("true")
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Previously that was only the case when running tests via `python
-mtests` wrapper.

Part of #1888.