### PR TITLE
Fix 2170: pipeline show command does not work

### DIFF
--- a/dvc/command/pipeline.py
+++ b/dvc/command/pipeline.py
@@ -29,6 +29,8 @@ class CmdPipelineShow(CmdBase):
 
         for n in nodes:
             if commands:
+                if stages[n].cmd is None:
+                    continue
                 logger.info(stages[n].cmd)
             elif outs:
                 for out in stages[n].outs:

--- a/dvc/logger.py
+++ b/dvc/logger.py
@@ -10,6 +10,12 @@ import logging.config
 import colorama
 
 
+class LoggingException(Exception):
+    def __init__(self, record):
+        msg = "failed to log {}".format(str(record))
+        super(LoggingException, self).__init__(msg)
+
+
 class ExcludeErrorsFilter(logging.Filter):
     def filter(self, record):
         return record.levelno < logging.ERROR
@@ -149,6 +155,12 @@ class ColorFormatter(logging.Formatter):
         progress.clearln()
 
 
+class LoggerHandler(logging.StreamHandler):
+    def handleError(self, record):
+        super(LoggerHandler, self).handleError(record)
+        raise LoggingException(record)
+
+
 def setup(level=logging.INFO):
     colorama.init()
 
@@ -159,14 +171,14 @@ def setup(level=logging.INFO):
             "formatters": {"color": {"()": ColorFormatter}},
             "handlers": {
                 "console": {
-                    "class": "logging.StreamHandler",
+                    "class": "dvc.logger.LoggerHandler",
                     "level": "DEBUG",
                     "formatter": "color",
                     "stream": "ext://sys.stdout",
                     "filters": ["exclude_errors"],
                 },
                 "console_errors": {
-                    "class": "logging.StreamHandler",
+                    "class": "dvc.logger.LoggerHandler",
                     "level": "ERROR",
                     "formatter": "color",
                     "stream": "ext://sys.stderr",

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -296,8 +296,9 @@ class TestShouldUpdateStateEntryForDirectoryAfterAdd(TestDvc):
             self.assertEqual(ret, 0)
             self.assertEqual(file_md5_counter.mock.call_count, 3)
 
+            ls = "dir" if os.name == "nt" else "ls"
             ret = main(
-                ["run", "-d", self.DATA_DIR, "dir {}".format(self.DATA_DIR)]
+                ["run", "-d", self.DATA_DIR, "{} {}".format(ls, self.DATA_DIR)]
             )
             self.assertEqual(ret, 0)
             self.assertEqual(file_md5_counter.mock.call_count, 3)


### PR DESCRIPTION
Fixes #2170 

Introduces custom logger handler to propagate logging exceptions that are swallowed by default: 

https://docs.python.org/3/library/logging.html#logging.Handler.handleError

* [X] Have you followed the guidelines in our
      [Contributing document](https://dvc.org/doc/user-guide/contributing)?

