### PR TITLE
system: win: use win32file for _getdirinfo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ install_requires = [
     "tqdm>=4.36.1,<5",
     "packaging>=19.0",
     "win-unicode-console>=0.5; sys_platform == 'win32'",
+    "pywin32>=225; sys_platform == 'win32'",
 ]
 
 if sys.version_info[0] == 2:
@@ -118,7 +119,6 @@ tests_requirements = [
     "xmltodict>=0.11.0",
     "awscli==1.16.266",
     "google-compute-engine==2.8.13",
-    "pywin32; sys_platform == 'win32'",
     "Pygments",  # required by collective.checkdocs,
     "collective.checkdocs",
     "flake8",


### PR DESCRIPTION
Current implementation is triggering some non-obvious gc bug, that
causes memory leaks. Using win32file simplifies the code and gets rid of
this bug.

To reproduce it, run:

```
from dvc.system import System

while True:
    System.inode(__file__)
```

and see your Windows machine run out of memory pretty quickly.

* [x] ❗ Have you followed the guidelines in the
      [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core)
      list?

* [x] 📖 Check this box if this PR **does not** require
      [documentation](https://dvc.org/doc) updates, or if it does **and** you
      have created a separate PR in
      [dvc.org](https://github.com/iterative/dvc.org)
      with such updates (or at least opened an issue about it in that repo).
      Please link below to your PR (or issue) in the
      [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks
      below? We consider their findings recommendatory and don't expect
      everything to be addresses. Please review them carefully and fix those
      that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

