### PR TITLE
[wip] add: support directories with unicode filenames in py2

### DIFF
--- a/dvc/command/add.py
+++ b/dvc/command/add.py
@@ -5,6 +5,7 @@ import logging
 
 from dvc.exceptions import DvcException
 from dvc.command.base import CmdBase, append_doc_link
+from dvc.utils.compat import decode
 
 
 logger = logging.getLogger(__name__)
@@ -54,9 +55,15 @@ def add_parser(subparsers, parent_parser):
         help="Don't put files/directories into cache.",
     )
     add_parser.add_argument(
-        "-f", "--file", help="Specify name of the DVC-file it generates."
+        "-f",
+        "--file",
+        help="Specify name of the DVC-file it generates.",
+        type=lambda s: decode(s, "utf8"),
     )
     add_parser.add_argument(
-        "targets", nargs="+", help="Input files/directories to add."
+        "targets",
+        nargs="+",
+        help="Input files/directories to add.",
+        type=lambda s: decode(s, "utf8"),
     )
     add_parser.set_defaults(func=CmdAdd)

--- a/dvc/command/checkout.py
+++ b/dvc/command/checkout.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import argparse
 
 from dvc.command.base import CmdBase, append_doc_link
+from dvc.utils.compat import decode
 
 
 class CmdCheckout(CmdBase):
@@ -56,5 +57,6 @@ def add_parser(subparsers, parent_parser):
         nargs="*",
         help="DVC-files to checkout. Optional. "
         "(Finds all DVC-files in the workspace by default.)",
+        type=lambda s: decode(s, "utf8"),
     )
     checkout_parser.set_defaults(func=CmdCheckout)

--- a/dvc/command/commit.py
+++ b/dvc/command/commit.py
@@ -5,6 +5,7 @@ import logging
 
 from dvc.exceptions import DvcException
 from dvc.command.base import CmdBase, append_doc_link
+from dvc.utils.compat import decode
 
 
 logger = logging.getLogger(__name__)
@@ -69,5 +70,6 @@ def add_parser(subparsers, parent_parser):
         nargs="*",
         help="DVC-files to commit. Optional. "
         "(Finds all DVC-files in the workspace by default.)",
+        type=lambda s: decode(s, "utf8"),
     )
     commit_parser.set_defaults(func=CmdCommit)

--- a/dvc/command/data_sync.py
+++ b/dvc/command/data_sync.py
@@ -5,6 +5,7 @@ import logging
 
 from dvc.command.base import CmdBase, append_doc_link
 from dvc.exceptions import DvcException
+from dvc.utils.compat import decode
 
 
 logger = logging.getLogger(__name__)
@@ -90,6 +91,7 @@ def shared_parent_parser():
         nargs="*",
         help="Limit command scope to these DVC-files. "
         "Using -R, directories to search DVC-files in can also be given.",
+        type=lambda s: decode(s, "utf8"),
     )
 
     return shared_parent_parser

--- a/dvc/command/get.py
+++ b/dvc/command/get.py
@@ -6,6 +6,7 @@ import logging
 from dvc.repo import Repo
 from dvc.exceptions import DvcException
 from .base import CmdBaseNoRepo, append_doc_link
+from dvc.utils.compat import decode
 
 
 logger = logging.getLogger(__name__)
@@ -44,7 +45,11 @@ def add_parser(subparsers, parent_parser):
     )
     get_parser.add_argument("path", help="Path to data within DVC repository.")
     get_parser.add_argument(
-        "-o", "--out", nargs="?", help="Destination path to put data to."
+        "-o",
+        "--out",
+        nargs="?",
+        help="Destination path to put data to.",
+        type=lambda s: decode(s, "utf8"),
     )
     get_parser.add_argument(
         "--rev", nargs="?", help="DVC repository git revision."

--- a/dvc/command/get_url.py
+++ b/dvc/command/get_url.py
@@ -6,6 +6,7 @@ import logging
 from dvc.repo import Repo
 from dvc.exceptions import DvcException
 from .base import CmdBaseNoRepo, append_doc_link
+from dvc.utils.compat import decode
 
 
 logger = logging.getLogger(__name__)
@@ -34,6 +35,9 @@ def add_parser(subparsers, parent_parser):
         "url", help="See `dvc import-url -h` for full list of supported URLs."
     )
     get_parser.add_argument(
-        "out", nargs="?", help="Destination path to put data to."
+        "out",
+        nargs="?",
+        help="Destination path to put data to.",
+        type=lambda s: decode(s, "utf8"),
     )
     get_parser.set_defaults(func=CmdGetUrl)

--- a/dvc/command/imp.py
+++ b/dvc/command/imp.py
@@ -5,6 +5,7 @@ import logging
 
 from dvc.exceptions import DvcException
 from dvc.command.base import CmdBase, append_doc_link
+from dvc.utils.compat import decode
 
 
 logger = logging.getLogger(__name__)
@@ -45,10 +46,16 @@ def add_parser(subparsers, parent_parser):
         "url", help="URL of Git repository with DVC project to download from."
     )
     import_parser.add_argument(
-        "path", help="Path to data within DVC repository."
+        "path",
+        help="Path to data within DVC repository.",
+        type=lambda s: decode(s, "utf8"),
     )
     import_parser.add_argument(
-        "-o", "--out", nargs="?", help="Destination path to put data to."
+        "-o",
+        "--out",
+        nargs="?",
+        help="Destination path to put data to.",
+        type=lambda s: decode(s, "utf8"),
     )
     import_parser.add_argument(
         "--rev", nargs="?", help="DVC repository git revision."

--- a/dvc/command/imp_url.py
+++ b/dvc/command/imp_url.py
@@ -5,6 +5,7 @@ import logging
 
 from dvc.exceptions import DvcException
 from dvc.command.base import CmdBase, append_doc_link
+from dvc.utils.compat import decode
 
 
 logger = logging.getLogger(__name__)
@@ -52,9 +53,15 @@ def add_parser(subparsers, parent_parser):
         "remote://myremote/path/to/file (see `dvc remote`)",
     )
     import_parser.add_argument(
-        "out", nargs="?", help="Destination path to put files to."
+        "out",
+        nargs="?",
+        help="Destination path to put files to.",
+        type=lambda s: decode(s, "utf8"),
     )
     import_parser.add_argument(
-        "-f", "--file", help="Specify name of the DVC-file it generates."
+        "-f",
+        "--file",
+        help="Specify name of the DVC-file it generates.",
+        type=lambda s: decode(s, "utf8"),
     )
     import_parser.set_defaults(func=CmdImportUrl)

--- a/dvc/command/lock.py
+++ b/dvc/command/lock.py
@@ -5,6 +5,7 @@ import logging
 
 from dvc.exceptions import DvcException
 from dvc.command.base import CmdBase, append_doc_link
+from dvc.utils.compat import decode
 
 
 logger = logging.getLogger(__name__)
@@ -45,7 +46,12 @@ def add_parser(subparsers, parent_parser):
         help=LOCK_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    lock_parser.add_argument("targets", nargs="+", help="DVC-files to lock.")
+    lock_parser.add_argument(
+        "targets",
+        nargs="+",
+        help="DVC-files to lock.",
+        type=lambda s: decode(s, "utf8"),
+    )
     lock_parser.set_defaults(func=CmdLock)
 
     UNLOCK_HELP = "Unlock DVC-files."
@@ -57,6 +63,9 @@ def add_parser(subparsers, parent_parser):
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     unlock_parser.add_argument(
-        "targets", nargs="+", help="DVC-files to unlock."
+        "targets",
+        nargs="+",
+        help="DVC-files to unlock.",
+        type=lambda s: decode(s, "utf8"),
     )
     unlock_parser.set_defaults(func=CmdUnlock)

--- a/dvc/command/metrics.py
+++ b/dvc/command/metrics.py
@@ -5,6 +5,7 @@ import logging
 
 from dvc.exceptions import DvcException, BadMetricError
 from dvc.command.base import CmdBase, fix_subparsers, append_doc_link
+from dvc.utils.compat import decode
 
 
 logger = logging.getLogger(__name__)
@@ -130,6 +131,7 @@ def add_parser(subparsers, parent_parser):
         nargs="*",
         help="Metric files or directories (see -R) to show "
         "(leave empty to display all)",
+        type=lambda s: decode(s, "utf8"),
     )
     metrics_show_parser.add_argument(
         "-t",
@@ -183,7 +185,9 @@ def add_parser(subparsers, parent_parser):
     metrics_add_parser.add_argument(
         "-x", "--xpath", help="json/tsv/htsv/csv/hcsv path."
     )
-    metrics_add_parser.add_argument("path", help="Path to a metric file.")
+    metrics_add_parser.add_argument(
+        "path", help="Path to a metric file.", type=lambda s: decode(s, "utf8")
+    )
     metrics_add_parser.set_defaults(func=CmdMetricsAdd)
 
     METRICS_MODIFY_HELP = "Modify metric file options."
@@ -200,7 +204,9 @@ def add_parser(subparsers, parent_parser):
     metrics_modify_parser.add_argument(
         "-x", "--xpath", help="json/tsv/htsv/csv/hcsv path."
     )
-    metrics_modify_parser.add_argument("path", help="Path to a metric file.")
+    metrics_modify_parser.add_argument(
+        "path", help="Path to a metric file.", type=lambda s: decode(s, "utf8")
+    )
     metrics_modify_parser.set_defaults(func=CmdMetricsModify)
 
     METRICS_REMOVE_HELP = "Remove files's metric tag."
@@ -211,5 +217,7 @@ def add_parser(subparsers, parent_parser):
         help=METRICS_REMOVE_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    metrics_remove_parser.add_argument("path", help="Path to a metric file.")
+    metrics_remove_parser.add_argument(
+        "path", help="Path to a metric file.", type=lambda s: decode(s, "utf8")
+    )
     metrics_remove_parser.set_defaults(func=CmdMetricsRemove)

--- a/dvc/command/move.py
+++ b/dvc/command/move.py
@@ -5,6 +5,7 @@ import logging
 
 from dvc.exceptions import DvcException
 from dvc.command.base import CmdBase, append_doc_link
+from dvc.utils.compat import decode
 
 
 logger = logging.getLogger(__name__)
@@ -39,7 +40,11 @@ def add_parser(subparsers, parent_parser):
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     move_parser.add_argument(
-        "src", help="Source path to a data file or directory."
+        "src",
+        help="Source path to a data file or directory.",
+        type=lambda s: decode(s, "utf8"),
     )
-    move_parser.add_argument("dst", help="Destination path.")
+    move_parser.add_argument(
+        "dst", help="Destination path.", type=lambda s: decode(s, "utf8")
+    )
     move_parser.set_defaults(func=CmdMove)

--- a/dvc/command/pipeline.py
+++ b/dvc/command/pipeline.py
@@ -8,6 +8,7 @@ import logging
 
 from dvc.exceptions import DvcException
 from dvc.command.base import CmdBase, fix_subparsers, append_doc_link
+from dvc.utils.compat import decode
 
 
 logger = logging.getLogger(__name__)
@@ -250,6 +251,7 @@ def add_parser(subparsers, parent_parser):
         nargs="*",
         help="DVC-files to show pipeline for. Optional. "
         "(Finds all DVC-files in the workspace by default.)",
+        type=lambda s: decode(s, "utf8"),
     )
     pipeline_show_parser.set_defaults(func=CmdPipelineShow)
 

--- a/dvc/command/remove.py
+++ b/dvc/command/remove.py
@@ -6,6 +6,7 @@ import logging
 import dvc.prompt as prompt
 from dvc.exceptions import DvcException
 from dvc.command.base import CmdBase, append_doc_link
+from dvc.utils.compat import decode
 
 
 logger = logging.getLogger(__name__)
@@ -74,6 +75,9 @@ def add_parser(subparsers, parent_parser):
         help="Force purge.",
     )
     remove_parser.add_argument(
-        "targets", nargs="+", help="DVC-files to remove."
+        "targets",
+        nargs="+",
+        help="DVC-files to remove.",
+        type=lambda s: decode(s, "utf8"),
     )
     remove_parser.set_defaults(func=CmdRemove)

--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -8,6 +8,7 @@ from dvc.command.base import CmdBase, append_doc_link
 from dvc.command.metrics import show_metrics
 from dvc.command.status import CmdDataStatus
 from dvc.exceptions import DvcException
+from dvc.utils.compat import decode
 
 
 logger = logging.getLogger(__name__)
@@ -70,6 +71,7 @@ def add_parser(subparsers, parent_parser):
         "targets",
         nargs="*",
         help="DVC-file to reproduce. 'Dvcfile' by default.",
+        type=lambda s: decode(s, "utf8"),
     )
     repro_parser.add_argument(
         "-f",

--- a/dvc/command/run.py
+++ b/dvc/command/run.py
@@ -5,6 +5,7 @@ import logging
 
 from dvc.command.base import CmdBase, append_doc_link
 from dvc.exceptions import DvcException
+from dvc.utils.compat import decode
 
 
 logger = logging.getLogger(__name__)
@@ -96,6 +97,7 @@ def add_parser(subparsers, parent_parser):
         action="append",
         default=[],
         help="Declare dependencies for reproducible cmd.",
+        type=lambda s: decode(s, "utf8"),
     )
     run_parser.add_argument(
         "-o",
@@ -103,6 +105,7 @@ def add_parser(subparsers, parent_parser):
         action="append",
         default=[],
         help="Declare output file or directory.",
+        type=lambda s: decode(s, "utf8"),
     )
     run_parser.add_argument(
         "-O",
@@ -111,6 +114,7 @@ def add_parser(subparsers, parent_parser):
         default=[],
         help="Declare output file or directory "
         "(do not put into DVC cache).",
+        type=lambda s: decode(s, "utf8"),
     )
     run_parser.add_argument(
         "-m",
@@ -118,6 +122,7 @@ def add_parser(subparsers, parent_parser):
         action="append",
         default=[],
         help="Declare output metric file or directory.",
+        type=lambda s: decode(s, "utf8"),
     )
     run_parser.add_argument(
         "-M",
@@ -126,9 +131,13 @@ def add_parser(subparsers, parent_parser):
         default=[],
         help="Declare output metric file or directory "
         "(do not put into DVC cache).",
+        type=lambda s: decode(s, "utf8"),
     )
     run_parser.add_argument(
-        "-f", "--file", help="Specify name of the DVC-file it generates."
+        "-f",
+        "--file",
+        help="Specify name of the DVC-file it generates.",
+        type=lambda s: decode(s, "utf8"),
     )
     run_parser.add_argument(
         "-c", "--cwd", help="Deprecated, use -w and -f instead."
@@ -182,6 +191,7 @@ def add_parser(subparsers, parent_parser):
         default=[],
         help="Declare output file or directory that will not be "
         "removed upon repro.",
+        type=lambda s: decode(s, "utf8"),
     )
     run_parser.add_argument(
         "--outs-persist-no-cache",
@@ -189,6 +199,7 @@ def add_parser(subparsers, parent_parser):
         default=[],
         help="Declare output file or directory that will not be "
         "removed upon repro (do not put into DVC cache).",
+        type=lambda s: decode(s, "utf8"),
     )
     run_parser.add_argument(
         "--always-changed",

--- a/dvc/command/tag.py
+++ b/dvc/command/tag.py
@@ -1,6 +1,7 @@
 import logging
 
 from dvc.utils import to_yaml_string
+from dvc.utils.compat import decode
 from dvc.exceptions import DvcException
 from dvc.command.base import CmdBase, fix_subparsers, append_doc_link
 
@@ -82,7 +83,11 @@ def add_parser(subparsers, parent_parser):
     )
     tag_add_parser.add_argument("tag", help="Dvc tag.")
     tag_add_parser.add_argument(
-        "targets", nargs="*", default=[None], help="DVC-files."
+        "targets",
+        nargs="*",
+        default=[None],
+        help="DVC-files.",
+        type=lambda s: decode(s, "utf8"),
     )
     tag_add_parser.add_argument(
         "-d",
@@ -109,7 +114,11 @@ def add_parser(subparsers, parent_parser):
     )
     tag_remove_parser.add_argument("tag", help="Dvc tag.")
     tag_remove_parser.add_argument(
-        "targets", nargs="*", default=[None], help="DVC-files."
+        "targets",
+        nargs="*",
+        default=[None],
+        help="DVC-files.",
+        type=lambda s: decode(s, "utf8"),
     )
     tag_remove_parser.add_argument(
         "-d",
@@ -135,7 +144,11 @@ def add_parser(subparsers, parent_parser):
         help=TAG_LIST_HELP,
     )
     tag_list_parser.add_argument(
-        "targets", nargs="*", default=[None], help="DVC-files."
+        "targets",
+        nargs="*",
+        default=[None],
+        help="DVC-files.",
+        type=lambda s: decode(s, "utf8"),
     )
     tag_list_parser.add_argument(
         "-d",

--- a/dvc/command/unprotect.py
+++ b/dvc/command/unprotect.py
@@ -5,6 +5,7 @@ import logging
 
 from dvc.exceptions import DvcException
 from dvc.command.base import CmdBase, append_doc_link
+from dvc.utils.compat import decode
 
 
 logger = logging.getLogger(__name__)
@@ -32,6 +33,9 @@ def add_parser(subparsers, parent_parser):
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     unprotect_parser.add_argument(
-        "targets", nargs="+", help="Data files/directories to unprotect."
+        "targets",
+        nargs="+",
+        help="Data files/directories to unprotect.",
+        type=lambda s: decode(s, "utf8"),
     )
     unprotect_parser.set_defaults(func=CmdUnprotect)

--- a/dvc/command/update.py
+++ b/dvc/command/update.py
@@ -5,6 +5,7 @@ import logging
 
 from dvc.exceptions import DvcException
 from dvc.command.base import CmdBase, append_doc_link
+from dvc.utils.compat import decode
 
 
 logger = logging.getLogger(__name__)
@@ -32,6 +33,9 @@ def add_parser(subparsers, parent_parser):
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     update_parser.add_argument(
-        "targets", nargs="+", help="DVC-files to update."
+        "targets",
+        nargs="+",
+        help="DVC-files to update.",
+        type=lambda s: decode(s, "utf8"),
     )
     update_parser.set_defaults(func=CmdUpdate)

--- a/dvc/dagascii.py
+++ b/dvc/dagascii.py
@@ -6,6 +6,8 @@ from __future__ import print_function
 import sys
 import math
 
+from dvc.utils.compat import decode
+
 from grandalf.graphs import Vertex, Edge, Graph
 from grandalf.layouts import SugiyamaLayout
 from grandalf.routing import route_with_lines, EdgeViewer
@@ -264,7 +266,7 @@ def _build_sugiyama_layout(vertexes, edges):
     # Y
     #
 
-    vertexes = {v: Vertex(" {} ".format(v)) for v in vertexes}
+    vertexes = {v: Vertex(" {} ".format(decode(v, 'utf-8'))) for v in vertexes}
     # NOTE: reverting edges to correctly orientate the graph
     edges = [Edge(vertexes[e], vertexes[s]) for s, e in edges]
     vertexes = vertexes.values()

--- a/dvc/dagascii.py
+++ b/dvc/dagascii.py
@@ -266,7 +266,7 @@ def _build_sugiyama_layout(vertexes, edges):
     # Y
     #
 
-    vertexes = {v: Vertex(" {} ".format(decode(v, 'utf-8'))) for v in vertexes}
+    vertexes = {v: Vertex(" {} ".format(decode(v, "utf-8"))) for v in vertexes}
     # NOTE: reverting edges to correctly orientate the graph
     edges = [Edge(vertexes[e], vertexes[s]) for s, e in edges]
     vertexes = vertexes.values()

--- a/dvc/ignore.py
+++ b/dvc/ignore.py
@@ -66,7 +66,7 @@ class DvcIgnoreFilter(object):
         self._update(root_dir)
         for root, dirs, _ in os.walk(root_dir):
             for d in dirs:
-                self._update(os.path.join(root, decode(d, 'utf-8')))
+                self._update(os.path.join(root, decode(d, "utf-8")))
 
     def _update(self, dirname):
         ignore_file_path = os.path.join(dirname, DvcIgnore.DVCIGNORE_FILE)

--- a/dvc/ignore.py
+++ b/dvc/ignore.py
@@ -7,7 +7,7 @@ from pathspec.patterns import GitWildMatchPattern
 
 from dvc.utils import relpath
 
-from dvc.utils.compat import open, decode
+from dvc.utils.compat import open
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +66,7 @@ class DvcIgnoreFilter(object):
         self._update(root_dir)
         for root, dirs, _ in os.walk(root_dir):
             for d in dirs:
-                self._update(os.path.join(root, decode(d, "utf-8")))
+                self._update(os.path.join(root, d))
 
     def _update(self, dirname):
         ignore_file_path = os.path.join(dirname, DvcIgnore.DVCIGNORE_FILE)

--- a/dvc/ignore.py
+++ b/dvc/ignore.py
@@ -7,7 +7,7 @@ from pathspec.patterns import GitWildMatchPattern
 
 from dvc.utils import relpath
 
-from dvc.utils.compat import open
+from dvc.utils.compat import open, decode
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +66,7 @@ class DvcIgnoreFilter(object):
         self._update(root_dir)
         for root, dirs, _ in os.walk(root_dir):
             for d in dirs:
-                self._update(os.path.join(root, d))
+                self._update(os.path.join(root, decode(d, 'utf-8')))
 
     def _update(self, dirname):
         ignore_file_path = os.path.join(dirname, DvcIgnore.DVCIGNORE_FILE)

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -18,7 +18,12 @@ from dvc.exceptions import (
 from dvc.ignore import DvcIgnoreFilter
 from dvc.path_info import PathInfo
 from dvc.remote.base import RemoteActionNotImplemented
-from dvc.utils.compat import open as _open, fspath_py35, FileNotFoundError
+from dvc.utils.compat import (
+    open as _open,
+    fspath_py35,
+    FileNotFoundError,
+    decode,
+)
 from dvc.utils import relpath
 
 logger = logging.getLogger(__name__)
@@ -111,6 +116,8 @@ class Repo(object):
             root = os.getcwd()
         else:
             root = os.path.abspath(os.path.realpath(root))
+
+        root = decode(root, "utf-8")
 
         while True:
             dvc_dir = os.path.join(root, cls.DVC_DIR)

--- a/dvc/utils/compat.py
+++ b/dvc/utils/compat.py
@@ -28,6 +28,12 @@ def encode(u, encoding=None):
     return u.encode(encoding, "replace")
 
 
+def decode(u, encoding=None):
+    if is_py2:
+        return u.decode(encoding)
+    return u
+
+
 def csv_reader(unicode_csv_data, dialect=None, **kwargs):
     """csv.reader doesn't support Unicode input, so need to use some tricks
     to work around this.


### PR DESCRIPTION
**Issue**: https://github.com/iterative/dvc/issues/2524

**Script**:
```bash
virtualenv -p python2 .venv
source .venv/bin/activate
pip install dvc
dvc init --no-scm

# This works
echo "試" > 貓.txt
dvc add 貓.txt

# This doesn't
mkdir 貓
echo "試" > 貓/foo.txt
dvc add -v 貓
```

**TODO**:
  * [ ] Write tests