### PR TITLE
Desc fix

### DIFF
--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -136,5 +136,5 @@ class Tqdm(tqdm):
         else:
             # work-around for zero-width desc
             d["ncols_desc"] = 1
-            d["desc"] = 0
+            d["desc"] = ""
         return d

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -134,7 +134,7 @@ class Tqdm(tqdm):
         if ncols_desc:
             d["ncols_desc"] = ncols_desc
         else:
-            # work-around for zero-width desc
+            # work-around for zero-width description
             d["ncols_desc"] = 1
-            d["desc"] = ""
+            d["prefix"] = ""
         return d


### PR DESCRIPTION
Fixes zero-width description edge cases (#2659, #2598 -> #2627)

- correct usage of `tqdm.tqdm` API
- fix desc printing `0` instead of blank

I must've been tired.