### PR TITLE
progressbar cleanup

### DIFF
--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -32,11 +32,14 @@ class Tqdm(tqdm):
     """
     maximum-compatibility tqdm-based progressbars
     """
+
     BAR_FMT_DEFAULT = (
         "{percentage:3.0f}%|{bar:10}|{desc} {bar:-10b}{n}/{total}"
         " [{elapsed}<{remaining}, {rate_fmt:>11}{postfix}]"
     )
-    BAR_FMT_NOTOTAL = "{desc} {bar:b}{n} [{elapsed}<??:??, {rate_fmt:>11}{postfix}]"
+    BAR_FMT_NOTOTAL = (
+        "{desc} {bar:b}{n} [{elapsed}<??:??, {rate_fmt:>11}{postfix}]"
+    )
 
     def __init__(
         self,
@@ -69,10 +72,10 @@ class Tqdm(tqdm):
                 >= logging.CRITICAL
             )
         if bar_format is None:
-            if kwargs.get('total', getattr(iterable, '__len__', None)) is None:
-                bar_format = self.BAR_FMT_NOTOTAL
-            else:
+            if kwargs.get("total", hasattr(iterable, "__len__")):
                 bar_format = self.BAR_FMT_DEFAULT
+            else:
+                bar_format = self.BAR_FMT_NOTOTAL
         super(Tqdm, self).__init__(
             iterable=iterable,
             disable=disable,

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -36,11 +36,13 @@ class Tqdm(tqdm):
     """
 
     BAR_FMT_DEFAULT = (
-        "{percentage:3.0f}%|{bar:10}|{desc} {bar:-10b}{n}/{total}"
+        "{percentage:3.0f}%|{bar:10}|"
+        "{desc:{ncols_desc}.{ncols_desc}}{n}/{total}"
         " [{elapsed}<{remaining}, {rate_fmt:>11}{postfix}]"
     )
     BAR_FMT_NOTOTAL = (
-        "{desc} {bar:b}{n} [{elapsed}<??:??, {rate_fmt:>11}{postfix}]"
+        "{desc:{ncols_desc}.{ncols_desc}}{n}"
+        " [{elapsed}<??:??, {rate_fmt:>11}{postfix}]"
     )
 
     def __init__(
@@ -49,7 +51,6 @@ class Tqdm(tqdm):
         disable=None,
         level=logging.ERROR,
         desc=None,
-        desc_truncate=None,
         leave=False,
         bar_format=None,
         bytes=False,  # pylint: disable=W0622
@@ -59,7 +60,6 @@ class Tqdm(tqdm):
         bytes   : shortcut for
             `unit='B', unit_scale=True, unit_divisor=1024, miniters=1`
         desc  : persists after `close()`
-        desc_truncate  : like `desc` but will `truncate()` and not persist
         level  : effective logging level for determining `disable`;
             used only if `disable` is unspecified
         kwargs  : anything accepted by `tqdm.tqdm()`
@@ -72,8 +72,6 @@ class Tqdm(tqdm):
                 kwargs,
             )
         self.desc_persist = desc
-        if desc_truncate is not None:
-            desc = self.truncate(desc_truncate)
         if disable is None:
             disable = logger.getEffectiveLevel() > level
         super(Tqdm, self).__init__(
@@ -81,7 +79,7 @@ class Tqdm(tqdm):
             disable=disable,
             leave=leave,
             desc=desc,
-            bar_format="",
+            bar_format="!",
             **kwargs
         )
         if bar_format is None:
@@ -92,13 +90,11 @@ class Tqdm(tqdm):
             self.bar_format = bar_format
         self.refresh()
 
-    def update_desc(self, desc, n=1, truncate=True):
+    def update_desc(self, desc, n=1):
         """
-        Calls `set_description_str(truncate(desc))` and `update(n)`
+        Calls `set_description_str(desc)` and `update(n)`
         """
-        self.set_description_str(
-            self.truncate(desc) if truncate else desc, refresh=False
-        )
+        self.set_description_str(desc, refresh=False)
         self.update(n)
 
     def update_to(self, current, total=None):
@@ -107,20 +103,15 @@ class Tqdm(tqdm):
         self.update(current - self.n)
 
     def close(self):
-        if self.desc_persist:
+        if self.desc_persist is not None:
             self.set_description_str(self.desc_persist, refresh=False)
         super(Tqdm, self).close()
 
-    @classmethod
-    def truncate(cls, s, max_len=25, end=True, fill="..."):
-        """
-        Guarantee len(output) < max_lenself.
-        >>> truncate("hello", 4)
-        '...o'
-        """
-        if len(s) <= max_len:
-            return s
-        if len(fill) > max_len:
-            return fill[-max_len:] if end else fill[:max_len]
-        i = max_len - len(fill)
-        return (fill + s[-i:]) if end else (s[:i] + fill)
+    @property
+    def format_dict(self):
+        """inject `ncols_desc` to fill the display width (`ncols`)"""
+        d = super(Tqdm, self).format_dict
+        ncols = d.get("ncols", 80)
+        ncols_desc = ncols - len(self.format_meter(ncols_desc=1, **d)) + 1
+        d["ncols_desc"] = max(ncols_desc, 0)
+        return d

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -32,6 +32,11 @@ class Tqdm(tqdm):
     """
     maximum-compatibility tqdm-based progressbars
     """
+    BAR_FMT_DEFAULT = (
+        "{percentage:3.0f}%|{bar:10}|{desc} {bar:-10b}{n}/{total}"
+        " [{elapsed}<{remaining}, {rate_fmt:>11}{postfix}]"
+    )
+    BAR_FMT_NOTOTAL = "{desc} {bar:b}{n} [{elapsed}<??:??, {rate_fmt:>11}{postfix}]"
 
     def __init__(
         self,
@@ -40,10 +45,7 @@ class Tqdm(tqdm):
         bytes=False,  # pylint: disable=W0622
         desc_truncate=None,
         leave=None,
-        bar_format=(
-            "{percentage:3.0f}%|{bar:10}|{desc} {bar:-10b}{n}/{total}"
-            " [{elapsed}<{remaining}, {rate_fmt:>11}{postfix}]"
-        ),
+        bar_format=None,
         **kwargs
     ):
         """
@@ -66,6 +68,11 @@ class Tqdm(tqdm):
                 logging.getLogger(__name__).getEffectiveLevel()
                 >= logging.CRITICAL
             )
+        if bar_format is None:
+            if kwargs.get('total', getattr(iterable, '__len__', None)) is None:
+                bar_format = self.BAR_FMT_NOTOTAL
+            else:
+                bar_format = self.BAR_FMT_DEFAULT
         super(Tqdm, self).__init__(
             iterable=iterable,
             disable=disable,

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -40,6 +40,10 @@ class Tqdm(tqdm):
         bytes=False,  # pylint: disable=W0622
         desc_truncate=None,
         leave=None,
+        bar_format=(
+            "{percentage:3.0f}%|{bar:10}|{desc} {bar:-10b}{n}/{total}"
+            " [{elapsed}<{remaining}, {rate_fmt:>11}{postfix}]"
+        ),
         **kwargs
     ):
         """
@@ -49,6 +53,7 @@ class Tqdm(tqdm):
         kwargs  : anything accepted by `tqdm.tqdm()`
         """
         kwargs = deepcopy(kwargs)
+        kwargs.setdefault("unit_scale", True)
         if bytes:
             for k, v in dict(
                 unit="B", unit_scale=True, unit_divisor=1024, miniters=1
@@ -62,14 +67,18 @@ class Tqdm(tqdm):
                 >= logging.CRITICAL
             )
         super(Tqdm, self).__init__(
-            iterable=iterable, disable=disable, leave=leave, **kwargs
+            iterable=iterable,
+            disable=disable,
+            leave=leave,
+            bar_format=bar_format,
+            **kwargs
         )
 
     def update_desc(self, desc, n=1, truncate=True):
         """
-        Calls `set_description(truncate(desc))` and `update(n)`
+        Calls `set_description_str(truncate(desc))` and `update(n)`
         """
-        self.set_description(
+        self.set_description_str(
             self.truncate(desc) if truncate else desc, refresh=False
         )
         self.update(n)

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import logging
 from tqdm import tqdm
 from concurrent.futures import ThreadPoolExecutor
+from funcy import merge
 
 logger = logging.getLogger(__name__)
 
@@ -69,10 +70,10 @@ class Tqdm(tqdm):
         kwargs = kwargs.copy()
         kwargs.setdefault("unit_scale", True)
         if bytes:
-            for k, v in dict(
-                unit="B", unit_scale=True, unit_divisor=1024, miniters=1
-            ).items():
-                kwargs.setdefault(k, v)
+            kwargs = merge(
+                dict(unit="B", unit_scale=True, unit_divisor=1024, miniters=1),
+                kwargs,
+            )
         self.desc_persist = desc
         if desc_truncate is not None:
             desc = self.truncate(desc_truncate)

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -81,19 +81,21 @@ class Tqdm(tqdm):
             disable = logger.getEffectiveLevel() > level
         if leave is None:
             leave = logger.getEffectiveLevel() <= level_leave
-        if bar_format is None:
-            if kwargs.get("total", hasattr(iterable, "__len__")):
-                bar_format = self.BAR_FMT_DEFAULT
-            else:
-                bar_format = self.BAR_FMT_NOTOTAL
         super(Tqdm, self).__init__(
             iterable=iterable,
             disable=disable,
             leave=leave,
             desc=desc,
-            bar_format=bar_format,
+            bar_format="",
             **kwargs
         )
+        if bar_format is None:
+            self.bar_format = (
+                self.BAR_FMT_DEFAULT if len(self) else self.BAR_FMT_NOTOTAL
+            )
+        else:
+            self.bar_format = bar_format
+        self.refresh()
 
     def update_desc(self, desc, n=1, truncate=True):
         """

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -67,10 +67,10 @@ class Tqdm(tqdm):
         kwargs = kwargs.copy()
         kwargs.setdefault("unit_scale", True)
         if bytes:
-            kwargs = merge(
-                dict(unit="B", unit_scale=True, unit_divisor=1024, miniters=1),
-                kwargs,
+            bytes_defaults = dict(
+                unit="B", unit_scale=True, unit_divisor=1024, miniters=1
             )
+            kwargs = merge(bytes_defaults, kwargs)
         self.desc_persist = desc
         if disable is None:
             disable = logger.getEffectiveLevel() > level

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -2,7 +2,6 @@
 from __future__ import print_function
 import logging
 from tqdm import tqdm
-from copy import deepcopy
 from concurrent.futures import ThreadPoolExecutor
 
 logger = logging.getLogger(__name__)
@@ -67,15 +66,14 @@ class Tqdm(tqdm):
             used only if `leave` is unspecified
         kwargs  : anything accepted by `tqdm.tqdm()`
         """
-        kwargs = deepcopy(kwargs)
+        kwargs = kwargs.copy()
         kwargs.setdefault("unit_scale", True)
         if bytes:
             for k, v in dict(
                 unit="B", unit_scale=True, unit_divisor=1024, miniters=1
             ).items():
                 kwargs.setdefault(k, v)
-        if desc is not None:
-            self.desc_persist = desc
+        self.desc_persist = desc
         if desc_truncate is not None:
             desc = self.truncate(desc_truncate)
         if disable is None:
@@ -111,7 +109,7 @@ class Tqdm(tqdm):
         self.update(current - self.n)
 
     def close(self):
-        if hasattr(self, "desc_persist"):
+        if self.desc_persist:
             self.set_description_str(self.desc_persist, refresh=False)
         super(Tqdm, self).close()
 

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -50,8 +50,7 @@ class Tqdm(tqdm):
         level=logging.ERROR,
         desc=None,
         desc_truncate=None,
-        leave=None,
-        level_leave=logging.DEBUG,
+        leave=False,
         bar_format=None,
         bytes=False,  # pylint: disable=W0622
         **kwargs
@@ -63,8 +62,6 @@ class Tqdm(tqdm):
         desc_truncate  : like `desc` but will `truncate()` and not persist
         level  : effective logging level for determining `disable`;
             used only if `disable` is unspecified
-        level_leave  : effective logging level for determining `leave`;
-            used only if `leave` is unspecified
         kwargs  : anything accepted by `tqdm.tqdm()`
         """
         kwargs = kwargs.copy()
@@ -79,8 +76,6 @@ class Tqdm(tqdm):
             desc = self.truncate(desc_truncate)
         if disable is None:
             disable = logger.getEffectiveLevel() > level
-        if leave is None:
-            leave = logger.getEffectiveLevel() <= level_leave
         super(Tqdm, self).__init__(
             iterable=iterable,
             disable=disable,

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -83,9 +83,10 @@ class Tqdm(tqdm):
             **kwargs
         )
         if bar_format is None:
-            self.bar_format = (
-                self.BAR_FMT_DEFAULT if len(self) else self.BAR_FMT_NOTOTAL
-            )
+            if self.__len__():
+                self.bar_format = self.BAR_FMT_DEFAULT
+            else:
+                self.bar_format = self.BAR_FMT_NOTOTAL
         else:
             self.bar_format = bar_format
         self.refresh()
@@ -111,7 +112,7 @@ class Tqdm(tqdm):
     def format_dict(self):
         """inject `ncols_desc` to fill the display width (`ncols`)"""
         d = super(Tqdm, self).format_dict
-        ncols = d.get("ncols", 80)
+        ncols = d["ncols"] or 80
         ncols_desc = ncols - len(self.format_meter(ncols_desc=1, **d)) + 1
         d["ncols_desc"] = max(ncols_desc, 0)
         return d

--- a/dvc/remote/azure.py
+++ b/dvc/remote/azure.py
@@ -115,9 +115,7 @@ class RemoteAZURE(RemoteBASE):
     def _upload(
         self, from_file, to_info, name=None, no_progress_bar=False, **_kwargs
     ):
-        with Tqdm(
-            desc_truncate=name, disable=no_progress_bar, bytes=True
-        ) as pbar:
+        with Tqdm(desc=name, disable=no_progress_bar, bytes=True) as pbar:
             self.blob_service.create_blob_from_path(
                 to_info.bucket,
                 to_info.path,
@@ -128,9 +126,7 @@ class RemoteAZURE(RemoteBASE):
     def _download(
         self, from_info, to_file, name=None, no_progress_bar=False, **_kwargs
     ):
-        with Tqdm(
-            desc_truncate=name, disable=no_progress_bar, bytes=True
-        ) as pbar:
+        with Tqdm(desc=name, disable=no_progress_bar, bytes=True) as pbar:
             self.blob_service.get_blob_to_path(
                 from_info.bucket,
                 from_info.path,

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -638,7 +638,9 @@ class RemoteBASE(object):
         if not self.no_traverse:
             return list(set(checksums) & set(self.all()))
 
-        with Tqdm(total=len(checksums), unit="md5") as pbar:
+        with Tqdm(
+            desc="Querying remote cache", total=len(checksums), unit="md5"
+        ) as pbar:
 
             def exists_with_progress(path_info):
                 ret = self.exists(path_info)

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -650,16 +650,16 @@ class RemoteBASE(object):
             desc="Querying "
             + ("cache in " + name if name else "remote cache"),
             total=len(checksums),
-            unit="md5",
+            unit="file",
         ) as pbar:
 
             def exists_with_progress(path_info):
                 ret = self.exists(path_info)
-                pbar.update()
+                pbar.update_desc(str(path_info))
                 return ret
 
             with ThreadPoolExecutor(max_workers=jobs or self.JOBS) as executor:
-                path_infos = [self.checksum_to_path_info(x) for x in checksums]
+                path_infos = map(self.checksum_to_path_info, checksums)
                 in_remote = executor.map(exists_with_progress, path_infos)
                 ret = list(itertools.compress(checksums, in_remote))
                 return ret

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -140,14 +140,6 @@ class RemoteBASE(object):
     def cache(self):
         return getattr(self.repo.cache, self.scheme)
 
-    @property
-    def cache_dir(self):
-        return (
-            getattr(self.path_info, "fspath", self.path_info.url)
-            if self.path_info
-            else None
-        )
-
     def get_file_checksum(self, path_info):
         raise NotImplementedError
 

--- a/dvc/remote/http.py
+++ b/dvc/remote/http.py
@@ -38,7 +38,7 @@ class RemoteHTTP(RemoteBASE):
             total=None if no_progress_bar else self._content_length(from_info),
             leave=False,
             bytes=True,
-            desc_truncate=from_info.url if name is None else name,
+            desc=from_info.url if name is None else name,
             disable=no_progress_bar,
         ) as pbar:
             with open(to_file, "wb") as fd:

--- a/dvc/remote/local/__init__.py
+++ b/dvc/remote/local/__init__.py
@@ -315,12 +315,13 @@ class RemoteLOCAL(RemoteBASE):
         show_checksums=False,
         download=False,
     ):
-        logger.info(
+        logger.debug(
             "Preparing to collect status from {}".format(remote.path_info)
         )
         ret = self._group(checksum_infos, show_checksums=show_checksums) or {}
         md5s = list(ret)
 
+        logger.debug("Collecting information from local cache...")
         local_exists = self.cache_exists(md5s, jobs=jobs)
 
         # This is a performance optimization. We can safely assume that,
@@ -330,6 +331,7 @@ class RemoteLOCAL(RemoteBASE):
         if download and sorted(local_exists) == sorted(md5s):
             remote_exists = local_exists
         else:
+            logger.debug("Collecting information from remote cache...")
             remote_exists = list(remote.cache_exists(md5s, jobs=jobs))
 
         self._fill_statuses(ret, local_exists, remote_exists)
@@ -377,7 +379,7 @@ class RemoteLOCAL(RemoteBASE):
         show_checksums=False,
         download=False,
     ):
-        logger.info(
+        logger.debug(
             "Preparing to {} '{}'".format(
                 "download data from" if download else "upload data to",
                 remote.path_info,

--- a/dvc/remote/local/__init__.py
+++ b/dvc/remote/local/__init__.py
@@ -97,6 +97,10 @@ class RemoteLOCAL(RemoteBASE):
     def state(self):
         return self.repo.state
 
+    @property
+    def cache_dir(self):
+        return self.path_info.fspath if self.path_info else None
+
     @classmethod
     def supported(cls, config):
         return True
@@ -332,7 +336,9 @@ class RemoteLOCAL(RemoteBASE):
         else:
             logger.debug("Collecting information from remote cache...")
             remote_exists = list(
-                remote.cache_exists(md5s, jobs=jobs, name=remote.cache_dir)
+                remote.cache_exists(
+                    md5s, jobs=jobs, name=str(remote.path_info)
+                )
             )
 
         self._fill_statuses(ret, local_exists, remote_exists)

--- a/dvc/remote/local/__init__.py
+++ b/dvc/remote/local/__init__.py
@@ -254,7 +254,9 @@ class RemoteLOCAL(RemoteBASE):
     def cache_exists(self, checksums, jobs=None):
         return [
             checksum
-            for checksum in Tqdm(checksums, unit="md5")
+            for checksum in Tqdm(
+                checksums, unit="md5", desc="Querying local cache"
+            )
             if not self.changed_cache_file(checksum)
         ]
 
@@ -319,7 +321,6 @@ class RemoteLOCAL(RemoteBASE):
         ret = self._group(checksum_infos, show_checksums=show_checksums) or {}
         md5s = list(ret)
 
-        logger.info("Collecting information from local cache...")
         local_exists = self.cache_exists(md5s, jobs=jobs)
 
         # This is a performance optimization. We can safely assume that,
@@ -329,7 +330,6 @@ class RemoteLOCAL(RemoteBASE):
         if download and sorted(local_exists) == sorted(md5s):
             remote_exists = local_exists
         else:
-            logger.info("Collecting information from remote cache...")
             remote_exists = list(remote.cache_exists(md5s, jobs=jobs))
 
         self._fill_statuses(ret, local_exists, remote_exists)

--- a/dvc/remote/local/__init__.py
+++ b/dvc/remote/local/__init__.py
@@ -252,7 +252,7 @@ class RemoteLOCAL(RemoteBASE):
             checksum
             for checksum in Tqdm(
                 checksums,
-                unit="md5",
+                unit="file",
                 desc="Querying "
                 + ("cache in " + name if name else "local cache"),
             )

--- a/dvc/remote/oss.py
+++ b/dvc/remote/oss.py
@@ -107,9 +107,7 @@ class RemoteOSS(RemoteBASE):
     def _upload(
         self, from_file, to_info, name=None, no_progress_bar=False, **_kwargs
     ):
-        with Tqdm(
-            desc_truncate=name, disable=no_progress_bar, bytes=True
-        ) as pbar:
+        with Tqdm(desc=name, disable=no_progress_bar, bytes=True) as pbar:
             self.oss_service.put_object_from_file(
                 to_info.path, from_file, progress_callback=pbar.update_to
             )
@@ -117,9 +115,7 @@ class RemoteOSS(RemoteBASE):
     def _download(
         self, from_info, to_file, name=None, no_progress_bar=False, **_kwargs
     ):
-        with Tqdm(
-            desc_truncate=name, disable=no_progress_bar, bytes=True
-        ) as pbar:
+        with Tqdm(desc=name, disable=no_progress_bar, bytes=True) as pbar:
             self.oss_service.get_object_to_file(
                 from_info.path, to_file, progress_callback=pbar.update_to
             )

--- a/dvc/remote/s3.py
+++ b/dvc/remote/s3.py
@@ -208,10 +208,7 @@ class RemoteS3(RemoteBASE):
     def _upload(self, from_file, to_info, name=None, no_progress_bar=False):
         total = os.path.getsize(from_file)
         with Tqdm(
-            disable=no_progress_bar,
-            total=total,
-            bytes=True,
-            desc_truncate=name,
+            disable=no_progress_bar, total=total, bytes=True, desc=name
         ) as pbar:
             self.s3.upload_file(
                 from_file,
@@ -229,10 +226,7 @@ class RemoteS3(RemoteBASE):
                 Bucket=from_info.bucket, Key=from_info.path
             )["ContentLength"]
         with Tqdm(
-            disable=no_progress_bar,
-            total=total,
-            bytes=True,
-            desc_truncate=name,
+            disable=no_progress_bar, total=total, bytes=True, desc=name
         ) as pbar:
             self.s3.download_file(
                 from_info.bucket, from_info.path, to_file, Callback=pbar.update

--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -258,7 +258,7 @@ class RemoteSSH(RemoteBASE):
 
             return results
 
-    def cache_exists(self, checksums, jobs=None):
+    def cache_exists(self, checksums, jobs=None, name=None):
         """This is older implementation used in remote/base.py
         We are reusing it in RemoteSSH, because SSH's batch_exists proved to be
         faster than current approach (relying on exists(path_info)) applied in
@@ -268,7 +268,10 @@ class RemoteSSH(RemoteBASE):
             return list(set(checksums) & set(self.all()))
 
         with Tqdm(
-            desc="Querying remote cache", total=len(checksums), unit="md5"
+            desc="Querying "
+            + ("cache in " + name if name else "remote cache"),
+            total=len(checksums),
+            unit="md5",
         ) as pbar:
 
             def exists_with_progress(chunks):

--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -280,5 +280,4 @@ class RemoteSSH(RemoteBASE):
                 results = executor.map(exists_with_progress, chunks)
                 in_remote = itertools.chain.from_iterable(results)
                 ret = list(itertools.compress(checksums, in_remote))
-                pbar.set_description_str("Querying remote cache")
                 return ret

--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -271,7 +271,7 @@ class RemoteSSH(RemoteBASE):
             desc="Querying "
             + ("cache in " + name if name else "remote cache"),
             total=len(checksums),
-            unit="md5",
+            unit="file",
         ) as pbar:
 
             def exists_with_progress(chunks):

--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -267,7 +267,9 @@ class RemoteSSH(RemoteBASE):
         if not self.no_traverse:
             return list(set(checksums) & set(self.all()))
 
-        with Tqdm(total=len(checksums), unit="md5") as pbar:
+        with Tqdm(
+            desc="Querying remote cache", total=len(checksums), unit="md5"
+        ) as pbar:
 
             def exists_with_progress(chunks):
                 return self.batch_exists(chunks, callback=pbar.update_desc)
@@ -278,5 +280,5 @@ class RemoteSSH(RemoteBASE):
                 results = executor.map(exists_with_progress, chunks)
                 in_remote = itertools.chain.from_iterable(results)
                 ret = list(itertools.compress(checksums, in_remote))
-                pbar.update_desc("", 0)  # clear path name description
+                pbar.set_description_str("Querying remote cache")
                 return ret

--- a/dvc/remote/ssh/connection.py
+++ b/dvc/remote/ssh/connection.py
@@ -169,7 +169,7 @@ class SSHConnection:
 
     def download(self, src, dest, no_progress_bar=False, progress_title=None):
         with Tqdm(
-            desc_truncate=progress_title or os.path.basename(src),
+            desc=progress_title or os.path.basename(src),
             disable=no_progress_bar,
             bytes=True,
         ) as pbar:
@@ -186,7 +186,7 @@ class SSHConnection:
             progress_title = posixpath.basename(dest)
 
         with Tqdm(
-            desc_truncate=progress_title, disable=no_progress_bar, bytes=True
+            desc=progress_title, disable=no_progress_bar, bytes=True
         ) as pbar:
             self.sftp.put(src, tmp_file, callback=pbar.update_to)
 

--- a/dvc/repo/checkout.py
+++ b/dvc/repo/checkout.py
@@ -41,11 +41,7 @@ def checkout(self, target=None, with_deps=False, force=False, recursive=False):
         if total == 0:
             logger.info("Nothing to do")
         with Tqdm(
-            total=total,
-            unit="file",
-            desc="Checkout",
-            disable=total == 0,
-            leave=logger.getEffectiveLevel() < logging.CRITICAL,
+            total=total, unit="file", desc="Checkout", disable=total == 0
         ) as pbar:
             for stage in stages:
                 if stage.locked:

--- a/dvc/repo/checkout.py
+++ b/dvc/repo/checkout.py
@@ -51,4 +51,4 @@ def checkout(self, target=None, with_deps=False, force=False, recursive=False):
                     )
 
                 stage.checkout(force=force, progress_callback=pbar.update_desc)
-            pbar.update_desc("Checkout", 0)  # clear path name description
+            pbar.set_description_str("Checkout")

--- a/dvc/repo/checkout.py
+++ b/dvc/repo/checkout.py
@@ -38,8 +38,14 @@ def checkout(self, target=None, with_deps=False, force=False, recursive=False):
     with self.state:
         _cleanup_unused_links(self, all_stages)
         total = get_all_files_numbers(stages)
+        if total == 0:
+            logger.info("Nothing to do")
         with Tqdm(
-            total=total, unit="file", desc="Checkout", disable=total == 0
+            total=total,
+            unit="file",
+            desc="Checkout",
+            disable=total == 0,
+            level_leave=logging.INFO,
         ) as pbar:
             for stage in stages:
                 if stage.locked:

--- a/dvc/repo/checkout.py
+++ b/dvc/repo/checkout.py
@@ -57,4 +57,3 @@ def checkout(self, target=None, with_deps=False, force=False, recursive=False):
                     )
 
                 stage.checkout(force=force, progress_callback=pbar.update_desc)
-            pbar.set_description_str("Checkout")

--- a/dvc/repo/checkout.py
+++ b/dvc/repo/checkout.py
@@ -45,7 +45,7 @@ def checkout(self, target=None, with_deps=False, force=False, recursive=False):
             unit="file",
             desc="Checkout",
             disable=total == 0,
-            level_leave=logging.INFO,
+            leave=logger.getEffectiveLevel() < logging.CRITICAL,
         ) as pbar:
             for stage in stages:
                 if stage.locked:

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -51,16 +51,16 @@ def file_md5(fname):
         hash_md5 = hashlib.md5()
         binary = not istextfile(fname)
         size = os.path.getsize(fname)
-        bar = False
+        no_progress_bar = True
         if size >= LARGE_FILE_SIZE:
-            bar = True
+            no_progress_bar = False
             msg = "Computing md5 for a large file {}. This is only done once."
             logger.info(msg.format(relpath(fname)))
         name = relpath(fname)
 
         with Tqdm(
             desc_truncate=name,
-            disable=not bar,
+            disable=no_progress_bar,
             total=size,
             bytes=True,
             leave=False,

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -59,7 +59,7 @@ def file_md5(fname):
         name = relpath(fname)
 
         with Tqdm(
-            desc_truncate=name,
+            desc=name,
             disable=no_progress_bar,
             total=size,
             bytes=True,
@@ -132,10 +132,7 @@ def copyfile(src, dest, no_progress_bar=False, name=None):
         System.reflink(src, dest)
     except DvcException:
         with Tqdm(
-            desc_truncate=name,
-            disable=no_progress_bar,
-            total=total,
-            bytes=True,
+            desc=name, disable=no_progress_bar, total=total, bytes=True
         ) as pbar:
             with open(src, "rb") as fsrc, open(dest, "wb+") as fdest:
                 while True:

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ install_requires = [
     "funcy>=1.12",
     "pathspec>=0.5.9",
     "shortuuid>=0.5.0",
-    "tqdm>=4.34.0",
+    "tqdm>=4.35.0",
     "win-unicode-console>=0.5; sys_platform == 'win32'",
 ]
 


### PR DESCRIPTION
Post-merge of #2333, sort out a few issues (both new and pre-existing)

- [x] custom default `bar_format`
  + [x] fix bar width (https://github.com/tqdm/tqdm/issues/623)
  + [x] truncate ~~and/or justify file names (right align? max truncation len? prefix ellipsis? multi-line (https://github.com/tqdm/tqdm/issues/630)?)~~ description (from right) to fit into terminal width
    * [x] remove `progress.Tqdm.truncate`
    * [x] remove `progress.Tqdm.__init__(desc_truncate)`
    * [x] remove `progress.Tqdm.update_desc(truncate)`
  + [x] still auto-detect `ncols` (fill space with whitespace rather than variable bar width?)
    * [x] add `progress.Tqdm.format_dict["ncols_desc"]`
- [x] make progressbars less verbose
  + [x] add `level=INFO` (when `disable=None`)
  + [x] ~~add `leave_level=DEBUG` (when `leave=None`)~~ add `leave=False`
- [x] demote other messages `info` -> `debug`
- [x] make `progress.Tqdm.desc` persistent
  + [x] get rid of `progress.Tqdm.update_desc("", 0)`
  + [x] get rid of `progress.Tqdm.set_description_str()`
- [x] ~~depends on https://github.com/tqdm/tqdm/pull/800~~
- [x] include the name of the remote into `cache_exists` bar
  + - [x] bar descriptions such as `Querying cache in .dvc/cache` and `Querying cache in s3://mybucket/mypath`
- [x] replace md5?
- [x] remove all output (incl. `Checkout` progress bar)
- fixes #2434

[![asciicast](https://asciinema.org/a/jDmhBlsa7TPY88GRE56WHqJYk.svg)](https://asciinema.org/a/jDmhBlsa7TPY88GRE56WHqJYk?speed=2)