### PR TITLE
remote: Extend S3 remote support for custom ACL

### DIFF
--- a/dvc/config.py
+++ b/dvc/config.py
@@ -171,6 +171,10 @@ class Config(object):  # pylint: disable=too-many-instance-attributes
     SECTION_AWS_USE_SSL = "use_ssl"
     SECTION_AWS_SSE = "sse"
     SECTION_AWS_ACL = "acl"
+    SECTION_AWS_GRANT_READ = "grant_read"
+    SECTION_AWS_GRANT_READ_ACP = "grant_read_acp"
+    SECTION_AWS_GRANT_WRITE_ACP = "grant_write_acp"
+    SECTION_AWS_GRANT_FULL_CONTROL = "grant_full_control"
 
     # gcp specific options
     SECTION_GCP_CREDENTIALPATH = CREDENTIALPATH
@@ -210,6 +214,10 @@ class Config(object):  # pylint: disable=too-many-instance-attributes
         Optional(SECTION_AWS_USE_SSL, default=True): Bool,
         SECTION_AWS_SSE: str,
         SECTION_AWS_ACL: str,
+        SECTION_AWS_GRANT_READ: str,
+        SECTION_AWS_GRANT_READ_ACP: str,
+        SECTION_AWS_GRANT_WRITE_ACP: str,
+        SECTION_AWS_GRANT_FULL_CONTROL: str,
         SECTION_GCP_PROJECTNAME: str,
         SECTION_CACHE_TYPE: supported_cache_type,
         Optional(SECTION_CACHE_PROTECTED, default=False): Bool,

--- a/dvc/remote/s3.py
+++ b/dvc/remote/s3.py
@@ -352,7 +352,9 @@ class RemoteS3(RemoteBASE):
                 Config.SECTION_AWS_GRANT_WRITE_ACP,
             ]
             warning_message = [
-                f"Using one of the [{', '.join(overwriting_fields)}] will",
+                "Using one of the [{0}] will".format(
+                    ", ".join(overwriting_fields)
+                ),
                 "overwrite default ACL Grantees list. Default ACL Grantees",
                 "list include Owner with FULL_CONTROL permissions.",
             ]

--- a/tests/unit/remote/test_s3.py
+++ b/tests/unit/remote/test_s3.py
@@ -1,40 +1,56 @@
-from unittest import TestCase
+import pytest
 
+from dvc.config import ConfigError
 from dvc.remote.s3 import RemoteS3
 
 
-class TestRemoteS3(TestCase):
-    bucket_name = "bucket-name"
-    prefix = "some/prefix"
-    url = "s3://{}/{}".format(bucket_name, prefix)
+bucket_name = "bucket-name"
+prefix = "some/prefix"
+url = "s3://{}/{}".format(bucket_name, prefix)
 
-    def test_init(self):
-        config = {"url": self.url}
-        remote = RemoteS3(None, config)
 
-        self.assertEqual(remote.path_info, self.url)
+@pytest.fixture(autouse=True)
+def grants():
+    return {
+        "grant_read": "id=read-permission-id,id=other-read-permission-id",
+        "grant_read_acp": "id=read-acp-permission-id",
+        "grant_write_acp": "id=write-acp-permission-id",
+        "grant_full_control": "id=full-control-permission-id",
+    }
 
-    def test_grants(self):
-        config = {
-            "url": self.url,
-            "grant_read": "id=read-permission-id,id=other-read-permission-id",
-            "grant_read_acp": "id=read-acp-permission-id",
-            "grant_write_acp": "id=write-acp-permission-id",
-            "grant_full_control": "id=full-control-permission-id",
-        }
-        remote = RemoteS3(None, config)
 
-        self.assertEqual(
-            remote.extra_args["GrantRead"],
-            "id=read-permission-id,id=other-read-permission-id",
-        )
-        self.assertEqual(
-            remote.extra_args["GrantReadACP"], "id=read-acp-permission-id"
-        )
-        self.assertEqual(
-            remote.extra_args["GrantWriteACP"], "id=write-acp-permission-id"
-        )
-        self.assertEqual(
-            remote.extra_args["GrantFullControl"],
-            "id=full-control-permission-id",
-        )
+def test_init():
+    config = {"url": url}
+    remote = RemoteS3(None, config)
+
+    assert remote.path_info == url
+
+
+def test_grants():
+    config = {
+        "url": url,
+        "grant_read": "id=read-permission-id,id=other-read-permission-id",
+        "grant_read_acp": "id=read-acp-permission-id",
+        "grant_write_acp": "id=write-acp-permission-id",
+        "grant_full_control": "id=full-control-permission-id",
+    }
+    remote = RemoteS3(None, config)
+
+    assert (
+        remote.extra_args["GrantRead"]
+        == "id=read-permission-id,id=other-read-permission-id"
+    )
+    assert remote.extra_args["GrantReadACP"] == "id=read-acp-permission-id"
+    assert remote.extra_args["GrantWriteACP"] == "id=write-acp-permission-id"
+    assert (
+        remote.extra_args["GrantFullControl"]
+        == "id=full-control-permission-id"
+    )
+
+
+def test_grants_mutually_exclusive_acl_error(grants):
+    for grant_option, grant_value in grants.items():
+        config = {"url": url, "acl": "public-read", grant_option: grant_value}
+
+        with pytest.raises(ConfigError):
+            RemoteS3(None, config)

--- a/tests/unit/remote/test_s3.py
+++ b/tests/unit/remote/test_s3.py
@@ -1,0 +1,40 @@
+from unittest import TestCase
+
+from dvc.remote.s3 import RemoteS3
+
+
+class TestRemoteS3(TestCase):
+    bucket_name = "bucket-name"
+    prefix = "some/prefix"
+    url = "s3://{}/{}".format(bucket_name, prefix)
+
+    def test_init(self):
+        config = {"url": self.url}
+        remote = RemoteS3(None, config)
+
+        self.assertEqual(remote.path_info, self.url)
+
+    def test_grants(self):
+        config = {
+            "url": self.url,
+            "grant_read": "id=read-permission-id,id=other-read-permission-id",
+            "grant_read_acp": "id=read-acp-permission-id",
+            "grant_write_acp": "id=write-acp-permission-id",
+            "grant_full_control": "id=full-control-permission-id",
+        }
+        remote = RemoteS3(None, config)
+
+        self.assertEqual(
+            remote.extra_args["GrantRead"],
+            "id=read-permission-id,id=other-read-permission-id",
+        )
+        self.assertEqual(
+            remote.extra_args["GrantReadACP"], "id=read-acp-permission-id"
+        )
+        self.assertEqual(
+            remote.extra_args["GrantWriteACP"], "id=write-acp-permission-id"
+        )
+        self.assertEqual(
+            remote.extra_args["GrantFullControl"],
+            "id=full-control-permission-id",
+        )


### PR DESCRIPTION
Besides AWS boto3 extra_arg `ACL` (`x-amz-acl` header), there four more
that could be used to grant specific permissions to specific grantees on
the uploaded object.
These headers are:
  - `x-amz-grant-full-control` with boto3's extra_arg `GrantFullControl`
  - `x-amz-grant-read` with boto3's extra_arg `GrantRead`
  - `x-amz-grant-read-acp` with boto3's extra_arg `GrantReadACP`
  - `x-amz-grant-write-acp` with boto3's extra_arg `GrantWriteACP`

As `ACL` (`x-amz-acl` header) is limited to be used with predefined canned ACLs,
adding support for the aformentioned headers will help in applying
more customized persmissions solutions according to different project
needs.

References:
  - https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#permissions
  - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/customizations/s3.html#boto3.s3.transfer.S3Transfer.ALLOWED_UPLOAD_ARGS
  - https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectAcl.html

Fixes (#2930).

* [X] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [X] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

