### PR TITLE
[bikeshed] Discussion around cognitive load, aesthetics, wasting time

### DIFF
--- a/dvc/config.py
+++ b/dvc/config.py
@@ -17,8 +17,7 @@ from schema import Use
 
 from dvc.exceptions import DvcException
 from dvc.exceptions import NotDvcRepoError
-from dvc.utils.compat import open
-from dvc.utils.compat import str
+from dvc.utils.compat import open, str, pathlib
 
 logger = logging.getLogger(__name__)
 
@@ -345,8 +344,8 @@ class Config(object):  # pylint: disable=too-many-instance-attributes
         """
         from appdirs import user_config_dir
 
-        return user_config_dir(
-            appname=Config.APPNAME, appauthor=Config.APPAUTHOR
+        return pathlib.Path(
+            user_config_dir(appname=Config.APPNAME, appauthor=Config.APPAUTHOR)
         )
 
     @staticmethod
@@ -358,8 +357,8 @@ class Config(object):  # pylint: disable=too-many-instance-attributes
         """
         from appdirs import site_config_dir
 
-        return site_config_dir(
-            appname=Config.APPNAME, appauthor=Config.APPAUTHOR
+        return pathlib.Path(
+            site_config_dir(appname=Config.APPNAME, appauthor=Config.APPAUTHOR)
         )
 
     @staticmethod

--- a/dvc/lock.py
+++ b/dvc/lock.py
@@ -58,7 +58,7 @@ if is_py3:
             # [1] https://github.com/iterative/dvc/issues/2582
             self._hostname = socket.gethostname()
 
-            self._lockfile = lockfile
+            self._lockfile = str(lockfile)
             self._lifetime = timedelta(days=365)  # Lock for good by default
             self._separator = flufl.lock.SEP
             self._set_claimfile()
@@ -111,7 +111,7 @@ else:
         """
 
         def __init__(self, lockfile, tmp_dir=None):
-            self.lockfile = lockfile
+            self.lockfile = str(lockfile)
             self._lock = None
 
         @property

--- a/dvc/utils/serializers.py
+++ b/dvc/utils/serializers.py
@@ -1,0 +1,26 @@
+import abc
+import json
+import cattr
+
+
+class JSONMixin(abc.ABC):
+    @classmethod
+    def from_file(cls, path):
+        with open(path, 'r') as fobj:
+            data = json.load(fobj)
+
+        return cattr.structure(data, cls)
+
+    def to_file(self, path):
+        with open(path, "w+") as fobj:
+            json.dump(cattr.unstructure(self), fobj)
+
+    @property
+    def asdict(self):
+        return cattr.unstructure(self)
+
+def json_serializer(cls):
+    cls.from_file = classmethod(JSONMixin.from_file.__func__)
+    cls.to_file = JSONMixin.to_file
+    cls.asdict = JSONMixin.asdict
+    return cls


### PR DESCRIPTION
:warning: **DO NOT MERGE!** :warning:

---

**Backstory**:

During the weekend, while trying to finish the sprint, I found myself procrastinating --well, not sure if procrastinating or just not being able to focus-- but this time I decided to explore what was going on down there at the rabbit hole.

It all started with #2683. After some discussions with @efiop about the implementation, we agreed to support adding empty directories directly (e.g. `mkdir empty && dvc add empty`) but not bother with empty directories inside another directory (e.g. `mkdir -p data/empty && echo foo > data/foo && dvc add data` -- this will ignore `data/empty` when `dvc checkout`).

Anyways, understanding how `dvc add empty/` worked _internally_ was hard, mainly:
  * Following the trace requires the reader to navigate through several classes (i.e. `Stage`, `State`, `RemoteBASE`, `RemoteLOCAL`, `OutputBASE`) in a non-linear fashion.

Then, when I tried to _pin point_ why `dvc add empty/` was behaving differently than `dvc add s3://bucket/empty/` (same operation but handled by different remotes), it was hard to tell right away. I plugged `pudb`, went through both executions and it turned out `get_checksum` didn't return the checksum with the `.dir` prefix for S3:

```python
    def changed_cache_file(self, checksum):
        """Compare the given checksum with the (corresponding) actual one.

        - Use `State` as a cache for computed checksums
            + The entries are invalidated by taking into account the following:
                * mtime
                * inode
                * size
                * checksum

        - Remove the file from cache if it doesn't match the actual checksum
        """
        cache_info = self.checksum_to_path_info(checksum)
        actual = self.get_checksum(cache_info)
```

I spent significant time to find that it was a bug on my implementation.

A day passed, integrated master into my branch, tried a different implementation and wanted to see if it didn't affect the code base, so I ran the tests.

_A wild #2806 appears!_

Tests weren't passing because disabling analytics affected the tests.

Instead of doing what a sane human being would do --enabling analytics to continue working on the previous issue--, I tried to fix the issue myself. _It shouldn't be that hard_, I thought. Spoiler alert: ~It  was~.

---

**Problem**:

I'm having a hard time trying to understand the execution of the code. Sometimes, reading through it is not enough for me and I need to use an interactive debugger.

Not sure if I'm the only one having troubles with this and is just a matter of **Git Gud** in general. Maybe my approach to reading/developing is not _The Correct One ®_ (_should I use Mac or change my text editor?_).

At this point, Arnold Schwarzenegger would yield out loud: "Stop whining".

So I tried to refactor `Analytics` and see if could do better.

---

**Refactoring**:

First, I needed to understand what the `analytics.py` module does.

The first thing I found on the module was a class with several `PARAM_*` variables. This is a quite common pattern around the codebase, used to keep "consistancy" while accessing elements inside a container (i.e. slicing a dictionary -- `d.get(Stage.PARAM_ALWAYS_CHANGED, False)`).

Among with this pattern is writing those containers (_dictionaries_) into a file and reading from them (i.e. _dvcfiles_, `Config`, `Analytics`), each with their own idiosyncrasies.

This is by no means a new pattern. `PyYAML`, `JSON`, and `TOML` supports the same interface: `dump` & `load`

We have defined the `dump` and `load` methods in such classes (`Stage`, `State`, `Config`, `Analytics`).

We also need **validation** upon object creation and often **conversion**, that's why we added `schema` (@Suor took the effort recently to switch to `voluptuous` on #2796).

As a summary, you could view this workflow as:
```
unstructured -> open(file) -> json.load -> dict -> validation / conversion -> class -> structured
```

Sometimes, you have to do several _conversions_ to fully _structure_ the data, as with `Stage`, by having to structure also the `Dependencies` and `Outputs`. Another example would be `Remote`s needing to gather information from `Config`.

In case of analytics, you have one file where the `user_id` is stored as a JSON, although, there's no `UserID` object with `load`/`dump`.

There's a `load`/`dump` for Analytics, however, `load` also `unlinks` the given path, and `dump` writes into a temporary file instead of accepting an argument. (Same interface, different _side effects_).

The whole idea of the class is to `collect` some reports by calling specific modules and classes and then `send` them _home_ through HTTP.
I wanted to know the report structure, but I didn't saw anything related to **reports** except from comments referencing them (in the code it was stored under the `info` variable).

`PARAM_*` variables gave me a clue about the keys, but not the structure (i.e. how those keys were nested), so I kept reading.

Under the class initialization, there was some code creating a global directory:
```python
cdir = Config.get_global_config_dir()
try:
    os.makedirs(cdir)
except OSError as exc:
    if exc.errno != errno.EEXIST:
        raise
```
Not clear why it was needed right away.
Why was `Analytics` creating a directory that came from `Config`, why is in charge of handling it?

Anyways, the info was modified during the `collect` and `collect_cmd` methods.

It looked like this:

```python
report = {
  "dvc_version": None,
  "user_id": None,
  "scm_class": None,
  "is_binary": None,
  "cmd_class": None,
  "cmd_return_code": None,
  "system_info": {
    "os": None,
      "linux_distro": None,
      "linux_distro_like": None,
      "linux_distro_version": None,
      "mac_version": None,
      "windows_version_build": None,
      "windows_version_major": None,
      "windows_version_minor": None,
      "windows_version_service_pack": None,
  },
}
```

I wondered whether there's a better way to deal with all this collected data.

---

**Pull request**:

I looked at `attrs` library and it was promising, this PR uses it to create the data structure used for the `Report`.
  * Slim declaration and initialization.
  * Typed structures (with Python 3 type hints :heart:)
  * Decorate them with a `json_serializer` to formalize the `from_file`, `to_file` (also know as `load` & `dump`) methods ussing `cattrs`.
  * Dot notation over `PARAM_<key>`

It also distributes the tasks among several classes:
```python
Analytics:
  _collect_darwin(self)
  _collect_linux(self)
  _collect_system_info(self)
  _collect_windows(self)
  _get_user_id(self)
  _read_user_id(self)
  _write_user_id(self)
  collect(self)
  collect_cmd(self, args, ret)
  dump(self)
  is_enabled(cmd=None)
  load(path)
  send(self)
  send_cmd(cmd, args, ret)
```

```python
Analytics:
   dump(self)
   is_enabled()
   load(path)
   send(self)
   send_cmd(cmd, args, ret)

Report:
   collect(self)
   collect_cmd(self, args, ret)

SystemInfo:
   collect(self)
   darwin(self)
   linux(self)
   windows(self)

UserID:
   generate(cls)
   load(cls)
```

Also, use `pathinfo.Path` when possible when dealing with paths.

---

**Beyond PR**:

We could do better than this.

I could argue that there's no need for a `daemon`.

Here's a proposal https://github.com/iterative/dvc/pull/2826

This implementation allows for easy debugging since you can run the process on the foreground.

---

**Aesthetics**:

Even that I work on the code base, I don't feel entitled to make changes that don't affect the logic. making aesthetic changes _inappropiate_ (compared to features / bug fixes).

This is in line with having **cognitive empathy** since it doesn't frame other's abstractions into _good_ or _bad_.

@efiop wrote the analytics module about a year ago, and he was dealing with a bunch of stuff at the same time (support, bug fixes, reviews, coordinating the efforts, discussions, etc.). Honestly, huge respect! (_holds F_)

So here are several _controversial & opinionated_ comments that would reduce the code complexity for _me_.

---

**Comments**:

  * Be clear and explicit with the **side effects**.
  * **Consistent wording** between documentation/comments and code (when possible)
  * Use **standard library** and **common third-party libraries** (when possbile)
  * Choose **modules over classes** (when possible)
  * Use **path-like objects** instead of plain strings

---

**Conclusion**:

The intention is not to drag you into this plethora of nonsense, if you feel like it's not worth discussing these topics, I'm totally fine with putting more time into the _grind_, (practice is the only way to **git gud**. :slightly_smiling_face:).