### PR TITLE
api: make .open() stream data for Azure

### DIFF
--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -498,6 +498,9 @@ class RemoteBASE(object):
 
         return 0
 
+    def open(self, path_info, mode="r", encoding=None):
+        raise RemoteActionNotImplemented("open", self.scheme)
+
     def remove(self, path_info):
         raise RemoteActionNotImplemented("remove", self.scheme)
 

--- a/dvc/utils/http.py
+++ b/dvc/utils/http.py
@@ -1,0 +1,106 @@
+from contextlib import contextmanager
+import io
+
+import requests
+
+
+@contextmanager
+def open_url(url, mode="r", encoding=None):
+    """Opens an url as a readable stream.
+
+    Resumes on connection error.
+    Url could be a string or a callable returning a string.
+    """
+    assert mode in {"r", "rt", "rb"}
+
+    with iter_url(url) as (response, it):
+        bytes_stream = IterStream(it)
+
+        if mode == "rb":
+            yield bytes_stream
+        else:
+            encoding = encoding or response.encoding
+            yield io.TextIOWrapper(bytes_stream, encoding=encoding)
+
+
+@contextmanager
+def iter_url(url, chunk_size=io.DEFAULT_BUFFER_SIZE):
+    """Iterate over chunks requested from url."""
+
+    def request(headers=None):
+        the_url = url() if callable(url) else url
+        response = requests.get(the_url, stream=True, headers=headers)
+        response.raise_for_status()
+        return response
+
+    def gen(response):
+        try:
+            pos = 0
+            while True:
+                try:
+                    for chunk in response.iter_content(chunk_size):
+                        pos += len(chunk)
+                        yield chunk
+                    break
+                except requests.ConnectionError:
+                    response.close()
+                    if response.headers.get("Accept-Ranges") != "bytes":
+                        raise
+
+                    # Reopen request from where we stopped
+                    headers = {"Range": "bytes={}-".format(pos)}
+                    response = request(headers)
+        finally:
+            response.close()
+
+    response = request()
+    it = gen(response)
+    try:
+        yield response, it
+    finally:
+        # Ensure connection is closed
+        it.close()
+
+
+class IterStream(io.RawIOBase):
+    """Wraps an iterator yielding bytes as a file object"""
+
+    def __init__(self, iterator):
+        self.iterator = iterator
+        self.leftover = None
+
+    def readable(self):
+        return True
+
+    # Python 3 requires only .readinto() method, it still uses other ones
+    # under some circumstances and falls back if those are absent. Since
+    # iterator already constructs byte strings for us, .readinto() is not the
+    # most optimal, so we provide .read1() too.
+
+    def readinto(self, b):
+        try:
+            n = len(b)  # We're supposed to return at most this much
+            chunk = self.leftover or next(self.iterator)
+            output, self.leftover = chunk[:n], chunk[n:]
+
+            n_out = len(output)
+            b[:n_out] = output
+            return n_out
+        except StopIteration:
+            return 0  # indicate EOF
+
+    readinto1 = readinto
+
+    def read1(self, n=-1):
+        try:
+            chunk = self.leftover or next(self.iterator)
+        except StopIteration:
+            return b""
+
+        # Return an arbitrary number or bytes
+        if n <= 0:
+            self.leftover = None
+            return chunk
+
+        output, self.leftover = chunk[:n], chunk[n:]
+        return output

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,7 @@ tests_requirements = [
     "jaraco.windows==3.9.2",
     "mock-ssh-server>=0.5.0",
     "moto>=1.3.14.dev55",
+    "rangehttpserver==1.2.0",
 ]
 
 if (sys.version_info) >= (3, 6):

--- a/tests/unit/utils/test_http.py
+++ b/tests/unit/utils/test_http.py
@@ -1,0 +1,37 @@
+from __future__ import unicode_literals
+
+import io
+import requests
+
+from dvc.utils.http import open_url
+from tests.utils.httpd import StaticFileServer
+
+
+def test_open_url(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    # Simulate bad connection
+    original_iter_content = requests.Response.iter_content
+
+    def bad_iter_content(self, *args, **kwargs):
+        it = original_iter_content(self, *args, **kwargs)
+        for i, chunk in enumerate(it):
+            # Drop connection error on second chunk if there is one
+            if i > 0:
+                raise requests.ConnectionError("Simulated connection drop")
+            yield chunk
+
+    monkeypatch.setattr(requests.Response, "iter_content", bad_iter_content)
+
+    # Text should be longer than default chunk to test resume,
+    # using twice of that plus something tests second resume,
+    # this is important because second response is different
+    text = "0123456789" * (io.DEFAULT_BUFFER_SIZE // 10 + 1)
+    (tmp_path / "sample.txt").write_text(text * 2)
+
+    with StaticFileServer() as httpd:
+        url = "http://localhost:{}/sample.txt".format(httpd.server_port)
+        with open_url(url) as fd:
+            # Test various .read() variants
+            assert fd.read(len(text)) == text
+            assert fd.read() == text


### PR DESCRIPTION
This employs generating temporary signed public url and then streaming
from it. The bulk of the code might be reused for other remotes.

Url streaming does resume on connection error using "Range" header and
regenerates public url too.

If remote class doesn't provide .open() then this falls back to pulling
a file and opening it locally.