### PR TITLE
Sigint support

### DIFF
--- a/dvc/stage.py
+++ b/dvc/stage.py
@@ -767,14 +767,17 @@ class Stage(object):
         executable = os.getenv("SHELL") if os.name != "nt" else None
         self._warn_if_fish(executable)
 
-        p = subprocess.Popen(
-            self.cmd,
-            cwd=self.wdir,
-            shell=True,
-            env=fix_env(os.environ),
-            executable=executable,
-        )
-        p.communicate()
+        try:
+            p = subprocess.Popen(
+                self.cmd,
+                cwd=self.wdir,
+                shell=True,
+                env=fix_env(os.environ),
+                executable=executable,
+            )
+            p.communicate()
+        except KeyboardInterrupt:
+            p.communicate()
 
         if p.returncode != 0:
             raise StageCmdFailedError(self)

--- a/tests/func/test_run.py
+++ b/tests/func/test_run.py
@@ -5,7 +5,6 @@ import logging
 import mock
 import shutil
 import filecmp
-import subprocess
 
 from dvc.main import main
 from dvc.output import OutputBase
@@ -322,11 +321,6 @@ class TestCmdRun(TestDvc):
         stage = Stage.load(self.dvc, fname="Dvcfile")
         self.assertEqual(ret, 0)
         self.assertEqual(stage.cmd, 'echo "foo bar"')
-
-    @mock.patch.object(subprocess, "Popen", side_effect=KeyboardInterrupt)
-    def test_keyboard_interrupt(self, _):
-        ret = main(["run", "mycmd"])
-        self.assertEqual(ret, 252)
 
 
 class TestRunRemoveOuts(TestDvc):


### PR DESCRIPTION
* [x] I followed the guidelines in [Contributing document](https://dvc.org/doc/user-guide/contributing)?

* [ ] Does your PR affect documented changes or does it add new functionality
      that should be documented? Not actually. Previous behaviour wasn't documented either.
-----
This PR closes #1593.

Why don't we let users to decide how to handle SIGINT?

If they don't handle SIGINT they will see an error message as well. Is there any reason for KeyboardInterrupt to be a special case?