### PR TITLE
[WIP][Showcase] dvc: use dynamic scope to stop callback/flag passing

### DIFF
--- a/dvc/output/base.py
+++ b/dvc/output/base.py
@@ -6,6 +6,7 @@ from copy import copy
 from voluptuous import Any
 
 import dvc.prompt as prompt
+from dvc.progress import flags, noop
 from dvc.cache import NamedCache
 from dvc.exceptions import CollectCacheError
 from dvc.exceptions import DvcException
@@ -282,12 +283,10 @@ class OutputBase(object):
     def download(self, to):
         self.remote.download(self.path_info, to.path_info)
 
-    def checkout(
-        self, force=False, progress_callback=None, tag=None, relink=False
-    ):
+    def checkout(self, force=False, tag=None, relink=False):
         if not self.use_cache:
-            if progress_callback:
-                progress_callback(str(self.path_info), self.get_files_number())
+            pbar = flags.tqdm or noop
+            pbar.update_desc(str(self), self.get_files_number())
             return None
 
         if tag:
@@ -296,11 +295,7 @@ class OutputBase(object):
             info = self.info
 
         return self.cache.checkout(
-            self.path_info,
-            info,
-            force=force,
-            progress_callback=progress_callback,
-            relink=relink,
+            self.path_info, info, force=force, relink=relink
         )
 
     def remove(self, ignore_remove=False):

--- a/dvc/remote/azure.py
+++ b/dvc/remote/azure.py
@@ -110,10 +110,8 @@ class RemoteAZURE(RemoteBASE):
     def list_cache_paths(self):
         return self._list_paths(self.path_info.bucket, self.path_info.path)
 
-    def _upload(
-        self, from_file, to_info, name=None, no_progress_bar=False, **_kwargs
-    ):
-        with Tqdm(desc=name, disable=no_progress_bar, bytes=True) as pbar:
+    def _upload(self, from_file, to_info, name=None, **_kwargs):
+        with Tqdm(desc=name, bytes=True) as pbar:
             self.blob_service.create_blob_from_path(
                 to_info.bucket,
                 to_info.path,
@@ -121,10 +119,8 @@ class RemoteAZURE(RemoteBASE):
                 progress_callback=pbar.update_to,
             )
 
-    def _download(
-        self, from_info, to_file, name=None, no_progress_bar=False, **_kwargs
-    ):
-        with Tqdm(desc=name, disable=no_progress_bar, bytes=True) as pbar:
+    def _download(self, from_info, to_file, name=None, **_kwargs):
+        with Tqdm(desc=name, bytes=True) as pbar:
             self.blob_service.get_blob_to_path(
                 from_info.bucket,
                 from_info.path,

--- a/dvc/remote/gs.py
+++ b/dvc/remote/gs.py
@@ -49,14 +49,7 @@ def dynamic_chunk_size(func):
 
 
 @dynamic_chunk_size
-def _upload_to_bucket(
-    bucket,
-    from_file,
-    to_info,
-    chunk_size=None,
-    name=None,
-    no_progress_bar=True,
-):
+def _upload_to_bucket(bucket, from_file, to_info, name=None, chunk_size=None):
     blob = bucket.blob(to_info.path, chunk_size=chunk_size)
     with io.open(from_file, mode="rb") as fobj:
         with Tqdm.wrapattr(
@@ -64,7 +57,6 @@ def _upload_to_bucket(
             "read",
             desc=name or to_info.path,
             total=os.path.getsize(from_file),
-            disable=no_progress_bar,
         ) as wrapped:
             blob.upload_from_file(wrapped)
 
@@ -170,26 +162,16 @@ class RemoteGS(RemoteBASE):
         """
         return self.isfile(path_info) or self.isdir(path_info)
 
-    def _upload(self, from_file, to_info, name=None, no_progress_bar=True):
+    def _upload(self, from_file, to_info, name=None):
         bucket = self.gs.bucket(to_info.bucket)
-        _upload_to_bucket(
-            bucket,
-            from_file,
-            to_info,
-            name=name,
-            no_progress_bar=no_progress_bar,
-        )
+        _upload_to_bucket(bucket, from_file, to_info, name=name)
 
-    def _download(self, from_info, to_file, name=None, no_progress_bar=True):
+    def _download(self, from_info, to_file, name=None):
         bucket = self.gs.bucket(from_info.bucket)
         blob = bucket.get_blob(from_info.path)
         with io.open(to_file, mode="wb") as fobj:
             with Tqdm.wrapattr(
-                fobj,
-                "write",
-                desc=name or from_info.path,
-                total=blob.size,
-                disable=no_progress_bar,
+                fobj, "write", desc=name or from_info.path, total=blob.size
             ) as wrapped:
                 blob.download_to_file(wrapped)
 

--- a/dvc/remote/http.py
+++ b/dvc/remote/http.py
@@ -36,16 +36,16 @@ class RemoteHTTP(RemoteBASE):
                 "files. Use: `dvc remote modify <name> no_traverse true`"
             )
 
-    def _download(self, from_info, to_file, name=None, no_progress_bar=False):
+    def _download(self, from_info, to_file, name=None):
         response = self._request("GET", from_info.url, stream=True)
         if response.status_code != 200:
             raise HTTPError(response.status_code, response.reason)
+
         with Tqdm(
-            total=None if no_progress_bar else self._content_length(response),
+            total=self._content_length(response),
             leave=False,
             bytes=True,
             desc=from_info.url if name is None else name,
-            disable=no_progress_bar,
         ) as pbar:
             with open(to_file, "wb") as fd:
                 for chunk in response.iter_content(chunk_size=self.CHUNK_SIZE):

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -219,23 +219,15 @@ class RemoteLOCAL(RemoteBASE):
             if not self.changed_cache_file(checksum)
         ]
 
-    def _upload(
-        self, from_file, to_info, name=None, no_progress_bar=False, **_kwargs
-    ):
+    def _upload(self, from_file, to_info, name=None, **_kwargs):
         makedirs(to_info.parent, exist_ok=True)
 
         tmp_file = tmp_fname(to_info)
-        copyfile(
-            from_file, tmp_file, name=name, no_progress_bar=no_progress_bar
-        )
+        copyfile(from_file, tmp_file, name=name)
         os.rename(tmp_file, fspath_py35(to_info))
 
-    def _download(
-        self, from_info, to_file, name=None, no_progress_bar=False, **_kwargs
-    ):
-        copyfile(
-            from_info, to_file, no_progress_bar=no_progress_bar, name=name
-        )
+    def _download(self, from_info, to_file, name=None, **_kwargs):
+        copyfile(from_info, to_file, name=name)
 
     @staticmethod
     def open(path_info, mode="r", encoding=None):

--- a/dvc/remote/oss.py
+++ b/dvc/remote/oss.py
@@ -104,18 +104,14 @@ class RemoteOSS(RemoteBASE):
     def list_cache_paths(self):
         return self._list_paths(self.path_info.path)
 
-    def _upload(
-        self, from_file, to_info, name=None, no_progress_bar=False, **_kwargs
-    ):
-        with Tqdm(desc=name, disable=no_progress_bar, bytes=True) as pbar:
+    def _upload(self, from_file, to_info, name=None, **_kwargs):
+        with Tqdm(desc=name, bytes=True) as pbar:
             self.oss_service.put_object_from_file(
                 to_info.path, from_file, progress_callback=pbar.update_to
             )
 
-    def _download(
-        self, from_info, to_file, name=None, no_progress_bar=False, **_kwargs
-    ):
-        with Tqdm(desc=name, disable=no_progress_bar, bytes=True) as pbar:
+    def _download(self, from_info, to_file, name=None, **_kwargs):
+        with Tqdm(desc=name, bytes=True) as pbar:
             self.oss_service.get_object_to_file(
                 from_info.path, to_file, progress_callback=pbar.update_to
             )

--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -228,25 +228,17 @@ class RemoteSSH(RemoteBASE):
         with self.ssh(from_info) as ssh:
             ssh.move(from_info.path, to_info.path)
 
-    def _download(self, from_info, to_file, name=None, no_progress_bar=False):
+    def _download(self, from_info, to_file, name=None):
         assert from_info.isin(self.path_info)
-        with self.ssh(self.path_info) as ssh:
-            ssh.download(
-                from_info.path,
-                to_file,
-                progress_title=name,
-                no_progress_bar=no_progress_bar,
-            )
 
-    def _upload(self, from_file, to_info, name=None, no_progress_bar=False):
-        assert to_info.isin(self.path_info)
         with self.ssh(self.path_info) as ssh:
-            ssh.upload(
-                from_file,
-                to_info.path,
-                progress_title=name,
-                no_progress_bar=no_progress_bar,
-            )
+            ssh.download(from_info.path, to_file, name=name)
+
+    def _upload(self, from_file, to_info, name=None):
+        assert to_info.isin(self.path_info)
+
+        with self.ssh(self.path_info) as ssh:
+            ssh.upload(from_file, to_info.path, name=name)
 
     @contextmanager
     def open(self, path_info, mode="r", encoding=None):

--- a/dvc/remote/ssh/connection.py
+++ b/dvc/remote/ssh/connection.py
@@ -177,12 +177,8 @@ class SSHConnection:
         else:
             self._remove_file(path)
 
-    def download(self, src, dest, no_progress_bar=False, progress_title=None):
-        with Tqdm(
-            desc=progress_title or os.path.basename(src),
-            disable=no_progress_bar,
-            bytes=True,
-        ) as pbar:
+    def download(self, src, dest, name=None):
+        with Tqdm(desc=name or os.path.basename(src), bytes=True) as pbar:
             self.sftp.get(src, dest, callback=pbar.update_to)
 
     def move(self, src, dst):
@@ -207,15 +203,11 @@ class SSHConnection:
         finally:
             self.remove(tmp)
 
-    def upload(self, src, dest, no_progress_bar=False, progress_title=None):
+    def upload(self, src, dest, name=None):
         self.makedirs(posixpath.dirname(dest))
         tmp_file = tmp_fname(dest)
-        if not progress_title:
-            progress_title = posixpath.basename(dest)
 
-        with Tqdm(
-            desc=progress_title, disable=no_progress_bar, bytes=True
-        ) as pbar:
+        with Tqdm(desc=name or posixpath.basename(dest), bytes=True) as pbar:
             self.sftp.put(src, tmp_file, callback=pbar.update_to)
 
         self.sftp.rename(tmp_file, dest)

--- a/dvc/repo/checkout.py
+++ b/dvc/repo/checkout.py
@@ -56,6 +56,7 @@ def _checkout(
     total = get_all_files_numbers(stages)
     if total == 0:
         logger.info("Nothing to do")
+        # We might need to create empty dirs though, so no return here
 
     with Tqdm(total=total, unit="file", desc="Checkout") as pbar, flags(
         tqdm=pbar

--- a/dvc/stage.py
+++ b/dvc/stage.py
@@ -960,15 +960,10 @@ class Stage(object):
             raise MissingDataSource(paths)
 
     @rwlocked(write=["outs"])
-    def checkout(self, force=False, progress_callback=None, relink=False):
+    def checkout(self, force=False, relink=False):
         failed_checkouts = []
         for out in self.outs:
-            failed = out.checkout(
-                force=force,
-                tag=self.tag,
-                progress_callback=progress_callback,
-                relink=relink,
-            )
+            failed = out.checkout(force=force, tag=self.tag, relink=relink)
             if failed:
                 failed_checkouts.append(failed)
         return failed_checkouts

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -112,7 +112,7 @@ def dict_md5(d, exclude=()):
     return bytes_md5(byts)
 
 
-def copyfile(src, dest, no_progress_bar=False, name=None):
+def copyfile(src, dest, name=None):
     """Copy file with progress bar"""
     from dvc.exceptions import DvcException
     from dvc.progress import Tqdm
@@ -130,9 +130,7 @@ def copyfile(src, dest, no_progress_bar=False, name=None):
     try:
         System.reflink(src, dest)
     except DvcException:
-        with Tqdm(
-            desc=name, disable=no_progress_bar, total=total, bytes=True
-        ) as pbar:
+        with Tqdm(desc=name, total=total, bytes=True) as pbar:
             with open(src, "rb") as fsrc, open(dest, "wb+") as fdest:
                 while True:
                     buf = fsrc.read(LOCAL_CHUNK_SIZE)


### PR DESCRIPTION
The idea is to simplify function signatures and make intermediate calls not need to know when some high-level code is talking some low-level one. 

Showcased on annoying enough `no_progress_bar` and `progress_callback`. Might be also used to simplify:
- combining pbars
- jobs
- force
- other cli or config options only low level code needs to know about 