### PR TITLE
Ensure `file_md5` accept str and Path-like objects

### DIFF
--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -149,7 +149,7 @@ class RemoteLOCAL(RemoteBASE):
             yield PathInfo(fname)
 
     def get_file_checksum(self, path_info):
-        return file_md5(fspath_py35(path_info))[0]
+        return file_md5(path_info)[0]
 
     def remove(self, path_info):
         if path_info.scheme != "local":

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -44,6 +44,8 @@ def file_md5(fname):
     from dvc.progress import Tqdm
     from dvc.istextfile import istextfile
 
+    fname = fspath_py35(fname)
+
     if os.path.exists(fname):
         hash_md5 = hashlib.md5()
         binary = not istextfile(fname)

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -2,6 +2,8 @@ import os
 
 import pytest
 
+from dvc.path_info import PathInfo
+from dvc.utils import file_md5
 from dvc.utils import fix_env
 from dvc.utils import to_chunks
 
@@ -71,3 +73,9 @@ def test_fix_env_pyenv(path, orig):
         "PYENV_HOOK_PATH": "/some/hook/path",
     }
     assert fix_env(env)["PATH"] == orig
+
+
+def test_file_md5(repo_dir):
+    fname = repo_dir.FOO
+    fname_object = PathInfo(fname)
+    assert file_md5(fname) == file_md5(fname_object)


### PR DESCRIPTION
* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addresses. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

With reference: #2137 
- I used `fspath_py35` since all `os.path.*` functions, `open` and `istextfile` accept str and Path like objects.
- `repo_dir` fixture is used because I wanted to compare MD5 digest of a non-empty file. Not using this fixture would have required me to make such file manually.