### PR TITLE
[WIP] dvc: wrap checkout error as download error

### DIFF
--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import logging
 
 from dvc.config import NoRemoteError
-from dvc.exceptions import DownloadError, OutputNotFoundError, CheckoutError
+from dvc.exceptions import DownloadError, OutputNotFoundError
 from dvc.scm.base import CloneError
 
 
@@ -64,7 +64,7 @@ def _fetch(
             downloaded += out.get_files_number()
         except DownloadError as exc:
             failed += exc.amount
-        except (CloneError, OutputNotFoundError, CheckoutError):
+        except (CloneError, OutputNotFoundError):
             failed += 1
             logger.exception(
                 "failed to fetch data for '{}'".format(dep.stage.outs[0])

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import logging
 
 from dvc.config import NoRemoteError
-from dvc.exceptions import DownloadError, OutputNotFoundError
+from dvc.exceptions import DownloadError, OutputNotFoundError, CheckoutError
 from dvc.scm.base import CloneError
 
 
@@ -64,7 +64,7 @@ def _fetch(
             downloaded += out.get_files_number()
         except DownloadError as exc:
             failed += exc.amount
-        except (CloneError, OutputNotFoundError):
+        except (CloneError, OutputNotFoundError, CheckoutError):
             failed += 1
             logger.exception(
                 "failed to fetch data for '{}'".format(dep.stage.outs[0])

--- a/dvc/repo/pull.py
+++ b/dvc/repo/pull.py
@@ -24,6 +24,7 @@ def pull(
         with_deps=with_deps,
         recursive=recursive,
     )
+    # This throws CheckoutError
     self._checkout(
         targets=targets, with_deps=with_deps, force=force, recursive=recursive
     )

--- a/tests/func/test_import.py
+++ b/tests/func/test_import.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import os
 import filecmp
+import shutil
 
 import pytest
 from mock import patch
@@ -82,6 +83,12 @@ def test_download_error_pulling_imported_stage(dvc_repo, erepo):
     with patch(
         "dvc.remote.RemoteLOCAL._download", side_effect=Exception
     ), pytest.raises(DownloadError):
+        dvc_repo.pull(["foo_imported.dvc"])
+
+    # When repo is absent we should still get DownloadError
+    shutil.rmtree(erepo.dvc.cache.local.cache_dir)
+
+    with pytest.raises(DownloadError):
         dvc_repo.pull(["foo_imported.dvc"])
 
 


### PR DESCRIPTION
This will happen on missing caches and similar to download error in its
effect.

We might want to think of making missing caches an error. That is, however, not an easy thing to do since we will need to postpone/collect those errors in fetch and turn into a warning in status.