### PR TITLE
dvc: revert checkout to be silly and fast, relink on dvc add though

### DIFF
--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -850,6 +850,7 @@ class RemoteBASE(object):
 
         checksum = checksum_info.get(self.PARAM_CHECKSUM)
         failed = None
+        skip = False
         if not checksum:
             logger.warning(
                 "No checksum info found for '{}'. "
@@ -858,13 +859,18 @@ class RemoteBASE(object):
             self.safe_remove(path_info, force=force)
             failed = path_info
 
+        elif not self.changed(path_info, checksum_info):
+            msg = "Data '{}' didn't change."
+            logger.debug(msg.format(str(path_info)))
+            skip = True
+
         elif self.changed_cache(checksum):
             msg = "Cache '{}' not found. File '{}' won't be created."
             logger.warning(msg.format(checksum, str(path_info)))
             self.safe_remove(path_info, force=force)
             failed = path_info
 
-        if failed:
+        if failed or skip:
             if progress_callback:
                 progress_callback(
                     str(path_info), self.get_files_number(checksum)

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -128,6 +128,11 @@ class RemoteLOCAL(RemoteBASE):
     def isdir(path_info):
         return os.path.isdir(fspath_py35(path_info))
 
+    def iscopy(self, path_info):
+        return not (
+            System.is_symlink(path_info) or System.is_hardlink(path_info)
+        )
+
     @staticmethod
     def getsize(path_info):
         return os.path.getsize(fspath_py35(path_info))
@@ -504,21 +509,3 @@ class RemoteLOCAL(RemoteBASE):
             if self.is_dir_checksum(c):
                 unpacked.add(c + self.UNPACKED_DIR_SUFFIX)
         return unpacked
-
-    def _get_cache_type(self, path_info):
-        if self.cache_type_confirmed:
-            return self.cache_types[0]
-
-        workspace_file = path_info.with_name("." + uuid())
-        test_cache_file = self.path_info / ".cache_type_test_file"
-        if not self.exists(test_cache_file):
-            with open(fspath_py35(test_cache_file), "wb") as fobj:
-                fobj.write(bytes(1))
-        try:
-            self.link(test_cache_file, workspace_file)
-        finally:
-            self.remove(workspace_file)
-            self.remove(test_cache_file)
-
-        self.cache_type_confirmed = True
-        return self.cache_types[0]

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -394,22 +394,19 @@ class RemoteLOCAL(RemoteBASE):
             logger.warning(msg)
 
     @staticmethod
-    def _unprotect_file(path, allow_copy=True):
+    def _unprotect_file(path):
         if System.is_symlink(path) or System.is_hardlink(path):
-            if allow_copy:
-                logger.debug("Unprotecting '{}'".format(path))
-                tmp = os.path.join(os.path.dirname(path), "." + str(uuid()))
+            logger.debug("Unprotecting '{}'".format(path))
+            tmp = os.path.join(os.path.dirname(path), "." + str(uuid()))
 
-                # The operations order is important here - if some application
-                # would access the file during the process of copyfile then it
-                # would get only the part of file. So, at first, the file
-                # should be copied with the temporary name, and then
-                # original file should be replaced by new.
-                copyfile(
-                    path, tmp, name="Unprotecting '{}'".format(relpath(path))
-                )
-                remove(path)
-                os.rename(tmp, path)
+            # The operations order is important here - if some application
+            # would access the file during the process of copyfile then it
+            # would get only the part of file. So, at first, the file should be
+            # copied with the temporary name, and then original file should be
+            # replaced by new.
+            copyfile(path, tmp, name="Unprotecting '{}'".format(relpath(path)))
+            remove(path)
+            os.rename(tmp, path)
 
         else:
             logger.debug(
@@ -419,11 +416,11 @@ class RemoteLOCAL(RemoteBASE):
 
         os.chmod(path, os.stat(path).st_mode | stat.S_IWRITE)
 
-    def _unprotect_dir(self, path, allow_copy=True):
+    def _unprotect_dir(self, path):
         for fname in walk_files(path, self.repo.dvcignore):
-            self._unprotect_file(fname, allow_copy)
+            RemoteLOCAL._unprotect_file(fname)
 
-    def unprotect(self, path_info, allow_copy=True):
+    def unprotect(self, path_info):
         path = path_info.fspath
         if not os.path.exists(path):
             raise DvcException(
@@ -431,9 +428,9 @@ class RemoteLOCAL(RemoteBASE):
             )
 
         if os.path.isdir(path):
-            self._unprotect_dir(path, allow_copy)
+            self._unprotect_dir(path)
         else:
-            self._unprotect_file(path, allow_copy)
+            RemoteLOCAL._unprotect_file(path)
 
     @staticmethod
     def protect(path_info):
@@ -525,18 +522,3 @@ class RemoteLOCAL(RemoteBASE):
 
         self.cache_type_confirmed = True
         return self.cache_types[0]
-
-    def _link_matches(self, path_info):
-        is_hardlink = System.is_hardlink(path_info)
-        is_symlink = System.is_symlink(path_info)
-        is_copy_or_reflink = not is_hardlink and not is_symlink
-
-        cache_type = self._get_cache_type(path_info)
-
-        if cache_type == "symlink":
-            return is_symlink
-
-        if cache_type == "hardlink":
-            return is_hardlink
-
-        return is_copy_or_reflink

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -598,28 +598,6 @@ def test_should_relink_on_repeated_add(
     assert link_test_func(repo_dir.FOO)
 
 
-@pytest.mark.parametrize(
-    "link, link_func",
-    [("hardlink", System.hardlink), ("symlink", System.symlink)],
-)
-def test_should_relink_single_file_in_dir(link, link_func, dvc_repo, repo_dir):
-    dvc_repo.cache.local.cache_types = [link]
-
-    dvc_repo.add(repo_dir.DATA_DIR)
-
-    # NOTE status triggers unpacked dir creation for hardlink case
-    dvc_repo.status()
-
-    dvc_repo.unprotect(repo_dir.DATA_SUB)
-
-    link_spy = spy(link_func)
-
-    with patch.object(dvc_repo.cache.local, link, link_spy):
-        dvc_repo.add(repo_dir.DATA_DIR)
-
-        assert link_spy.mock.call_count == 1
-
-
 @pytest.mark.parametrize("link", ["hardlink", "symlink", "copy"])
 def test_should_protect_on_repeated_add(link, dvc_repo, repo_dir):
     dvc_repo.cache.local.cache_types = [link]

--- a/tests/func/test_checkout.py
+++ b/tests/func/test_checkout.py
@@ -482,6 +482,7 @@ def test_checkout_no_checksum(repo_dir, dvc_repo):
     assert not os.path.exists(repo_dir.FOO)
 
 
+@pytest.mark.skip
 @pytest.mark.parametrize(
     "link, link_test_func",
     [("hardlink", System.is_hardlink), ("symlink", System.is_symlink)],
@@ -497,6 +498,7 @@ def test_should_relink_on_checkout(link, link_test_func, repo_dir, dvc_repo):
     assert link_test_func(repo_dir.DATA_SUB)
 
 
+@pytest.mark.skip
 @pytest.mark.parametrize("link", ["hardlink", "symlink", "copy"])
 def test_should_protect_on_checkout(link, dvc_repo, repo_dir):
     dvc_repo.cache.local.cache_types = [link]
@@ -510,6 +512,7 @@ def test_should_protect_on_checkout(link, dvc_repo, repo_dir):
     assert not os.access(repo_dir.FOO, os.W_OK)
 
 
+@pytest.mark.skip
 def test_should_relink_only_one_file_in_dir(dvc_repo, repo_dir):
     dvc_repo.cache.local.cache_types = ["symlink"]
 
@@ -523,6 +526,7 @@ def test_should_relink_only_one_file_in_dir(dvc_repo, repo_dir):
     assert link_spy.mock.call_count == 1
 
 
+@pytest.mark.skip
 @pytest.mark.parametrize("link", ["hardlink", "symlink", "copy"])
 def test_should_not_relink_on_unchanged_dependency(link, dvc_repo, repo_dir):
     dvc_repo.cache.local.cache_types = [link]

--- a/tests/unit/remote/test_base.py
+++ b/tests/unit/remote/test_base.py
@@ -35,37 +35,3 @@ class TestCmdError(TestCase, TestRemoteBASE):
         ):
             with self.assertRaises(RemoteCmdError):
                 self.REMOTE_CLS(repo, config).remove("file")
-
-
-class TestCacheExists(TestCase):
-    def test(self):
-        config = {
-            "url": "base://example/prefix",
-            "connection_string": "1234567",
-        }
-        remote = RemoteBASE(None, config)
-
-        remote.PARAM_CHECKSUM = "checksum"
-        remote.path_info = remote.path_cls(config["url"])
-        remote.url = ""
-        remote.prefix = ""
-        path_info = remote.path_info / "example"
-        checksum_info = {remote.PARAM_CHECKSUM: "1234567890"}
-
-        with mock.patch.object(remote, "_checkout") as mock_checkout:
-            with mock.patch.object(remote, "_save") as mock_save:
-                with mock.patch.object(
-                    remote, "changed_cache", return_value=True
-                ):
-                    remote.save(path_info, checksum_info)
-                    mock_save.assert_called_once()
-                    mock_checkout.assert_not_called()
-
-        with mock.patch.object(remote, "_checkout") as mock_checkout:
-            with mock.patch.object(remote, "_save") as mock_save:
-                with mock.patch.object(
-                    remote, "changed_cache", return_value=False
-                ):
-                    remote.save(path_info, checksum_info)
-                    mock_save.assert_not_called()
-                    mock_checkout.assert_called_once()


### PR DESCRIPTION
This fixes #2492, reverts #2358 and fixes #2016 other way.

So now:
- `dvc checkout` does not relink unless out is changed
- `dvc add/run` always relinks, but slow unneeded copy is not made

I left @pared checkout tests and marked them as skipped to be reused later to test `--relink`.