### PR TITLE
Ensure `contains_symlink_up_to` accept both str and Path-like objects

### DIFF
--- a/dvc/utils/fs.py
+++ b/dvc/utils/fs.py
@@ -9,6 +9,7 @@ import nanotime
 from dvc.exceptions import DvcException
 from dvc.system import System
 from dvc.utils import dict_md5
+from dvc.utils import fspath
 from dvc.utils import fspath_py35
 from dvc.utils import walk_files
 from dvc.utils.compat import str
@@ -61,6 +62,9 @@ class BasePathNotInCheckedPathException(DvcException):
 
 
 def contains_symlink_up_to(path, base_path):
+    base_path = fspath(base_path)
+    path = fspath(path)
+
     if base_path not in path:
         raise BasePathNotInCheckedPathException(path, base_path)
 

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -94,6 +94,14 @@ class TestContainsLink(TestCase):
         ):
             self.assertFalse(contains_symlink_up_to(target_path, base_path))
 
+    def test_path_object_and_str_are_valid_arg_types(self):
+        base_path = "foo"
+        target_path = os.path.join(base_path, "bar")
+        self.assertFalse(contains_symlink_up_to(target_path, base_path))
+        self.assertFalse(
+            contains_symlink_up_to(PathInfo(target_path), PathInfo(base_path))
+        )
+
 
 @pytest.mark.parametrize(
     "path1, path2",


### PR DESCRIPTION
* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addresses. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

With reference: #2137 
These changes test if `contains_symlink_up_to` can accept both `str` and `Path` like objects.

<del>I have purposely added the `patch.object` decorator since I wanted to make the symlink true so that it comes out of recursion loop. There can be one addition to this test where we check for this condition as well - https://github.com/iterative/dvc/compare/master...algomaster99:test-arg-types-symlink?expand=1#diff-24be7b52326b428c2569724796020192R72. How to proceed with the latter?</del> Resolved here - https://github.com/iterative/dvc/pull/2740#discussion_r342727237