### PR TITLE
remote: base: dump dir_info json with sorted keys

### DIFF
--- a/tests/func/test_remote.py
+++ b/tests/func/test_remote.py
@@ -1,5 +1,6 @@
 import os
 import configobj
+from dvc.remote.base import RemoteBase
 from mock import patch
 
 from dvc.main import main
@@ -183,3 +184,40 @@ def test_large_dir_progress(repo_dir, dvc):
     with patch.object(progress, "update_target") as update_target:
         dvc.add("gen")
         assert update_target.called
+
+
+def test_dir_checksum_should_be_key_order_agnostic(dvc):
+    data_dir = os.path.join(dvc.root_dir, "data")
+    file1 = os.path.join(data_dir, "1")
+    file2 = os.path.join(data_dir, "2")
+
+    os.mkdir(data_dir)
+    with open(file1, "w") as fobj:
+        fobj.write("1")
+
+    with open(file2, "w") as fobj:
+        fobj.write("2")
+
+    path_info = {"scheme": "local", "path": data_dir}
+    with dvc.state:
+        with patch.object(
+            RemoteBase,
+            "_collect_dir",
+            return_value=[
+                {"relpath": "1", "md5": "1"},
+                {"relpath": "2", "md5": "2"},
+            ],
+        ):
+            checksum1 = dvc.cache.local.get_dir_checksum(path_info)
+
+        with patch.object(
+            RemoteBase,
+            "_collect_dir",
+            return_value=[
+                {"md5": "1", "relpath": "1"},
+                {"md5": "2", "relpath": "2"},
+            ],
+        ):
+            checksum2 = dvc.cache.local.get_dir_checksum(path_info)
+
+    assert checksum1 == checksum2


### PR DESCRIPTION
* [x] Have you followed the guidelines in our
      [Contributing document](https://dvc.org/doc/user-guide/contributing)?

* [x] Does your PR affect documented changes or does it add new functionality
      that should be documented? If yes, have you created a PR for
      [dvc.org](https://github.com/iterative/dvc.org) documenting it or at
      least opened an issue for it? If so, please add a link to it.

-----
After change https://github.com/iterative/dvc/pull/1892/commits/00cfb04fea046946c0604985b3336e35bf7afd56

we did not dump directory info as json sorted by keys (as we used to), which resulted with different checksums calculation. That could lead to situation where user:
- `git checkout && dvc pull` 
- `dvc status` returning "repo changed", if repo was created before mentioned commit. (E.g: our sample project: https://github.com/iterative/example-get-started)
