### PR TITLE
use SI prefixes for progress

### DIFF
--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -21,11 +21,11 @@ class Tqdm(tqdm):
 
     BAR_FMT_DEFAULT = (
         "{percentage:3.0f}%|{bar:10}|"
-        "{desc:{ncols_desc}.{ncols_desc}}{n}/{total}"
+        "{desc:{ncols_desc}.{ncols_desc}}{n_fmt}/{total_fmt}"
         " [{elapsed}<{remaining}, {rate_fmt:>11}{postfix}]"
     )
     BAR_FMT_NOTOTAL = (
-        "{desc:{ncols_desc}.{ncols_desc}}{n}"
+        "{desc:{ncols_desc}.{ncols_desc}}{n_fmt}"
         " [{elapsed}<??:??, {rate_fmt:>11}{postfix}]"
     )
 


### PR DESCRIPTION
changes `560000/1000023` in progress bars to `560k/1M`

Note that this looses some precision for large numbers but looks nicer. Not sure if this is a good or bad thing.

[![asciicast](https://asciinema.org/a/1frqvezje8S9T8woIDfcpYbSu.svg)](https://asciinema.org/a/1frqvezje8S9T8woIDfcpYbSu?speed=4)