### PR TITLE
remote: add support for ssh config

### DIFF
--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -40,14 +40,7 @@ class RemoteSSH(RemoteBase):
         parsed = urlparse(self.url)
         self.host = parsed.hostname
 
-        user_config_file = os.path.expanduser("~/.ssh/config")
-        user_ssh_config = dict()
-        if self.host:
-            if os.path.exists(user_config_file):
-                with open(user_config_file) as f:
-                    ssh_config = paramiko.SSHConfig()
-                    ssh_config.parse(f)
-                    user_ssh_config = ssh_config.lookup(self.host)
+        user_ssh_config = self._load_user_ssh_config(self.host)
 
         self.user = (
             config.get(Config.SECTION_REMOTE_USER)
@@ -75,6 +68,17 @@ class RemoteSSH(RemoteBase):
             "user": self.user,
             "port": self.port,
         }
+
+    @staticmethod
+    def _load_user_ssh_config(hostname):
+        user_config_file = os.path.expanduser("~/.ssh/config")
+        user_ssh_config = dict()
+        if hostname and os.path.exists(user_config_file):
+            with open(user_config_file) as f:
+                ssh_config = paramiko.SSHConfig()
+                ssh_config.parse(f)
+                user_ssh_config = ssh_config.lookup(hostname)
+        return user_ssh_config
 
     def ssh(self, host=None, user=None, port=None, **kwargs):
         logger.debug(

--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -73,8 +73,12 @@ class RemoteSSH(RemoteBase):
         }
 
     @staticmethod
+    def ssh_config_filename():
+        return os.path.expanduser(os.path.join("~", ".ssh", "config"))
+
+    @staticmethod
     def _load_user_ssh_config(hostname):
-        user_config_file = os.path.expanduser("~/.ssh/config")
+        user_config_file = RemoteSSH.ssh_config_filename()
         user_ssh_config = dict()
         if hostname and os.path.exists(user_config_file):
             with open(user_config_file) as f:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,7 +4,7 @@ pytest-cov>=2.6.1
 pytest-xdist>=1.26.1
 pytest-mock>=1.10.4
 flaky>=3.5.3
-mock>=2.0.0
+mock>=3.0.0
 xmltodict>=0.11.0
 awscli>=1.16.125
 google-compute-engine

--- a/tests/unit/remote/ssh/test_ssh.py
+++ b/tests/unit/remote/ssh/test_ssh.py
@@ -4,8 +4,7 @@ import sys
 
 from unittest import TestCase
 
-import mock
-from mock import patch
+from mock import patch, mock_open
 import pytest
 
 from dvc.remote.ssh import RemoteSSH
@@ -53,24 +52,6 @@ Host example.com
    Port 1234
    IdentityFile ~/.ssh/not_default.key
 """
-
-# compat version for mock library version 2
-# mock 2.0.0 can't iterate in mock_open
-if mock.version_info[0] < 3:
-
-    def mock_open_compat(*args, **kargs):
-        f_open = mock.mock_open(*args, **kargs)
-        if sys.version_info.major == 3:
-            f_open.return_value.__iter__ = lambda self: self
-            f_open.return_value.__next__ = lambda self: self.readline()
-        else:
-            f_open.return_value.__iter__ = lambda self: iter(self.readline, "")
-
-        return f_open
-
-    mock_open = mock_open_compat
-else:
-    mock_open = mock.mock_open
 
 if sys.version_info.major == 3:
     builtin_module_name = "builtins"

--- a/tests/unit/remote/ssh/test_ssh.py
+++ b/tests/unit/remote/ssh/test_ssh.py
@@ -96,8 +96,8 @@ def test_ssh_host_override_from_config(
 ):
     remote = RemoteSSH(None, config)
 
-    mock_exists.assert_called_with(os.path.expanduser("~/.ssh/config"))
-    mock_file.assert_called_with(os.path.expanduser("~/.ssh/config"))
+    mock_exists.assert_called_with(RemoteSSH.ssh_config_filename())
+    mock_file.assert_called_with(RemoteSSH.ssh_config_filename())
     assert remote.host == expected_host
 
 
@@ -124,8 +124,8 @@ def test_ssh_host_override_from_config(
 def test_ssh_user(mock_file, mock_exists, config, expected_user):
     remote = RemoteSSH(None, config)
 
-    mock_exists.assert_called_with(os.path.expanduser("~/.ssh/config"))
-    mock_file.assert_called_with(os.path.expanduser("~/.ssh/config"))
+    mock_exists.assert_called_with(RemoteSSH.ssh_config_filename())
+    mock_file.assert_called_with(RemoteSSH.ssh_config_filename())
     assert remote.user == expected_user
 
 
@@ -149,8 +149,8 @@ def test_ssh_user(mock_file, mock_exists, config, expected_user):
 def test_ssh_port(mock_file, mock_exists, config, expected_port):
     remote = RemoteSSH(None, config)
 
-    mock_exists.assert_called_with(os.path.expanduser("~/.ssh/config"))
-    mock_file.assert_called_with(os.path.expanduser("~/.ssh/config"))
+    mock_exists.assert_called_with(RemoteSSH.ssh_config_filename())
+    mock_file.assert_called_with(RemoteSSH.ssh_config_filename())
     assert remote.port == expected_port
 
 
@@ -184,6 +184,6 @@ def test_ssh_port(mock_file, mock_exists, config, expected_port):
 def test_ssh_keyfile(mock_file, mock_exists, config, expected_keyfile):
     remote = RemoteSSH(None, config)
 
-    mock_exists.assert_called_with(os.path.expanduser("~/.ssh/config"))
-    mock_file.assert_called_with(os.path.expanduser("~/.ssh/config"))
+    mock_exists.assert_called_with(RemoteSSH.ssh_config_filename())
+    mock_file.assert_called_with(RemoteSSH.ssh_config_filename())
     assert remote.keyfile == expected_keyfile

--- a/tests/unit/remote/ssh/test_ssh.py
+++ b/tests/unit/remote/ssh/test_ssh.py
@@ -63,10 +63,11 @@ Host example.com
 @patch("os.path.exists", return_value=True)
 @patch("builtins.open", new_callable=mock_open, read_data=mock_ssh_config)
 def test_ssh_host_override_from_config(
-    mock_exists, mock_file, config, expected_host
+    mock_file, mock_exists, config, expected_host
 ):
     remote = RemoteSSH(None, config)
 
+    mock_exists.assert_called_with(os.path.expanduser("~/.ssh/config"))
     mock_file.assert_called_with(os.path.expanduser("~/.ssh/config"))
     assert remote.host == expected_host
 
@@ -87,9 +88,10 @@ def test_ssh_host_override_from_config(
 )
 @patch("os.path.exists", return_value=True)
 @patch("builtins.open", new_callable=mock_open, read_data=mock_ssh_config)
-def test_ssh_user(mock_exists, mock_file, config, expected_user):
+def test_ssh_user(mock_file, mock_exists, config, expected_user):
     remote = RemoteSSH(None, config)
 
+    mock_exists.assert_called_with(os.path.expanduser("~/.ssh/config"))
     mock_file.assert_called_with(os.path.expanduser("~/.ssh/config"))
     assert remote.user == expected_user
 
@@ -107,9 +109,10 @@ def test_ssh_user(mock_exists, mock_file, config, expected_user):
 )
 @patch("os.path.exists", return_value=True)
 @patch("builtins.open", new_callable=mock_open, read_data=mock_ssh_config)
-def test_ssh_port(mock_exists, mock_file, config, expected_port):
+def test_ssh_port(mock_file, mock_exists, config, expected_port):
     remote = RemoteSSH(None, config)
 
+    mock_exists.assert_called_with(os.path.expanduser("~/.ssh/config"))
     mock_file.assert_called_with(os.path.expanduser("~/.ssh/config"))
     assert remote.port == expected_port
 
@@ -137,7 +140,7 @@ def test_ssh_port(mock_exists, mock_file, config, expected_port):
 )
 @patch("os.path.exists", return_value=True)
 @patch("builtins.open", new_callable=mock_open, read_data=mock_ssh_config)
-def test_ssh_keyfile(mock_exists, mock_file, config, expected_keyfile):
+def test_ssh_keyfile(mock_file, mock_exists, config, expected_keyfile):
     remote = RemoteSSH(None, config)
 
     mock_exists.assert_called_with(os.path.expanduser("~/.ssh/config"))

--- a/tests/unit/remote/ssh/test_ssh.py
+++ b/tests/unit/remote/ssh/test_ssh.py
@@ -60,8 +60,11 @@ Host example.com
         ({"url": "ssh://not_in_ssh_config.com"}, "not_in_ssh_config.com"),
     ],
 )
+@patch("os.path.exists", return_value=True)
 @patch("builtins.open", new_callable=mock_open, read_data=mock_ssh_config)
-def test_ssh_host_override_from_config(mock_file, config, expected_host):
+def test_ssh_host_override_from_config(
+    mock_exists, mock_file, config, expected_host
+):
     remote = RemoteSSH(None, config)
 
     mock_file.assert_called_with(os.path.expanduser("~/.ssh/config"))
@@ -82,8 +85,9 @@ def test_ssh_host_override_from_config(mock_file, config, expected_host):
         ({"url": "ssh://not_in_ssh_config.com"}, getpass.getuser()),
     ],
 )
+@patch("os.path.exists", return_value=True)
 @patch("builtins.open", new_callable=mock_open, read_data=mock_ssh_config)
-def test_ssh_user(mock_file, config, expected_user):
+def test_ssh_user(mock_exists, mock_file, config, expected_user):
     remote = RemoteSSH(None, config)
 
     mock_file.assert_called_with(os.path.expanduser("~/.ssh/config"))
@@ -101,8 +105,9 @@ def test_ssh_user(mock_file, config, expected_user):
         ({"url": "ssh://not_in_ssh_config.com:2222", "port": 4321}, 4321),
     ],
 )
+@patch("os.path.exists", return_value=True)
 @patch("builtins.open", new_callable=mock_open, read_data=mock_ssh_config)
-def test_ssh_port(mock_file, config, expected_port):
+def test_ssh_port(mock_exists, mock_file, config, expected_port):
     remote = RemoteSSH(None, config)
 
     mock_file.assert_called_with(os.path.expanduser("~/.ssh/config"))
@@ -130,9 +135,11 @@ def test_ssh_port(mock_file, config, expected_port):
         ({"url": "ssh://not_in_ssh_config.com"}, None),
     ],
 )
+@patch("os.path.exists", return_value=True)
 @patch("builtins.open", new_callable=mock_open, read_data=mock_ssh_config)
-def test_ssh_keyfile(mock_file, config, expected_keyfile):
+def test_ssh_keyfile(mock_exists, mock_file, config, expected_keyfile):
     remote = RemoteSSH(None, config)
 
+    mock_exists.assert_called_with(os.path.expanduser("~/.ssh/config"))
     mock_file.assert_called_with(os.path.expanduser("~/.ssh/config"))
     assert remote.keyfile == expected_keyfile


### PR DESCRIPTION
* [x] Have you followed the guidelines in our
      [Contributing document](https://dvc.org/doc/user-guide/contributing)?

* [x] Does your PR affect documented changes or does it add new functionality
      that should be documented? If yes, have you created a PR for
      [dvc.org](https://github.com/iterative/dvc.org) documenting it or at
      least opened an issue for it? If so, please add a link to it. Created PR [dvc.org#290](https://github.com/iterative/dvc.org/pull/290)

-----
Fixes #1613

Add parsing user ssh config for username and port. However settings from remote url has the priority over ssh config.