### PR TITLE
remote: base: call makedirs in move

### DIFF
--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -364,7 +364,6 @@ class RemoteBASE(object):
 
         cache_info = self.checksum_to_path_info(checksum)
         if self.changed_cache(checksum):
-            self.makedirs(cache_info.parent)
             self.move(path_info, cache_info)
         else:
             self.remove(path_info)

--- a/dvc/remote/local/__init__.py
+++ b/dvc/remote/local/__init__.py
@@ -243,6 +243,8 @@ class RemoteLOCAL(RemoteBASE):
         if from_info.scheme != "local" or to_info.scheme != "local":
             raise NotImplementedError
 
+        self.makedirs(to_info.parent)
+
         if self.isfile(from_info):
             mode = self._file_mode
         else:


### PR DESCRIPTION
Remotes like s3/gs/etc don't need to create dirs in advance.

Signed-off-by: Ruslan Kuprieiev <ruslan@iterative.ai>

* [x] Have you followed the guidelines in our
      [Contributing document](https://dvc.org/doc/user-guide/contributing)?

* [x] Does your PR affect documented changes or does it add new functionality
      that should be documented? If yes, have you created a PR for
      [dvc.org](https://github.com/iterative/dvc.org) documenting it or at
      least opened an issue for it? If so, please add a link to it.

-----
