### PR TITLE
Improve Google Drive auth failure error reporting

### DIFF
--- a/tests/unit/remote/test_gdrive.py
+++ b/tests/unit/remote/test_gdrive.py
@@ -1,9 +1,46 @@
-import mock
-from dvc.remote.gdrive import RemoteGDrive
+from unittest import TestCase
+
+import pytest
+import os
+
+from dvc.remote.gdrive import (
+    RemoteGDrive,
+    GDriveAccessTokenRefreshError,
+    GDriveMissedCredentialKeyError,
+)
+
+USER_CREDS_TOKEN_REFRESH_ERROR = '{"access_token": "", "client_id": "", "client_secret": "", "refresh_token": "", "token_expiry": "", "token_uri": "https://oauth2.googleapis.com/token", "user_agent": null, "revoke_uri": "https://oauth2.googleapis.com/revoke", "id_token": null, "id_token_jwt": null, "token_response": {"access_token": "", "expires_in": 3600, "scope": "https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/drive", "token_type": "Bearer"}, "scopes": ["https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/drive.appdata"], "token_info_uri": "https://oauth2.googleapis.com/tokeninfo", "invalid": true, "_class": "OAuth2Credentials", "_module": "oauth2client.client"}'  # noqa: E501
+
+USER_CREDS_MISSED_KEY_ERROR = "{}"
 
 
-@mock.patch("dvc.remote.gdrive.RemoteGDrive.init_drive")
-def test_init(repo):
-    url = "gdrive://root/data"
-    gdrive = RemoteGDrive(repo, {"url": url})
-    assert str(gdrive.path_info) == url
+class Repo(object):
+    tmp_dir = ""
+
+
+class TestRemoteGDrive(TestCase):
+    CONFIG = {
+        "url": "gdrive://root/data",
+        "gdrive_client_id": "client",
+        "gdrive_client_secret": "secret",
+    }
+
+    def test_init(self):
+        remote = RemoteGDrive(Repo(), self.CONFIG)
+        assert str(remote.path_info) == self.CONFIG["url"]
+
+    def test_drive(self):
+        remote = RemoteGDrive(Repo(), self.CONFIG)
+        os.environ[
+            RemoteGDrive.GDRIVE_USER_CREDENTIALS_DATA
+        ] = USER_CREDS_TOKEN_REFRESH_ERROR
+        with pytest.raises(GDriveAccessTokenRefreshError):
+            remote.drive
+
+        os.environ[RemoteGDrive.GDRIVE_USER_CREDENTIALS_DATA] = ""
+        remote = RemoteGDrive(Repo(), self.CONFIG)
+        os.environ[
+            RemoteGDrive.GDRIVE_USER_CREDENTIALS_DATA
+        ] = USER_CREDS_MISSED_KEY_ERROR
+        with pytest.raises(GDriveMissedCredentialKeyError):
+            remote.drive


### PR DESCRIPTION
Related to https://github.com/iterative/dvc/issues/2865

Addresses issue "Processing of auth exceptions and printing more meaningful error message on failure. [#2551 (comment)](https://github.com/iterative/dvc/pull/2551#discussion_r348182771)"

* [ ] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [ ] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [ ] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

