### PR TITLE
fix NPE when we do get that does not provide progress callback

### DIFF
--- a/dvc/output/base.py
+++ b/dvc/output/base.py
@@ -287,7 +287,8 @@ class OutputBase(object):
 
     def checkout(self, force=False, progress_callback=None, tag=None):
         if not self.use_cache:
-            progress_callback(str(self.path_info), self.get_files_number())
+            if progress_callback:
+                progress_callback(str(self.path_info), self.get_files_number())
             return None
 
         if tag:


### PR DESCRIPTION
* Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?
* Check this box if this PR **does not** require
[documentation](https://dvc.org/doc) updates, or if it does **and** you
      have created a separate PR in
      [dvc.org](https://github.com/iterative/dvc.org)
      with such updates (or at least opened an issue about it in that repo).
      Please link below to your PR (or issue) in the
      [dvc.org](https://github.com/iterative/dvc.org) repo.

* [X] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks
      below? We consider their findings recommendatory and don't expect
      everything to be addresses. Please review them carefully and fix those
      that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

------------

Fixes the following NPE:

```$ dvc get -v https://github.com/shcheklein/example-get-started.git auc.metric
DEBUG: Adding '../../../../private/var/folders/_1/dxrf7_f15sn4r01jvqvr5b6h0000gn/T/tmpo61q66dudvc-erepo/.dvc/tmp' to '../../../../private/var/folders/_1/dxrf7_f15sn4r01jvqvr5b6h0000gn/T/tmpo61q66dudvc-erepo/.dvc/.gitignore'.
DEBUG: Writing '/private/var/folders/_1/dxrf7_f15sn4r01jvqvr5b6h0000gn/T/tmpo61q66dudvc-erepo/.dvc/config.local'.
DEBUG: Writing '/private/var/folders/_1/dxrf7_f15sn4r01jvqvr5b6h0000gn/T/tmpo61q66dudvc-erepo/.dvc/config'.
DEBUG: Preparing to download data from 'https://remote.dvc.org/get-started'
DEBUG: Preparing to collect status from https://remote.dvc.org/get-started
DEBUG: Collecting information from local cache...
DEBUG: Removing '.nGQkE64Vk5hi736fG5kpUE'
ERROR: unexpected error - 'NoneType' object is not callable
------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ivan/Projects/dvc/dvc/main.py", line 44, in main
    ret = cmd.run()
  File "/Users/ivan/Projects/dvc/dvc/command/get.py", line 22, in run
    rev=self.args.rev,
  File "/Users/ivan/Projects/dvc/dvc/repo/get.py", line 62, in get
    o.checkout()
  File "/Users/ivan/Projects/dvc/dvc/output/base.py", line 290, in checkout
    progress_callback(str(self.path_info), self.get_files_number())
TypeError: 'NoneType' object is not callable
------------------------------------------------------------
```