### PR TITLE
stage: don't ignore SIGINT in the child

### DIFF
--- a/dvc/stage.py
+++ b/dvc/stage.py
@@ -775,9 +775,6 @@ class Stage(object):
         main_thread = isinstance(
             threading.current_thread(), threading._MainThread
         )
-        if main_thread:
-            old_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
-
         p = None
 
         try:
@@ -789,6 +786,8 @@ class Stage(object):
                 executable=executable,
                 close_fds=True,
             )
+            if main_thread:
+                old_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
             p.communicate()
         finally:
             if main_thread:


### PR DESCRIPTION
Signal mask is inherited by the child, so when we set it up before
Popen, our child ignores SIGINT, which is wrong. What we should've
done ideally, is to setup the signal handler after fork() but before
exec(). That is pretty much what preexec_fn is used for in Popen, but
unfortunately for us, it is not available on windows, so we can't use
it. What we will do instead is just setup signal handler after Popen()
but before communicate(), which would leave a slight gap where we might
also get affected by SIGINTS meant for the child, but that is the best
we can do.

Fixes https://github.com/iterative/dvc/issues/2272

Signed-off-by: Ruslan Kuprieiev <ruslan@iterative.ai>

* [x] Have you followed the guidelines in our
      [Contributing document](https://dvc.org/doc/user-guide/contributing)?

* [x] Does your PR affect documented changes or does it add new functionality
      that should be documented? If yes, have you created a PR for
      [dvc.org](https://github.com/iterative/dvc.org) documenting it or at
      least opened an issue for it? If so, please add a link to it.

-----
