### PR TITLE
non-blocking intermediate progress IO

### DIFF
--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 
 import logging
 import sys
+from threading import RLock
 
 from funcy import merge
 from tqdm import tqdm
@@ -10,6 +11,7 @@ from tqdm import tqdm
 from dvc.utils import env2bool
 
 logger = logging.getLogger(__name__)
+tqdm.set_lock(RLock())
 
 
 class Tqdm(tqdm):
@@ -76,6 +78,7 @@ class Tqdm(tqdm):
             leave=leave,
             desc=desc,
             bar_format="!",
+            lock_args=(False,),
             **kwargs
         )
         if bar_format is None:

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ install_requires = [
     "funcy>=1.12",
     "pathspec>=0.6.0",
     "shortuuid>=0.5.0",
-    "tqdm>=4.36.1,<5",
+    "tqdm>=4.38.0,<5",
     "packaging>=19.0",
     "win-unicode-console>=0.5; sys_platform == 'win32'",
     "pywin32>=225; sys_platform == 'win32'",


### PR DESCRIPTION
- [x] non-blocking for intermediate progress (creation, iteration, update)
- [x] block only upon completion (printing 100%, stats, etc)
- fixes #2766 (from #2697)
- depends on https://github.com/tqdm/tqdm/issues/838 -> https://github.com/tqdm/tqdm/pull/839