### PR TITLE
dvc: use remove() instead of shutil.rmtree()

### DIFF
--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -12,6 +12,7 @@ from dvc.config import Config
 from dvc.cache import CacheConfig
 from dvc.exceptions import DvcException
 from dvc.utils.compat import makedirs, str
+from dvc.utils import remove
 
 
 logger = logging.getLogger(__name__)
@@ -120,7 +121,7 @@ class ExternalRepo(object):
             self._install_to(tmp_dir, cache_dir)
         except ExternalRepoError:
             if os.path.exists(tmp_dir):
-                shutil.rmtree(tmp_dir)
+                remove(tmp_dir)
             raise
 
         if self.installed:
@@ -137,7 +138,7 @@ class ExternalRepo(object):
             )
             return
 
-        shutil.rmtree(self.path)
+        remove(self.path)
 
     def update(self):
         self.repo.scm.fetch(self.rev)

--- a/dvc/repo/destroy.py
+++ b/dvc/repo/destroy.py
@@ -1,8 +1,8 @@
-import shutil
+from dvc.utils import remove
 
 
 def destroy(self):
     for stage in self.stages():
         stage.remove(remove_outs=False)
 
-    shutil.rmtree(self.dvc_dir)
+    remove(self.dvc_dir)

--- a/dvc/repo/get.py
+++ b/dvc/repo/get.py
@@ -1,11 +1,11 @@
 import os
-import shutil
 import shortuuid
 
 from dvc.config import Config
 from dvc.path_info import PathInfo
 from dvc.external_repo import ExternalRepo
 from dvc.utils.compat import urlparse
+from dvc.utils import remove
 
 
 @staticmethod
@@ -45,4 +45,4 @@ def get(url, path, out=None, rev=None):
         erepo.repo.scm.git.close()
     finally:
         if os.path.exists(tmp_dir):
-            shutil.rmtree(tmp_dir)
+            remove(tmp_dir)

--- a/dvc/repo/init.py
+++ b/dvc/repo/init.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import colorama
 import logging
 
@@ -7,8 +6,7 @@ from dvc.repo import Repo
 from dvc.scm import SCM, NoSCM
 from dvc.config import Config
 from dvc.exceptions import InitError
-from dvc.utils import boxify
-from dvc.utils import relpath
+from dvc.utils import boxify, relpath, remove
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +76,7 @@ def init(root_dir=os.curdir, no_scm=False, force=False):
                 )
             )
 
-        shutil.rmtree(dvc_dir)
+        remove(dvc_dir)
 
     os.mkdir(dvc_dir)
 


### PR DESCRIPTION
Our `remove()` is able to handle read-only files which we or git
sometimes leave behind.

Signed-off-by: Ruslan Kuprieiev <ruslan@iterative.ai>

* [x] Have you followed the guidelines in our
      [Contributing document](https://dvc.org/doc/user-guide/contributing)?

* [x] Does your PR affect documented changes or does it add new functionality
      that should be documented? If yes, have you created a PR for
      [dvc.org](https://github.com/iterative/dvc.org) documenting it or at
      least opened an issue for it? If so, please add a link to it.

-----
