### PR TITLE
ci: unify pip cache location for all platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   global:
     - PYENV_ROOT="$HOME/.pyenv"
     - PATH="$PYENV_ROOT/bin:$PATH"
+    - PIP_CACHE_DIR="$HOME/.cache/pip"  # unify pip cache location for all platforms
 stages:
   - test
   - build


### PR DESCRIPTION
Windows and OSX builds don't use the pip cache because its location is
different from ~/.cache/pip.

-----