### PR TITLE
dvc: fix tqdm dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ install_requires = [
     "funcy>=1.12",
     "pathspec>=0.6.0",
     "shortuuid>=0.5.0",
-    "tqdm>=4.35.0,<5",
+    "tqdm>=4.36.1,<5",
     "packaging>=19.0",
     "win-unicode-console>=0.5; sys_platform == 'win32'",
 ]


### PR DESCRIPTION
`tqdm==4.35.0` was throwing `KeyError` in `tests/func/test_add.py::TestDoubleAddUnchanged::test_dir`.

The stack trace:
```
Traceback (most recent call last):
  File "/home/suor/projects/dvc/dvc/main.py", line 43, in main
    ret = cmd.run()
  File "/home/suor/projects/dvc/dvc/command/add.py", line 24, in run
    fname=self.args.file,
  File "/home/suor/projects/dvc/dvc/repo/__init__.py", line 33, in wrapper
    ret = f(repo, *args, **kwargs)
  File "/home/suor/projects/dvc/dvc/repo/scm_context.py", line 4, in run
    result = method(repo, *args, **kw)
  File "/home/suor/projects/dvc/dvc/repo/add.py", line 60, in add
    pbar.bar_format = pbar.BAR_FMT_DEFAULT.replace("|{bar:10}|", " ")
  File "/home/suor/.virtualenvs/dvc/lib/python3.7/site-packages/tqdm/_tqdm.py", line 1015, in __exit__
    self.close()
  File "/home/suor/projects/dvc/dvc/progress.py", line 125, in close
    super(Tqdm, self).close()
  File "/home/suor/.virtualenvs/dvc/lib/python3.7/site-packages/tqdm/_tqdm.py", line 1225, in close
    self.display(pos=0)
  File "/home/suor/.virtualenvs/dvc/lib/python3.7/site-packages/tqdm/_tqdm.py", line 1376, in display
    self.sp(self.__repr__() if msg is None else msg)
  File "/home/suor/.virtualenvs/dvc/lib/python3.7/site-packages/tqdm/_tqdm.py", line 1022, in __repr__
    return self.format_meter(**self.format_dict)
  File "/home/suor/projects/dvc/dvc/progress.py", line 132, in format_dict
    ncols_desc = ncols - len(self.format_meter(ncols_desc=1, **d)) + 1
  File "/home/suor/.virtualenvs/dvc/lib/python3.7/site-packages/tqdm/_tqdm.py", line 482, in format_meter
    return bar_format.format(bar='?', **format_dict)
KeyError: 'percentage'
```
