### PR TITLE
Exclude compat files from DeepSource analysis

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -5,7 +5,7 @@ test_patterns = [
 ]
 
 exclude_patterns = [
-  
+  'dvc/utils/compat.py'
 ]
 
 [[analyzers]]


### PR DESCRIPTION
Hi team,

I just [noticed](https://github.com/iterative/dvc/pull/2548#issuecomment-536255251) that there are could be quite a number of false-positives in `dvc/utils/compat.py` because of, well, the things we have to do for compatibility. I would recommend adding that file to `exclude_patterns` to prevent the noise. I've proposed that in this PR.

We've seen some other projects report this as well, and we're working on proactively suggesting this via the product's UI to make it easier.

Hope this helps!

Best,
Sanket
Founder, DeepSource