### PR TITLE
remote: local: don't auto-create directory in `__init__`

### DIFF
--- a/dvc/command/version.py
+++ b/dvc/command/version.py
@@ -48,9 +48,21 @@ class CmdVersion(CmdBaseNoRepo):
             repo = Repo()
             root_directory = repo.root_dir
 
-            info += "Cache: {cache}\n".format(
-                cache=self.get_linktype_support_info(repo)
-            )
+            # cache_dir might not exist yet (e.g. after `dvc init`), and we
+            # can't auto-create it, as it might cause issues if the user
+            # later decides to enable shared cache mode with
+            # `dvc config cache.shared group`.
+            if os.path.exists(repo.cache.local.cache_dir):
+                info += "Cache: {cache}\n".format(
+                    cache=self.get_linktype_support_info(repo)
+                )
+            else:
+                logger.warning(
+                    "Unable to detect supported link types, as cache "
+                    "directory '{}' doesn't exist. It is usually auto-created "
+                    "by commands such as `dvc add/fetch/pull/run/import`, but "
+                    "you could create it manually to enable this check."
+                )
 
             if psutil:
                 info += (

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -69,9 +69,6 @@ class RemoteLOCAL(RemoteBASE):
             cwd = config[Config.PRIVATE_CWD]
             cache_dir = os.path.abspath(os.path.join(cwd, cache_dir))
 
-        if cache_dir is not None and not os.path.exists(cache_dir):
-            os.mkdir(cache_dir)
-
         self.path_info = PathInfo(cache_dir) if cache_dir else None
         self._dir_info = {}
 

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -325,7 +325,7 @@ class TestAddCommit(TestDvc):
         ret = main(["add", self.FOO, "--no-commit"])
         self.assertEqual(ret, 0)
         self.assertTrue(os.path.isfile(self.FOO))
-        self.assertEqual(len(os.listdir(self.dvc.cache.local.cache_dir)), 0)
+        self.assertFalse(os.path.exists(self.dvc.cache.local.cache_dir))
 
         ret = main(["commit", self.FOO + ".dvc"])
         self.assertEqual(ret, 0)

--- a/tests/func/test_cache.py
+++ b/tests/func/test_cache.py
@@ -1,7 +1,6 @@
 import os
 import stat
 import pytest
-import shutil
 import configobj
 
 from dvc.cache import Cache
@@ -66,7 +65,7 @@ class TestExternalCacheDir(TestDvc):
         ret = main(["config", "cache.dir", cache_dir])
         self.assertEqual(ret, 0)
 
-        shutil.rmtree(".dvc/cache")
+        self.assertFalse(os.path.exists(self.dvc.cache.local.cache_dir))
 
         ret = main(["add", self.FOO])
         self.assertEqual(ret, 0)
@@ -101,7 +100,7 @@ class TestSharedCacheDir(TestDir):
             ret = main(["config", "cache.dir", cache_dir])
             self.assertEqual(ret, 0)
 
-            shutil.rmtree(os.path.join(".dvc", "cache"))
+            self.assertFalse(os.path.exists(os.path.join(".dvc", "cache")))
 
             with open("common", "w+") as fd:
                 fd.write("common")

--- a/tests/func/test_repro.py
+++ b/tests/func/test_repro.py
@@ -1280,7 +1280,7 @@ class TestReproNoCommit(TestRepro):
         shutil.rmtree(self.dvc.cache.local.cache_dir)
         ret = main(["repro", self.file1_stage, "--no-commit"])
         self.assertEqual(ret, 0)
-        self.assertEqual(len(os.listdir(self.dvc.cache.local.cache_dir)), 0)
+        self.assertFalse(os.path.exists(self.dvc.cache.local.cache_dir))
 
 
 class TestReproAlreadyCached(TestRepro):

--- a/tests/func/test_run.py
+++ b/tests/func/test_run.py
@@ -706,7 +706,7 @@ class TestRunCommit(TestDvc):
         )
         self.assertEqual(ret, 0)
         self.assertTrue(os.path.isfile(fname))
-        self.assertEqual(len(os.listdir(self.dvc.cache.local.cache_dir)), 0)
+        self.assertFalse(os.path.exists(self.dvc.cache.local.cache_dir))
 
         ret = main(["commit", fname + ".dvc"])
         self.assertEqual(ret, 0)

--- a/tests/func/test_version.py
+++ b/tests/func/test_version.py
@@ -5,7 +5,11 @@ from dvc.main import main
 from dvc.command.version import psutil
 
 
-def test_info_in_repo(dvc_repo, caplog):
+def test_info_in_repo(repo_dir, dvc_repo, caplog):
+    # adding a file so that dvc creates `.dvc/cache`, that is needed for proper
+    # supported link types check.
+    assert main(["add", repo_dir.FOO]) == 0
+
     assert main(["version"]) == 0
 
     assert re.search(re.compile(r"DVC version: \d+\.\d+\.\d+"), caplog.text)


### PR DESCRIPTION
Imagine the scenario of shared cache. To set it up, user would do:

```
dvc config cache.dir /path
dvc config cache.shared group
```

Now, when he runs any dvc operation that involves the Repo instance,
RemoteLOCAL will also be initialized and it will currently auto-create
the directory with a regular `os.mkdir`, which is not using group
permissions. To solve that, we can't simply use `self.makdirs` instead,
as it will cause same issues if you run any dvc command before
`dvc config cache.shared group`. So what we should do is create
directories on demand, instead of creating it in advance, same as we do
in other remotes.

The change itself is pretty trivial and involved removing that `mkdir`
line, adjusting tests to not rely on cache dir existence and also
adjusting `dvc version` to create a directory if it doesn't exist yet,
to place a temporary file in it.

Fixes #2563

* [x] Have you followed the guidelines in our
      [Contributing document](https://dvc.org/doc/user-guide/contributing)?

* [x] Does your PR affect documented changes or does it add new functionality
      that should be documented? If yes, have you created a PR for
      [dvc.org](https://github.com/iterative/dvc.org) documenting it or at
      least opened an issue for it? If so, please add a link to it.

-----
