### PR TITLE
Fixed issue #2680 and Simple typo rectified

### DIFF
--- a/dvc/remote/s3.py
+++ b/dvc/remote/s3.py
@@ -144,7 +144,7 @@ class RemoteS3(RemoteBASE):
         # multipart.
         #
         # If an object's etag looks like '8978c98bb5a48c2fb5f2c4c905768afa',
-        # then it was transfered as a single part, which means that the chunk
+        # then it was transferred as a single part, which means that the chunk
         # size used to transfer it was greater or equal to the ContentLength
         # of that object. So to preserve that tag over the next transfer, we
         # could use any value >= ContentLength.

--- a/dvc/updater.py
+++ b/dvc/updater.py
@@ -123,7 +123,6 @@ class Updater(object):  # pragma: no cover
             "yum": "Run {yellow}yum{reset} update dvc",
             "yay": "Run {yellow}yay{reset} {blue}-S{reset} dvc",
             "formula": "Run {yellow}brew{reset} upgrade dvc",
-            "cask": "Run {yellow}brew cask{reset} upgrade dvc",
             "apt": (
                 "Run {yellow}apt-get{reset} install"
                 " {blue}--only-upgrade{reset} dvc"
@@ -169,14 +168,6 @@ class Updater(object):  # pragma: no cover
                 return "formula"
             else:
                 return "pip"
-
-        # NOTE: both pkg and cask put dvc binary into /usr/local/bin,
-        # so in order to know which method of installation was used,
-        # we need to actually call `brew cask`
-        ret = os.system("brew cask ls dvc")
-        if ret == 0:
-            return "cask"
-
         return None
 
     def _get_windows(self):


### PR DESCRIPTION
dvc/remote/s3.py : Rectified simple typo
dvc/updater.py : Removed "Cask 'dvc' is not installed." error

dvc/remote/s3.py:L148: transfered -> transferred
Delete https://github.com/iterative/dvc/blob/0.66.3/dvc/updater.py#L126 and code block https://github.com/iterative/dvc/blob/0.66.3/dvc/updater.py#L173

Fixes #2680 