### PR TITLE
UI progress cleanup

### DIFF
--- a/dvc/cli.py
+++ b/dvc/cli.py
@@ -3,37 +3,39 @@ import argparse
 import logging
 import sys
 
-import dvc.command.add as add
-import dvc.command.cache as cache
-import dvc.command.checkout as checkout
-import dvc.command.commit as commit
-import dvc.command.config as config
-import dvc.command.daemon as daemon
-import dvc.command.data_sync as data_sync
-import dvc.command.destroy as destroy
-import dvc.command.diff as diff
-import dvc.command.gc as gc
-import dvc.command.get as get
-import dvc.command.get_url as get_url
-import dvc.command.imp as imp
-import dvc.command.imp_url as imp_url
-import dvc.command.init as init
-import dvc.command.install as install
-import dvc.command.lock as lock
-import dvc.command.metrics as metrics
-import dvc.command.move as move
-import dvc.command.pipeline as pipeline
-import dvc.command.remote as remote
-import dvc.command.remove as remove
-import dvc.command.repro as repro
-import dvc.command.root as root
-import dvc.command.run as run
-import dvc.command.tag as tag
-import dvc.command.unprotect as unprotect
-import dvc.command.update as update
-import dvc.command.version as version
-from dvc.command.base import fix_subparsers
-from dvc.exceptions import DvcParserError
+from .command import (
+    add,
+    cache,
+    checkout,
+    commit,
+    config,
+    daemon,
+    data_sync,
+    destroy,
+    diff,
+    gc,
+    get,
+    get_url,
+    imp,
+    imp_url,
+    init,
+    install,
+    lock,
+    metrics,
+    move,
+    pipeline,
+    remote,
+    remove,
+    repro,
+    root,
+    run,
+    tag,
+    unprotect,
+    update,
+    version,
+)
+from .command.base import fix_subparsers
+from .exceptions import DvcParserError
 
 
 logger = logging.getLogger(__name__)

--- a/dvc/output/base.py
+++ b/dvc/output/base.py
@@ -405,7 +405,7 @@ class OutputBase(object):
 
         if self.stage.is_repo_import:
             cache = NamedCache()
-            dep, = self.stage.deps
+            (dep,) = self.stage.deps
             cache.external[dep.repo_pair].add(dep.def_path)
             return cache
 

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -117,15 +117,10 @@ class Tqdm(tqdm):
     def close(self):
         if self.desc_persist is not None:
             self.set_description_str(self.desc_persist, refresh=False)
-        for fmt in [
-            "<??:??",  # unknown ETA
-            "<{remaining}",  # 00:00 ETA
-        ]:
-            self.bar_format = self.bar_format.replace(fmt, "")
-        for fmt in [
-            "|{bar:10}|",  # completed progressbar
-        ]:
-            self.bar_format = self.bar_format.replace(fmt, " ")
+        # unknown/zero ETA
+        self.bar_format = self.bar_format.replace("<{remaining}", "")
+        # remove completed bar
+        self.bar_format = self.bar_format.replace("|{bar:10}|", " ")
         super().close()
 
     @property

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -117,10 +117,15 @@ class Tqdm(tqdm):
     def close(self):
         if self.desc_persist is not None:
             self.set_description_str(self.desc_persist, refresh=False)
-        # remove ETA (either zero or unknown)
-        self.bar_format = self.bar_format.replace("<??:??", "").replace(
-            "<{remaining}", ""
-        )
+        for fmt in [
+            "<??:??",  # unknown ETA
+            "<{remaining}",  # 00:00 ETA
+        ]:
+            self.bar_format = self.bar_format.replace(fmt, "")
+        for fmt in [
+            "|{bar:10}|",  # completed progressbar
+        ]:
+            self.bar_format = self.bar_format.replace(fmt, " ")
         super().close()
 
     @property

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -33,6 +33,9 @@ class Tqdm(tqdm):
         "{desc:{ncols_desc}.{ncols_desc}}{n_fmt}"
         " [{elapsed}<??:??, {rate_fmt:>11}{postfix}]"
     )
+    BYTES_DEFAULTS = dict(
+        unit="B", unit_scale=True, unit_divisor=1024, miniters=1
+    )
 
     def __init__(
         self,
@@ -60,10 +63,7 @@ class Tqdm(tqdm):
         kwargs = kwargs.copy()
         kwargs.setdefault("unit_scale", True)
         if bytes:
-            bytes_defaults = dict(
-                unit="B", unit_scale=True, unit_divisor=1024, miniters=1
-            )
-            kwargs = merge(bytes_defaults, kwargs)
+            kwargs = merge(self.BYTES_DEFAULTS, kwargs)
         if file is None:
             file = sys.stderr
         self.desc_persist = desc
@@ -114,6 +114,10 @@ class Tqdm(tqdm):
     def close(self):
         if self.desc_persist is not None:
             self.set_description_str(self.desc_persist, refresh=False)
+        # remove ETA (either zero or unknown)
+        self.bar_format = self.bar_format.replace("<??:??", "").replace(
+            "<{remaining}", ""
+        )
         super().close()
 
     @property

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -47,6 +47,7 @@ class Tqdm(tqdm):
         bar_format=None,
         bytes=False,  # pylint: disable=W0622
         file=None,
+        total=None,
         **kwargs
     ):
         """
@@ -61,9 +62,10 @@ class Tqdm(tqdm):
         kwargs  : anything accepted by `tqdm.tqdm()`
         """
         kwargs = kwargs.copy()
-        kwargs.setdefault("unit_scale", True)
         if bytes:
             kwargs = merge(self.BYTES_DEFAULTS, kwargs)
+        else:
+            kwargs.setdefault("unit_scale", total > 999 if total else True)
         if file is None:
             file = sys.stderr
         self.desc_persist = desc
@@ -84,6 +86,7 @@ class Tqdm(tqdm):
             desc=desc,
             bar_format="!",
             lock_args=(False,),
+            total=total,
             **kwargs
         )
         if bar_format is None:

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -4,7 +4,6 @@ import logging
 import sys
 from threading import RLock
 
-from funcy import merge
 from tqdm import tqdm
 
 from dvc.utils import env2bool
@@ -63,7 +62,7 @@ class Tqdm(tqdm):
         """
         kwargs = kwargs.copy()
         if bytes:
-            kwargs = merge(self.BYTES_DEFAULTS, kwargs)
+            kwargs = {**self.BYTES_DEFAULTS, **kwargs}
         else:
             kwargs.setdefault("unit_scale", total > 999 if total else True)
         if file is None:

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -31,7 +31,7 @@ class Tqdm(tqdm):
     )
     BAR_FMT_NOTOTAL = (
         "{desc:{ncols_desc}.{ncols_desc}}{n_fmt}"
-        " [{elapsed}<??:??, {rate_fmt:>11}{postfix}]"
+        " [{elapsed}, {rate_fmt:>11}{postfix}]"
     )
     BYTES_DEFAULTS = dict(
         unit="B", unit_scale=True, unit_divisor=1024, miniters=1

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -493,7 +493,9 @@ class RemoteBASE(object):
         cache_info = self.checksum_to_path_info(checksum)
         dir_info = self.get_dir_cache(checksum)
 
-        for entry in dir_info:
+        for entry in Tqdm(
+            dir_info, desc="Saving " + path_info.name, unit="file"
+        ):
             entry_info = path_info / entry[self.PARAM_RELPATH]
             entry_checksum = entry[self.PARAM_CHECKSUM]
             self._save_file(entry_info, entry_checksum, save_link=False)

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -205,7 +205,7 @@ class Repo(object):
             return [(stage, None) for stage in self.stages]
 
         try:
-            out, = self.find_outs_by_path(target, strict=False)
+            (out,) = self.find_outs_by_path(target, strict=False)
             filter_info = PathInfo(os.path.abspath(target))
             return [(out.stage, filter_info)]
         except OutputNotFoundError:
@@ -419,7 +419,7 @@ class Repo(object):
 
     def find_out_by_relpath(self, relpath):
         path = os.path.join(self.root_dir, relpath)
-        out, = self.find_outs_by_path(path)
+        (out,) = self.find_outs_by_path(path)
         return out
 
     def is_dvc_internal(self, path):

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -23,7 +23,14 @@ def add(repo, targets, recursive=False, no_commit=False, fname=None):
         targets = [targets]
 
     stages_list = []
-    with Tqdm(total=len(targets), desc="Add", unit="file", leave=True) as pbar:
+    num_targets = len(targets)
+    with Tqdm(
+        total=num_targets,
+        desc="Add",
+        unit="file",
+        leave=True,
+        disable=True if num_targets < 2 else None,
+    ) as pbar:
         for target in targets:
             sub_targets = _find_all_targets(repo, target, recursive)
             pbar.total += len(sub_targets) - 1
@@ -54,6 +61,9 @@ def add(repo, targets, recursive=False, no_commit=False, fname=None):
                 stage.dump()
 
             stages_list += stages
+
+        if pbar.disable:
+            pbar.write("100% Add")
 
     return stages_list
 

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -60,7 +60,7 @@ def add(repo, targets, recursive=False, no_commit=False, fname=None):
 
             stages_list += stages
 
-        if num_targets == 1:
+        if num_targets == 1:  # restore bar format for stats
             pbar.bar_format = pbar.BAR_FMT_DEFAULT
 
     return stages_list

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -50,7 +50,7 @@ def add(repo, targets, recursive=False, no_commit=False, fname=None):
 
             repo.check_modified_graph(stages)
 
-            for stage in stages:
+            for stage in Tqdm(stages, desc="Processing", unit="file"):
                 stage.save()
 
                 if not no_commit:
@@ -88,7 +88,10 @@ def _create_stages(repo, targets, fname, pbar=None):
     stages = []
 
     for out in Tqdm(
-        targets, desc="Creating stages", disable=len(targets) < LARGE_DIR_SIZE
+        targets,
+        desc="Creating stages",
+        disable=len(targets) < LARGE_DIR_SIZE,
+        unit="file",
     ):
         stage = Stage.create(repo, outs=[out], add=True, fname=fname)
 

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -84,7 +84,7 @@ def _find_all_targets(repo, target, recursive):
             fname
             for fname in Tqdm(
                 repo.tree.walk_files(target),
-                desc="Recursing " + target,
+                desc="Searching " + target,
                 bar_format=Tqdm.BAR_FMT_NOTOTAL,
                 unit="file",
             )

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -56,6 +56,7 @@ def add(repo, targets, recursive=False, no_commit=False, fname=None):
                 unit="file",
                 disable=True if len(stages) == 1 else None,
             ):
+                stage.save()
 
                 if not no_commit:
                     stage.commit()

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -101,7 +101,7 @@ def _create_stages(repo, targets, fname, pbar=None):
 
     for out in Tqdm(
         targets,
-        desc="Creating stages",
+        desc="Creating DVC-files",
         disable=True if len(targets) < LARGE_DIR_SIZE else None,
         unit="file",
     ):

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -54,8 +54,6 @@ def add(repo, targets, recursive=False, no_commit=False, fname=None):
                 stage.dump()
 
             stages_list += stages
-        # remove filled bar bit of progress, leaving stats
-        pbar.bar_format = pbar.BAR_FMT_DEFAULT.replace("|{bar:10}|", " ")
 
     return stages_list
 

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -72,9 +72,9 @@ def _find_all_targets(repo, target, recursive):
             fname
             for fname in Tqdm(
                 repo.tree.walk_files(target),
-                desc="Finding files",
+                desc="Recursing " + target,
                 bar_format=Tqdm.BAR_FMT_NOTOTAL,
-                leave=False,
+                unit="file",
             )
             if not repo.is_dvc_internal(fname)
             if not Stage.is_stage_file(fname)
@@ -87,7 +87,9 @@ def _find_all_targets(repo, target, recursive):
 def _create_stages(repo, targets, fname, pbar=None):
     stages = []
 
-    for out in targets:
+    for out in Tqdm(
+        targets, desc="Creating stages", disable=len(targets) < LARGE_DIR_SIZE
+    ):
         stage = Stage.create(repo, outs=[out], add=True, fname=fname)
 
         if not stage:

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -4,12 +4,12 @@ import os
 import colorama
 
 from . import locked
-from dvc.exceptions import RecursiveAddingWhileUsingFilename
-from dvc.output.base import OutputDoesNotExistError
-from dvc.progress import Tqdm
-from dvc.repo.scm_context import scm_context
-from dvc.stage import Stage
-from dvc.utils import LARGE_DIR_SIZE
+from ..exceptions import RecursiveAddingWhileUsingFilename
+from ..output.base import OutputDoesNotExistError
+from ..progress import Tqdm
+from ..repo.scm_context import scm_context
+from ..stage import Stage
+from ..utils import LARGE_DIR_SIZE
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -50,8 +50,12 @@ def add(repo, targets, recursive=False, no_commit=False, fname=None):
 
             repo.check_modified_graph(stages)
 
-            for stage in Tqdm(stages, desc="Processing", unit="file"):
-                stage.save()
+            for stage in Tqdm(
+                stages,
+                desc="Processing",
+                unit="file",
+                disable=len(stages) == 1,
+            ):
 
                 if not no_commit:
                     stage.commit()

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -70,7 +70,12 @@ def _find_all_targets(repo, target, recursive):
     if os.path.isdir(target) and recursive:
         return [
             fname
-            for fname in repo.tree.walk_files(target)
+            for fname in Tqdm(
+                repo.tree.walk_files(target),
+                desc="Finding files",
+                bar_format=Tqdm.BAR_FMT_NOTOTAL,
+                leave=False,
+            )
             if not repo.is_dvc_internal(fname)
             if not Stage.is_stage_file(fname)
             if not repo.scm.belongs_to_scm(fname)

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -24,13 +24,9 @@ def add(repo, targets, recursive=False, no_commit=False, fname=None):
 
     stages_list = []
     num_targets = len(targets)
-    with Tqdm(
-        total=num_targets,
-        desc="Add",
-        unit="file",
-        leave=True,
-        disable=True if num_targets < 2 else None,
-    ) as pbar:
+    with Tqdm(total=num_targets, desc="Add", unit="file", leave=True) as pbar:
+        if num_targets == 1:
+            pbar.bar_format = "Adding..."
         for target in targets:
             sub_targets = _find_all_targets(repo, target, recursive)
             pbar.total += len(sub_targets) - 1
@@ -62,8 +58,8 @@ def add(repo, targets, recursive=False, no_commit=False, fname=None):
 
             stages_list += stages
 
-        if pbar.disable:
-            pbar.write("100% Add")
+        if num_targets == 1:
+            pbar.bar_format = pbar.BAR_FMT_DEFAULT
 
     return stages_list
 

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -26,7 +26,9 @@ def add(repo, targets, recursive=False, no_commit=False, fname=None):
     num_targets = len(targets)
     with Tqdm(total=num_targets, desc="Add", unit="file", leave=True) as pbar:
         if num_targets == 1:
+            # clear unneeded top-level progress bar for single target
             pbar.bar_format = "Adding..."
+            pbar.refresh()
         for target in targets:
             sub_targets = _find_all_targets(repo, target, recursive)
             pbar.total += len(sub_targets) - 1

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -54,7 +54,7 @@ def add(repo, targets, recursive=False, no_commit=False, fname=None):
                 stages,
                 desc="Processing",
                 unit="file",
-                disable=len(stages) == 1,
+                disable=True if len(stages) == 1 else None,
             ):
 
                 if not no_commit:
@@ -94,7 +94,7 @@ def _create_stages(repo, targets, fname, pbar=None):
     for out in Tqdm(
         targets,
         desc="Creating stages",
-        disable=len(targets) < LARGE_DIR_SIZE,
+        disable=True if len(targets) < LARGE_DIR_SIZE else None,
         unit="file",
     ):
         stage = Stage.create(repo, outs=[out], add=True, fname=fname)

--- a/dvc/repo/get_url.py
+++ b/dvc/repo/get_url.py
@@ -14,6 +14,6 @@ def get_url(url, out=None):
 
     out = os.path.abspath(out)
 
-    dep, = dependency.loads_from(None, [url])
-    out, = output.loads_from(None, [out], use_cache=False)
+    (dep,) = dependency.loads_from(None, [url])
+    (out,) = output.loads_from(None, [out], use_cache=False)
     dep.download(out)


### PR DESCRIPTION
- [x] remove `<00:00`/`<??:??` from completed bars
- [x] don't use SI prefixes for small totals < 999 (i.e. `1.00/32.0 files` => `1/32 files`)
- [x] don't increment bar when a target fails (backtrack bar)
- [x] make sure we don't show an extra progress bar when there is only one target (majority of cases, see below)
- [x] large dirs progress bar hanging when collecting files before computing checksums https://github.com/iterative/dvc/issues/2770 https://github.com/iterative/dvc/issues/2699#issuecomment-548149404
- [x] cleanup output when if fails  https://github.com/iterative/dvc/issues/2699#issuecomment-548082165
- [x] add before/after recordings
- fixes #2699
- continued in #3060

**Extra progress bar concern:**

We started using an extra progress bar that is counting targets, as described and shown here: #2658 . In most cases though there is a single target - `dvc add file` or `dvc add directory`. That extra progress bar is not needed in those cases. It's needed in case of multiple targets or if `-R` option is specified.

most issues fixed:
[![asciicast](https://asciinema.org/a/kuXz8YYQOoCxsQ0v3zqzOFBQE.svg)](https://asciinema.org/a/kuXz8YYQOoCxsQ0v3zqzOFBQE?speed=4)

large dir fix, no outer bar for single target, more progress output rather than hanging:
[![asciicast](https://asciinema.org/a/1DDfK2DvD41rNk1RJGMOXM7me.svg)](https://asciinema.org/a/1DDfK2DvD41rNk1RJGMOXM7me?speed=4)

recursive:
[![asciicast](https://asciinema.org/a/hLL8k2LE7gwFoY338Io9He6ZK.svg)](https://asciinema.org/a/hLL8k2LE7gwFoY338Io9He6ZK?speed=4)