### PR TITLE
Standardize gdrive tests with others remotes

### DIFF
--- a/tests/unit/remote/gdrive/conftest.py
+++ b/tests/unit/remote/gdrive/conftest.py
@@ -1,9 +1,0 @@
-import pytest
-
-from dvc.remote.gdrive import RemoteGDrive
-
-
-@pytest.fixture
-def gdrive(repo):
-    ret = RemoteGDrive(None, {"url": "gdrive://root/data"})
-    return ret

--- a/tests/unit/remote/test_gdrive.py
+++ b/tests/unit/remote/test_gdrive.py
@@ -3,7 +3,7 @@ from dvc.remote.gdrive import RemoteGDrive
 
 
 @mock.patch("dvc.remote.gdrive.RemoteGDrive.init_drive")
-def test_init_drive(repo):
+def test_init(repo):
     url = "gdrive://root/data"
     gdrive = RemoteGDrive(repo, {"url": url})
     assert str(gdrive.path_info) == url


### PR DESCRIPTION
Related to https://github.com/iterative/dvc/issues/2865

Have found that available remote tests (`test_azure.py`, `test_s3.py`, `test_oss.py` and others) don't have dvc's API tests, but test only remote specific implementations ( initializing, etc ).

This PR standardize gdrive tests to look similar to other remotes tests.

Test of dvc's APIs for gdrive seems should happen on run of `test_data_cloud.py`. We need to setup Google Project and special account to be used by Travis.

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

