### PR TITLE
perf: do not import http.server each run

### DIFF
--- a/dvc/utils/compat.py
+++ b/dvc/utils/compat.py
@@ -103,8 +103,6 @@ def ignore_file_not_found():
 if is_py2:
     from urlparse import urlparse, urlunparse, urljoin  # noqa: F401
     from urllib import urlencode  # noqa: F401
-    from BaseHTTPServer import HTTPServer  # noqa: F401
-    from SimpleHTTPServer import SimpleHTTPRequestHandler  # noqa: F401
     import ConfigParser  # noqa: F401
     from io import open  # noqa: F401
     import pathlib2 as pathlib  # noqa: F401
@@ -150,10 +148,6 @@ elif is_py3:
         urljoin,  # noqa: F401
     )
     from io import StringIO, BytesIO  # noqa: F401
-    from http.server import (  # noqa: F401
-        HTTPServer,  # noqa: F401
-        SimpleHTTPRequestHandler,  # noqa: F401
-    )  # noqa: F401
     import configparser as ConfigParser  # noqa: F401
     from collections.abc import Mapping  # noqa: F401
 

--- a/tests/utils/httpd.py
+++ b/tests/utils/httpd.py
@@ -2,9 +2,14 @@ import hashlib
 import os
 import threading
 
-from RangeHTTPServer import RangeRequestHandler
+# Moved in Python 2 -> 3, used only here.
+# Not adding to dvc.utils.compat to not load http.server for non-test runs.
+try:
+    from http.server import HTTPServer
+except ImportError:
+    from BaseHTTPServer import HTTPServer
 
-from dvc.utils.compat import HTTPServer
+from RangeHTTPServer import RangeRequestHandler
 
 
 class TestRequestHandler(RangeRequestHandler):


### PR DESCRIPTION
It is only used in tests. Shaves out 30ms startup time for me. 