### PR TITLE
pyinstaller: fix build for oss2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ configparser>=3.5.0
 zc.lockfile>=1.2.1
 future>=0.16.0
 google-cloud-storage==1.13.0
-PyInstaller==3.3.1
+PyInstaller==3.4
 colorama>=0.3.9
 configobj>=5.0.6
 networkx>=2.1

--- a/scripts/hooks/hook-Crypto.py
+++ b/scripts/hooks/hook-Crypto.py
@@ -1,0 +1,60 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2005-2019, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+# -----------------------------------------------------------------------------
+
+"""
+Hook for PyCryptodome library: https://pypi.python.org/pypi/pycryptodome
+
+PyCryptodome is an almost drop-in replacement for the now unmaintained
+PyCrypto library. The two are mutually exclusive as they live under
+the same package ("Crypto").
+
+PyCryptodome distributes dynamic libraries and builds them as if they were
+Python C extensions (even though they are not extensions - as they can't be
+imported by Python). It might sound a bit weird, but this decision is rooted
+in PyPy and its partial and slow support for C extensions. However, this also
+invalidates several of the existing methods used by PyInstaller to decide the
+right files to pull in.
+
+Even though this hook is meant to help with PyCryptodome only, it will be
+triggered also when PyCrypto is installed, so it must be tested with both.
+
+Tested with PyCryptodome 3.5.1, PyCrypto 2.6.1, Python 2.7 & 3.6, Fedora &
+Windows
+"""
+
+import os
+import glob
+
+from PyInstaller.compat import EXTENSION_SUFFIXES
+from PyInstaller.utils.hooks import get_module_file_attribute
+
+# Include the modules as binaries in a subfolder named like the package.
+# Cryptodome's loader expects to find them inside the package directory for
+# the main module. We cannot use hiddenimports because that would add the
+# modules outside the package.
+
+binaries = []
+binary_module_names = [
+    "Crypto.Math",  # First in the list
+    "Crypto.Cipher",
+    "Crypto.Util",
+    "Crypto.Hash",
+    "Crypto.Protocol",
+]
+
+try:
+    for module_name in binary_module_names:
+        m_dir = os.path.dirname(get_module_file_attribute(module_name))
+        for ext in EXTENSION_SUFFIXES:
+            module_bin = glob.glob(os.path.join(m_dir, "_*%s" % ext))
+            for f in module_bin:
+                binaries.append((f, module_name.replace(".", os.sep)))
+except ImportError:
+    # Do nothing for PyCrypto (Crypto.Math does not exist there)
+    pass

--- a/scripts/hooks/hook-aliyunsdkcore.py
+++ b/scripts/hooks/hook-aliyunsdkcore.py
@@ -1,0 +1,3 @@
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files("aliyunsdkcore")

--- a/scripts/hooks/hook-google.api.py
+++ b/scripts/hooks/hook-google.api.py
@@ -1,3 +1,0 @@
-from PyInstaller.utils.hooks import copy_metadata
-
-datas = copy_metadata("google-api-core")

--- a/scripts/hooks/hook-google.cloud.py
+++ b/scripts/hooks/hook-google.cloud.py
@@ -1,4 +1,0 @@
-from PyInstaller.utils.hooks import copy_metadata
-
-datas = copy_metadata("google-cloud-core")
-hiddenimports = ["google.api"]


### PR DESCRIPTION
This version added support for oss as a remote, which has caused some
issues when building the binary package. To fix those, we need two
pyinstaller hools:

1) hook-Crypto.py
    This one has been added to PyInstaller's upstream, but wasn't
    released yet, so we are using an upstream hook for now.

2) hook-aliyunsdkcore.py
    This one is a new one. Sent it to PyInstaller's team in a PR [1].

[1] https://github.com/pyinstaller/pyinstaller/pull/4228

Signed-off-by: Ruslan Kuprieiev <ruslan@iterative.ai>

* [x] Have you followed the guidelines in our
      [Contributing document](https://dvc.org/doc/user-guide/contributing)?

* [x] Does your PR affect documented changes or does it add new functionality
      that should be documented? If yes, have you created a PR for
      [dvc.org](https://github.com/iterative/dvc.org) documenting it or at
      least opened an issue for it? If so, please add a link to it.

-----
