### PR TITLE
remote: hdfs: use pyarrow and connection pool

### DIFF
--- a/dvc/main.py
+++ b/dvc/main.py
@@ -8,7 +8,7 @@ from dvc.cli import parse_args
 from dvc.config import ConfigError
 from dvc.analytics import Analytics
 from dvc.exceptions import NotDvcRepoError, DvcParserError
-from dvc.remote.ssh.pool import close_ssh_pools
+from dvc.remote.pool import close_pools
 
 
 logger = logging.getLogger("dvc")
@@ -56,7 +56,7 @@ def main(argv=None):
         logger.setLevel(outerLogLevel)
         # Python 2 fails to close these clean occasionally and users see
         # weird error messages, so we do it manually
-        close_ssh_pools()
+        close_pools()
 
     Analytics().send_cmd(cmd, args, ret)
 

--- a/dvc/path_info.py
+++ b/dvc/path_info.py
@@ -129,7 +129,7 @@ class _URLPathParents(object):
 
 
 class URLInfo(object):
-    DEFAULT_PORTS = {"http": 80, "https": 443, "ssh": 22}
+    DEFAULT_PORTS = {"http": 80, "https": 443, "ssh": 22, "hdfs": 0}
 
     def __init__(self, url):
         self.parsed = urlparse(url)

--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -18,7 +18,9 @@ from dvc.utils import to_chunks
 from dvc.utils.compat import urlparse, StringIO
 from dvc.remote.base import RemoteBASE
 from dvc.scheme import Schemes
-from .pool import ssh_connection
+from dvc.remote.pool import get_connection
+
+from .connection import SSHConnection
 
 
 logger = logging.getLogger(__name__)
@@ -121,7 +123,8 @@ class RemoteSSH(RemoteBASE):
                 )
             )
 
-        return ssh_connection(
+        return get_connection(
+            SSHConnection,
             host,
             username=user,
             port=port,

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,12 @@ s3 = ["boto3==1.9.115"]
 azure = ["azure-storage-blob==2.0.1"]
 oss = ["oss2==2.6.1"]
 ssh = ["paramiko>=2.5.0"]
+hdfs = ["pyarrow>=0.14.0"]
 all_remotes = gs + s3 + azure + ssh + oss
+
+if os.name != "nt" or sys.version_info[0] != 2:
+    # NOTE: there are no pyarrow wheels for python2 on windows
+    all_remotes += hdfs
 
 # Extra dependecies to run tests
 tests_requirements = [
@@ -125,6 +130,7 @@ setup(
         "azure": azure,
         "oss": oss,
         "ssh": ssh,
+        "hdfs": hdfs,
         # NOTE: https://github.com/inveniosoftware/troubleshooting/issues/1
         ":python_version=='2.7'": ["futures", "pathlib2"],
         "tests": tests_requirements,

--- a/tests/func/test_output.py
+++ b/tests/func/test_output.py
@@ -1,3 +1,6 @@
+import os
+import sys
+
 import pytest
 
 from dvc.stage import Stage
@@ -8,7 +11,14 @@ TESTS = [
     ("s3://bucket/path", "s3"),
     ("gs://bucket/path", "gs"),
     ("ssh://example.com:/dir/path", "ssh"),
-    ("hdfs://example.com/dir/path", "hdfs"),
+    pytest.param(
+        "hdfs://example.com/dir/path",
+        "hdfs",
+        marks=pytest.mark.skipif(
+            sys.version_info[0] == 2 and os.name == "nt",
+            reason="Not supported for python 2 on Windows.",
+        ),
+    ),
     ("path/to/file", "local"),
     ("path\\to\\file", "local"),
     ("file", "local"),

--- a/tests/unit/dependency/test_hdfs.py
+++ b/tests/unit/dependency/test_hdfs.py
@@ -1,8 +1,16 @@
+import os
+import sys
+import pytest
+
 from dvc.dependency.hdfs import DependencyHDFS
 
 from tests.unit.dependency.test_local import TestDependencyLOCAL
 
 
+@pytest.mark.skipif(
+    sys.version_info[0] == 2 and os.name == "nt",
+    reason="Not supported for python 2 on Windows.",
+)
 class TestDependencyHDFS(TestDependencyLOCAL):
     def _get_cls(self):
         return DependencyHDFS

--- a/tests/unit/output/test_hdfs.py
+++ b/tests/unit/output/test_hdfs.py
@@ -1,8 +1,16 @@
+import os
+import sys
+import pytest
+
 from dvc.output.hdfs import OutputHDFS
 
 from tests.unit.output.test_local import TestOutputLOCAL
 
 
+@pytest.mark.skipif(
+    sys.version_info[0] == 2 and os.name == "nt",
+    reason="Not supported for python 2 on Windows.",
+)
 class TestOutputHDFS(TestOutputLOCAL):
     def _get_cls(self):
         return OutputHDFS

--- a/tests/unit/remote/ssh/test_pool.py
+++ b/tests/unit/remote/ssh/test_pool.py
@@ -1,11 +1,14 @@
 import pytest
 
-from dvc.remote.ssh.pool import ssh_connection
+from dvc.remote.pool import get_connection
+from dvc.remote.ssh.connection import SSHConnection
 
 
 def test_doesnt_swallow_errors(ssh_server):
     class MyError(Exception):
         pass
 
-    with pytest.raises(MyError), ssh_connection(**ssh_server.test_creds):
+    with pytest.raises(MyError), get_connection(
+        SSHConnection, **ssh_server.test_creds
+    ):
         raise MyError


### PR DESCRIPTION
Related to #1629

Speeds up HDFS tests significantly. E.g.
TestReproExternalHDFS from 600sec to 190sec (we are still using hadoop cli there to get checksum).
test_open_external[HDFS] from 160sec to 3sec.

Signed-off-by: Ruslan Kuprieiev <ruslan@iterative.ai>

* [x] Have you followed the guidelines in our
      [Contributing document](https://dvc.org/doc/user-guide/contributing)?

* [x] Does your PR affect documented changes or does it add new functionality
      that should be documented? If yes, have you created a PR for
      [dvc.org](https://github.com/iterative/dvc.org) documenting it or at
      least opened an issue for it? If so, please add a link to it.

-----
