### PR TITLE
fix s3 credential handling: DVC config overrides environment

### DIFF
--- a/dvc/remote/s3.py
+++ b/dvc/remote/s3.py
@@ -50,13 +50,9 @@ class RemoteS3(RemoteBASE):
         url = config.get(Config.SECTION_REMOTE_URL, storagepath)
         self.path_info = self.path_cls(url)
 
-        self.region = os.environ.get("AWS_DEFAULT_REGION") or config.get(
-            Config.SECTION_AWS_REGION
-        )
+        self.region = config.get(Config.SECTION_AWS_REGION)
 
-        self.profile = os.environ.get("AWS_PROFILE") or config.get(
-            Config.SECTION_AWS_PROFILE
-        )
+        self.profile = config.get(Config.SECTION_AWS_PROFILE)
 
         self.endpoint_url = config.get(Config.SECTION_AWS_ENDPOINT_URL)
 


### PR DESCRIPTION
Changes the priority of different ways users can provide AWS settings:

1. DVC config (with a usual priority local/repo/global) - this would be similar to someone using a direct `aws` command line option (like `--profile`). Internally it means we pass those to the Session object. It means, for example, that env vars are ignored, etc.
2. Other regular ways to provide in their regular order - env, files, etc.

* [X ] Have you followed the guidelines in our
      [Contributing document](https://dvc.org/doc/user-guide/contributing)?

-----
