### PR TITLE
graph: use find_cycle instead of simple_cycle

### DIFF
--- a/dvc/repo/graph.py
+++ b/dvc/repo/graph.py
@@ -5,10 +5,17 @@ def check_acyclic(graph):
     import networkx as nx
     from dvc.exceptions import CyclicGraphError
 
-    cycle = next(nx.simple_cycles(graph), None)
+    try:
+        edges = nx.find_cycle(graph, orientation="original")
+    except nx.NetworkXNoCycle:
+        return
 
-    if cycle:
-        raise CyclicGraphError(cycle)
+    stages = set()
+    for from_node, to_node, _ in edges:
+        stages.add(from_node)
+        stages.add(to_node)
+
+    raise CyclicGraphError(list(stages))
 
 
 def get_pipeline(pipelines, node):


### PR DESCRIPTION
We are incorrectly using `simple_cycle` here, `find_cycle` is much more
suitable for this application and much faster too. For example:

```
$ cat test_networkx.py
import networkx as nx
from dvc.repo.graph import check_acyclic

G = nx.scale_free_graph(1200)

list(nx.find_cycle(G, orientation='ignore'))

list(nx.simple_cycles(G))

$ python -mcProfile -scumtime test_networkx.py &> log.log
```

shows ~100s for `simple_cycles` and ~0s for `find_cycle`.

Fixes #2666


* [x] Have you followed the guidelines in our
      [Contributing document](https://dvc.org/doc/user-guide/contributing/core)?

* [x] Does your PR affect documented changes or does it add new functionality
      that should be documented? If yes, have you created a PR for
      [dvc.org](https://github.com/iterative/dvc.org) documenting it or at
      least opened an issue for it? If so, please add a link to it.

-----
