### PR TITLE
RemoteNotSpecifiedInExternalRepoError: dont pass cause of exception

### DIFF
--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -332,13 +332,12 @@ class CollectCacheError(DvcException):
     pass
 
 
-class RemoteNotSpecifiedInExternalRepoError(DvcException):
-    def __init__(self, url, cause=None):
-        super(RemoteNotSpecifiedInExternalRepoError, self).__init__(
+class NoRemoteInExternalRepoError(DvcException):
+    def __init__(self, url):
+        super(NoRemoteInExternalRepoError, self).__init__(
             "No DVC remote is specified in the target repository '{}'".format(
                 url
-            ),
-            cause=cause,
+            )
         )
 
 

--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -8,7 +8,7 @@ from distutils.dir_util import copy_tree
 from funcy import retry
 
 from dvc.config import NoRemoteError
-from dvc.exceptions import RemoteNotSpecifiedInExternalRepoError
+from dvc.exceptions import NoRemoteInExternalRepoError
 from dvc.exceptions import NoOutputInExternalRepoError
 from dvc.exceptions import OutputNotFoundError
 from dvc.utils.fs import remove
@@ -25,8 +25,8 @@ def external_repo(url=None, rev=None, rev_lock=None, cache_dir=None):
     repo = Repo(path)
     try:
         yield repo
-    except NoRemoteError as exc:
-        raise RemoteNotSpecifiedInExternalRepoError(url, cause=exc)
+    except NoRemoteError:
+        raise NoRemoteInExternalRepoError(url)
     except OutputNotFoundError as exc:
         if exc.repo is repo:
             raise NoOutputInExternalRepoError(exc.output, repo.root_dir, url)


### PR DESCRIPTION
* [ ] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [ ] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [ ] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Related to #2711 
Original solution (#2777) was passing `cause` of exception resulting in obscure error message:

https://asciinema.org/a/283668

For the sake of UI we [agreed](https://github.com/iterative/dvc/issues/2711#issuecomment-558270517) not to pass the cause, so that we don't end up with this long message.

https://asciinema.org/a/283669 
