### PR TITLE
pull: download data from imported stages

### DIFF
--- a/dvc/config.py
+++ b/dvc/config.py
@@ -31,6 +31,18 @@ class ConfigError(DvcException):
         )
 
 
+class NoRemoteRepositoryError(ConfigError):
+    def __init__(self, command, cause=None):
+        msg = (
+            "No remote repository specified. Setup default repository with\n"
+            "    dvc config core.remote <name>\n"
+            "or use:\n"
+            "    dvc {} -r <name>\n".format(command)
+        )
+
+        super(NoRemoteRepositoryError, self).__init__(msg, cause=cause)
+
+
 def supported_cache_type(types):
     """Checks if link type config option has a valid value.
 

--- a/dvc/config.py
+++ b/dvc/config.py
@@ -31,16 +31,16 @@ class ConfigError(DvcException):
         )
 
 
-class NoRemoteRepositoryError(ConfigError):
+class NoRemoteError(ConfigError):
     def __init__(self, command, cause=None):
         msg = (
-            "No remote repository specified. Setup default repository with\n"
+            "no remote specified. Setup default remote with\n"
             "    dvc config core.remote <name>\n"
             "or use:\n"
             "    dvc {} -r <name>\n".format(command)
         )
 
-        super(NoRemoteRepositoryError, self).__init__(msg, cause=cause)
+        super(NoRemoteError, self).__init__(msg, cause=cause)
 
 
 def supported_cache_type(types):

--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 import logging
 
-from dvc.config import Config, NoRemoteRepositoryError
+from dvc.config import Config, NoRemoteError
 from dvc.remote import Remote
 from dvc.remote.s3 import RemoteS3
 from dvc.remote.gs import RemoteGS
@@ -27,7 +27,7 @@ class DataCloud(object):
             we are working on.
 
     Raises:
-        config.NoRemoteRepositoryErro: thrown when config has invalid format.
+        config.ConfigError: thrown when config has invalid format.
     """
 
     CLOUD_MAP = {
@@ -60,7 +60,7 @@ class DataCloud(object):
         if remote:
             return self._init_remote(remote)
 
-        raise NoRemoteRepositoryError(command)
+        raise NoRemoteError(command)
 
     def _init_remote(self, remote):
         return Remote(self.repo, name=remote)

--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 import logging
 
-from dvc.config import Config, ConfigError
+from dvc.config import Config, NoRemoteRepositoryError
 from dvc.remote import Remote
 from dvc.remote.s3 import RemoteS3
 from dvc.remote.gs import RemoteGS
@@ -27,7 +27,7 @@ class DataCloud(object):
             we are working on.
 
     Raises:
-        config.ConfigError: thrown when config has invalid format.
+        config.NoRemoteRepositoryErro: thrown when config has invalid format.
     """
 
     CLOUD_MAP = {
@@ -60,12 +60,7 @@ class DataCloud(object):
         if remote:
             return self._init_remote(remote)
 
-        raise ConfigError(
-            "No remote repository specified. Setup default repository with\n"
-            "    dvc config core.remote <name>\n"
-            "or use:\n"
-            "    dvc {} -r <name>\n".format(command)
-        )
+        raise NoRemoteRepositoryError(command)
 
     def _init_remote(self, remote):
         return Remote(self.repo, name=remote)

--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -99,11 +99,6 @@ class DataCloud(object):
             show_checksums (bool): show checksums instead of file names in
                 information messages.
         """
-        # XXX: returning earlier to prevent `get_remote` from
-        # raising a ConfigError
-        if not targets:
-            return 0
-
         return self.repo.cache.local.pull(
             targets,
             jobs=jobs,

--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -99,6 +99,11 @@ class DataCloud(object):
             show_checksums (bool): show checksums instead of file names in
                 information messages.
         """
+        # XXX: returning earlier to prevent `get_remote` from
+        # raising a ConfigError
+        if not targets:
+            return 0
+
         return self.repo.cache.local.pull(
             targets,
             jobs=jobs,

--- a/dvc/dependency/repo.py
+++ b/dvc/dependency/repo.py
@@ -61,7 +61,7 @@ class DependencyREPO(DependencyLOCAL):
     def dumpd(self):
         return {self.PARAM_PATH: self.def_path, self.PARAM_REPO: self.def_repo}
 
-    def download(self, to, resume=False):
+    def fetch(self):
         with self._make_repo(
             cache_dir=self.repo.cache.local.cache_dir
         ) as repo:
@@ -70,8 +70,13 @@ class DependencyREPO(DependencyLOCAL):
             out = repo.find_out_by_relpath(self.def_path)
             with repo.state:
                 repo.cloud.pull(out.get_used_cache())
-            to.info = copy.copy(out.info)
-            to.checkout()
+
+        return out
+
+    def download(self, to):
+        out = self.fetch()
+        to.info = copy.copy(out.info)
+        to.checkout()
 
     def update(self):
         with self._make_repo(rev_lock=None) as repo:

--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -305,19 +305,19 @@ class GitHookAlreadyExistsError(DvcException):
         )
 
 
-class FailedDownloadError(DvcException):
+class DownloadError(DvcException):
     def __init__(self, amount):
         self.amount = amount
 
-        super(FailedDownloadError, self).__init__(
+        super(DownloadError, self).__init__(
             "{amount} files failed to download".format(amount=amount)
         )
 
 
-class FailedUploadError(DvcException):
+class UploadError(DvcException):
     def __init__(self, amount):
         self.amount = amount
 
-        super(FailedUploadError, self).__init__(
+        super(UploadError, self).__init__(
             "{amount} files failed to upload".format(amount=amount)
         )

--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -303,3 +303,21 @@ class GitHookAlreadyExistsError(DvcException):
             "https://man.dvc.org/install "
             "for more info.".format(hook_name)
         )
+
+
+class FailedDownloadError(DvcException):
+    def __init__(self, amount):
+        self.amount = amount
+
+        super(FailedDownloadError, self).__init__(
+            "{amount} files failed to download".format(amount=amount)
+        )
+
+
+class FailedUploadError(DvcException):
+    def __init__(self, amount):
+        self.amount = amount
+
+        super(FailedUploadError, self).__init__(
+            "{amount} files failed to upload".format(amount=amount)
+        )

--- a/dvc/output/base.py
+++ b/dvc/output/base.py
@@ -402,11 +402,6 @@ class OutputBase(object):
         include the `info` of its files.
         """
 
-        # XXX: There's no test for this one, it might not be needed
-        #
-        # if self.stage.is_repo_import:
-        #     return []
-
         if not self.use_cache:
             return []
 

--- a/dvc/output/base.py
+++ b/dvc/output/base.py
@@ -393,8 +393,10 @@ class OutputBase(object):
         include the `info` of its files.
         """
 
-        if self.stage.is_repo_import:
-            return []
+        # XXX: There's no test for this one, it might not be needed
+        #
+        # if self.stage.is_repo_import:
+        #     return []
 
         if not self.use_cache:
             return []

--- a/dvc/remote/local/__init__.py
+++ b/dvc/remote/local/__init__.py
@@ -30,7 +30,7 @@ from dvc.utils import (
     makedirs,
 )
 from dvc.config import Config
-from dvc.exceptions import DvcException
+from dvc.exceptions import DvcException, FailedDownloadError, FailedUploadError
 from dvc.progress import Tqdm, TqdmThreadPoolExecutor
 
 from dvc.path_info import PathInfo
@@ -388,10 +388,9 @@ class RemoteLOCAL(RemoteBASE):
             fails = sum(map(func, *plans))
 
         if fails:
-            msg = "{} files failed to {}"
-            raise DvcException(
-                msg.format(fails, "download" if download else "upload")
-            )
+            if download:
+                raise FailedDownloadError(fails)
+            raise FailedUploadError(fails)
 
         return len(plans[0])
 

--- a/dvc/remote/local/__init__.py
+++ b/dvc/remote/local/__init__.py
@@ -30,7 +30,7 @@ from dvc.utils import (
     makedirs,
 )
 from dvc.config import Config
-from dvc.exceptions import DvcException, FailedDownloadError, FailedUploadError
+from dvc.exceptions import DvcException, DownloadError, UploadError
 from dvc.progress import Tqdm, TqdmThreadPoolExecutor
 
 from dvc.path_info import PathInfo
@@ -389,8 +389,8 @@ class RemoteLOCAL(RemoteBASE):
 
         if fails:
             if download:
-                raise FailedDownloadError(fails)
-            raise FailedUploadError(fails)
+                raise DownloadError(fails)
+            raise UploadError(fails)
 
         return len(plans[0])
 

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -214,6 +214,7 @@ class Repo(object):
         cache["hdfs"] = []
         cache["ssh"] = []
         cache["azure"] = []
+        cache["repo"] = []
 
         for branch in self.brancher(
             all_branches=all_branches, all_tags=all_tags
@@ -231,6 +232,10 @@ class Repo(object):
                 stages = self.stages()
 
             for stage in stages:
+                if stage.is_repo_import:
+                    cache["repo"].append(stage)
+                    continue
+
                 for out in stage.outs:
                     scheme = out.path_info.scheme
                     used_cache = out.get_used_cache(

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -233,7 +233,7 @@ class Repo(object):
 
             for stage in stages:
                 if stage.is_repo_import:
-                    cache["repo"].append(stage)
+                    cache["repo"] += stage.deps
                     continue
 
                 for out in stage.outs:

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -70,7 +70,7 @@ def fetch(
                 failed += exc.amount
             except (CloneError, OutputNotFoundError) as exc:
                 failed += 1
-                logger.exception(str(exc))
+                logger.exception("failed to fetch data for '{}'".format(dep.stage.outs[0]))
 
         if failed:
             raise DownloadError(failed)

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -1,7 +1,13 @@
 from __future__ import unicode_literals
+
+import logging
+
 from dvc.config import NoRemoteError
 from dvc.exceptions import DownloadError, OutputNotFoundError
 from dvc.scm.base import CloneError
+
+
+logger = logging.getLogger(__name__)
 
 
 def fetch(
@@ -60,11 +66,11 @@ def fetch(
             try:
                 out = dep.fetch()
                 downloaded += out.get_files_number()
-            except (DownloadError, CloneError, OutputNotFoundError) as exc:
-                if hasattr(exc, "amount"):
-                    failed += exc.amount
-                else:
-                    failed += 1
+            except DownloadError as exc:
+                failed += exc.amount
+            except (CloneError, OutputNotFoundError) as exc:
+                failed += 1
+                logger.exception(str(exc))
 
         if failed:
             raise DownloadError(failed)

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from dvc.config import ConfigError
 
 
 def fetch(
@@ -27,6 +28,13 @@ def fetch(
         for dep in used["repo"]:
             dep.fetch()
 
-        return self.cloud.pull(
-            used["local"], jobs, remote=remote, show_checksums=show_checksums
-        ) + len(used["repo"])
+        try:
+            return self.cloud.pull(
+                used["local"],
+                jobs,
+                remote=remote,
+                show_checksums=show_checksums,
+            ) + len(used["repo"])
+        except ConfigError:
+            if not used["repo"]:
+                raise

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -24,8 +24,8 @@ def fetch(
             recursive=recursive,
         )
 
-        for stage in used["repo"]:
-            stage.reproduce()
+        for dep in used["repo"]:
+            dep.fetch()
 
         return self.cloud.pull(
             used["local"], jobs, remote=remote, show_checksums=show_checksums

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -68,9 +68,11 @@ def fetch(
                 downloaded += out.get_files_number()
             except DownloadError as exc:
                 failed += exc.amount
-            except (CloneError, OutputNotFoundError) as exc:
+            except (CloneError, OutputNotFoundError):
                 failed += 1
-                logger.exception("failed to fetch data for '{}'".format(dep.stage.outs[0]))
+                logger.exception(
+                    "failed to fetch data for '{}'".format(dep.stage.outs[0])
+                )
 
         if failed:
             raise DownloadError(failed)

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from dvc.config import NoRemoteError
-from dvc.exceptions import FailedDownloadError
+from dvc.exceptions import DownloadError
 
 
 def fetch(
@@ -20,7 +20,7 @@ def fetch(
         int: number of succesfully downloaded files
 
     Raises:
-        FailedDownloadError: thrown when there are failed downloads, either
+        DownloadError: thrown when there are failed downloads, either
             during `cloud.pull` or trying to fetch imported files
 
         config.NoRemoteError: thrown when downloading only local files and no
@@ -48,20 +48,21 @@ def fetch(
                 remote=remote,
                 show_checksums=show_checksums,
             )
-        except NoRemoteError as exc:
+        except NoRemoteError:
             if not used["repo"]:
                 raise
-        except FailedDownloadError as exc:
+
+        except DownloadError as exc:
             failed += exc.amount
 
         for dep in used["repo"]:
             try:
                 out = dep.fetch()
                 downloaded += out.get_files_number()
-            except FailedDownloadError as exc:
+            except DownloadError as exc:
                 failed += exc.amount
 
         if failed:
-            raise FailedDownloadError(failed)
+            raise DownloadError(failed)
 
         return downloaded

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -22,7 +22,11 @@ def fetch(
             remote=remote,
             jobs=jobs,
             recursive=recursive,
-        )["local"]
-        return self.cloud.pull(
-            used, jobs, remote=remote, show_checksums=show_checksums
         )
+
+        for stage in used["repo"]:
+            stage.reproduce()
+
+        return self.cloud.pull(
+            used["local"], jobs, remote=remote, show_checksums=show_checksums
+        ) + len(used["repo"])

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from dvc.config import ConfigError
+from dvc.config import NoRemoteRepositoryError
 
 
 def fetch(
@@ -25,16 +25,21 @@ def fetch(
             recursive=recursive,
         )
 
-        for dep in used["repo"]:
-            dep.fetch()
+        downloaded_files = 0
 
         try:
-            return self.cloud.pull(
+            downloaded_files += self.cloud.pull(
                 used["local"],
                 jobs,
                 remote=remote,
                 show_checksums=show_checksums,
-            ) + len(used["repo"])
-        except ConfigError:
+            )
+        except NoRemoteRepositoryError:
             if not used["repo"]:
                 raise
+
+        for dep in used["repo"]:
+            dep.fetch()
+            downloaded_files += 1
+
+        return downloaded_files

--- a/tests/func/test_import.py
+++ b/tests/func/test_import.py
@@ -49,12 +49,12 @@ def test_fetching_imported_stage(dvc_repo, erepo):
 
     dvc_repo.imp(erepo.root_dir, src, dst)
 
-    dst_stage = Stage.load(dvc_repo, 'foo_imported.dvc')
+    dst_stage = Stage.load(dvc_repo, "foo_imported.dvc")
     dst_cache = dst_stage.outs[0].cache_path
 
     os.remove(dst_cache)
 
-    dvc_repo.fetch(['foo_imported.dvc'])
+    dvc_repo.fetch(["foo_imported.dvc"])
 
     assert os.path.isfile(dst_cache)
 
@@ -65,13 +65,13 @@ def test_pulling_imported_stage(dvc_repo, erepo):
 
     dvc_repo.imp(erepo.root_dir, src, dst)
 
-    dst_stage = Stage.load(dvc_repo, 'foo_imported.dvc')
+    dst_stage = Stage.load(dvc_repo, "foo_imported.dvc")
     dst_cache = dst_stage.outs[0].cache_path
 
     os.remove(dst)
     os.remove(dst_cache)
 
-    dvc_repo.pull(['foo_imported.dvc'])
+    dvc_repo.pull(["foo_imported.dvc"])
 
     assert os.path.isfile(dst)
     assert os.path.isfile(dst_cache)

--- a/tests/func/test_import.py
+++ b/tests/func/test_import.py
@@ -1,9 +1,12 @@
 import os
 import filecmp
+import shutil
 
+import pytest
 from tests.utils import trees_equal
 
 from dvc.stage import Stage
+from dvc.exceptions import DownloadError
 
 
 def test_import(repo_dir, git, dvc_repo, erepo):
@@ -59,3 +62,20 @@ def test_pull_imported_stage(dvc_repo, erepo):
 
     assert os.path.isfile(dst)
     assert os.path.isfile(dst_cache)
+
+
+def test_download_error_pulling_imported_stage(dvc_repo, erepo):
+    src = erepo.FOO
+    dst = erepo.FOO + "_imported"
+
+    dvc_repo.imp(erepo.root_dir, src, dst)
+
+    dst_stage = Stage.load(dvc_repo, "foo_imported.dvc")
+    dst_cache = dst_stage.outs[0].cache_path
+
+    shutil.rmtree(erepo.root_dir)
+    os.remove(dst)
+    os.remove(dst_cache)
+
+    with pytest.raises(DownloadError):
+        dvc_repo.pull(["foo_imported.dvc"])

--- a/tests/func/test_import.py
+++ b/tests/func/test_import.py
@@ -1,6 +1,5 @@
 import os
 import filecmp
-import shutil
 
 from tests.utils import trees_equal
 

--- a/tests/func/test_import.py
+++ b/tests/func/test_import.py
@@ -1,5 +1,6 @@
 import os
 import filecmp
+import shutil
 
 from tests.utils import trees_equal
 
@@ -43,23 +44,7 @@ def test_import_rev(repo_dir, git, dvc_repo, erepo):
     assert git.git.check_ignore(dst)
 
 
-def test_fetching_imported_stage(dvc_repo, erepo):
-    src = erepo.FOO
-    dst = erepo.FOO + "_imported"
-
-    dvc_repo.imp(erepo.root_dir, src, dst)
-
-    dst_stage = Stage.load(dvc_repo, "foo_imported.dvc")
-    dst_cache = dst_stage.outs[0].cache_path
-
-    os.remove(dst_cache)
-
-    dvc_repo.fetch(["foo_imported.dvc"])
-
-    assert os.path.isfile(dst_cache)
-
-
-def test_pulling_imported_stage(dvc_repo, erepo):
+def test_pull_imported_stage(dvc_repo, erepo):
     src = erepo.FOO
     dst = erepo.FOO + "_imported"
 

--- a/tests/func/test_import.py
+++ b/tests/func/test_import.py
@@ -3,6 +3,8 @@ import filecmp
 
 from tests.utils import trees_equal
 
+from dvc.stage import Stage
+
 
 def test_import(repo_dir, git, dvc_repo, erepo):
     src = erepo.FOO
@@ -39,3 +41,37 @@ def test_import_rev(repo_dir, git, dvc_repo, erepo):
     with open(dst, "r+") as fobj:
         assert fobj.read() == "branch"
     assert git.git.check_ignore(dst)
+
+
+def test_fetching_imported_stage(dvc_repo, erepo):
+    src = erepo.FOO
+    dst = erepo.FOO + "_imported"
+
+    dvc_repo.imp(erepo.root_dir, src, dst)
+
+    dst_stage = Stage.load(dvc_repo, 'foo_imported.dvc')
+    dst_cache = dst_stage.outs[0].cache_path
+
+    os.remove(dst_cache)
+
+    dvc_repo.fetch(['foo_imported.dvc'])
+
+    assert os.path.isfile(dst_cache)
+
+
+def test_pulling_imported_stage(dvc_repo, erepo):
+    src = erepo.FOO
+    dst = erepo.FOO + "_imported"
+
+    dvc_repo.imp(erepo.root_dir, src, dst)
+
+    dst_stage = Stage.load(dvc_repo, 'foo_imported.dvc')
+    dst_cache = dst_stage.outs[0].cache_path
+
+    os.remove(dst)
+    os.remove(dst_cache)
+
+    dvc_repo.pull(['foo_imported.dvc'])
+
+    assert os.path.isfile(dst)
+    assert os.path.isfile(dst_cache)


### PR DESCRIPTION
Fix #2423 

TODO:
* [x] Write a test for `DownloadError`
* [x] Wrap `dependency.repo.fetch` to always return `DownloadError` (what about a `git clone` error? what about a `find_out_by_relpath` error? This will continue halting the `repo.fetch` operation)