### PR TITLE
makedirs: fix mode flag is being ignored starting from Python 3.7

### DIFF
--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -152,6 +152,9 @@ def makedirs(path, exist_ok=False, mode=None):
         _makedirs(path, exist_ok=exist_ok)
         return
 
+    # utilize umask to set proper permissions since Python 3.7 the `mode`
+    # `makedirs` argument no longer affects the file permission bits of
+    # newly-created intermediate-level directories.
     umask = os.umask(0o777 - mode)
     try:
         _makedirs(path, exist_ok=exist_ok)

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -152,9 +152,9 @@ def makedirs(path, exist_ok=False, mode=None):
         _makedirs(path, exist_ok=exist_ok)
         return
 
-    umask = os.umask(0)
+    umask = os.umask(0o777 - mode)
     try:
-        _makedirs(path, exist_ok=exist_ok, mode=mode)
+        _makedirs(path, exist_ok=exist_ok)
     finally:
         os.umask(umask)
 

--- a/dvc/utils/compat.py
+++ b/dvc/utils/compat.py
@@ -85,8 +85,6 @@ def _makedirs(name, mode=0o777, exist_ok=False):
             if e.errno != errno.EEXIST:
                 raise
         cdir = os.curdir
-        if isinstance(tail, bytes):
-            cdir = bytes(os.curdir, "ASCII")
         if tail == cdir:
             return
     try:

--- a/tests/func/test_utils.py
+++ b/tests/func/test_utils.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 import filecmp
 import os
 import shutil
@@ -77,11 +78,14 @@ class TestUtils(TestDvc):
 @pytest.mark.skipif(os.name == "nt", reason="Not supported for Windows.")
 def test_makedirs_permissions():
     dir_mode = 0o755
-    intermediate_dir = "testdir"
+    intermediate_dir = "тестовая-директория"
     test_dir = os.path.join(intermediate_dir, "data")
-    utils.makedirs(test_dir, mode=dir_mode)
 
-    assert stat.S_IMODE(os.stat(test_dir).st_mode) == dir_mode
-    assert stat.S_IMODE(os.stat(intermediate_dir).st_mode) == dir_mode
+    assert not os.path.exists(intermediate_dir)
 
-    shutil.rmtree(test_dir)
+    try:
+        utils.makedirs(test_dir, mode=dir_mode)
+        assert stat.S_IMODE(os.stat(test_dir).st_mode) == dir_mode
+        assert stat.S_IMODE(os.stat(intermediate_dir).st_mode) == dir_mode
+    finally:
+        shutil.rmtree(intermediate_dir)

--- a/tests/func/test_utils.py
+++ b/tests/func/test_utils.py
@@ -76,16 +76,15 @@ class TestUtils(TestDvc):
 
 
 @pytest.mark.skipif(os.name == "nt", reason="Not supported for Windows.")
-def test_makedirs_permissions():
+def test_makedirs_permissions(tmpdir):
     dir_mode = 0o755
+    os.chdir(str(tmpdir))
     intermediate_dir = "тестовая-директория"
     test_dir = os.path.join(intermediate_dir, "data")
 
     assert not os.path.exists(intermediate_dir)
 
-    try:
-        utils.makedirs(test_dir, mode=dir_mode)
-        assert stat.S_IMODE(os.stat(test_dir).st_mode) == dir_mode
-        assert stat.S_IMODE(os.stat(intermediate_dir).st_mode) == dir_mode
-    finally:
-        shutil.rmtree(intermediate_dir)
+    utils.makedirs(test_dir, mode=dir_mode)
+
+    assert stat.S_IMODE(os.stat(test_dir).st_mode) == dir_mode
+    assert stat.S_IMODE(os.stat(intermediate_dir).st_mode) == dir_mode

--- a/tests/func/test_utils.py
+++ b/tests/func/test_utils.py
@@ -1,6 +1,9 @@
 import filecmp
 import os
 import shutil
+import stat
+
+import pytest
 
 from dvc import utils
 from tests.basic_env import TestDvc
@@ -69,3 +72,16 @@ class TestUtils(TestDvc):
         )
 
         assert expected == utils.boxify("message")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Not supported for Windows.")
+def test_makedirs_permissions():
+    dir_mode = 0o755
+    intermediate_dir = "testdir"
+    test_dir = os.path.join(intermediate_dir, "data")
+    utils.makedirs(test_dir, mode=dir_mode)
+
+    assert stat.S_IMODE(os.stat(test_dir).st_mode) == dir_mode
+    assert stat.S_IMODE(os.stat(intermediate_dir).st_mode) == dir_mode
+
+    shutil.rmtree(test_dir)


### PR DESCRIPTION
Fixes #2789 

* [X] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [X] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [X] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addresses. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

