### PR TITLE
dvc: standard way to refer to DVC-files

### DIFF
--- a/dvc/command/add.py
+++ b/dvc/command/add.py
@@ -54,7 +54,7 @@ def add_parser(subparsers, parent_parser):
         help="Don't put files/directories into cache.",
     )
     add_parser.add_argument(
-        "-f", "--file", help="Specify name of the DVC file it generates."
+        "-f", "--file", help="Specify name of the DVC-file it generates."
     )
     add_parser.add_argument(
         "targets", nargs="+", help="Input files/directories."

--- a/dvc/command/checkout.py
+++ b/dvc/command/checkout.py
@@ -51,5 +51,5 @@ def add_parser(subparsers, parent_parser):
         default=False,
         help="Checkout all subdirectories of the specified directory.",
     )
-    checkout_parser.add_argument("targets", nargs="*", help="DVC files.")
+    checkout_parser.add_argument("targets", nargs="*", help="DVC-files.")
     checkout_parser.set_defaults(func=CmdCheckout)

--- a/dvc/command/commit.py
+++ b/dvc/command/commit.py
@@ -34,7 +34,7 @@ class CmdCommit(CmdBase):
 
 
 def add_parser(subparsers, parent_parser):
-    COMMIT_HELP = "Save changed data to cache and update DVC files."
+    COMMIT_HELP = "Save changed data to cache and update DVC-files."
 
     commit_parser = subparsers.add_parser(
         "commit",
@@ -65,6 +65,6 @@ def add_parser(subparsers, parent_parser):
         help="Commit cache for subdirectories of the specified directory.",
     )
     commit_parser.add_argument(
-        "targets", nargs="*", default=None, help="DVC files."
+        "targets", nargs="*", default=None, help="DVC-files."
     )
     commit_parser.set_defaults(func=CmdCommit)

--- a/dvc/command/data_sync.py
+++ b/dvc/command/data_sync.py
@@ -113,7 +113,7 @@ def shared_parent_parser():
         help="Show checksums instead of file names.",
     )
     shared_parent_parser.add_argument(
-        "targets", nargs="*", default=None, help="DVC files."
+        "targets", nargs="*", default=None, help="DVC-files."
     )
 
     return shared_parent_parser

--- a/dvc/command/destroy.py
+++ b/dvc/command/destroy.py
@@ -35,7 +35,7 @@ class CmdDestroy(CmdBase):
 
 
 def add_parser(subparsers, parent_parser):
-    DESTROY_HELP = "Remove DVC files, local DVC config and data cache."
+    DESTROY_HELP = "Remove DVC-files, local DVC config and data cache."
 
     destroy_parser = subparsers.add_parser(
         "destroy",

--- a/dvc/command/imp.py
+++ b/dvc/command/imp.py
@@ -65,6 +65,6 @@ def add_parser(subparsers, parent_parser):
         "out", nargs="?", help="Destination path to put files to."
     )
     import_parser.add_argument(
-        "-f", "--file", help="Specify name of the DVC file it generates."
+        "-f", "--file", help="Specify name of the DVC-file it generates."
     )
     import_parser.set_defaults(func=CmdImport)

--- a/dvc/command/lock.py
+++ b/dvc/command/lock.py
@@ -37,7 +37,7 @@ class CmdUnlock(CmdLockBase):
 
 
 def add_parser(subparsers, parent_parser):
-    LOCK_HELP = "Lock DVC file."
+    LOCK_HELP = "Lock DVC-file."
     lock_parser = subparsers.add_parser(
         "lock",
         parents=[parent_parser],
@@ -45,10 +45,10 @@ def add_parser(subparsers, parent_parser):
         help=LOCK_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    lock_parser.add_argument("targets", nargs="+", help="DVC files.")
+    lock_parser.add_argument("targets", nargs="+", help="DVC-files.")
     lock_parser.set_defaults(func=CmdLock)
 
-    UNLOCK_HELP = "Unlock DVC file."
+    UNLOCK_HELP = "Unlock DVC-file."
     unlock_parser = subparsers.add_parser(
         "unlock",
         parents=[parent_parser],
@@ -56,5 +56,5 @@ def add_parser(subparsers, parent_parser):
         help=UNLOCK_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    unlock_parser.add_argument("targets", nargs="+", help="DVC files.")
+    unlock_parser.add_argument("targets", nargs="+", help="DVC-files.")
     unlock_parser.set_defaults(func=CmdUnlock)

--- a/dvc/command/move.py
+++ b/dvc/command/move.py
@@ -27,7 +27,7 @@ def add_parser(subparsers, parent_parser):
     MOVE_HELP = "Rename or move a DVC controlled data file or a directory."
     MOVE_DESCRIPTION = (
         "Rename or move a DVC controlled data file or a directory.\n"
-        "It renames and modifies the corresponding DVC file to reflect the"
+        "It renames and modifies the corresponding DVC-file to reflect the"
         " changes."
     )
 

--- a/dvc/command/pipeline.py
+++ b/dvc/command/pipeline.py
@@ -209,14 +209,14 @@ def add_parser(subparsers, parent_parser):
         "--commands",
         action="store_true",
         default=False,
-        help="Print commands instead of paths to DVC files.",
+        help="Print commands instead of paths to DVC-files.",
     )
     pipeline_show_group.add_argument(
         "-o",
         "--outs",
         action="store_true",
         default=False,
-        help="Print output files instead of paths to DVC files.",
+        help="Print output files instead of paths to DVC-files.",
     )
     pipeline_show_parser.add_argument(
         "-l",
@@ -244,7 +244,7 @@ def add_parser(subparsers, parent_parser):
         help="Output DAG as Dependencies Tree.",
     )
     pipeline_show_parser.add_argument(
-        "targets", nargs="*", help="DVC files. 'Dvcfile' by default."
+        "targets", nargs="*", help="DVC-files. 'Dvcfile' by default."
     )
     pipeline_show_parser.set_defaults(func=CmdPipelineShow)
 

--- a/dvc/command/remove.py
+++ b/dvc/command/remove.py
@@ -43,7 +43,7 @@ class CmdRemove(CmdBase):
 
 
 def add_parser(subparsers, parent_parser):
-    REMOVE_HELP = "Remove outputs of DVC file."
+    REMOVE_HELP = "Remove outputs of DVC-file."
     remove_parser = subparsers.add_parser(
         "remove",
         parents=[parent_parser],
@@ -57,14 +57,14 @@ def add_parser(subparsers, parent_parser):
         "--outs",
         action="store_true",
         default=True,
-        help="Only remove DVC file outputs. (Default)",
+        help="Only remove DVC-file outputs. (Default)",
     )
     remove_parser_group.add_argument(
         "-p",
         "--purge",
         action="store_true",
         default=False,
-        help="Remove DVC file and all its outputs.",
+        help="Remove DVC-file and all its outputs.",
     )
     remove_parser.add_argument(
         "-f",
@@ -73,5 +73,5 @@ def add_parser(subparsers, parent_parser):
         default=False,
         help="Force purge.",
     )
-    remove_parser.add_argument("targets", nargs="+", help="DVC files.")
+    remove_parser.add_argument("targets", nargs="+", help="DVC-files.")
     remove_parser.set_defaults(func=CmdRemove)

--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -58,7 +58,7 @@ class CmdRepro(CmdBase):
 
 
 def add_parser(subparsers, parent_parser):
-    REPRO_HELP = "Check for changes and reproduce DVC file and dependencies."
+    REPRO_HELP = "Check for changes and reproduce DVC-file and dependencies."
     repro_parser = subparsers.add_parser(
         "repro",
         parents=[parent_parser],
@@ -69,7 +69,7 @@ def add_parser(subparsers, parent_parser):
     repro_parser.add_argument(
         "targets",
         nargs="*",
-        help="DVC file to reproduce (default - 'Dvcfile').",
+        help="DVC-file to reproduce (default - 'Dvcfile').",
     )
     repro_parser.add_argument(
         "-f",

--- a/dvc/command/run.py
+++ b/dvc/command/run.py
@@ -127,7 +127,7 @@ def add_parser(subparsers, parent_parser):
         "(do not put into DVC cache).",
     )
     run_parser.add_argument(
-        "-f", "--file", help="Specify name of the DVC file it generates."
+        "-f", "--file", help="Specify name of the DVC-file it generates."
     )
     run_parser.add_argument(
         "-c", "--cwd", default=None, help="Deprecated, use -w and -f instead."
@@ -155,7 +155,7 @@ def add_parser(subparsers, parent_parser):
         "--overwrite-dvcfile",
         action="store_true",
         default=False,
-        help="Overwrite existing dvc file without asking for confirmation.",
+        help="Overwrite existing DVC-file without asking for confirmation.",
     )
     run_parser.add_argument(
         "--ignore-build-cache",

--- a/dvc/command/tag.py
+++ b/dvc/command/tag.py
@@ -82,14 +82,14 @@ def add_parser(subparsers, parent_parser):
     )
     tag_add_parser.add_argument("tag", help="Dvc tag.")
     tag_add_parser.add_argument(
-        "targets", nargs="*", default=[None], help="Dvc files."
+        "targets", nargs="*", default=[None], help="DVC-files."
     )
     tag_add_parser.add_argument(
         "-d",
         "--with-deps",
         action="store_true",
         default=False,
-        help="Add tag for all dependencies of the specified DVC file.",
+        help="Add tag for all dependencies of the specified DVC-file.",
     )
     tag_add_parser.add_argument(
         "-R",
@@ -109,14 +109,14 @@ def add_parser(subparsers, parent_parser):
     )
     tag_remove_parser.add_argument("tag", help="Dvc tag.")
     tag_remove_parser.add_argument(
-        "targets", nargs="*", default=[None], help="Dvc files."
+        "targets", nargs="*", default=[None], help="DVC-files."
     )
     tag_remove_parser.add_argument(
         "-d",
         "--with-deps",
         action="store_true",
         default=False,
-        help="Remove tag for all dependencies of the specified DVC file.",
+        help="Remove tag for all dependencies of the specified DVC-file.",
     )
     tag_remove_parser.add_argument(
         "-R",
@@ -135,14 +135,14 @@ def add_parser(subparsers, parent_parser):
         help=TAG_LIST_HELP,
     )
     tag_list_parser.add_argument(
-        "targets", nargs="*", default=[None], help="Dvc files."
+        "targets", nargs="*", default=[None], help="DVC-files."
     )
     tag_list_parser.add_argument(
         "-d",
         "--with-deps",
         action="store_true",
         default=False,
-        help="List tags for all dependencies of the specified DVC file.",
+        help="List tags for all dependencies of the specified DVC-file.",
     )
     tag_list_parser.add_argument(
         "-R",

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -318,7 +318,7 @@ class Repo(object):
             for stage in stages:
                 if active and not target and stage.locked:
                     logger.warning(
-                        "DVC file '{path}' is locked. Its dependencies are"
+                        "DVC-file '{path}' is locked. Its dependencies are"
                         " not going to be pushed/pulled/fetched.".format(
                             path=stage.relpath
                         )

--- a/dvc/repo/checkout.py
+++ b/dvc/repo/checkout.py
@@ -47,7 +47,7 @@ def checkout(self, target=None, with_deps=False, force=False, recursive=False):
         for stage in stages:
             if stage.locked:
                 logger.warning(
-                    "DVC file '{path}' is locked. Its dependencies are"
+                    "DVC-file '{path}' is locked. Its dependencies are"
                     " not going to be checked out.".format(path=stage.relpath)
                 )
 

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -15,7 +15,7 @@ def _reproduce_stage(stages, node, force, dry, interactive, no_commit):
 
     if stage.locked:
         logger.warning(
-            "DVC file '{path}' is locked. Its dependencies are"
+            "DVC-file '{path}' is locked. Its dependencies are"
             " not going to be reproduced.".format(path=stage.relpath)
         )
 

--- a/dvc/repo/status.py
+++ b/dvc/repo/status.py
@@ -14,7 +14,7 @@ def _local_status(self, target=None, with_deps=False):
     for stage in stages:
         if stage.locked:
             logger.warning(
-                "DVC file '{path}' is locked. Its dependencies are"
+                "DVC-file '{path}' is locked. Its dependencies are"
                 " not going to be shown in the status output.".format(
                     path=stage.relpath
                 )

--- a/dvc/stage.py
+++ b/dvc/stage.py
@@ -54,7 +54,7 @@ class StageFileAlreadyExistsError(DvcException):
 
 class StageFileIsNotDvcFileError(DvcException):
     def __init__(self, fname):
-        msg = "'{}' is not a dvc file".format(fname)
+        msg = "'{}' is not a DVC-file".format(fname)
 
         sname = fname + Stage.STAGE_FILE_SUFFIX
         if Stage.is_stage_file(sname):
@@ -218,7 +218,7 @@ class Stage(object):
 
         if self.is_callback:
             logger.warning(
-                "Dvc file '{fname}' is a 'callback' stage "
+                "DVC-file '{fname}' is a 'callback' stage "
                 "(has a command and no dependencies) and thus always "
                 "considered as changed.".format(fname=self.relpath)
             )
@@ -253,7 +253,7 @@ class Stage(object):
 
     def _changed_md5(self):
         if self.changed_md5():
-            logger.warning("Dvc file '{}' changed.".format(self.relpath))
+            logger.warning("DVC-file '{}' changed.".format(self.relpath))
             return True
         return False
 
@@ -583,7 +583,7 @@ class Stage(object):
 
         # it raises the proper exceptions by priority:
         # 1. when the file doesn't exists
-        # 2. filename is not a dvc filename
+        # 2. filename is not a DVC-file
         # 3. path doesn't represent a regular file
         Stage._check_file_exists(repo, fname)
         Stage._check_dvc_filename(fname)

--- a/scripts/completion/dvc.zsh
+++ b/scripts/completion/dvc.zsh
@@ -15,28 +15,28 @@ _dvc_commands() {
     "add:Take data files or directories under DVC control."
     "cache:Manage cache settings."
     "checkout:Checkout data files from cache."
-    "commit:Save changed data to cache and update DVC files."
+    "commit:Save changed data to cache and update DVC-files."
     "config:Get or set config settings."
-    "destroy:Remove DVC files, local DVC config and data cache."
+    "destroy:Remove DVC-files, local DVC config and data cache."
     "diff:Show a diff of a DVC controlled data file or a directory."
     "fetch:Fetch data files from a DVC remote storage."
     "gc:Collect unused data from DVC cache or a remote storage."
     "import:Download or copy files from URL and take under DVC control."
     "init:Initialize DVC in the current directory."
     "install:Install DVC git hooks into the repository."
-    "lock:Lock DVC file."
+    "lock:Lock DVC-file."
     "metrics:Commands to add, manage, collect and display metrics."
     "move:Rename or move a DVC controlled data file or a directory."
     "pipeline:Manage pipelines."
     "pull:Pull data files from a DVC remote storage."
     "push:Push data files to a DVC remote storage."
     "remote:Manage remote storage configuration."
-    "remove:Remove outputs of DVC file."
-    "repro:Check for changes and reproduce DVC file and dependencies."
+    "remove:Remove outputs of DVC-file."
+    "repro:Check for changes and reproduce DVC-file and dependencies."
     "root:Relative path to project's directory."
     "run:Generate a stage file from a command and execute the command."
     "status:Show changed stages, compare local cache and a remote storage."
-    "unlock:Unlock DVC file."
+    "unlock:Unlock DVC-file."
     "unprotect:Unprotect data file/directory."
     "version:Show DVC version and system/environment informaion."
   )
@@ -58,7 +58,7 @@ _dvc_global_options=(
 _dvc_add=(
   {-R,--recursive}"[Recursively add each file under the directory.]"
   "--no-commit[Don't put files/directories into cache.]"
-  {-f,--file}"[Specify name of the DVC file it generates.]:File:_files"
+  {-f,--file}"[Specify name of the DVC-file it generates.]:File:_files"
   "1:File:_files"
 )
 
@@ -118,7 +118,7 @@ _dvc_gc=(
 
 _dvc_import=(
   "--resume[Resume previously started download.]"
-  {-f,--file}"[Specify name of the DVC file it generates.]:File:_files"
+  {-f,--file}"[Specify name of the DVC-file it generates.]:File:_files"
   "1:URL:"
   "2:Output:"
 )
@@ -177,8 +177,8 @@ _dvc_remote=(
 _dvc_remove=(
   "*:Stages:_files -g '(*.dvc|Dvcfile)'"
   "--dry[Only print the commands that would be executed without actually executing]"
-  {-o,--outs}"[Only remove DVC file outputs. (Default)]"
-  {-p,--purge}"[Remove DVC file and all its outputs.]"
+  {-o,--outs}"[Only remove DVC-file outputs. (Default)]"
+  {-p,--purge}"[Remove DVC-file and all its outputs.]"
   {-f,--force}"[Force purge.]"
 )
 
@@ -206,12 +206,12 @@ _dvc_run=(
   "*"{-O,--outs-no-cache}"[Declare output file or directory (do not put into DVC cache).]:Output regular:_files"
   "*"{-m,--metrics}"[Declare output metric file or directory.]:Metrics:_files"
   "*"{-M,--metrics-no-cache}"[Declare output metric file or directory (do not put into DVC cache).]:Metrics (no cache):_files"
-  {-f,--file}"[Specify name of the DVC file it generates.]:File:_files"
+  {-f,--file}"[Specify name of the DVC-file it generates.]:File:_files"
   {-c,--cwd}"[Deprecated, use -w and -f instead.]:CWD:_files -/"
   {-w,--wdir}"[Directory within your repo to run your command in.]:WDIR:_files -/"
   "--no-exec[Only create stage file without actually running it.]"
   {-y,--yes}"[Deprecated, use --overwrite-dvcfile instead]"
-  "--overwrite-dvcfile[Overwrite existing dvc file without asking for confirmation.]"
+  "--overwrite-dvcfile[Overwrite existing DVC-file without asking for confirmation.]"
   "--ignore-build-cache[Run this stage even if it has been already ran with the same command/dependencies/outputs/etc before.]"
   "--remove-outs[Deprecated, this is now the default behavior]"
   "--no-commit[Don't put files/directories into cache.]"


### PR DESCRIPTION
"DVC file(s)" an similar -> "DVC-file(s)"

E.g. in `dvc remove -h` and `dvc repro -h` output~~. Anywhere else?~~ and in many more places!

Companion to https://github.com/iterative/dvc.org/issues/321
---

* [x] Have you followed the guidelines in our
      [Contributing document](https://dvc.org/doc/user-guide/contributing)?

* [x] Does your PR affect documented changes or does it add new functionality
      that should be documented? If yes, have you created a PR for
      [dvc.org](https://github.com/iterative/dvc.org) documenting it or at
      least opened an issue for it? If so, please add a link to it.

-----
