### PR TITLE
system: use logging instead of dvc.logger

### DIFF
--- a/dvc/system.py
+++ b/dvc/system.py
@@ -1,12 +1,16 @@
 from __future__ import unicode_literals
 
 import errno
+import logging
 import os
 import shutil
 
 from dvc.utils.compat import fspath
 from dvc.utils.compat import open
 from dvc.utils.compat import str
+
+
+logger = logging.getLogger(__name__)
 
 
 class System(object):
@@ -74,7 +78,6 @@ class System(object):
     @staticmethod
     def _reflink_darwin(src, dst):
         import ctypes
-        import dvc.logger as logger
 
         LIBC = "libc.dylib"
         LIBC_FALLBACK = "/usr/lib/libSystem.dylib"


### PR DESCRIPTION
A leftover from an old logger refactoring.

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addresses. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

