### PR TITLE
get: refactor, clean up and fix `dvc get` implementation

### DIFF
--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -268,12 +268,6 @@ class FileMissingError(DvcException):
         )
 
 
-class PathOutsideRepoError(DvcException):
-    def __init__(self, path, repo):
-        msg = "The path '{}' does not exist in the target repository '{}'."
-        super(PathOutsideRepoError, self).__init__(msg.format(path, repo))
-
-
 class DvcIgnoreInCollectedDirError(DvcException):
     def __init__(self, ignore_dirname):
         super(DvcIgnoreInCollectedDirError, self).__init__(
@@ -286,14 +280,6 @@ class UrlNotDvcRepoError(DvcException):
     def __init__(self, url):
         super(UrlNotDvcRepoError, self).__init__(
             "URL '{}' is not a dvc repository.".format(url)
-        )
-
-
-class GetDVCFileError(DvcException):
-    def __init__(self):
-        super(GetDVCFileError, self).__init__(
-            "the given path is a DVC-file, you must specify a data file "
-            "or a directory"
         )
 
 

--- a/tests/func/test_get.py
+++ b/tests/func/test_get.py
@@ -7,10 +7,8 @@ import os
 import pytest
 
 from dvc.config import Config
-from dvc.exceptions import GetDVCFileError
 from dvc.exceptions import UrlNotDvcRepoError
-from dvc.exceptions import OutputNotFoundError
-from dvc.exceptions import PathOutsideRepoError
+from dvc.repo.get import GetDVCFileError, PathMissingError
 from dvc.repo import Repo
 from dvc.system import System
 from dvc.utils import makedirs
@@ -145,14 +143,14 @@ def test_non_cached_output(tmp_path, erepo):
 
 
 # https://github.com/iterative/dvc/pull/2837#discussion_r352123053
-def test_fails_with_files_outside_repo(erepo):
-    with pytest.raises(OutputNotFoundError):
+def test_absolute_file_outside_repo(erepo):
+    with pytest.raises(PathMissingError):
         Repo.get(erepo.root_dir, "/root/")
 
 
-def test_fails_with_non_existing_files(erepo):
-    with pytest.raises(PathOutsideRepoError):
-        Repo.get(erepo.root_dir, "file_does_not_exist")
+def test_unknown_path(erepo):
+    with pytest.raises(PathMissingError):
+        Repo.get(erepo.root_dir, "a_non_existing_file")
 
 
 @pytest.mark.parametrize("dname", [".", "dir", "dir/subdir"])


### PR DESCRIPTION
Things changed:
- both no output and no git file result into PathMissingError now
- fail on missing cache or cache download error loudly
- removed sqlite bypass, since we use nolock now anyway

Refactoring:
- streamlined logic and made it similar to Repo.open() one
- moved exclusive exception classes to dvc.repo.get

Things are more complicated here than expected. Still have some issues, things to decide:
- `FileMissingError` has bad message
- should we unify FileMissingError and PathMissingError?
- should we distinguish between?
    - neither out nor path is found
    - found external out with abs path doesn't use cache 
    - abs path for git file
    - cache for out is missing
    - cache download failed for an arbitrary reason
- how should we treat `dvc get scheme://repo /an/absolute/git/path` when there is no out:
    - strip leading /
    - show PathMissingError
    - show PathMissingError with a hint "did you mean <path-with-stripped-/>"

**P.S.** Silent errors on DataCloud.pull() and `RemoteBase.download() are still an issue.