### PR TITLE
pull, at import stage: replace warning with info report

### DIFF
--- a/dvc/repo/checkout.py
+++ b/dvc/repo/checkout.py
@@ -50,12 +50,6 @@ def _checkout(
         total=total, unit="file", desc="Checkout", disable=total == 0
     ) as pbar:
         for stage in stages:
-            if stage.locked:
-                logger.warning(
-                    "DVC-file '{path}' is locked. Its dependencies are"
-                    " not going to be checked out.".format(path=stage.relpath)
-                )
-
             failed.extend(
                 stage.checkout(force=force, progress_callback=pbar.update_desc)
             )

--- a/dvc/repo/pull.py
+++ b/dvc/repo/pull.py
@@ -25,8 +25,8 @@ def pull(
         jobs,
         remote=remote,
         all_branches=all_branches,
-        with_deps=with_deps,
         all_tags=all_tags,
+        with_deps=with_deps,
         recursive=recursive,
     )
     self._checkout(

--- a/dvc/repo/pull.py
+++ b/dvc/repo/pull.py
@@ -32,5 +32,4 @@ def pull(
     self._checkout(
         targets=targets, with_deps=with_deps, force=force, recursive=recursive
     )
-    logger.info("Data retrieved successfully from DVC remote storage.")
     return processed_files_count

--- a/dvc/repo/pull.py
+++ b/dvc/repo/pull.py
@@ -1,6 +1,11 @@
 from __future__ import unicode_literals
 
-from . import locked
+import logging
+
+from dvc.repo import locked
+
+
+logger = logging.getLogger(__name__)
 
 
 @locked
@@ -20,11 +25,16 @@ def pull(
         jobs,
         remote=remote,
         all_branches=all_branches,
-        all_tags=all_tags,
         with_deps=with_deps,
+        all_tags=all_tags,
         recursive=recursive,
     )
     self._checkout(
-        targets=targets, with_deps=with_deps, force=force, recursive=recursive
+        targets=targets,
+        with_deps=with_deps,
+        force=force,
+        recursive=recursive,
+
     )
+    logger.info("Data retrieved successfully from DVC remote storage.")
     return processed_files_count

--- a/dvc/repo/pull.py
+++ b/dvc/repo/pull.py
@@ -30,11 +30,7 @@ def pull(
         recursive=recursive,
     )
     self._checkout(
-        targets=targets,
-        with_deps=with_deps,
-        force=force,
-        recursive=recursive,
-
+        targets=targets, with_deps=with_deps, force=force, recursive=recursive
     )
     logger.info("Data retrieved successfully from DVC remote storage.")
     return processed_files_count


### PR DESCRIPTION
Replace generic locked checkout warning with an information report on return when 'dvc pull' is run at import stage.

Related to #2685.

* [x] Have you followed the guidelines in our [Contributing document](https://dvc.org/doc/user-guide/contributing/core)?

* [x] ~~Does your PR affect documented changes or does it add new functionality
      that should be documented?~~ [It does not for both cases.]

-----

The new output, after the minimal steps to recreate as outlined in the Issue to close, is:

```console
$ dvc pull
Data retrieved successfully from DVC remote storage.
```