### PR TITLE
disable analytics warning message on init if disabled globally/system…

### DIFF
--- a/dvc/analytics.py
+++ b/dvc/analytics.py
@@ -236,7 +236,7 @@ class Analytics(object):
             return False
 
         config = (
-            self._get_current_config()
+            Analytics._get_current_config()
             if cmd is None or not hasattr(cmd, "config")
             else cmd.config
         )

--- a/dvc/analytics.py
+++ b/dvc/analytics.py
@@ -213,7 +213,7 @@ class Analytics(object):
         return core.get(Config.SECTION_CORE_ANALYTICS, True)
 
     @staticmethod
-    def _is_enabled(cmd=None):
+    def is_enabled(cmd=None):
         from dvc.config import Config
         from dvc.repo import Repo
         from dvc.exceptions import NotDvcRepoError
@@ -253,7 +253,7 @@ class Analytics(object):
         """
         from dvc.daemon import daemon
 
-        if not Analytics._is_enabled(cmd):
+        if not Analytics.is_enabled(cmd):
             return
 
         analytics = Analytics()
@@ -264,7 +264,7 @@ class Analytics(object):
         """Collect and send analytics."""
         import requests
 
-        if not self._is_enabled():
+        if not self.is_enabled():
             return
 
         self.collect()

--- a/dvc/analytics.py
+++ b/dvc/analytics.py
@@ -213,6 +213,15 @@ class Analytics(object):
         return core.get(Config.SECTION_CORE_ANALYTICS, True)
 
     @staticmethod
+    def _get_current_config():
+        try:
+            dvc_dir = Repo.find_dvc_dir()
+            config = Config(dvc_dir)
+        except NotDvcRepoError:
+            config = Config(validate=False)
+        return config
+
+    @staticmethod
     def is_enabled(cmd=None):
         from dvc.config import Config
         from dvc.repo import Repo
@@ -225,17 +234,13 @@ class Analytics(object):
         if isinstance(cmd, CmdDaemonBase):
             return False
 
-        if cmd is None or not hasattr(cmd, "config"):
-            try:
-                dvc_dir = Repo.find_dvc_dir()
-                config = Config(dvc_dir)
-                assert config is not None
-            except NotDvcRepoError:
-                config = Config(validate=False)
-                assert config is not None
-        else:
-            config = cmd.config
-            assert config is not None
+        config = (
+            self._get_current_config()
+            if cmd is None or not hasattr(cmd, "config")
+            else cmd.config
+        )
+
+        assert config is not None
 
         enabled = Analytics._is_enabled_config(config)
         logger.debug(

--- a/dvc/analytics.py
+++ b/dvc/analytics.py
@@ -214,6 +214,10 @@ class Analytics(object):
 
     @staticmethod
     def _get_current_config():
+        from dvc.config import Config
+        from dvc.repo import Repo
+        from dvc.exceptions import NotDvcRepoError
+
         try:
             dvc_dir = Repo.find_dvc_dir()
             config = Config(dvc_dir)
@@ -223,9 +227,6 @@ class Analytics(object):
 
     @staticmethod
     def is_enabled(cmd=None):
-        from dvc.config import Config
-        from dvc.repo import Repo
-        from dvc.exceptions import NotDvcRepoError
         from dvc.command.daemon import CmdDaemonBase
 
         if os.getenv("DVC_TEST"):

--- a/dvc/repo/init.py
+++ b/dvc/repo/init.py
@@ -7,21 +7,23 @@ from dvc.scm import SCM, NoSCM
 from dvc.config import Config
 from dvc.exceptions import InitError
 from dvc.utils import boxify, relpath, remove
+from dvc.analytics import Analytics
 
 logger = logging.getLogger(__name__)
 
 
 def _welcome_message():
-    logger.info(
-        boxify(
-            "DVC has enabled anonymous aggregate usage analytics.\n"
-            "Read the analytics documentation (and how to opt-out) here:\n"
-            "{blue}https://dvc.org/doc/user-guide/analytics{nc}".format(
-                blue=colorama.Fore.BLUE, nc=colorama.Fore.RESET
-            ),
-            border_color="red",
+    if Analytics._is_enabled():
+        logger.info(
+            boxify(
+                "DVC has enabled anonymous aggregate usage analytics.\n"
+                "Read the analytics documentation (and how to opt-out) here:\n"
+                "{blue}https://dvc.org/doc/user-guide/analytics{nc}".format(
+                    blue=colorama.Fore.BLUE, nc=colorama.Fore.RESET
+                ),
+                border_color="red",
+            )
         )
-    )
 
     msg = (
         "{yellow}What's next?{nc}\n"

--- a/dvc/repo/init.py
+++ b/dvc/repo/init.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 def _welcome_message():
-    if Analytics._is_enabled():
+    if Analytics.is_enabled():
         logger.info(
             boxify(
                 "DVC has enabled anonymous aggregate usage analytics.\n"


### PR DESCRIPTION
…-wide

Fixes #2267 by only printing an analytics warning message on `dvc init` if
`dvc.analytics.Analytics._is_enabled()` returns `True`.
Maybe a message that analytics is disabled should be printed too.
