### PR TITLE
Replace hyphen with underscore for command auto-completion

### DIFF
--- a/scripts/completion/dvc.bash
+++ b/scripts/completion/dvc.bash
@@ -71,11 +71,11 @@ _dvc_version=''
 #       x="hello"
 #       ${!x} ->  ${hello} ->  "world"
 #
-replace_hyphen () {
-  echo $(echo $1 | sed 's/-/_/g')
-}
-
 _dvc () {
+  replace_hyphen () {
+    echo $(echo $1 | sed 's/-/_/g')
+  }
+
   local word="${COMP_WORDS[COMP_CWORD]}"
 
   COMPREPLY=()
@@ -86,21 +86,13 @@ _dvc () {
       *)  COMPREPLY=($(compgen -W "$_dvc_commands" -- "$word")) ;;
     esac
   elif [ "${COMP_CWORD}" -eq 2 ]; then
-    if [[ ${COMP_WORDS[1]:0:1} == "-" ]]; then
-      return 0
-    else
-      local options_list="_dvc_$(replace_hyphen ${COMP_WORDS[1]})"
+    local options_list="_dvc_$(replace_hyphen ${COMP_WORDS[1]})"
 
-      COMPREPLY=($(compgen -W "$_dvc_global_options ${!options_list}" -- "$word"))
-    fi
+    COMPREPLY=($(compgen -W "$_dvc_global_options ${!options_list}" -- "$word"))
   elif [ "${COMP_CWORD}" -eq 3 ]; then
-    if [[ ${COMP_WORDS[2]:0:1} == "-" ]]; then
-      return 0
-    else
-      local options_list="_dvc_${COMP_WORDS[1]}_$(replace_hyphen ${COMP_WORDS[2]})"
+    local options_list="_dvc_$(replace_hyphen ${COMP_WORDS[1]})_$(replace_hyphen ${COMP_WORDS[2]})"
 
-      COMPREPLY=($(compgen -W "$_dvc_global_options ${!options_list}" -- "$word"))
-    fi
+    COMPREPLY=($(compgen -W "$_dvc_global_options ${!options_list}" -- "$word"))
   fi
 
   return 0

--- a/scripts/completion/dvc.bash
+++ b/scripts/completion/dvc.bash
@@ -82,7 +82,8 @@ _dvc () {
       *)  COMPREPLY=($(compgen -W "$_dvc_commands" -- "$word")) ;;
     esac
   elif [ "${COMP_CWORD}" -eq 2 ]; then
-    local options_list="_dvc_${COMP_WORDS[1]}"
+    local replace_hyphen=$(echo ${COMP_WORDS[1]} | sed 's/-/_/g')
+    local options_list="_dvc_${replace_hyphen}"
 
     COMPREPLY=($(compgen -W "$_dvc_global_options ${!options_list}" -- "$word"))
   elif [ "${COMP_CWORD}" -eq 3 ]; then

--- a/scripts/completion/dvc.bash
+++ b/scripts/completion/dvc.bash
@@ -71,6 +71,10 @@ _dvc_version=''
 #       x="hello"
 #       ${!x} ->  ${hello} ->  "world"
 #
+replace_hyphen () {
+  echo $(echo $1 | sed 's/-/_/g')
+}
+
 _dvc () {
   local word="${COMP_WORDS[COMP_CWORD]}"
 
@@ -82,14 +86,21 @@ _dvc () {
       *)  COMPREPLY=($(compgen -W "$_dvc_commands" -- "$word")) ;;
     esac
   elif [ "${COMP_CWORD}" -eq 2 ]; then
-    local replace_hyphen=$(echo ${COMP_WORDS[1]} | sed 's/-/_/g')
-    local options_list="_dvc_${replace_hyphen}"
+    if [[ ${COMP_WORDS[1]:0:1} == "-" ]]; then
+      return 0
+    else
+      local options_list="_dvc_$(replace_hyphen ${COMP_WORDS[1]})"
 
-    COMPREPLY=($(compgen -W "$_dvc_global_options ${!options_list}" -- "$word"))
+      COMPREPLY=($(compgen -W "$_dvc_global_options ${!options_list}" -- "$word"))
+    fi
   elif [ "${COMP_CWORD}" -eq 3 ]; then
-    local options_list="_dvc_${COMP_WORDS[1]}_${COMP_WORDS[2]}"
+    if [[ ${COMP_WORDS[2]:0:1} == "-" ]]; then
+      return 0
+    else
+      local options_list="_dvc_${COMP_WORDS[1]}_$(replace_hyphen ${COMP_WORDS[2]})"
 
-    COMPREPLY=($(compgen -W "$_dvc_global_options ${!options_list}" -- "$word"))
+      COMPREPLY=($(compgen -W "$_dvc_global_options ${!options_list}" -- "$word"))
+    fi
   fi
 
   return 0


### PR DESCRIPTION
Fixes #2279 

Although I found one potential bug in auto-completion.
![Screenshot from 2019-10-11 01-56-05](https://user-images.githubusercontent.com/35191225/66607163-3e741d00-ebd1-11e9-9973-82223bb651f7.png)

This is happening because of `${!options_list}` as `-h` is passed as `option_list`. Since, its variable doesn't exist, it throws this error.

