### PR TITLE
ssh: increase jobs and parallelize batch_exists

### DIFF
--- a/dvc/logger.py
+++ b/dvc/logger.py
@@ -176,7 +176,11 @@ def setup(level=logging.INFO):
                 "dvc": {
                     "level": level,
                     "handlers": ["console", "console_errors"],
-                }
+                },
+                "paramiko": {
+                    "level": logging.CRITICAL,
+                    "handlers": ["console", "console_errors"],
+                },
             },
         }
     )

--- a/dvc/main.py
+++ b/dvc/main.py
@@ -34,6 +34,7 @@ def main(argv=None):
 
         elif args.verbose:
             logger.setLevel(logging.DEBUG)
+            logging.getLogger("paramiko").setLevel(logging.DEBUG)
 
         cmd = args.func(args)
         ret = cmd.run_cmd()

--- a/dvc/utils/compat.py
+++ b/dvc/utils/compat.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 import sys
 import os
 import errno
+from contextlib import contextmanager
 
 # Syntax sugar.
 _ver = sys.version_info
@@ -87,6 +88,15 @@ def _makedirs(name, mode=0o777, exist_ok=False):
         os.mkdir(name, mode)
     except OSError:
         if not exist_ok or not os.path.isdir(name):
+            raise
+
+
+@contextmanager
+def ignore_file_not_found():
+    try:
+        yield
+    except IOError as exc:
+        if exc.errno != errno.ENOENT:
             raise
 
 


### PR DESCRIPTION
* [x] Have you followed the guidelines in our
      [Contributing document](https://dvc.org/doc/user-guide/contributing)?

* [ ] Does your PR affect documented changes or does it add new functionality
      that should be documented? If yes, have you created a PR for
      [dvc.org](https://github.com/iterative/dvc.org) documenting it or at
      least opened an issue for it? If so, please add a link to it.

-----

- SSH number of jobs increased from 4 to 8.

- `batch_exists` now opens all the SFTP sessions available to
distribute the work between them. Number of sessions is restricted
by the `MaxSessions` option configurable by the `sshd_config`.

- Fix #2104

With the optimizations mentioned above, we increased the speed by 8x
(using the default `MaxSessions` configuration -- 10).

Shout-outs to @efiop, @shcheklein, and @dmpetrov for suggesting the
optimization techniques.