### PR TITLE
Refactor `startswith` with `path_isin` util

### DIFF
--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -20,6 +20,7 @@ from dvc.ignore import DvcIgnoreFilter
 from dvc.path_info import PathInfo
 from dvc.remote.base import RemoteActionNotImplemented
 from dvc.utils import relpath
+from dvc.utils.fs import path_isin
 from dvc.utils.compat import FileNotFoundError
 from dvc.utils.compat import fspath_py35
 from dvc.utils.compat import open as _open
@@ -166,7 +167,7 @@ class Repo(object):
             + updater.lock.files
         )
 
-        if self.cache.local.cache_dir.startswith(self.root_dir + os.sep):
+        if path_isin(self.cache.local.cache_dir, self.root_dir):
             flist += [self.cache.local.cache_dir]
 
         self.scm.ignore_list(flist)
@@ -193,7 +194,7 @@ class Repo(object):
             ret = []
             for node in nodes:
                 stage = attrs[node]
-                if stage.path.startswith(target + os.sep):
+                if path_isin(stage.path, target):
                     ret.append(stage)
             return ret
 

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -17,6 +17,7 @@ from dvc.scm.git.tree import GitTree
 from dvc.utils import fix_env
 from dvc.utils import is_binary
 from dvc.utils import relpath
+from dvc.utils.fs import path_isin
 from dvc.utils.compat import cast_bytes_py2
 from dvc.utils.compat import open
 from dvc.utils.compat import str
@@ -134,7 +135,7 @@ class Git(Base):
 
         gitignore = os.path.join(ignore_file_dir, self.GITIGNORE)
 
-        if not gitignore.startswith(os.path.realpath(self.root_dir)):
+        if not path_isin(gitignore, os.path.realpath(self.root_dir)):
             raise FileNotInRepoError(path)
 
         return entry, gitignore

--- a/dvc/stage.py
+++ b/dvc/stage.py
@@ -18,6 +18,7 @@ from dvc.exceptions import DvcException
 from dvc.utils import dict_md5
 from dvc.utils import fix_env
 from dvc.utils import relpath
+from dvc.utils.fs import path_isin
 from dvc.utils.collections import apply_diff
 from dvc.utils.fs import contains_symlink_up_to
 from dvc.utils.stage import dump_stage_file
@@ -390,8 +391,9 @@ class Stage(object):
         if not os.path.isdir(real_path):
             raise StagePathNotDirectoryError(path)
 
-        proj_dir = os.path.realpath(repo.root_dir) + os.path.sep
-        if not (real_path + os.path.sep).startswith(proj_dir):
+        proj_dir = os.path.realpath(repo.root_dir)
+
+        if real_path != proj_dir and not path_isin(real_path, proj_dir):
             raise StagePathOutsideError(path)
 
     @property

--- a/dvc/stage.py
+++ b/dvc/stage.py
@@ -392,7 +392,6 @@ class Stage(object):
             raise StagePathNotDirectoryError(path)
 
         proj_dir = os.path.realpath(repo.root_dir)
-
         if real_path != proj_dir and not path_isin(real_path, proj_dir):
             raise StagePathOutsideError(path)
 

--- a/tests/func/test_external_repo.py
+++ b/tests/func/test_external_repo.py
@@ -4,6 +4,7 @@ from mock import patch
 
 from dvc.external_repo import external_repo
 from dvc.scm.git import Git
+from dvc.utils.fs import path_isin
 
 
 def test_external_repo(erepo):
@@ -22,8 +23,6 @@ def test_external_repo(erepo):
 
         # Check cache_dir is unset
         with external_repo(url) as repo:
-            assert repo.cache.local.cache_dir.startswith(
-                repo.root_dir + os.sep
-            )
+            assert path_isin(repo.cache.local.cache_dir, repo.root_dir)
 
         assert mock.call_count == 1


### PR DESCRIPTION
* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

### Description
Resolves #2823 

~~I did not feel brave enough on `dvc.remote.s3.RemoteS3.exists`.~~
EDIT: `dvc.remote.s3.RemoteS3.exists` cannot be changed, as `path_isin` is os-agnostic, whereas s3 requires posixpath. `dvc/utils/__init__.py:260` has a cyclic dependency problem.

There are few other cases of `startswith`, but are not related with filepaths (except for `dvc/utils/__init__.py` at the end :arrow_double_down:)
```
➜ rg -i startswith dvc tests
dvc/prompt.py
48:    return answer and answer.startswith("y")
dvc/remote/http.py
76:        if etag.startswith("W/"):
dvc/remote/config.py
97:        if remote == RemoteLOCAL and not url.startswith("remote://"):
tests/func/test_repro.py
1076:        assert i.startswith(prefix) and o.startswith(prefix)
1588:    elif line.startswith("cmd: "):
dvc/utils/fs.py
147:    return child != parent and child.startswith(parent)
dvc/utils/__init__.py
260:            while parts[0].startswith(plugin_bin):
```

Thank you for the contribution - we'll try to review it as soon as possible. 🙏