### PR TITLE
remote: optimize UrlInfo.isin()

### DIFF
--- a/dvc/path_info.py
+++ b/dvc/path_info.py
@@ -172,7 +172,7 @@ class URLInfo(object):
 
     @cached_property
     def _path(self):
-        return pathlib.PurePosixPath(self.parsed.path)
+        return PosixPathInfo(self.parsed.path)
 
     @property
     def name(self):
@@ -210,7 +210,7 @@ class URLInfo(object):
         return (
             self.scheme == other.scheme
             and self.netloc == other.netloc
-            and PathInfo(self.path).isin(PathInfo(other.path))
+            and self._path.isin(other._path)
         )
 
 


### PR DESCRIPTION
This will use cached `_path`, which will use cached `_cparts`. Saves
some time skipping repetitive parsing.