### PR TITLE
test: try using azurite 3.3.0-preview

### DIFF
--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -10,12 +10,6 @@ scriptdir="$(dirname $0)"
 # work or not.
 $scriptdir/retry.sh pip install --upgrade pip setuptools wheel
 $scriptdir/retry.sh pip install .[all,tests]
-# Installing specific packages to workaround some bugs. Please see [1] and [2]
-#
-# [1] https://github.com/iterative/dvc/issues/2284
-# [2] https://github.com/iterative/dvc/issues/2387
-$scriptdir/retry.sh pip uninstall -y azure-storage-blob
-$scriptdir/retry.sh pip install psutil azure-storage-blob==1.5.0
 
 git config --global user.email "dvctester@example.com"
 git config --global user.name "DVC Tester"

--- a/scripts/ci/install_azurite.sh
+++ b/scripts/ci/install_azurite.sh
@@ -13,7 +13,7 @@ set -x
 # run azurite
 sudo docker run -d --restart always -e executable=blob -p 10000:10000 \
 	--tmpfs /opt/azurite/folder \
-	mcr.microsoft.com/azure-storage/azurite:3.1.2-preview \
+	mcr.microsoft.com/azure-storage/azurite:3.3.0-preview \
 	azurite -l /data --blobHost 0.0.0.0
 
 # save secrets


### PR DESCRIPTION
Azurite was updated [2] to support new SAS tokens, so we no longer need
to downgrade azure-storage-blob for our tests.

PS: psutil line was removed because we already have it in our test requirements.

[1] https://github.com/iterative/dvc/issues/2387
[2] https://github.com/Azure/Azurite/issues/250

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addresses. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

