### PR TITLE
ssh: add gss_auth option

### DIFF
--- a/dvc/config.py
+++ b/dvc/config.py
@@ -253,6 +253,7 @@ class Config(object):  # pylint: disable=too-many-instance-attributes
     SECTION_REMOTE_TIMEOUT = "timeout"
     SECTION_REMOTE_PASSWORD = "password"
     SECTION_REMOTE_ASK_PASSWORD = "ask_password"
+    SECTION_REMOTE_GSS_AUTH = "gss_auth"
     SECTION_REMOTE_NO_TRAVERSE = "no_traverse"
     SECTION_REMOTE_SCHEMA = {
         SECTION_REMOTE_URL: str,
@@ -273,6 +274,7 @@ class Config(object):  # pylint: disable=too-many-instance-attributes
         Optional(SECTION_REMOTE_TIMEOUT): Use(int),
         Optional(SECTION_REMOTE_PASSWORD): str,
         Optional(SECTION_REMOTE_ASK_PASSWORD): BOOL_SCHEMA,
+        Optional(SECTION_REMOTE_GSS_AUTH): BOOL_SCHEMA,
         Optional(SECTION_AZURE_CONNECTION_STRING): str,
         Optional(SECTION_OSS_ACCESS_KEY_ID): str,
         Optional(SECTION_OSS_ACCESS_KEY_SECRET): str,

--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -87,6 +87,7 @@ class RemoteSSH(RemoteBASE):
         self.ask_password = config.get(
             Config.SECTION_REMOTE_ASK_PASSWORD, False
         )
+        self.gss_auth = config.get(Config.SECTION_REMOTE_GSS_AUTH, False)
 
     @staticmethod
     def ssh_config_filename():
@@ -145,6 +146,7 @@ class RemoteSSH(RemoteBASE):
             key_filename=self.keyfile,
             timeout=self.timeout,
             password=self.password,
+            gss_auth=self.gss_auth,
         )
 
     def exists(self, path_info):

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ gs = ["google-cloud-storage==1.13.0"]
 s3 = ["boto3==1.9.115"]
 azure = ["azure-storage-blob==2.1.0"]
 oss = ["oss2==2.6.1"]
-ssh = ["paramiko>=2.5.0"]
+ssh = ["paramiko[gssapi]>=2.5.0"]
 hdfs = ["pyarrow==0.14.0"]
 all_remotes = gs + s3 + azure + ssh + oss
 

--- a/tests/unit/remote/ssh/test_ssh.py
+++ b/tests/unit/remote/ssh/test_ssh.py
@@ -160,3 +160,25 @@ def test_ssh_keyfile(mock_file, mock_exists, config, expected_keyfile):
     mock_exists.assert_called_with(RemoteSSH.ssh_config_filename())
     mock_file.assert_called_with(RemoteSSH.ssh_config_filename())
     assert remote.keyfile == expected_keyfile
+
+
+@pytest.mark.parametrize(
+    "config,expected_gss_auth",
+    [
+        ({"url": "ssh://example.com", "gss_auth": True}, True),
+        ({"url": "ssh://example.com", "gss_auth": False}, False),
+        ({"url": "ssh://not_in_ssh_config.com"}, False),
+    ],
+)
+@patch("os.path.exists", return_value=True)
+@patch(
+    "{}.open".format(builtin_module_name),
+    new_callable=mock_open,
+    read_data=mock_ssh_config,
+)
+def test_ssh_gss_auth(mock_file, mock_exists, config, expected_gss_auth):
+    remote = RemoteSSH(None, config)
+
+    mock_exists.assert_called_with(RemoteSSH.ssh_config_filename())
+    mock_file.assert_called_with(RemoteSSH.ssh_config_filename())
+    assert remote.gss_auth == expected_gss_auth


### PR DESCRIPTION
This is my proposed implementation of #2327.

If the user has a valid kerberos ticket (generated with [`kinit`](https://web.mit.edu/kerberos/krb5-1.12/doc/user/user_commands/kinit.html)), this feature allows `dvc` to interact with the remote machine without asking the user to type in their password or hard code their password in `.dvc/conf`.

After reading a bit more about kerberos, passing the keytab file no longer made sense to me.  I did not include the `gss_kex` option for paramiko, as I imagine users will trust the server they specify and I did not deem it necessary.  However, I do not fully understand GSS-API key exchange and someone with more knowledge may know better.  

I included a simple unit test, however, it is not clear to me how to write a functional test for this feature.  If details about my manual testing are needed, please let me know. 

Associated documentation PR: [#578](https://github.com/iterative/dvc.org/pull/578)