### PR TITLE
dvc: move Updater out of Repo()

### DIFF
--- a/dvc/command/base.py
+++ b/dvc/command/base.py
@@ -38,10 +38,13 @@ def append_doc_link(help_message, path):
 class CmdBase(object):
     def __init__(self, args):
         from dvc.repo import Repo
+        from dvc.updater import Updater
 
         self.repo = Repo()
         self.config = self.repo.config
         self.args = args
+        updater = Updater(self.repo.dvc_dir)
+        updater.check()
 
     @property
     def default_targets(self):

--- a/dvc/command/diff.py
+++ b/dvc/command/diff.py
@@ -16,7 +16,8 @@ logger = logging.getLogger(__name__)
 
 
 class CmdDiff(CmdBase):
-    def _print_size(self, size):
+    @staticmethod
+    def _print_size(size):
         if size < 0:
             change = "decreased by {}"
         elif size > 0:
@@ -26,14 +27,16 @@ class CmdDiff(CmdBase):
         natur_size = humanize.naturalsize(abs(size))
         return change.format(natur_size)
 
-    def _get_md5_string(self, sign, file_name, checksum):
+    @staticmethod
+    def _get_md5_string(sign, file_name, checksum):
         sample_msg = ""
         if file_name:
             sample_msg = "{}{} with md5 {}\n"
             sample_msg = sample_msg.format(sign, file_name, checksum)
         return sample_msg
 
-    def _get_dir_changes(self, dct):
+    @classmethod
+    def _get_dir_changes(cls, dct):
         engine = inflect.engine()
         changes_msg = (
             "{} {} not changed, {} {} modified, {} {} added, "
@@ -48,11 +51,12 @@ class CmdDiff(CmdBase):
             engine.plural("file", dct[diff.DIFF_NEW]),
             dct[diff.DIFF_DEL],
             engine.plural("file", dct[diff.DIFF_DEL]),
-            self._print_size(dct[diff.DIFF_SIZE]),
+            cls._print_size(dct[diff.DIFF_SIZE]),
         )
         return changes_msg
 
-    def _get_file_changes(self, dct):
+    @classmethod
+    def _get_file_changes(cls, dct):
         if (
             dct.get(diff.DIFF_OLD_FILE)
             and dct.get(diff.DIFF_NEW_FILE)
@@ -69,19 +73,21 @@ class CmdDiff(CmdBase):
             )
         else:
             msg = "file was modified, file size {}".format(
-                self._print_size(dct[diff.DIFF_SIZE])
+                cls._print_size(dct[diff.DIFF_SIZE])
             )
         return msg
 
-    def _get_royal_changes(self, dct):
+    @classmethod
+    def _get_royal_changes(cls, dct):
         if dct[diff.DIFF_SIZE] != diff.DIFF_SIZE_UNKNOWN:
             if dct.get("is_dir"):
-                return self._get_dir_changes(dct)
+                return cls._get_dir_changes(dct)
             else:
-                return self._get_file_changes(dct)
+                return cls._get_file_changes(dct)
         return "size is ?"
 
-    def _show(self, diff_dct):
+    @classmethod
+    def _show(cls, diff_dct):
         msg = "dvc diff from {} to {}".format(
             diff_dct[diff.DIFF_A_REF], diff_dct[diff.DIFF_B_REF]
         )
@@ -90,18 +96,18 @@ class CmdDiff(CmdBase):
             return
         for dct in diff_dct[diff.DIFF_LIST]:
             msg += "\n\ndiff for '{}'\n".format(dct[diff.DIFF_TARGET])
-            msg += self._get_md5_string(
+            msg += cls._get_md5_string(
                 "-",
                 dct.get(diff.DIFF_OLD_FILE),
                 dct.get(diff.DIFF_OLD_CHECKSUM),
             )
-            msg += self._get_md5_string(
+            msg += cls._get_md5_string(
                 "+",
                 dct.get(diff.DIFF_NEW_FILE),
                 dct.get(diff.DIFF_NEW_CHECKSUM),
             )
             msg += "\n"
-            msg += self._get_royal_changes(dct)
+            msg += cls._get_royal_changes(dct)
         logger.info(msg)
         return msg
 

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -47,7 +47,6 @@ class Repo(object):
         from dvc.scm import SCM
         from dvc.cache import Cache
         from dvc.data_cloud import DataCloud
-        from dvc.updater import Updater
         from dvc.repo.metrics import Metrics
         from dvc.scm.tree import WorkingTree
         from dvc.repo.tag import Tag
@@ -76,15 +75,12 @@ class Repo(object):
 
         self.cache = Cache(self)
         self.cloud = DataCloud(self)
-        self.updater = Updater(self.dvc_dir)
 
         self.metrics = Metrics(self)
         self.tag = Tag(self)
         self.pkg = Pkg(self)
 
         self._ignore()
-
-        self.updater.check()
 
     def __repr__(self):
         return "Repo: '{root_dir}'".format(root_dir=self.root_dir)
@@ -121,12 +117,16 @@ class Repo(object):
         return self.cache.local.unprotect(PathInfo(target))
 
     def _ignore(self):
+        from dvc.updater import Updater
+
+        updater = Updater(self.dvc_dir)
+
         flist = [
             self.state.state_file,
             self.lock.lock_file,
             self.config.config_local_file,
-            self.updater.updater_file,
-            self.updater.lock.lock_file,
+            updater.updater_file,
+            updater.lock.lock_file,
         ] + self.state.temp_files
 
         if self.cache.local.cache_dir.startswith(self.root_dir):

--- a/tests/func/test_diff.py
+++ b/tests/func/test_diff.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 import os
-from mock import patch, Mock
 
 from dvc.main import main
 
@@ -65,34 +64,28 @@ class TestDiffRepo(TestDiff):
 
 class TestDiffCmdLine(TestDiff):
     def test(self):
-        with patch("dvc.cli.diff.CmdDiff._show", autospec=True):
-            with patch("dvc.repo.Repo", config="testing") as MockRepo:
-                MockRepo.return_value.diff.return_value = "testing"
-                ret = main(["diff", "-t", self.new_file, self.a_ref])
-                self.assertEqual(ret, 0)
+        ret = main(["diff", "-t", self.new_file, self.a_ref])
+        self.assertEqual(ret, 0)
 
 
 class TestDiffCmdMessage(TestDiff):
     maxDiff = None
 
     def test(self):
-        with patch("dvc.repo.Repo", config="testing"):
-            m = Mock()
-            cmd_diff = CmdDiff(m)
-            msg = cmd_diff._show(self.test_dct)
-            test_msg = (
-                "dvc diff from {0} to {1}\n\n"
-                "diff for '{2}'\n"
-                "+{2} with md5 {3}\n\n"
-                "added file with size 13 Bytes"
-            )
-            test_msg = test_msg.format(
-                self.test_dct[diff.DIFF_A_REF],
-                self.test_dct[diff.DIFF_B_REF],
-                self.test_dct[diff.DIFF_LIST][0][diff.DIFF_TARGET],
-                self.test_dct[diff.DIFF_LIST][0][diff.DIFF_NEW_CHECKSUM],
-            )
-            self.assertEqual(test_msg, msg)
+        msg = CmdDiff._show(self.test_dct)
+        test_msg = (
+            "dvc diff from {0} to {1}\n\n"
+            "diff for '{2}'\n"
+            "+{2} with md5 {3}\n\n"
+            "added file with size 13 Bytes"
+        )
+        test_msg = test_msg.format(
+            self.test_dct[diff.DIFF_A_REF],
+            self.test_dct[diff.DIFF_B_REF],
+            self.test_dct[diff.DIFF_LIST][0][diff.DIFF_TARGET],
+            self.test_dct[diff.DIFF_LIST][0][diff.DIFF_NEW_CHECKSUM],
+        )
+        self.assertEqual(test_msg, msg)
 
 
 class TestDiffDir(TestDvc):


### PR DESCRIPTION
Fixes #2039

Required by #2012 to be able to fetch data through the API without
interuption from updater.

Signed-off-by: Ruslan Kuprieiev <ruslan@iterative.ai>

* [x] Have you followed the guidelines in our
      [Contributing document](https://dvc.org/doc/user-guide/contributing)?

* [x] Does your PR affect documented changes or does it add new functionality
      that should be documented? If yes, have you created a PR for
      [dvc.org](https://github.com/iterative/dvc.org) documenting it or at
      least opened an issue for it? If so, please add a link to it.

-----
