### PR TITLE
ignore: remove dulwich in favour of pathspec

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,10 +58,10 @@ install_requires = [
     "treelib>=1.5.5",
     "inflect>=2.1.0",
     "humanize>=0.5.1",
-    "dulwich>=0.19.11",
     "ruamel.yaml>=0.15.91",
     "psutil==5.6.2",
     "funcy>=1.12",
+    "pathspec>=0.5.9",
 ]
 
 # Extra dependencies for remote integrations

--- a/tests/func/test_ignore.py
+++ b/tests/func/test_ignore.py
@@ -1,6 +1,6 @@
 import os
 
-from dvc.ignore import DvcIgnoreFromFile, DvcIgnore, DvcIgnoreFileHandler
+from dvc.ignore import DvcIgnore, DvcIgnoreFileHandler
 from dvc.utils.compat import cast_bytes
 from tests.basic_env import TestDvc
 
@@ -24,16 +24,6 @@ class TestDvcIgnore(TestDvc):
                 paths.append(os.path.join(root, fname))
 
         return paths
-
-    def test_ignore_comments(self):
-        ignore_file = os.path.join(self.dvc.root_dir, DvcIgnore.DVCIGNORE_FILE)
-        with open(ignore_file, "w") as fobj:
-            fobj.write(os.path.basename(self.DATA))
-            fobj.write(" #this is comment")
-
-        ignore = DvcIgnoreFromFile(ignore_file, self.ignore_file_handler)
-
-        self.assertEqual(1, len(ignore.patterns))
 
     def test_ignore_in_child_dir(self):
         ignore_file = os.path.join(self.dvc.root_dir, DvcIgnore.DVCIGNORE_FILE)


### PR DESCRIPTION
* [x] Have you followed the guidelines in our
      [Contributing document](https://dvc.org/doc/user-guide/contributing)?

* [x] Does your PR affect documented changes or does it add new functionality
      that should be documented? If yes, have you created a PR for
      [dvc.org](https://github.com/iterative/dvc.org) documenting it or at
      least opened an issue for it? If so, please add a link to it.

-----
related to #1876 

Edit:
When (if) this change is approved, we should create issue to optimize pathspec usage. Now, during dvc_walk we check files one by one, while pathspec allows to check set/list of paths against spec.

Edit 2:
But first it might be better to do some performance testing if its worth our time