### PR TITLE
dvc: dedup used cache

### DIFF
--- a/dvc/cache.py
+++ b/dvc/cache.py
@@ -124,15 +124,9 @@ class NamedCache(object):
         self._items[scheme][checksum].add(name)
 
     def update(self, cache, suffix=""):
-        for scheme in cache._items:
-            for checksum, name in cache.items_for(scheme):
-                self.add(scheme, checksum, name + suffix)
+        for scheme, src in cache._items.items():
+            dst = self._items[scheme]
+            for checksum, names in src.items():
+                dst[checksum].update(names)
 
         self.repo.extend(cache.repo)
-
-    def checksums_for(self, scheme):
-        return self._items[scheme].keys()
-
-    def items_for(self, scheme):
-        for checksum, names in self._items[scheme].items():
-            yield checksum, " ".join(sorted(names))

--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -45,11 +45,11 @@ class DataCloud(object):
     def _init_remote(self, remote):
         return Remote(self.repo, name=remote)
 
-    def push(self, targets, jobs=None, remote=None, show_checksums=False):
+    def push(self, cache, jobs=None, remote=None, show_checksums=False):
         """Push data items in a cloud-agnostic way.
 
         Args:
-            targets (list): list of targets to push to the cloud.
+            cache (NamedCache): named checksums to push to the cloud.
             jobs (int): number of jobs that can be running simultaneously.
             remote (dvc.remote.base.RemoteBASE): optional remote to push to.
                 By default remote from core.remote config option is used.
@@ -57,17 +57,17 @@ class DataCloud(object):
                 information messages.
         """
         return self.repo.cache.local.push(
-            targets,
+            cache,
             jobs=jobs,
             remote=self.get_remote(remote, "push"),
             show_checksums=show_checksums,
         )
 
-    def pull(self, targets, jobs=None, remote=None, show_checksums=False):
+    def pull(self, cache, jobs=None, remote=None, show_checksums=False):
         """Pull data items in a cloud-agnostic way.
 
         Args:
-            targets (list): list of targets to pull from the cloud.
+            cache (NamedCache): named checksums to pull from the cloud.
             jobs (int): number of jobs that can be running simultaneously.
             remote (dvc.remote.base.RemoteBASE): optional remote to pull from.
                 By default remote from core.remote config option is used.
@@ -75,25 +75,25 @@ class DataCloud(object):
                 information messages.
         """
         return self.repo.cache.local.pull(
-            targets,
+            cache,
             jobs=jobs,
             remote=self.get_remote(remote, "pull"),
             show_checksums=show_checksums,
         )
 
-    def status(self, targets, jobs=None, remote=None, show_checksums=False):
+    def status(self, cache, jobs=None, remote=None, show_checksums=False):
         """Check status of data items in a cloud-agnostic way.
 
         Args:
-            targets (list): list of targets to check status for.
+            cache (NamedCache): named checksums to check status for.
             jobs (int): number of jobs that can be running simultaneously.
             remote (dvc.remote.base.RemoteBASE): optional remote to compare
-                targets to. By default remote from core.remote config option
+                cache to. By default remote from core.remote config option
                 is used.
             show_checksums (bool): show checksums instead of file names in
                 information messages.
         """
         remote = self.get_remote(remote, "status")
         return self.repo.cache.local.status(
-            targets, jobs=jobs, remote=remote, show_checksums=show_checksums
+            cache, jobs=jobs, remote=remote, show_checksums=show_checksums
         )

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -627,7 +627,7 @@ class RemoteBASE(object):
         used = self.extract_used_local_checksums(named_cache)
 
         if self.scheme != "":
-            used.update(named_cache.checksums_for(self.scheme))
+            used.update(named_cache[self.scheme])
 
         removed = False
         for checksum in self.all():
@@ -910,7 +910,7 @@ class RemoteBASE(object):
         return set()
 
     def extract_used_local_checksums(self, named_cache):
-        used = set(named_cache.checksums_for("local"))
+        used = set(named_cache["local"])
         unpacked = self._get_unpacked_dir_names(used)
         return used | unpacked
 

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -623,14 +623,11 @@ class RemoteBASE(object):
                 # We ignore all the non-cache looking files
                 pass
 
-    def gc(self, cinfos):
-        used = self.extract_used_local_checksums(cinfos)
+    def gc(self, named_cache):
+        used = self.extract_used_local_checksums(named_cache)
 
         if self.scheme != "":
-            used |= {
-                info[self.PARAM_CHECKSUM]
-                for info in cinfos.get(self.scheme, [])
-            }
+            used.update(named_cache.checksums_for(self.scheme))
 
         removed = False
         for checksum in self.all():
@@ -912,10 +909,8 @@ class RemoteBASE(object):
     def _get_unpacked_dir_names(self, checksums):
         return set()
 
-    def extract_used_local_checksums(self, cinfos):
-        from dvc.remote import RemoteLOCAL
-
-        used = {info[RemoteLOCAL.PARAM_CHECKSUM] for info in cinfos["local"]}
+    def extract_used_local_checksums(self, named_cache):
+        used = set(named_cache.checksums_for("local"))
         unpacked = self._get_unpacked_dir_names(used)
         return used | unpacked
 

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -260,7 +260,7 @@ class RemoteLOCAL(RemoteBASE):
         logger.debug(
             "Preparing to collect status from {}".format(remote.path_info)
         )
-        md5s = named_cache.checksums_for(self.scheme)
+        md5s = list(named_cache[self.scheme])
 
         logger.debug("Collecting information from local cache...")
         local_exists = self.cache_exists(md5s, jobs=jobs, name=self.cache_dir)
@@ -280,8 +280,8 @@ class RemoteLOCAL(RemoteBASE):
             )
 
         ret = {
-            checksum: {"name": checksum if show_checksums else name}
-            for checksum, name in named_cache.items_for(self.scheme)
+            checksum: {"name": checksum if show_checksums else " ".join(names)}
+            for checksum, names in named_cache[self.scheme].items()
         }
         self._fill_statuses(ret, local_exists, remote_exists)
 

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -49,16 +49,16 @@ def _fetch(
 
     try:
         downloaded += self.cloud.pull(
-            used["local"], jobs, remote=remote, show_checksums=show_checksums
+            used, jobs, remote=remote, show_checksums=show_checksums
         )
     except NoRemoteError:
-        if not used["repo"] and used["local"]:
+        if not used.repo and used["local"]:
             raise
 
     except DownloadError as exc:
         failed += exc.amount
 
-    for dep in used["repo"]:
+    for dep in used.repo:
         try:
             out = dep.fetch()
             downloaded += out.get_files_number()

--- a/dvc/repo/push.py
+++ b/dvc/repo/push.py
@@ -23,5 +23,5 @@ def push(
         remote=remote,
         jobs=jobs,
         recursive=recursive,
-    )["local"]
+    )
     return self.cloud.push(used, jobs, remote=remote)

--- a/dvc/repo/status.py
+++ b/dvc/repo/status.py
@@ -76,7 +76,7 @@ def _cloud_status(
         force=True,
         remote=remote,
         jobs=jobs,
-    )["local"]
+    )
 
     ret = {}
     status_info = self.cloud.status(used, jobs, remote=remote)

--- a/tests/unit/remote/test_local.py
+++ b/tests/unit/remote/test_local.py
@@ -1,3 +1,4 @@
+from dvc.cache import NamedCache
 from dvc.remote.local import RemoteLOCAL
 
 
@@ -8,16 +9,11 @@ def test_status_download_optimization(mocker):
     """
     remote = RemoteLOCAL(None, {})
 
-    infos = [
-        {"name": "foo", "md5": "acbd18db4cc2f85cedef654fccc4a4d8"},
-        {"name": "bar", "md5": "37b51d194a7513e45b56f6524f2d51f2"},
-    ]
+    infos = NamedCache()
+    infos.add("local", "acbd18db4cc2f85cedef654fccc4a4d8", "foo")
+    infos.add("local", "37b51d194a7513e45b56f6524f2d51f2", "bar")
 
-    local_exists = [
-        "acbd18db4cc2f85cedef654fccc4a4d8",
-        "37b51d194a7513e45b56f6524f2d51f2",
-    ]
-
+    local_exists = list(infos.checksums_for("local"))
     mocker.patch.object(remote, "cache_exists", return_value=local_exists)
 
     other_remote = mocker.Mock()

--- a/tests/unit/remote/test_local.py
+++ b/tests/unit/remote/test_local.py
@@ -13,7 +13,7 @@ def test_status_download_optimization(mocker):
     infos.add("local", "acbd18db4cc2f85cedef654fccc4a4d8", "foo")
     infos.add("local", "37b51d194a7513e45b56f6524f2d51f2", "bar")
 
-    local_exists = list(infos.checksums_for("local"))
+    local_exists = list(infos["local"])
     mocker.patch.object(remote, "cache_exists", return_value=local_exists)
 
     other_remote = mocker.Mock()


### PR DESCRIPTION
This is a preparation step to make garbage collector work with more
commits. It has a value of its own:
- less exists calls to show cloud status or prepare push/pull
- same names are not repeated in status and pbar texts
