### PR TITLE
test: http: use random port

### DIFF
--- a/tests/utils/httpd.py
+++ b/tests/utils/httpd.py
@@ -30,34 +30,22 @@ class ContentMD5Handler(SimpleHTTPRequestHandler):
 
 
 class StaticFileServer:
-    _server_lock = threading.Lock()
+    _lock = threading.Lock()
 
     def __init__(self, handler="etag"):
-        self._server_lock.acquire()
+        self._lock.acquire()
         handler_class = ETagHandler if handler == "etag" else ContentMD5Handler
-        self.bind_port_by_any_means(handler_class)
-
-    def bind_port_by_any_means(self, handler_class):
-        import time
-
-        # shutdowning/closing socket/server does not unbind port in time,
-        # locking the server also does not bring results, hence
-        # this method
-        for i in range(10000):
-            try:
-                self.httpd = HTTPServer(("localhost", 8000), handler_class)
-            except Exception:
-                time.sleep(0.01)
-                continue
-            break
+        self._httpd = HTTPServer(("localhost", 0), handler_class)
+        self._thread = None
 
     def __enter__(self):
-        self.server_thread = threading.Thread(target=self.httpd.serve_forever)
-        self.server_thread.daemon = True
-        self.server_thread.start()
+        self._thread = threading.Thread(target=self._httpd.serve_forever)
+        self._thread.daemon = True
+        self._thread.start()
+        return self._httpd
 
     def __exit__(self, *args):
-        self.httpd.socket.close()
-        self.httpd.shutdown()
-        self.httpd.server_close()
-        self._server_lock.release()
+        self._httpd.socket.close()
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        self._lock.release()


### PR DESCRIPTION
This patch doesn't change the logic behind the tests, focusing on just using random port instead.

Fixes #1878

Signed-off-by: Ruslan Kuprieiev <ruslan@iterative.ai>

* [x] Have you followed the guidelines in our
      [Contributing document](https://dvc.org/doc/user-guide/contributing)?

* [x] Does your PR affect documented changes or does it add new functionality
      that should be documented? If yes, have you created a PR for
      [dvc.org](https://github.com/iterative/dvc.org) documenting it or at
      least opened an issue for it? If so, please add a link to it.

-----
