### PR TITLE
add: output improvements

### DIFF
--- a/dvc/command/add.py
+++ b/dvc/command/add.py
@@ -6,6 +6,7 @@ import logging
 from dvc.exceptions import DvcException
 from dvc.command.base import CmdBase, append_doc_link
 from dvc.exceptions import RecursiveAddingWhileUsingFilename
+from dvc.progress import Tqdm
 
 
 logger = logging.getLogger(__name__)
@@ -19,13 +20,17 @@ class CmdAdd(CmdBase):
                     "can't use '--file' with multiple targets"
                 )
 
-            for target in self.args.targets:
-                self.repo.add(
-                    target,
-                    recursive=self.args.recursive,
-                    no_commit=self.args.no_commit,
-                    fname=self.args.file,
-                )
+            with Tqdm(
+                total=len(self.args.targets), desc="Adding", unit="file"
+            ) as pbar:
+                for target in self.args.targets:
+                    stages = self.repo.add(
+                        target,
+                        recursive=self.args.recursive,
+                        no_commit=self.args.no_commit,
+                        fname=self.args.file,
+                        pbar=pbar,
+                    )
 
         except DvcException as e:
             logger.exception("{}:{}".format(type(e).__name__, e))

--- a/dvc/command/add.py
+++ b/dvc/command/add.py
@@ -24,7 +24,7 @@ class CmdAdd(CmdBase):
                 total=len(self.args.targets), desc="Adding", unit="file"
             ) as pbar:
                 for target in self.args.targets:
-                    stages = self.repo.add(
+                    self.repo.add(
                         target,
                         recursive=self.args.recursive,
                         no_commit=self.args.no_commit,

--- a/dvc/command/add.py
+++ b/dvc/command/add.py
@@ -32,20 +32,20 @@ class CmdAdd(CmdBase):
                         pbar=pbar,
                     )
 
-        except DvcException as e:
-            logger.exception("{}:{}".format(type(e).__name__, e))
+        except DvcException as err:
+            logger.exception("{}:{}".format(type(err).__name__, err))
             return 1
         return 0
 
 
 def add_parser(subparsers, parent_parser):
-    ADD_HELP = "Add data files or directories to DVC control."
+    add_help = "Add data files or directories to DVC control."
 
     add_parser = subparsers.add_parser(
         "add",
         parents=[parent_parser],
-        description=append_doc_link(ADD_HELP, "add"),
-        help=ADD_HELP,
+        description=append_doc_link(add_help, "add"),
+        help=add_help,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     add_parser.add_argument(

--- a/dvc/command/add.py
+++ b/dvc/command/add.py
@@ -15,9 +15,7 @@ class CmdAdd(CmdBase):
     def run(self):
         try:
             if len(self.args.targets) > 1 and self.args.file:
-                raise RecursiveAddingWhileUsingFilename(
-                    "can't use '--file' with multiple targets"
-                )
+                raise RecursiveAddingWhileUsingFilename()
 
             self.repo.add(
                 self.args.targets,

--- a/dvc/command/add.py
+++ b/dvc/command/add.py
@@ -25,8 +25,8 @@ class CmdAdd(CmdBase):
                 progress=True,
             )
 
-        except DvcException as err:
-            logger.exception("{}:{}".format(type(err).__name__, err))
+        except DvcException:
+            logger.exception("")
             return 1
         return 0
 

--- a/dvc/command/add.py
+++ b/dvc/command/add.py
@@ -6,7 +6,6 @@ import logging
 from dvc.exceptions import DvcException
 from dvc.command.base import CmdBase, append_doc_link
 from dvc.exceptions import RecursiveAddingWhileUsingFilename
-from dvc.progress import Tqdm
 
 
 logger = logging.getLogger(__name__)
@@ -20,17 +19,13 @@ class CmdAdd(CmdBase):
                     "can't use '--file' with multiple targets"
                 )
 
-            with Tqdm(
-                total=len(self.args.targets), desc="Adding", unit="file"
-            ) as pbar:
-                for target in self.args.targets:
-                    self.repo.add(
-                        target,
-                        recursive=self.args.recursive,
-                        no_commit=self.args.no_commit,
-                        fname=self.args.file,
-                        pbar=pbar,
-                    )
+            self.repo.add(
+                self.args.targets,
+                recursive=self.args.recursive,
+                no_commit=self.args.no_commit,
+                fname=self.args.file,
+                progress=True,
+            )
 
         except DvcException as err:
             logger.exception("{}:{}".format(type(err).__name__, err))

--- a/dvc/command/add.py
+++ b/dvc/command/add.py
@@ -34,30 +34,32 @@ class CmdAdd(CmdBase):
 def add_parser(subparsers, parent_parser):
     add_help = "Add data files or directories to DVC control."
 
-    add_parser = subparsers.add_parser(
+    parser = subparsers.add_parser(
         "add",
         parents=[parent_parser],
         description=append_doc_link(add_help, "add"),
         help=add_help,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    add_parser.add_argument(
+    parser.add_argument(
         "-R",
         "--recursive",
         action="store_true",
         default=False,
-        help="Recursively add files under directories.",
+        help="Recursively add files under directory targets.",
     )
-    add_parser.add_argument(
+    parser.add_argument(
         "--no-commit",
         action="store_true",
         default=False,
         help="Don't put files/directories into cache.",
     )
-    add_parser.add_argument(
-        "-f", "--file", help="Specify name of the generated DVC-file."
+    parser.add_argument(
+        "-f",
+        "--file",
+        help="Specify name of the DVC-file this command will generate.",
     )
-    add_parser.add_argument(
+    parser.add_argument(
         "targets", nargs="+", help="Input files/directories to add."
     )
-    add_parser.set_defaults(func=CmdAdd)
+    parser.set_defaults(func=CmdAdd)

--- a/dvc/command/add.py
+++ b/dvc/command/add.py
@@ -57,7 +57,7 @@ def add_parser(subparsers, parent_parser):
         help="Don't put files/directories into cache.",
     )
     add_parser.add_argument(
-        "-f", "--file", help="Specify name of the generated DVC file."
+        "-f", "--file", help="Specify name of the generated DVC-file."
     )
     add_parser.add_argument(
         "targets", nargs="+", help="Input files/directories to add."

--- a/dvc/command/add.py
+++ b/dvc/command/add.py
@@ -32,7 +32,7 @@ class CmdAdd(CmdBase):
 
 
 def add_parser(subparsers, parent_parser):
-    add_help = "Add data files or directories to DVC control."
+    add_help = "Track data files or directories with DVC."
 
     parser = subparsers.add_parser(
         "add",

--- a/dvc/command/add.py
+++ b/dvc/command/add.py
@@ -32,13 +32,13 @@ class CmdAdd(CmdBase):
 
 
 def add_parser(subparsers, parent_parser):
-    add_help = "Track data files or directories with DVC."
+    ADD_HELP = "Track data files or directories with DVC."
 
     parser = subparsers.add_parser(
         "add",
         parents=[parent_parser],
-        description=append_doc_link(add_help, "add"),
-        help=add_help,
+        description=append_doc_link(ADD_HELP, "add"),
+        help=ADD_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(

--- a/dvc/command/add.py
+++ b/dvc/command/add.py
@@ -22,7 +22,6 @@ class CmdAdd(CmdBase):
                 recursive=self.args.recursive,
                 no_commit=self.args.no_commit,
                 fname=self.args.file,
-                progress=True,
             )
 
         except DvcException:

--- a/dvc/command/base.py
+++ b/dvc/command/base.py
@@ -26,7 +26,7 @@ def append_doc_link(help_message, path):
     if not path:
         return help_message
     doc_base = "https://man.dvc.org/"
-    return "{message}\ndocumentation: {blue}{base}{path}{nc}".format(
+    return "{message}\nDocumentation: <{blue}{base}{path}{nc}>".format(
         message=help_message,
         base=doc_base,
         path=path,
@@ -57,7 +57,7 @@ class CmdBase(object):
 
     # Abstract methods that have to be implemented by any inheritance class
     def run(self):
-        pass
+        raise NotImplementedError("Abstract")
 
 
 class CmdBaseNoRepo(CmdBase):

--- a/dvc/command/base.py
+++ b/dvc/command/base.py
@@ -57,7 +57,7 @@ class CmdBase(object):
 
     # Abstract methods that have to be implemented by any inheritance class
     def run(self):
-        raise NotImplementedError("Abstract")
+        raise NotImplementedError
 
 
 class CmdBaseNoRepo(CmdBase):

--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -224,9 +224,9 @@ class StageFileCorruptedError(DvcException):
 
 
 class RecursiveAddingWhileUsingFilename(DvcException):
-    def __init__(self):
+    def __init__(self, msg=None):
         super(RecursiveAddingWhileUsingFilename, self).__init__(
-            "using fname with recursive is not allowed."
+            msg or "using fname with recursive is not allowed."
         )
 
 

--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -224,9 +224,9 @@ class StageFileCorruptedError(DvcException):
 
 
 class RecursiveAddingWhileUsingFilename(DvcException):
-    def __init__(self, msg=None):
+    def __init__(self):
         super(RecursiveAddingWhileUsingFilename, self).__init__(
-            msg or "using fname with recursive is not allowed."
+            "cannot use `fname` with multiple targets or `-R|--recursive`"
         )
 
 

--- a/dvc/logger.py
+++ b/dvc/logger.py
@@ -22,6 +22,11 @@ class ExcludeErrorsFilter(logging.Filter):
         return record.levelno < logging.WARNING
 
 
+class ExcludeInfoFilter(logging.Filter):
+    def filter(self, record):
+        return record.levelno < logging.INFO
+
+
 class ColorFormatter(logging.Formatter):
     """Enable color support when logging to a terminal that supports it.
 
@@ -170,15 +175,25 @@ def setup(level=logging.INFO):
     logging.config.dictConfig(
         {
             "version": 1,
-            "filters": {"exclude_errors": {"()": ExcludeErrorsFilter}},
+            "filters": {
+                "exclude_errors": {"()": ExcludeErrorsFilter},
+                "exclude_info": {"()": ExcludeInfoFilter},
+            },
             "formatters": {"color": {"()": ColorFormatter}},
             "handlers": {
-                "console": {
+                "console_info": {
+                    "class": "dvc.logger.LoggerHandler",
+                    "level": "INFO",
+                    # "formatter": "color",
+                    "stream": "ext://sys.stdout",
+                    "filters": ["exclude_errors"],
+                },
+                "console_debug": {
                     "class": "dvc.logger.LoggerHandler",
                     "level": "DEBUG",
                     "formatter": "color",
                     "stream": "ext://sys.stdout",
-                    "filters": ["exclude_errors"],
+                    "filters": ["exclude_info"],
                 },
                 "console_errors": {
                     "class": "dvc.logger.LoggerHandler",
@@ -190,15 +205,27 @@ def setup(level=logging.INFO):
             "loggers": {
                 "dvc": {
                     "level": level,
-                    "handlers": ["console", "console_errors"],
+                    "handlers": [
+                        "console_info",
+                        "console_debug",
+                        "console_errors",
+                    ],
                 },
                 "paramiko": {
                     "level": logging.CRITICAL,
-                    "handlers": ["console", "console_errors"],
+                    "handlers": [
+                        "console_info",
+                        "console_debug",
+                        "console_errors",
+                    ],
                 },
                 "flufl.lock": {
                     "level": logging.CRITICAL,
-                    "handlers": ["console", "console_errors"],
+                    "handlers": [
+                        "console_info",
+                        "console_debug",
+                        "console_errors",
+                    ],
                 },
             },
         }

--- a/dvc/logger.py
+++ b/dvc/logger.py
@@ -184,7 +184,7 @@ def setup(level=logging.INFO):
                 "console_info": {
                     "class": "dvc.logger.LoggerHandler",
                     "level": "INFO",
-                    # "formatter": "color",
+                    "formatter": "color",
                     "stream": "ext://sys.stdout",
                     "filters": ["exclude_errors"],
                 },

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -187,7 +187,8 @@ class RemoteBASE(object):
                 )
                 tasks = Tqdm(tasks, total=len(file_infos), unit="md5")
             checksums = dict(zip(file_infos, tasks))
-            del tasks
+            if hasattr(tasks, "close"):
+                tasks.close()
         return checksums
 
     def _collect_dir(self, path_info):

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -187,6 +187,7 @@ class RemoteBASE(object):
                 )
                 tasks = Tqdm(tasks, total=len(file_infos), unit="md5")
             checksums = dict(zip(file_infos, tasks))
+            del tasks
         return checksums
 
     def _collect_dir(self, path_info):

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -37,6 +37,7 @@ def add(
         desc="Adding",
         unit="file",
         disable=not progress,
+        leave=True,
     ) as pbar:
         for target in target_list:
             targets = _find_all_targets(repo, target, recursive)
@@ -68,6 +69,7 @@ def add(
                 stage.dump()
 
             stages_list += stages
+        pbar.bar_format = pbar.BAR_FMT_DEFAULT.replace("|{bar:10}|", " ")
 
     return stages_list
 

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -17,11 +17,13 @@ logger = logging.getLogger(__name__)
 
 @locked
 @scm_context
-def add(repo, target, recursive=False, no_commit=False, fname=None):
+def add(repo, target, recursive=False, no_commit=False, fname=None, pbar=None):
     if recursive and fname:
         raise RecursiveAddingWhileUsingFilename()
 
     targets = _find_all_targets(repo, target, recursive)
+    if pbar is not None:
+        pbar.total += len(targets) - 1
 
     if os.path.isdir(target) and len(targets) > LARGE_DIR_SIZE:
         logger.warning(
@@ -36,7 +38,12 @@ def add(repo, target, recursive=False, no_commit=False, fname=None):
             )
         )
 
-    stages = _create_stages(repo, targets, fname)
+    stages = _create_stages(
+            repo,
+            targets,
+            fname,
+            callback=pbar.update_desc if pbar is not None else None
+        )
 
     repo.check_modified_graph(stages)
 
@@ -64,7 +71,7 @@ def _find_all_targets(repo, target, recursive):
     return [target]
 
 
-def _create_stages(repo, targets, fname):
+def _create_stages(repo, targets, fname, callback=None):
     stages = []
 
     for out in targets:
@@ -74,5 +81,8 @@ def _create_stages(repo, targets, fname):
             continue
 
         stages.append(stage)
+
+        if callback is not None:
+            callback(out)
 
     return stages

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -3,54 +3,73 @@ from __future__ import unicode_literals
 import os
 import logging
 import colorama
+from six import string_types
 
 from dvc.repo.scm_context import scm_context
 from dvc.stage import Stage
 from dvc.utils import walk_files, LARGE_DIR_SIZE
 from dvc.exceptions import RecursiveAddingWhileUsingFilename
-
+from dvc.progress import Tqdm
 from . import locked
-
 
 logger = logging.getLogger(__name__)
 
 
 @locked
 @scm_context
-def add(repo, target, recursive=False, no_commit=False, fname=None, pbar=None):
+def add(
+    repo,
+    target_list,
+    recursive=False,
+    no_commit=False,
+    fname=None,
+    progress=False,
+):
     if recursive and fname:
         raise RecursiveAddingWhileUsingFilename()
 
-    targets = _find_all_targets(repo, target, recursive)
-    if pbar is not None:
-        pbar.total += len(targets) - 1
+    if isinstance(target_list, string_types):
+        target_list = [target_list]
 
-    if os.path.isdir(target) and len(targets) > LARGE_DIR_SIZE:
-        logger.warning(
-            "You are adding a large directory '{target}' recursively,"
-            " consider tracking it as a whole instead.\n"
-            "{purple}HINT:{nc} Remove the generated DVC-file and then"
-            " run {cyan}dvc add {target}{nc}".format(
-                purple=colorama.Fore.MAGENTA,
-                cyan=colorama.Fore.CYAN,
-                nc=colorama.Style.RESET_ALL,
-                target=target,
-            )
-        )
+    stages_list = []
+    with Tqdm(
+        total=len(target_list),
+        desc="Adding",
+        unit="file",
+        disable=not progress,
+    ) as pbar:
+        for target in target_list:
+            targets = _find_all_targets(repo, target, recursive)
+            pbar.total += len(targets) - 1
 
-    stages = _create_stages(repo, targets, fname, pbar=pbar)
+            if os.path.isdir(target) and len(targets) > LARGE_DIR_SIZE:
+                logger.warning(
+                    "You are adding a large directory '{target}' recursively,"
+                    " consider tracking it as a whole instead.\n"
+                    "{purple}HINT:{nc} Remove the generated DVC-file and then"
+                    " run {cyan}dvc add {target}{nc}".format(
+                        purple=colorama.Fore.MAGENTA,
+                        cyan=colorama.Fore.CYAN,
+                        nc=colorama.Style.RESET_ALL,
+                        target=target,
+                    )
+                )
 
-    repo.check_modified_graph(stages)
+            stages = _create_stages(repo, targets, fname, pbar=pbar)
 
-    for stage in stages:
-        stage.save()
+            repo.check_modified_graph(stages)
 
-        if not no_commit:
-            stage.commit()
+            for stage in stages:
+                stage.save()
 
-        stage.dump()
+                if not no_commit:
+                    stage.commit()
 
-    return stages
+                stage.dump()
+
+            stages_list += stages
+
+    return stages_list
 
 
 def _find_all_targets(repo, target, recursive):

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -38,12 +38,7 @@ def add(repo, target, recursive=False, no_commit=False, fname=None, pbar=None):
             )
         )
 
-    stages = _create_stages(
-            repo,
-            targets,
-            fname,
-            callback=pbar.update_desc if pbar is not None else None
-        )
+    stages = _create_stages(repo, targets, fname, pbar=pbar)
 
     repo.check_modified_graph(stages)
 
@@ -71,18 +66,19 @@ def _find_all_targets(repo, target, recursive):
     return [target]
 
 
-def _create_stages(repo, targets, fname, callback=None):
+def _create_stages(repo, targets, fname, pbar=None):
     stages = []
 
     for out in targets:
         stage = Stage.create(repo, outs=[out], add=True, fname=fname)
 
         if not stage:
+            if pbar is not None:
+                pbar.total -= 1
             continue
 
         stages.append(stage)
-
-        if callback is not None:
-            callback(out)
+        if pbar is not None:
+            pbar.update_desc(out)
 
     return stages

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -17,9 +17,7 @@ logger = logging.getLogger(__name__)
 
 @locked
 @scm_context
-def add(
-    repo, targets, recursive=False, no_commit=False, fname=None, progress=False
-):
+def add(repo, targets, recursive=False, no_commit=False, fname=None):
     if recursive and fname:
         raise RecursiveAddingWhileUsingFilename()
 
@@ -27,13 +25,7 @@ def add(
         targets = [targets]
 
     stages_list = []
-    with Tqdm(
-        total=len(targets),
-        desc="Add",
-        unit="file",
-        disable=not progress,
-        leave=True,
-    ) as pbar:
+    with Tqdm(total=len(targets), desc="Add", unit="file", leave=True) as pbar:
         for target in targets:
             sub_targets = _find_all_targets(repo, target, recursive)
             pbar.total += len(sub_targets) - 1

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -29,7 +29,7 @@ def add(
     stages_list = []
     with Tqdm(
         total=len(targets),
-        desc="Adding",
+        desc="Add",
         unit="file",
         disable=not progress,
         leave=True,

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -64,6 +64,7 @@ def add(
                 stage.dump()
 
             stages_list += stages
+        # remove filled bar bit of progress, leaving stats
         pbar.bar_format = pbar.BAR_FMT_DEFAULT.replace("|{bar:10}|", " ")
 
     return stages_list

--- a/dvc/stage.py
+++ b/dvc/stage.py
@@ -663,7 +663,7 @@ class Stage(object):
 
         self._check_dvc_filename(fname)
 
-        logger.info(
+        logger.debug(
             "Saving information to '{file}'.".format(file=relpath(fname))
         )
         d = self.dumpd()

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -182,7 +182,8 @@ class TestColorFormatter:
 
 
 def test_handlers():
-    stdout, stderr = logger.handlers
+    out, deb, err = logger.handlers
 
-    assert stdout.level == logging.DEBUG
-    assert stderr.level == logging.WARNING
+    assert out.level == logging.INFO
+    assert deb.level == logging.DEBUG
+    assert err.level == logging.WARNING


### PR DESCRIPTION
`dvc add` output improvements

- [x] slight wording updates
- [x] add progress for `stage.create()` (cleared upon completion)
- [x] leave some stats behind?
- [x] fix failing tests
- [x] fix md3sum progress not clearing properly
- [x] progress-aware `logger.info`
  + [x] fix/update tests
- [x] `To track the changes with git, run`: prints once rather than per-file
- [x] `Computing md5 for a large number of files. This is only done once.` message replaced with `Computing md5 for a large number of files` inside cleared away progress bars
- [x] `Saving information to '*.dvc'.` messages removed (since files are already mentioned in final commit reminder)
  + [ ] make sure all other calls to `stage.dump()` do not need this verbosity

old:
[![asciicast](https://asciinema.org/a/m9PX4jUPGZaE1gWp5eWbgEns3.svg)](https://asciinema.org/a/m9PX4jUPGZaE1gWp5eWbgEns3?speed=2)
new:
[![asciicast](https://asciinema.org/a/VC7HfMbG6XxkesVy5sRduHLNN.svg)](https://asciinema.org/a/VC7HfMbG6XxkesVy5sRduHLNN?speed=4)

## related
- #2545
- https://github.com/iterative/dvc/pull/2546#discussion_r337037137

## for future issue/PR
- #2658