### PR TITLE
analytics: don't verify config from repo

### DIFF
--- a/dvc/analytics.py
+++ b/dvc/analytics.py
@@ -219,10 +219,10 @@ class Analytics(object):
 
         try:
             dvc_dir = Repo.find_dvc_dir()
-            config = Config(dvc_dir)
         except NotDvcRepoError:
-            config = Config(validate=False)
-        return config
+            dvc_dir = None
+
+        return Config(dvc_dir, validate=False)
 
     @staticmethod
     def is_enabled(cmd=None):

--- a/dvc/analytics.py
+++ b/dvc/analytics.py
@@ -205,27 +205,8 @@ class Analytics(object):
             return fobj.name
 
     @staticmethod
-    def _is_enabled_config(config):
-        from dvc.config import Config
-
-        core = config.config.get(Config.SECTION_CORE, {})
-        return core.get(Config.SECTION_CORE_ANALYTICS, True)
-
-    @staticmethod
-    def _get_current_config():
-        from dvc.config import Config
-        from dvc.repo import Repo
-        from dvc.exceptions import NotDvcRepoError
-
-        try:
-            dvc_dir = Repo.find_dvc_dir()
-        except NotDvcRepoError:
-            dvc_dir = None
-
-        return Config(dvc_dir, validate=False)
-
-    @staticmethod
     def is_enabled(cmd=None):
+        from dvc.config import Config, to_bool
         from dvc.command.daemon import CmdDaemonBase
 
         if env2bool("DVC_TEST"):
@@ -234,15 +215,8 @@ class Analytics(object):
         if isinstance(cmd, CmdDaemonBase):
             return False
 
-        config = (
-            Analytics._get_current_config()
-            if cmd is None or not hasattr(cmd, "config")
-            else cmd.config
-        )
-
-        assert config is not None
-
-        enabled = Analytics._is_enabled_config(config)
+        core = Config(validate=False).config.get(Config.SECTION_CORE, {})
+        enabled = to_bool(core.get(Config.SECTION_CORE_ANALYTICS, "true"))
         logger.debug(
             "Analytics is {}.".format("enabled" if enabled else "disabled")
         )

--- a/tests/func/test_analytics.py
+++ b/tests/func/test_analytics.py
@@ -30,24 +30,18 @@ class TestAnalytics(TestDir):
         self.assertNotEqual(a.info[a.PARAM_SYSTEM_INFO], {})
 
     @mock.patch.object(os, "getenv", new=_clean_getenv)
-    @mock.patch(
-        "dvc.analytics.Analytics._is_enabled_config", return_value=True
-    )
     @mock.patch("requests.post")
-    def test_send(self, mockpost, _):
+    def test_send(self, mockpost):
         ret = main(["daemon", "analytics", Analytics().dump(), "-v"])
         self.assertEqual(ret, 0)
 
         self.assertTrue(mockpost.called)
 
     @mock.patch.object(os, "getenv", new=_clean_getenv)
-    @mock.patch(
-        "dvc.analytics.Analytics._is_enabled_config", return_value=True
-    )
     @mock.patch.object(
         requests, "post", side_effect=requests.exceptions.RequestException()
     )
-    def test_send_failed(self, mockpost, _):
+    def test_send_failed(self, mockpost):
         ret = main(["daemon", "analytics", Analytics().dump(), "-v"])
         self.assertEqual(ret, 0)
 

--- a/tests/unit/test_analytics.py
+++ b/tests/unit/test_analytics.py
@@ -1,0 +1,14 @@
+from dvc.analytics import Analytics
+from dvc.config import Config
+from dvc.repo import NotDvcRepoError
+
+
+def test_broken_config(mocker, dvc_repo):
+    Config(dvc_repo.dvc_dir, validate=False).set("cache", "type", "unknown")
+
+    assert Analytics._get_current_config()
+
+    with mocker.patch(
+        "dvc.repo.Repo.find_dvc_dir", side_effect=NotDvcRepoError(".")
+    ):
+        assert Analytics._get_current_config()


### PR DESCRIPTION
Otherwise this will raise an exception from analytics worker:
```
dvc config cache.type sometypo
```
But running that same command with `--system` or `--global` flag outside
of repo won't raise that.

Also need to better handle ConfigObjError, but that is a separate issue.

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addresses. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

