### PR TITLE
remote: refactor status functions

### DIFF
--- a/dvc/remote/http.py
+++ b/dvc/remote/http.py
@@ -93,17 +93,8 @@ class RemoteHTTP(RemoteBASE):
 
         return fails
 
-    def exists(self, path_info):
+    def exists(self, path_info, **_kwargs):
         return bool(self._request("HEAD", path_info.url))
-
-    def batch_exists(self, path_infos, callback):
-        results = []
-
-        for path_info in path_infos:
-            results.append(self.exists(path_info))
-            callback.update(str(path_info))
-
-        return results
 
     def _content_length(self, url):
         return self._request("HEAD", url).headers.get("Content-Length")

--- a/dvc/remote/local/__init__.py
+++ b/dvc/remote/local/__init__.py
@@ -249,9 +249,10 @@ class RemoteLOCAL(RemoteBASE):
         move(tmp, outp)
 
     def cache_exists(self, md5s):
+        name = "Collecting '{}'".format(str(self.path_info))
         return [
             checksum
-            for checksum in progress(md5s)
+            for checksum in progress(md5s, name)
             if not self.changed_cache_file(checksum)
         ]
 
@@ -312,7 +313,6 @@ class RemoteLOCAL(RemoteBASE):
         ret = self._group(checksum_infos, show_checksums=show_checksums) or {}
         md5s = list(ret)
 
-        logger.info("Collecting information from local cache...")
         local_exists = self.cache_exists(md5s)
 
         # This is a performance optimization. We can safely assume that,
@@ -322,7 +322,6 @@ class RemoteLOCAL(RemoteBASE):
         if download and sorted(local_exists) == sorted(md5s):
             remote_exists = local_exists
         else:
-            logger.info("Collecting information from remote cache...")
             remote_exists = list(remote.cache_exists(md5s))
 
         self._fill_statuses(ret, local_exists, remote_exists)

--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -128,19 +128,9 @@ class RemoteSSH(RemoteBASE):
             password=self.password,
         )
 
-    def exists(self, path_info):
-        with self.ssh(path_info) as ssh:
-            return ssh.exists(path_info.path)
-
-    def batch_exists(self, path_infos, callback):
-        results = []
-
-        with self.ssh(path_infos[0]) as ssh:
-            for path_info in path_infos:
-                results.append(ssh.exists(path_info.path))
-                callback.update(str(path_info))
-
-        return results
+    def exists(self, path_info, ctx=None):
+        ssh = ctx or self.ssh(path_info)
+        return ssh.exists(path_info.path)
 
     def get_file_checksum(self, path_info):
         if path_info.scheme != self.scheme:

--- a/dvc/utils/compat.py
+++ b/dvc/utils/compat.py
@@ -98,6 +98,7 @@ if is_py2:
     from io import open  # noqa: F401
     import pathlib2 as pathlib  # noqa: F401
     from collections import Mapping  # noqa: F401
+    from contextlib2 import ExitStack  # noqa: F401
 
     builtin_str = str  # noqa: F821
     bytes = str  # noqa: F821
@@ -144,6 +145,7 @@ elif is_py3:
     )  # noqa: F401
     import configparser as ConfigParser  # noqa: F401
     from collections.abc import Mapping  # noqa: F401
+    from contextlib import ExitStack  # noqa: F401
 
     builtin_str = str  # noqa: F821
     str = str  # noqa: F821

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ setup(
         "oss": oss,
         "ssh": ssh,
         # NOTE: https://github.com/inveniosoftware/troubleshooting/issues/1
-        ":python_version=='2.7'": ["futures", "pathlib2"],
+        ":python_version=='2.7'": ["futures", "pathlib2", "contextlib2"],
         "tests": tests_requirements,
     },
     keywords="data science, data version control, machine learning",


### PR DESCRIPTION
`TransferContextPool` will allow us to operate on individual connections, so we could control how many of them we need and how we should open them. Related to https://github.com/iterative/dvc/pull/2131 and will allow us to implement ssh multiplexing using `transfer_context` and `TransferContextPool`.

We are also getting rid of splitting things into chunks in favour of relying on `map`. Similar refactoring will be applied to push/pull later.

Also, as a side-effect, added support for no_traverse for Azure and OSS.

Signed-off-by: Ruslan Kuprieiev <ruslan@iterative.ai>

* [x] Have you followed the guidelines in our
      [Contributing document](https://dvc.org/doc/user-guide/contributing)?

* [x] Does your PR affect documented changes or does it add new functionality
      that should be documented? If yes, have you created a PR for
      [dvc.org](https://github.com/iterative/dvc.org) documenting it or at
      least opened an issue for it? If so, please add a link to it.

-----
