### PR TITLE
refactor: rely on RemoteBasic._changed_dir_cache

### DIFF
--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -524,14 +524,7 @@ class RemoteBASE(object):
 
         return True
 
-    def _changed_cache_dir(self):
-        # NOTE: only implemented for RemoteLOCAL
-        return True
-
     def _changed_dir_cache(self, checksum):
-        if not self._changed_cache_dir():
-            return False
-
         if self.changed_cache_file(checksum):
             return True
 

--- a/dvc/remote/local/__init__.py
+++ b/dvc/remote/local/__init__.py
@@ -495,7 +495,7 @@ class RemoteLOCAL(RemoteBASE):
             download=True,
         )
 
-    def _changed_cache_dir(self):
+    def _changed_dir_cache(self, checksum):
         mtime, size = get_mtime_and_size(self.cache_dir)
         inode = get_inode(self.cache_dir)
 
@@ -506,7 +506,10 @@ class RemoteLOCAL(RemoteBASE):
         else:
             changed = True
 
-        return changed
+        if not changed:
+            return False
+
+        return super(RemoteLOCAL, self)._changed_dir_cache(checksum)
 
     def _log_missing_caches(self, checksum_info_dict):
         missing_caches = [


### PR DESCRIPTION
Defining `_changed_cache_dir` for the sole purpose of executing
code before `_changed_dir_cache` was not that clear.

Now, it overwrites `_changed_dir_cache` but reference the
base method.

* [x] Have you followed the guidelines in our
      [Contributing document](https://dvc.org/doc/user-guide/contributing)?

* [x] Does your PR affect documented changes or does it add new functionality
      that should be documented? If yes, have you created a PR for
      [dvc.org](https://github.com/iterative/dvc.org) documenting it or at
      least opened an issue for it? If so, please add a link to it.

-----
