### PR TITLE
Fix relpath() with PathInfo

### DIFF
--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -2,14 +2,7 @@
 
 from __future__ import unicode_literals
 
-from dvc.utils.compat import (
-    str,
-    builtin_str,
-    open,
-    cast_bytes_py2,
-    StringIO,
-    fspath_py35,
-)
+from dvc.utils.compat import str, builtin_str, open, cast_bytes_py2, StringIO
 from dvc.utils.compat import fspath
 
 import os
@@ -380,8 +373,8 @@ def _visual_center(line, width):
 
 
 def relpath(path, start=os.curdir):
-    path = fspath_py35(path)
-    start = fspath_py35(os.path.abspath(start))
+    path = fspath(path)
+    start = os.path.abspath(fspath(start))
 
     # Windows path on different drive than curdir doesn't have relpath
     if os.name == "nt" and not os.path.commonprefix(

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 import dvc
 import pytest
 from dvc.system import System
+from dvc.path_info import PathInfo
 from dvc.utils import relpath
 from dvc.utils.compat import str
 from dvc.utils.fs import (
@@ -142,5 +143,9 @@ def test_get_parent_dirs_up_to(path1, path2, expected_dirs):
 def test_relpath_windows_different_drives():
     path1 = os.path.join("A:", os.sep, "some", "path")
     path2 = os.path.join("B:", os.sep, "other", "path")
-
     assert relpath(path1, path2) == path1
+
+    info1, info2 = PathInfo(path1), PathInfo(path2)
+    rel_info = relpath(info1, info2)
+    assert isinstance(rel_info, str)
+    assert rel_info == path1


### PR DESCRIPTION
Closes #2188.

Also fixes a bug in `relpath()`, which is not in use yet)