### PR TITLE
[RFC] tests: rename dvc repo fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,7 +67,7 @@ def git(repo_dir):
 
 
 @pytest.fixture
-def dvc(repo_dir, git):
+def dvc_repo(repo_dir, git):
     try:
         dvc = DvcRepo.init(repo_dir._root_dir)
         dvc.scm.commit("init dvc")

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -547,7 +547,7 @@ class TestAddUnprotected(TestDvc):
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows specific")
 def test_windows_should_add_when_cache_on_different_drive(
-    dvc, repo_dir, temporary_windows_drive
+    dvc_repo, repo_dir, temporary_windows_drive
 ):
     ret = main(["config", "cache.dir", temporary_windows_drive])
     assert ret == 0

--- a/tests/func/test_commit.py
+++ b/tests/func/test_commit.py
@@ -4,51 +4,51 @@ from dvc.utils.stage import load_stage_file, dump_stage_file
 from dvc.stage import StageCommitError
 
 
-def test_commit_recursive(dvc, repo_dir):
-    stages = dvc.add(repo_dir.DATA_DIR, recursive=True, no_commit=True)
+def test_commit_recursive(dvc_repo, repo_dir):
+    stages = dvc_repo.add(repo_dir.DATA_DIR, recursive=True, no_commit=True)
     assert len(stages) == 2
 
-    assert dvc.status() != {}
+    assert dvc_repo.status() != {}
 
-    dvc.commit(repo_dir.DATA_DIR, recursive=True)
+    dvc_repo.commit(repo_dir.DATA_DIR, recursive=True)
 
-    assert dvc.status() == {}
+    assert dvc_repo.status() == {}
 
 
-def test_commit_force(dvc, repo_dir):
-    stages = dvc.add(repo_dir.FOO, no_commit=True)
+def test_commit_force(dvc_repo, repo_dir):
+    stages = dvc_repo.add(repo_dir.FOO, no_commit=True)
     assert len(stages) == 1
     stage = stages[0]
 
-    with dvc.state:
+    with dvc_repo.state:
         assert stage.outs[0].changed_cache()
 
     with open(repo_dir.FOO, "a") as fobj:
         fobj.write(repo_dir.FOO_CONTENTS)
 
-    with dvc.state:
+    with dvc_repo.state:
         assert stage.outs[0].changed_cache()
 
     with pytest.raises(StageCommitError):
-        dvc.commit(stage.path)
+        dvc_repo.commit(stage.path)
 
-    with dvc.state:
+    with dvc_repo.state:
         assert stage.outs[0].changed_cache()
 
-    dvc.commit(stage.path, force=True)
+    dvc_repo.commit(stage.path, force=True)
 
-    assert dvc.status(stage.path) == {}
+    assert dvc_repo.status(stage.path) == {}
 
 
-def test_commit_with_deps(dvc, repo_dir):
-    stages = dvc.add(repo_dir.FOO, no_commit=True)
+def test_commit_with_deps(dvc_repo, repo_dir):
+    stages = dvc_repo.add(repo_dir.FOO, no_commit=True)
     assert len(stages) == 1
     foo_stage = stages[0]
     assert foo_stage is not None
     assert len(foo_stage.outs) == 1
 
     fname = "file"
-    stage = dvc.run(
+    stage = dvc_repo.run(
         cmd="python {} {} {}".format(repo_dir.CODE, repo_dir.FOO, fname),
         outs=[fname],
         deps=[repo_dir.FOO, repo_dir.CODE],
@@ -57,18 +57,18 @@ def test_commit_with_deps(dvc, repo_dir):
     assert stage is not None
     assert len(stage.outs) == 1
 
-    with dvc.state:
+    with dvc_repo.state:
         assert foo_stage.outs[0].changed_cache()
         assert stage.outs[0].changed_cache()
 
-    dvc.commit(stage.path, with_deps=True)
-    with dvc.state:
+    dvc_repo.commit(stage.path, with_deps=True)
+    with dvc_repo.state:
         assert not foo_stage.outs[0].changed_cache()
         assert not stage.outs[0].changed_cache()
 
 
-def test_commit_changed_md5(dvc, repo_dir):
-    stages = dvc.add(repo_dir.FOO, no_commit=True)
+def test_commit_changed_md5(dvc_repo, repo_dir):
+    stages = dvc_repo.add(repo_dir.FOO, no_commit=True)
     assert len(stages) == 1
     stage = stages[0]
 
@@ -77,6 +77,6 @@ def test_commit_changed_md5(dvc, repo_dir):
     dump_stage_file(stage.path, stage_file_content)
 
     with pytest.raises(StageCommitError):
-        dvc.commit(stage.path)
+        dvc_repo.commit(stage.path)
 
-    dvc.commit(stage.path, force=True)
+    dvc_repo.commit(stage.path, force=True)

--- a/tests/func/test_dependency.py
+++ b/tests/func/test_dependency.py
@@ -17,5 +17,5 @@ def _get_dep(dvc, path):
 
 
 @pytest.mark.parametrize("url,scheme", TESTS)
-def test_scheme(dvc, url, scheme):
-    assert type(_get_dep(dvc, url)) == DEP_MAP[scheme]
+def test_scheme(dvc_repo, url, scheme):
+    assert type(_get_dep(dvc_repo, url)) == DEP_MAP[scheme]

--- a/tests/func/test_metrics.py
+++ b/tests/func/test_metrics.py
@@ -807,16 +807,16 @@ class TestShouldDisplayMetricsEvenIfMetricIsMissing(object):
 
         self._commit_metric(dvc, "master")
 
-    def test(self, dvc, caplog):
-        self.setUp(dvc)
+    def test(self, dvc_repo, caplog):
+        self.setUp(dvc_repo)
 
-        dvc.scm.checkout(self.BRANCH_MISSING_METRIC)
+        dvc_repo.scm.checkout(self.BRANCH_MISSING_METRIC)
 
         self._write_metric()
         ret = main(["run", "-M", self.METRIC_FILE])
         assert 0 == ret
 
-        self._commit_metric(dvc, self.BRANCH_MISSING_METRIC)
+        self._commit_metric(dvc_repo, self.BRANCH_MISSING_METRIC)
         os.remove(self.METRIC_FILE)
 
         ret = main(["metrics", "show", "-a"])

--- a/tests/func/test_output.py
+++ b/tests/func/test_output.py
@@ -25,5 +25,5 @@ def _get_out(dvc, path):
 
 
 @pytest.mark.parametrize("url,scheme", TESTS)
-def test_scheme(dvc, url, scheme):
-    assert type(_get_out(dvc, url)) == OUTS_MAP[scheme]
+def test_scheme(dvc_repo, url, scheme):
+    assert type(_get_out(dvc_repo, url)) == OUTS_MAP[scheme]

--- a/tests/func/test_remote.py
+++ b/tests/func/test_remote.py
@@ -174,7 +174,7 @@ class TestRemoteShouldHandleUppercaseRemoteName(TestDvc):
         self.assertEqual(ret, 0)
 
 
-def test_large_dir_progress(repo_dir, dvc):
+def test_large_dir_progress(repo_dir, dvc_repo):
     from dvc.utils import LARGE_DIR_SIZE
     from dvc.progress import progress
 
@@ -183,12 +183,12 @@ def test_large_dir_progress(repo_dir, dvc):
         repo_dir.create(os.path.join("gen", "{}.txt".format(i)), str(i))
 
     with patch.object(progress, "update_target") as update_target:
-        dvc.add("gen")
+        dvc_repo.add("gen")
         assert update_target.called
 
 
-def test_dir_checksum_should_be_key_order_agnostic(dvc):
-    data_dir = os.path.join(dvc.root_dir, "data")
+def test_dir_checksum_should_be_key_order_agnostic(dvc_repo):
+    data_dir = os.path.join(dvc_repo.root_dir, "data")
     file1 = os.path.join(data_dir, "1")
     file2 = os.path.join(data_dir, "2")
 
@@ -200,7 +200,7 @@ def test_dir_checksum_should_be_key_order_agnostic(dvc):
         fobj.write("2")
 
     path_info = PathLOCAL(path=data_dir)
-    with dvc.state:
+    with dvc_repo.state:
         with patch.object(
             RemoteBASE,
             "_collect_dir",
@@ -209,7 +209,7 @@ def test_dir_checksum_should_be_key_order_agnostic(dvc):
                 {"relpath": "2", "md5": "2"},
             ],
         ):
-            checksum1 = dvc.cache.local.get_dir_checksum(path_info)
+            checksum1 = dvc_repo.cache.local.get_dir_checksum(path_info)
 
         with patch.object(
             RemoteBASE,
@@ -219,6 +219,6 @@ def test_dir_checksum_should_be_key_order_agnostic(dvc):
                 {"md5": "2", "relpath": "2"},
             ],
         ):
-            checksum2 = dvc.cache.local.get_dir_checksum(path_info)
+            checksum2 = dvc_repo.cache.local.get_dir_checksum(path_info)
 
     assert checksum1 == checksum2

--- a/tests/func/test_repro.py
+++ b/tests/func/test_repro.py
@@ -1371,15 +1371,15 @@ class TestShouldDisplayMetricsOnReproWithMetricsOption(TestDvc):
 
 
 @pytest.fixture
-def foo_copy(repo_dir, dvc):
-    stages = dvc.add(repo_dir.FOO)
+def foo_copy(repo_dir, dvc_repo):
+    stages = dvc_repo.add(repo_dir.FOO)
     assert len(stages) == 1
     foo_stage = stages[0]
     assert foo_stage is not None
 
     fname = "foo_copy"
     stage_fname = fname + ".dvc"
-    dvc.run(
+    dvc_repo.run(
         fname=stage_fname,
         outs=[fname],
         deps=[repo_dir.FOO, repo_dir.CODE],
@@ -1388,8 +1388,8 @@ def foo_copy(repo_dir, dvc):
     return {"fname": fname, "stage_fname": stage_fname}
 
 
-def test_dvc_formatting_retained(dvc, foo_copy):
-    root = Path(dvc.root_dir)
+def test_dvc_formatting_retained(dvc_repo, foo_copy):
+    root = Path(dvc_repo.root_dir)
     stage_file = root / foo_copy["stage_fname"]
 
     # Add comments and custom formatting to stage file
@@ -1400,7 +1400,7 @@ def test_dvc_formatting_retained(dvc, foo_copy):
 
     # Rewrite data source and repro
     (root / "foo").write_text("new_foo")
-    dvc.reproduce(foo_copy["stage_fname"])
+    dvc_repo.reproduce(foo_copy["stage_fname"])
 
     # All differences should be only about md5
     assert _hide_md5(stage_text) == _hide_md5(stage_file.read_text())

--- a/tests/func/test_stage.py
+++ b/tests/func/test_stage.py
@@ -159,18 +159,18 @@ class TestExternalRemoteResolution(TestDvc):
         assert os.path.exists("movie.txt")
 
 
-def test_md5_ignores_comments(repo_dir, dvc):
-    stage, = dvc.add("foo")
+def test_md5_ignores_comments(repo_dir, dvc_repo):
+    stage, = dvc_repo.add("foo")
 
     with open(stage.path, "a") as f:
         f.write("# End comment\n")
 
-    new_stage = Stage.load(dvc, stage.path)
+    new_stage = Stage.load(dvc_repo, stage.path)
     assert not new_stage.changed_md5()
 
 
-def test_meta_is_preserved(dvc):
-    stage, = dvc.add("foo")
+def test_meta_is_preserved(dvc_repo):
+    stage, = dvc_repo.add("foo")
 
     # Add meta to stage file
     data = load_stage_file(stage.path)
@@ -178,7 +178,7 @@ def test_meta_is_preserved(dvc):
     dump_stage_file(stage.path, data)
 
     # Loading and dumping to test that it works and meta is retained
-    new_stage = Stage.load(dvc, stage.path)
+    new_stage = Stage.load(dvc_repo, stage.path)
     new_stage.dump()
 
     new_data = load_stage_file(stage.path)

--- a/tests/unit/command/test_repro.py
+++ b/tests/unit/command/test_repro.py
@@ -14,14 +14,14 @@ default_arguments = {
 }
 
 
-def test_default_arguments(dvc, mocker):
+def test_default_arguments(dvc_repo, mocker):
     cmd = CmdRepro(parse_args(["repro"]))
     mocker.patch.object(cmd.repo, "reproduce")
     cmd.run()
     cmd.repo.reproduce.assert_called_with("Dvcfile", **default_arguments)
 
 
-def test_downstream(dvc, mocker):
+def test_downstream(dvc_repo, mocker):
     cmd = CmdRepro(parse_args(["repro", "--downstream"]))
     mocker.patch.object(cmd.repo, "reproduce")
     cmd.run()

--- a/tests/unit/command/test_version.py
+++ b/tests/unit/command/test_version.py
@@ -4,7 +4,7 @@ from dvc.command.version import CmdVersion
 from dvc.cli import parse_args
 
 
-def test_run_in_repo(repo_dir, dvc):
+def test_run_in_repo(repo_dir, dvc_repo):
     cmd = CmdVersion(parse_args(["version"]))
     ret = cmd.run_cmd()
     assert ret == 0


### PR DESCRIPTION
* [x] Have you followed the guidelines in our
      [Contributing document](https://dvc.org/doc/user-guide/contributing)?

* [x] Does your PR affect documented changes or does it add new functionality
      that should be documented? If yes, have you created a PR for
      [dvc.org](https://github.com/iterative/dvc.org) documenting it or at
      least opened an issue for it? If so, please add a link to it.

-----
Currently, dvc test fixture is named `dvc` just like our package, this might cause problems, for example when mocking. 