### PR TITLE
dvc: move repo lock from CLI to API

### DIFF
--- a/dvc/command/base.py
+++ b/dvc/command/base.py
@@ -55,16 +55,6 @@ class CmdBase(object):
         logger.warning(msg)
         return [Stage.STAGE_FILE]
 
-    def run_cmd(self):
-        from dvc.lock import LockError
-
-        try:
-            with self.repo.lock:
-                return self.run()
-        except LockError:
-            logger.exception("failed to lock before running a command")
-            return 1
-
     # Abstract methods that have to be implemented by any inheritance class
     def run(self):
         pass
@@ -73,6 +63,3 @@ class CmdBase(object):
 class CmdBaseNoRepo(CmdBase):
     def __init__(self, args):
         self.args = args
-
-    def run_cmd(self):
-        return self.run()

--- a/dvc/command/destroy.py
+++ b/dvc/command/destroy.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 class CmdDestroy(CmdBase):
-    def run_cmd(self):
+    def run(self):
         try:
             statement = (
                 "This will destroy all information about your pipelines,"

--- a/dvc/command/install.py
+++ b/dvc/command/install.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 class CmdInstall(CmdBase):
-    def run_cmd(self):
+    def run(self):
         try:
             self.repo.install()
         except Exception:

--- a/dvc/main.py
+++ b/dvc/main.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import logging
 
 from dvc.cli import parse_args
+from dvc.lock import LockError
 from dvc.config import ConfigError
 from dvc.analytics import Analytics
 from dvc.exceptions import NotDvcRepoError, DvcParserError
@@ -37,7 +38,10 @@ def main(argv=None):
             logger.setLevel(logging.DEBUG)
 
         cmd = args.func(args)
-        ret = cmd.run_cmd()
+        ret = cmd.run()
+    except LockError:
+        logger.exception("failed to lock before running a command")
+        ret = 250
     except ConfigError:
         logger.exception("configuration error")
         ret = 251

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -7,10 +7,13 @@ from dvc.stage import Stage
 from dvc.utils import walk_files, LARGE_DIR_SIZE
 from dvc.exceptions import RecursiveAddingWhileUsingFilename
 
+from . import locked
+
 
 logger = logging.getLogger(__name__)
 
 
+@locked
 @scm_context
 def add(repo, target, recursive=False, no_commit=False, fname=None):
     if recursive and fname:

--- a/dvc/repo/checkout.py
+++ b/dvc/repo/checkout.py
@@ -23,7 +23,9 @@ def get_all_files_numbers(stages):
     return sum(stage.get_all_files_number() for stage in stages)
 
 
-def checkout(self, target=None, with_deps=False, force=False, recursive=False):
+def _checkout(
+    self, target=None, with_deps=False, force=False, recursive=False
+):
     from dvc.stage import StageFileDoesNotExistError, StageFileBadNameError
 
     all_stages = self.stages()

--- a/dvc/repo/commit.py
+++ b/dvc/repo/commit.py
@@ -1,3 +1,7 @@
+from . import locked
+
+
+@locked
 def commit(self, target, with_deps=False, recursive=False, force=False):
     stages = self.collect(target, with_deps=with_deps, recursive=recursive)
     with self.state:

--- a/dvc/repo/diff.py
+++ b/dvc/repo/diff.py
@@ -14,6 +14,8 @@ from dvc.scm.git import (
     DIFF_EQUAL,
 )
 
+from . import locked
+
 
 DIFF_TARGET = "target"
 DIFF_IS_DIR = "is_dir"
@@ -220,6 +222,7 @@ def _diff_royal(self, target, diff_dct):
     return _diff_file(self, target, diff_dct)
 
 
+@locked
 def diff(self, a_ref, target=None, b_ref=None):
     """Gerenates diff message string output
 

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 
-def fetch(
+def _fetch(
     self,
     targets=None,
     jobs=None,

--- a/dvc/repo/gc.py
+++ b/dvc/repo/gc.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 import collections
 import logging
 
+from . import locked
+
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +55,7 @@ def _do_gc(typ, func, clist):
         logger.info("No unused {} cache to remove.".format(typ))
 
 
+@locked
 def gc(
     self,
     all_branches=False,

--- a/dvc/repo/imp_url.py
+++ b/dvc/repo/imp_url.py
@@ -1,7 +1,10 @@
 from dvc.utils.compat import pathlib
 from dvc.repo.scm_context import scm_context
 
+from . import locked as locked_repo
 
+
+@locked_repo
 @scm_context
 def imp_url(self, url, out=None, fname=None, erepo=None, locked=True):
     from dvc.stage import Stage

--- a/dvc/repo/lock.py
+++ b/dvc/repo/lock.py
@@ -1,3 +1,7 @@
+from . import locked
+
+
+@locked
 def lock(self, target, unlock=False):
     from dvc.stage import Stage
 

--- a/dvc/repo/move.py
+++ b/dvc/repo/move.py
@@ -3,6 +3,8 @@ import os
 from dvc.exceptions import MoveNotDataSourceError
 from dvc.repo.scm_context import scm_context
 
+from . import locked
+
 
 def _expand_target_path(from_path, to_path):
     if os.path.isdir(to_path):
@@ -10,6 +12,7 @@ def _expand_target_path(from_path, to_path):
     return to_path
 
 
+@locked
 @scm_context
 def move(self, from_path, to_path):
     """

--- a/dvc/repo/pull.py
+++ b/dvc/repo/pull.py
@@ -1,6 +1,9 @@
 from __future__ import unicode_literals
 
+from . import locked
 
+
+@locked
 def pull(
     self,
     targets=None,
@@ -12,7 +15,7 @@ def pull(
     force=False,
     recursive=False,
 ):
-    processed_files_count = self.fetch(
+    processed_files_count = self._fetch(
         targets,
         jobs,
         remote=remote,
@@ -22,7 +25,7 @@ def pull(
         recursive=recursive,
     )
     for target in targets or [None]:
-        self.checkout(
+        self._checkout(
             target=target,
             with_deps=with_deps,
             force=force,

--- a/dvc/repo/push.py
+++ b/dvc/repo/push.py
@@ -1,6 +1,9 @@
 from __future__ import unicode_literals
 
+from . import locked
 
+
+@locked
 def push(
     self,
     targets=None,

--- a/dvc/repo/remove.py
+++ b/dvc/repo/remove.py
@@ -1,3 +1,7 @@
+from . import locked
+
+
+@locked
 def remove(self, target, outs_only=False):
     from dvc.stage import Stage
 

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -7,6 +7,9 @@ from dvc.exceptions import ReproductionError
 from dvc.repo.scm_context import scm_context
 from dvc.utils import relpath
 
+from . import locked
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -29,6 +32,7 @@ def _reproduce_stage(stages, node, **kwargs):
     return [stage]
 
 
+@locked
 @scm_context
 def reproduce(
     self,

--- a/dvc/repo/run.py
+++ b/dvc/repo/run.py
@@ -1,8 +1,10 @@
 from __future__ import unicode_literals
 
-from dvc.repo.scm_context import scm_context
+from . import locked
+from .scm_context import scm_context
 
 
+@locked
 @scm_context
 def run(self, no_exec=False, **kwargs):
     from dvc.stage import Stage

--- a/dvc/repo/status.py
+++ b/dvc/repo/status.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 import logging
 from funcy.py3 import cat
 
+from . import locked
+
 
 logger = logging.getLogger(__name__)
 
@@ -91,6 +93,7 @@ def _cloud_status(
     return ret
 
 
+@locked
 def status(
     self,
     targets=None,

--- a/dvc/repo/update.py
+++ b/dvc/repo/update.py
@@ -1,3 +1,7 @@
+from . import locked
+
+
+@locked
 def update(self, target):
     from dvc.stage import Stage
 


### PR DESCRIPTION
For the longest time we've had `repo.lock`, but were only using it from
CLI when running specific command, instead of simply properly taking it
on API operations. This patch takes care of that.

Related to #755 

* [x] Have you followed the guidelines in our
      [Contributing document](https://dvc.org/doc/user-guide/contributing)?

* [x] Does your PR affect documented changes or does it add new functionality
      that should be documented? If yes, have you created a PR for
      [dvc.org](https://github.com/iterative/dvc.org) documenting it or at
      least opened an issue for it? If so, please add a link to it.

-----
