### PR TITLE
lengthen bars unless nested/threaded

### DIFF
--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -26,7 +26,7 @@ class Tqdm(tqdm):
     )
     # nested bars should have fixed bar widths to align nicely
     BAR_FMT_DEFAULT_NESTED = (
-        "{percentage:3.0f}% {desc:{ncols_desc}.{ncols_desc}}|{bar:10}|"
+        "{percentage:3.0f}%|{bar:10}|{desc:{ncols_desc}.{ncols_desc}}"
         "{n_fmt}/{total_fmt}"
         " [{elapsed}<{remaining}, {rate_fmt:>11}{postfix}]"
     )

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -20,7 +20,7 @@ class Tqdm(tqdm):
     """
 
     BAR_FMT_DEFAULT = (
-        "{percentage:3.0f}%|{bar:10}|"
+        "{percentage:3.0f}%|{bar}|"
         "{desc:{ncols_desc}.{ncols_desc}}{n_fmt}/{total_fmt}"
         " [{elapsed}<{remaining}, {rate_fmt:>11}{postfix}]"
     )
@@ -84,6 +84,11 @@ class Tqdm(tqdm):
         if bar_format is None:
             if self.__len__():
                 self.bar_format = self.BAR_FMT_DEFAULT
+                # nested bars should have fixed bar widths to align nicely
+                if self.pos:
+                    self.bar_format = self.bar_format.replace(
+                        "{bar}", "{bar:10}"
+                    )
             else:
                 self.bar_format = self.BAR_FMT_NOTOTAL
         else:

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -20,8 +20,14 @@ class Tqdm(tqdm):
     """
 
     BAR_FMT_DEFAULT = (
-        "{percentage:3.0f}%|{bar}|"
-        "{desc:{ncols_desc}.{ncols_desc}}{n_fmt}/{total_fmt}"
+        "{percentage:3.0f}% {desc}|{bar}|"
+        "{n_fmt}/{total_fmt}"
+        " [{elapsed}<{remaining}, {rate_fmt:>11}{postfix}]"
+    )
+    # nested bars should have fixed bar widths to align nicely
+    BAR_FMT_DEFAULT_NESTED = (
+        "{percentage:3.0f}% {desc:{ncols_desc}.{ncols_desc}}|{bar:10}|"
+        "{n_fmt}/{total_fmt}"
         " [{elapsed}<{remaining}, {rate_fmt:>11}{postfix}]"
     )
     BAR_FMT_NOTOTAL = (
@@ -83,12 +89,11 @@ class Tqdm(tqdm):
         )
         if bar_format is None:
             if self.__len__():
-                self.bar_format = self.BAR_FMT_DEFAULT
-                # nested bars should have fixed bar widths to align nicely
-                if self.pos:
-                    self.bar_format = self.bar_format.replace(
-                        "{bar}", "{bar:10}"
-                    )
+                self.bar_format = (
+                    self.BAR_FMT_DEFAULT_NESTED
+                    if self.pos
+                    else self.BAR_FMT_DEFAULT
+                )
             else:
                 self.bar_format = self.BAR_FMT_NOTOTAL
         else:


### PR DESCRIPTION
- progress bars now fill the available space
  + unless they're nested, in which case they remain width 10 to align nicely
- fixes #2487
- related #2846 which may remove nested bars altogether

issue:
[![asciicast](https://asciinema.org/a/267948.svg)](https://asciinema.org/a/267948?speed=4)
[![asciicast](https://asciinema.org/a/283771.svg)](https://asciinema.org/a/283771?speed=4)
fix:
[![asciicast](https://asciinema.org/a/Na4RkcFvVFlNruBJJNXFdRugD.svg)](https://asciinema.org/a/Na4RkcFvVFlNruBJJNXFdRugD?speed=4)