### PR TITLE
Use consistent max line length in lint config files

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -314,7 +314,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=79
 
 # Maximum number of lines in a module.
 max-module-lines=1000


### PR DESCRIPTION
Adjust the `max-line-length` option to the same value used by black and `.flake8` file.

* [x] Have you followed the guidelines in our
      [Contributing document](https://dvc.org/doc/user-guide/contributing)?
-----
