### PR TITLE
dvc: hooks only act in branches where dvc active

### DIFF
--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -217,17 +217,28 @@ class Git(Base):
 
     def _install_hook(self, name, cmd):
         command = "dvc {}".format(cmd)
+        dvc_present_check = """
+LS_FILES=`git ls-files .dvc`
+[ "$LS_FILES" = "" ] ||
+        """.strip()
 
         hook = os.path.join(self.root_dir, self.GIT_DIR, "hooks", name)
 
         if os.path.isfile(hook):
             with open(hook, "r+") as fobj:
                 if command not in fobj.read():
-                    fobj.write("exec {command}\n".format(command=command))
+                    fobj.write(
+                        "{check} exec {command}\n".format(
+                            check=dvc_present_check, command=command
+                        )
+                    )
         else:
             with open(hook, "w+") as fobj:
                 fobj.write(
-                    "#!/bin/sh\n" "exec {command}\n".format(command=command)
+                    "#!/bin/sh\n"
+                    "{check} exec {command}\n".format(
+                        check=dvc_present_check, command=command
+                    )
                 )
 
         os.chmod(hook, 0o777)

--- a/tests/func/test_install.py
+++ b/tests/func/test_install.py
@@ -39,8 +39,7 @@ class TestInstall(object):
         expected_script = (
             "#!/bin/sh\n"
             "echo hello\n"
-            "LS_FILES=`git ls-files .dvc`\n"
-            '[ "$LS_FILES" = "" ] || exec dvc checkout\n'
+            '[ -z "$(git ls-files .dvc)" ] || exec dvc checkout\n'
         )
 
         with open(self._hook("post-checkout"), "r") as fobj:
@@ -52,8 +51,7 @@ class TestInstall(object):
 
         expected_script = (
             "#!/bin/sh\n"
-            "LS_FILES=`git ls-files .dvc`\n"
-            '[ "$LS_FILES" = "" ] || exec dvc checkout\n'
+            '[ -z "$(git ls-files .dvc)" ] || exec dvc checkout\n'
         )
 
         with open(self._hook("post-checkout"), "r") as fobj:

--- a/tests/func/test_install.py
+++ b/tests/func/test_install.py
@@ -36,7 +36,12 @@ class TestInstall(object):
 
         assert main(["install"]) == 0
 
-        expected_script = "#!/bin/sh\n" "echo hello\n" "exec dvc checkout\n"
+        expected_script = (
+            "#!/bin/sh\n"
+            "echo hello\n"
+            "LS_FILES=`git ls-files .dvc`\n"
+            '[ "$LS_FILES" = "" ] || exec dvc checkout\n'
+        )
 
         with open(self._hook("post-checkout"), "r") as fobj:
             assert fobj.read() == expected_script
@@ -45,7 +50,11 @@ class TestInstall(object):
         assert main(["install"]) == 0
         assert main(["install"]) == 0
 
-        expected_script = "#!/bin/sh\n" "exec dvc checkout\n"
+        expected_script = (
+            "#!/bin/sh\n"
+            "LS_FILES=`git ls-files .dvc`\n"
+            '[ "$LS_FILES" = "" ] || exec dvc checkout\n'
+        )
 
         with open(self._hook("post-checkout"), "r") as fobj:
             assert fobj.read() == expected_script


### PR DESCRIPTION
In a branch where DVC hasn't been initialized (as detected by `git ls-files .dvc` not listing any files), don't invoke dvc in the git hooks. This avoids trouble when switching between branches with and without dvc initialized.

Fixes #2208

* [x] Have you followed the guidelines in our
      [Contributing document](https://dvc.org/doc/user-guide/contributing)?

* [x] Does your PR affect documented changes or does it add new functionality
      that should be documented? If yes, have you created a PR for
      [dvc.org](https://github.com/iterative/dvc.org) documenting it or at
      least opened an issue for it? If so, please add a link to it.

Doc issue link: https://github.com/iterative/dvc.org/issues/506