### PR TITLE
sftp: only remove src after an atomic copy during move

### DIFF
--- a/dvc/remote/ssh/connection.py
+++ b/dvc/remote/ssh/connection.py
@@ -196,8 +196,7 @@ class SSHConnection:
             self.sftp.rename(src, dst)
         except OSError:
             self._atomic_copy(src, dst)
-
-        self.remove(src)
+            self.remove(src)
 
     def _atomic_copy(self, src, dst):
         tmp = tmp_fname(dst)


### PR DESCRIPTION
Shout-out to @Suor for pointing this out