### PR TITLE
remote: support remote:// notation for push/pull/gc

### DIFF
--- a/dvc/config.py
+++ b/dvc/config.py
@@ -498,7 +498,15 @@ class Config(object):  # pylint: disable=too-many-instance-attributes
             >>> get_remote_settings("server")
             {'url': 'ssh://localhost/'}
         """
-        settings = self.config[self.SECTION_REMOTE_FMT.format(name)]
+        settings = self.config.get(
+            self.SECTION_REMOTE_FMT.format(name.lower())
+        )
+
+        if settings is None:
+            raise ConfigError(
+                "unable to find remote section '{}'".format(name)
+            )
+
         parsed = urlparse(settings["url"])
 
         # Support for cross referenced remotes.

--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -43,10 +43,16 @@ class DataCloud(object):
         "https": RemoteHTTP,
     }
 
-    def __init__(self, repo, config=None):
+    def __init__(self, repo):
         self.repo = repo
-        self._config = config
-        self._core = self._config[Config.SECTION_CORE]
+
+    @property
+    def _config(self):
+        return self.repo.config.config
+
+    @property
+    def _core(self):
+        return self._config.get(Config.SECTION_CORE, {})
 
     def get_remote(self, remote=None, command="<command>"):
         if not remote:
@@ -69,13 +75,8 @@ class DataCloud(object):
         )
 
     def _init_remote(self, remote):
-        section = Config.SECTION_REMOTE_FMT.format(remote).lower()
-        cloud_config = self._config.get(section, None)
-        if not cloud_config:
-            msg = "can't find remote section '{}' in config"
-            raise ConfigError(msg.format(section))
-
-        return Remote(self.repo, cloud_config)
+        config = self.repo.config.get_remote_settings(remote)
+        return Remote(self.repo, config)
 
     def _init_compat(self):
         name = self._core.get(Config.SECTION_CORE_CLOUD, "").strip().lower()

--- a/dvc/remote/local/slow_link_detection.py
+++ b/dvc/remote/local/slow_link_detection.py
@@ -48,7 +48,7 @@ class SlowLinkDetectorDecorator(object):
 def slow_link_guard(method):
     def call(remote_local, *args, **kwargs):
         cache_config = remote_local.repo.config.config.get(
-            Config.SECTION_CACHE
+            Config.SECTION_CACHE, {}
         )
         should_warn = cache_config.get(
             Config.SECTION_CACHE_SLOW_LINK_WARNING, True

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -75,7 +75,7 @@ class Repo(object):
             logger.setLevel(level.upper())
 
         self.cache = Cache(self)
-        self.cloud = DataCloud(self, config=self.config.config)
+        self.cloud = DataCloud(self)
         self.updater = Updater(self.dvc_dir)
 
         self.metrics = Metrics(self)

--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -235,7 +235,8 @@ def get_oss_url():
 
 class TestDataCloud(TestDvc):
     def _test_cloud(self, config, cl):
-        cloud = DataCloud(self.dvc, config=config)
+        self.dvc.config.config = config
+        cloud = DataCloud(self.dvc)
         self.assertIsInstance(cloud.get_remote(), cl)
 
     def test(self):
@@ -285,7 +286,8 @@ class TestDataCloudBase(TestDvc):
         config = copy.deepcopy(TEST_CONFIG)
         config[TEST_SECTION][Config.SECTION_REMOTE_URL] = repo
         config[TEST_SECTION][Config.SECTION_REMOTE_KEY_FILE] = keyfile
-        self.cloud = DataCloud(self.dvc, config)
+        self.dvc.config.config = config
+        self.cloud = DataCloud(self.dvc)
 
         self.assertIsInstance(self.cloud.get_remote(), self._get_cloud_class())
 
@@ -394,7 +396,8 @@ class TestRemoteGS(TestDataCloudBase):
         config[TEST_SECTION][
             Config.SECTION_GCP_CREDENTIALPATH
         ] = TEST_GCP_CREDS_FILE
-        self.cloud = DataCloud(self.dvc, config)
+        self.dvc.config.config = config
+        self.cloud = DataCloud(self.dvc)
 
         self.assertIsInstance(self.cloud.get_remote(), self._get_cloud_class())
 


### PR DESCRIPTION
This is a quick fix. DataCloud is definitely ugly and will be refactored within https://github.com/iterative/dvc/issues/2056 . 

Fixes #2066

Signed-off-by: Ruslan Kuprieiev <ruslan@iterative.ai>

* [x] Have you followed the guidelines in our
      [Contributing document](https://dvc.org/doc/user-guide/contributing)?

* [x] Does your PR affect documented changes or does it add new functionality
      that should be documented? If yes, have you created a PR for
      [dvc.org](https://github.com/iterative/dvc.org) documenting it or at
      least opened an issue for it? If so, please add a link to it.

-----
