### PR TITLE
snap: remove plugs (incompatible with classic)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,13 +6,6 @@ grade: stable
 confinement: classic  # for same reasons as snap `git-ubuntu`
 base: core18
 license: Apache-2.0
-plugs:
-  config-dvc:
-    interface: system-files
-    read:
-    - /etc/host.conf
-    - /etc/resolv.conf
-    - /etc/hosts
 layout:
   /etc/dvc:
     bind: $SNAP_DATA/etc/dvc
@@ -48,18 +41,7 @@ apps:
     environment:
       GIT_PYTHON_GIT_EXECUTABLE: $SNAP/usr/bin/git
       XDG_CONFIG_DIRS: /etc
-    plugs:
-    - config-dvc
-    - home
-    - mount-observe
-    - network-control
-    - removable-media
   git:
     command: usr/bin/git
     environment:
       GIT_DISCOVERY_ACROSS_FILESYSTEM: 1
-    plugs:
-    - home
-    - mount-observe
-    - network-control
-    - removable-media


### PR DESCRIPTION
Minor non-`classic` cleanup required for https://forum.snapcraft.io/t/classic-confinement-request-for-dvc/14124

> confinement 'classic' not allowed with plugs/slots lint-snap-v2_confinement_classic_with_interfaces https://launchpad.net/bugs/1655369