### PR TITLE
remote: add other way to perform `cache_exists`

### DIFF
--- a/dvc/config.py
+++ b/dvc/config.py
@@ -255,6 +255,7 @@ class Config(object):  # pylint: disable=too-many-instance-attributes
     SECTION_REMOTE_TIMEOUT = "timeout"
     SECTION_REMOTE_PASSWORD = "password"
     SECTION_REMOTE_ASK_PASSWORD = "ask_password"
+    SECTION_REMOTE_NO_TRAVERSE = "no_traverse"
     SECTION_REMOTE_SCHEMA = {
         SECTION_REMOTE_URL: str,
         Optional(SECTION_AWS_REGION): str,
@@ -278,6 +279,7 @@ class Config(object):  # pylint: disable=too-many-instance-attributes
         Optional(SECTION_OSS_ACCESS_KEY_SECRET): str,
         Optional(SECTION_OSS_ENDPOINT): str,
         Optional(PRIVATE_CWD): str,
+        Optional(SECTION_REMOTE_NO_TRAVERSE, default=True): BOOL_SCHEMA,
     }
 
     SECTION_STATE = "state"

--- a/dvc/remote/azure.py
+++ b/dvc/remote/azure.py
@@ -44,6 +44,7 @@ class RemoteAZURE(RemoteBASE):
     REQUIRES = {"azure-storage-blob": BlockBlobService}
     PARAM_CHECKSUM = "etag"
     COPY_POLL_SECONDS = 5
+    SUPPORTS_NO_TRAVERSE = False
 
     def __init__(self, repo, config):
         super(RemoteAZURE, self).__init__(repo, config)

--- a/dvc/remote/hdfs.py
+++ b/dvc/remote/hdfs.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 class RemoteHDFS(RemoteBASE):
     scheme = Schemes.HDFS
     REGEX = r"^hdfs://((?P<user>.*)@)?.*$"
+    SUPPORTS_NO_TRAVERSE = False
     PARAM_CHECKSUM = "checksum"
 
     def __init__(self, repo, config):

--- a/dvc/remote/http.py
+++ b/dvc/remote/http.py
@@ -89,10 +89,22 @@ class RemoteHTTP(RemoteBASE):
             if not no_progress_bar:
                 progress.finish_target(name)
 
-    def exists(self, path_info):
-        assert not isinstance(path_info, list)
-        assert path_info.scheme == self.scheme
-        return bool(self._request("HEAD", path_info.url))
+    def exists(self, path_infos):
+        single_path = False
+
+        if not isinstance(path_infos, list):
+            single_path = True
+            path_infos = [path_infos]
+
+        results = [
+            bool(self._request("HEAD", path_info.url))
+            for path_info in path_infos
+        ]
+
+        if single_path and results:
+            return all(results)
+
+        return results
 
     def cache_exists(self, md5s):
         assert isinstance(md5s, list)

--- a/dvc/remote/local/__init__.py
+++ b/dvc/remote/local/__init__.py
@@ -248,8 +248,11 @@ class RemoteLOCAL(RemoteBASE):
         move(tmp, outp)
 
     def cache_exists(self, md5s):
-        assert isinstance(md5s, list)
-        return list(filter(lambda md5: not self.changed_cache_file(md5), md5s))
+        return [
+            checksum
+            for checksum in md5s
+            if not self.changed_cache_file(checksum)
+        ]
 
     def upload(self, from_infos, to_infos, names=None, no_progress_bar=False):
         names = self._verify_path_args(to_infos, from_infos, names)
@@ -367,7 +370,7 @@ class RemoteLOCAL(RemoteBASE):
         progress.update_target(title, 10, 100)
 
         ret = self._group(checksum_infos, show_checksums=show_checksums)
-        md5s = list(ret.keys())
+        md5s = list(ret)
 
         progress.update_target(title, 30, 100)
 

--- a/dvc/remote/oss.py
+++ b/dvc/remote/oss.py
@@ -46,6 +46,7 @@ class RemoteOSS(RemoteBASE):
     path_cls = CloudURLInfo
     REQUIRES = {"oss2": oss2}
     PARAM_CHECKSUM = "etag"
+    SUPPORTS_NO_TRAVERSE = False
     COPY_POLL_SECONDS = 5
 
     def __init__(self, repo, config):

--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -129,12 +129,20 @@ class RemoteSSH(RemoteBASE):
             password=self.password,
         )
 
-    def exists(self, path_info):
-        assert not isinstance(path_info, list)
-        assert path_info.scheme == self.scheme
+    def exists(self, path_infos):
+        single_path = False
 
-        with self.ssh(path_info) as ssh:
-            return ssh.exists(path_info.path)
+        if not isinstance(path_infos, list):
+            single_path = True
+            path_infos = [path_infos]
+
+        with self.ssh(path_infos[0]) as ssh:
+            results = [ssh.exists(path_info.path) for path_info in path_infos]
+
+        if single_path and results:
+            return all(results)
+
+        return results
 
     def get_file_checksum(self, path_info):
         if path_info.scheme != self.scheme:


### PR DESCRIPTION
Close #1762

----

`push`/`pull` depends on `status` (cloud) to figure out the difference
between the _local_ and _remote_ cache. It compares them by getting a list
of _outputs_ from the targeted stage files, and a list of files from both
caches.

```bash
dvc init --no-scm --force
rm -rf /tmp/dvc-storage && mkdir /tmp/dvc-storage
dvc remote add -d ssh ssh://localhost/tmp/dvc-storage
dvc remote modify ssh ask_password true

echo "hello" > hello
dvc add hello
# cache: b1/946ac92492d2347c6235b4d2611184

echo "goodbye" > goodbye
dvc add goodbye
# cache: 32/d6c11747e03715521007d8c84b5aff

dvc push
# targets: ["hello.dvc", "goodbye.dvc"]
# outputs:
#   - { "hello.dvc": ["hello"] }
#   - { "goodbye.dvc": ["goodbye"] }

# First approach:
# - Fetch a list of all the files in the remote cache
# - Compare the sets of files
#   + push: (local - remote) == missing files on the remote cache
#   + pull: (remote - local) == missing files on the local cache
#
# Second approach:
# - For each file on the local cache, check if it already exists on the remote
#   + Check if "b1/946ac92492d2347c6235b4d2611184" exists on remote
#   + Check if "32/d6c11747e03715521007d8c84b5aff" exists on remote
```

The first approach works when: _local_ is **huge** but _remote_ is **small**.
The second approach works when: _local_ is **small** but _remote_ is **huge**.

This is because their opperations are proportional to the number of files.

Currently, we are using the former approach, and have no way to use other one,
so it could take forever when trying to `pull` / `push` a single file when
the remote cache is bloated.

The problem can't be solved in a _general_ way, it is better to introduce
an option to explictly switch between the two approaches, this way, the users
can choose the most efficient one for their use case.

This pull requests implement such option `remote.no_traverse`, where
_traversing_ refers to fetching the whole list of files on the remote cache
(first approach). By default, it will be `True` (second approach).

We are also parallelizing the second approach, by splitting the files to
compare with the cache in batches, speeding up the comparison.


### Benchmarks

**SSH**:
- With 100K files on the remote, listing them all takes: **~45s**
- Checking 100 checksums for existance (multithreading): **~50s**

_Note: Tested on the same computer and internet connection._

### To-Do
- [ ] Add tests
- [ ] ~Add benchmarks for the rest of the remotes (maybe we can come up with a heuristic)~  (no for this PR)
- [x] ~Research and document the implications of adding this feature~ (no for this PR)