### PR TITLE
dvc: dedup brancher

### DIFF
--- a/dvc/repo/brancher.py
+++ b/dvc/repo/brancher.py
@@ -1,3 +1,4 @@
+from funcy import group_by
 from dvc.scm.tree import WorkingTree
 
 
@@ -47,8 +48,8 @@ def brancher(  # noqa: E302
     # `brancher()`, but this could cause problems on exception handling
     # code which might expect the tree on which exception was raised to
     # stay in place. This behavior is a subject to change.
-    for rev in revs:
-        self.tree = scm.get_tree(rev)
-        yield rev
+    for sha, names in group_by(scm.resolve_rev, revs).items():
+        self.tree = scm.get_tree(sha)
+        yield ", ".join(names)
 
     self.tree = saved_tree

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -360,6 +360,9 @@ class Git(Base):
     def get_rev(self):
         return self.repo.git.rev_parse("HEAD")
 
+    def resolve_rev(self, rev):
+        return self.repo.git.rev_parse(rev)
+
     def close(self):
         self.repo.close()
 


### PR DESCRIPTION
This will prevent repetitive cache or metrics collections. Will be especially important for future `--all-commits` flag. 