### PR TITLE
imp: dedup and parallelize fetching imported deps

### DIFF
--- a/dvc/cache.py
+++ b/dvc/cache.py
@@ -109,7 +109,7 @@ class Cache(object):
 class NamedCache(object):
     def __init__(self):
         self._items = defaultdict(lambda: defaultdict(set))
-        self.repo = []
+        self.external = defaultdict(set)
 
     @classmethod
     def make(cls, scheme, checksum, name):
@@ -123,10 +123,14 @@ class NamedCache(object):
     def add(self, scheme, checksum, name):
         self._items[scheme][checksum].add(name)
 
+    def add_external(self, url, rev, path):
+        self.external[url, rev].add(path)
+
     def update(self, cache, suffix=""):
         for scheme, src in cache._items.items():
             dst = self._items[scheme]
             for checksum, names in src.items():
                 dst[checksum].update(names)
 
-        self.repo.extend(cache.repo)
+        for repo_pair, files in cache.external.items():
+            self.external[repo_pair].update(files)

--- a/dvc/dependency/repo.py
+++ b/dvc/dependency/repo.py
@@ -35,6 +35,11 @@ class DependencyREPO(DependencyLOCAL):
     def is_in_repo(self):
         return False
 
+    @property
+    def repo_pair(self):
+        d = self.def_repo
+        return d[self.PARAM_URL], d[self.PARAM_REV_LOCK] or d[self.PARAM_REV]
+
     def __str__(self):
         return "{} ({})".format(self.def_path, self.def_repo[self.PARAM_URL])
 

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -250,7 +250,8 @@ class Repo(object):
 
             for stage in stages:
                 if stage.is_repo_import:
-                    cache.repo += stage.deps
+                    dep, = stage.deps
+                    cache.external[dep.repo_pair].add(dep.def_path)
                     continue
 
                 for out in stage.outs:

--- a/tests/func/test_import.py
+++ b/tests/func/test_import.py
@@ -98,3 +98,20 @@ def test_import_to_dir(dname, repo_dir, dvc_repo, erepo):
     assert stage.outs[0].fspath == os.path.abspath(dst)
     assert os.path.isdir(dname)
     assert filecmp.cmp(repo_dir.FOO, dst, shallow=False)
+
+
+def test_pull_non_workspace(git, dvc_repo, erepo):
+    src = "version"
+    dst = src
+
+    stage = dvc_repo.imp(erepo.root_dir, src, dst, rev="branch")
+    dvc_repo.scm.add([stage.relpath])
+    dvc_repo.scm.commit("imported branch")
+    dvc_repo.scm.tag("ref-to-branch")
+
+    # Ovewrite via import
+    dvc_repo.imp(erepo.root_dir, src, dst, rev="master")
+
+    os.remove(stage.outs[0].cache_path)
+    dvc_repo.fetch(all_tags=True)
+    assert os.path.exists(stage.outs[0].cache_path)


### PR DESCRIPTION
This prevents same fetches for external artifacts, groups them by source
and fetches in parallel.