### PR TITLE
remote: fix remote default call with no arguments

### DIFF
--- a/dvc/command/remote.py
+++ b/dvc/command/remote.py
@@ -48,7 +48,7 @@ class CmdRemoteModify(CmdRemoteConfig):
 
 class CmdRemoteDefault(CmdRemoteConfig):
     def run(self):
-        if self.args.name is None:
+        if self.args.name is None and not self.args.unset:
             name = self.remote_config.get_default(level=self.args.level)
             logger.info("{}".format(name))
         else:

--- a/dvc/command/remote.py
+++ b/dvc/command/remote.py
@@ -50,7 +50,7 @@ class CmdRemoteDefault(CmdRemoteConfig):
     def run(self):
         if self.args.name is None and not self.args.unset:
             name = self.remote_config.get_default(level=self.args.level)
-            logger.info("{}".format(name))
+            print(name)
         else:
             self.remote_config.set_default(
                 self.args.name, unset=self.args.unset, level=self.args.level

--- a/dvc/command/remote.py
+++ b/dvc/command/remote.py
@@ -48,9 +48,13 @@ class CmdRemoteModify(CmdRemoteConfig):
 
 class CmdRemoteDefault(CmdRemoteConfig):
     def run(self):
-        self.remote_config.set_default(
-            self.args.name, unset=self.args.unset, level=self.args.level
-        )
+        if self.args.name is None:
+            name = self.remote_config.get_default(level=self.args.level)
+            logger.info("{}".format(name))
+        else:
+            self.remote_config.set_default(
+                self.args.name, unset=self.args.unset, level=self.args.level
+            )
         return 0
 
 

--- a/dvc/remote/config.py
+++ b/dvc/remote/config.py
@@ -151,3 +151,8 @@ class RemoteConfig(object):
         self.config.set(
             Config.SECTION_CORE, Config.SECTION_CORE_REMOTE, name, level=level
         )
+
+    def get_default(self, level=None):
+        return self.config.get(
+            Config.SECTION_CORE, Config.SECTION_CORE_REMOTE, level=level
+        )

--- a/tests/func/test_remote.py
+++ b/tests/func/test_remote.py
@@ -145,6 +145,12 @@ class TestRemoteDefault(TestDvc):
         self.assertEqual(default, None)
 
 
+def test_show_default(dvc_repo, caplog):
+    assert main(["remote", "default", "foo"]) == 0
+    assert main(["remote", "default"]) == 0
+    assert "foo" == caplog.record_tuples[0][2]
+
+
 class TestRemoteShouldHandleUppercaseRemoteName(TestDvc):
     upper_case_remote_name = "UPPERCASEREMOTE"
 

--- a/tests/func/test_remote.py
+++ b/tests/func/test_remote.py
@@ -145,7 +145,7 @@ class TestRemoteDefault(TestDvc):
         self.assertEqual(default, None)
 
 
-def test_show_default(caplog):
+def test_show_default(dvc_repo, caplog):
     assert main(["remote", "default", "foo"]) == 0
     assert main(["remote", "default"]) == 0
     assert "foo" == caplog.record_tuples[0][2]

--- a/tests/func/test_remote.py
+++ b/tests/func/test_remote.py
@@ -145,10 +145,11 @@ class TestRemoteDefault(TestDvc):
         self.assertEqual(default, None)
 
 
-def test_show_default(dvc_repo, caplog):
+def test_show_default(dvc_repo, capsys):
     assert main(["remote", "default", "foo"]) == 0
     assert main(["remote", "default"]) == 0
-    assert "foo" == caplog.record_tuples[0][2]
+    out, _ = capsys.readouterr()
+    assert out == "foo\n"
 
 
 class TestRemoteShouldHandleUppercaseRemoteName(TestDvc):

--- a/tests/func/test_remote.py
+++ b/tests/func/test_remote.py
@@ -145,7 +145,7 @@ class TestRemoteDefault(TestDvc):
         self.assertEqual(default, None)
 
 
-def test_show_default(dvc_repo, caplog):
+def test_show_default(caplog):
     assert main(["remote", "default", "foo"]) == 0
     assert main(["remote", "default"]) == 0
     assert "foo" == caplog.record_tuples[0][2]


### PR DESCRIPTION
remote default command with no arguments now returns default remote instead of
setting default remote to None.

Fixes #2813

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addresses. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

