### PR TITLE
dvc: support granularity for fetch/pull/push/status/checkout

### DIFF
--- a/dvc/path_info.py
+++ b/dvc/path_info.py
@@ -29,7 +29,10 @@ class _BasePath(object):
             other = self.__class__(other)
         elif self.__class__ != other.__class__:
             return False
-        return self == other or self.isin(other) or other.isin(self)
+        return self.isin_or_eq(other) or other.isin(self)
+
+    def isin_or_eq(self, other):
+        return self == other or self.isin(other)
 
 
 class PathInfo(pathlib.PurePath, _BasePath):

--- a/tests/func/test_checkout.py
+++ b/tests/func/test_checkout.py
@@ -510,3 +510,16 @@ def test_checkout_relink_protected(tmp_dir, dvc, link):
 
     dvc.checkout(["foo.dvc"], relink=True)
     assert not os.access("foo", os.W_OK)
+
+
+@pytest.mark.parametrize(
+    "target",
+    [os.path.join("dir", "subdir"), os.path.join("dir", "subdir", "file")],
+)
+def test_partial_checkout(tmp_dir, dvc, target):
+    tmp_dir.dvc_gen({"dir": {"subdir": {"file": "file"}, "other": "other"}})
+    shutil.rmtree("dir")
+    dvc.checkout([target])
+    assert list(walk_files("dir", None)) == [
+        os.path.join("dir", "subdir", "file")
+    ]

--- a/tests/unit/test_repo.py
+++ b/tests/unit/test_repo.py
@@ -1,6 +1,51 @@
 import os
 
+import pytest
+
 
 def test_is_dvc_internal(dvc):
     assert dvc.is_dvc_internal(os.path.join("path", "to", ".dvc", "file"))
     assert not dvc.is_dvc_internal(os.path.join("path", "to-non-.dvc", "file"))
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        os.path.join("dir", "subdir", "file"),
+        os.path.join("dir", "subdir"),
+        "dir",
+    ],
+)
+def test_find_outs_by_path(tmp_dir, dvc, path):
+    stage, = tmp_dir.dvc_gen(
+        {"dir": {"subdir": {"file": "file"}, "other": "other"}}
+    )
+
+    outs = dvc.find_outs_by_path(path, strict=False)
+    assert len(outs) == 1
+    assert outs[0].path_info == stage.outs[0].path_info
+
+
+@pytest.mark.parametrize(
+    "path",
+    [os.path.join("dir", "subdir", "file"), os.path.join("dir", "subdir")],
+)
+def test_used_cache(tmp_dir, dvc, path):
+    from dvc.cache import NamedCache
+
+    tmp_dir.dvc_gen({"dir": {"subdir": {"file": "file"}, "other": "other"}})
+    expected = NamedCache.make(
+        "local", "70922d6bf66eb073053a82f77d58c536.dir", "dir"
+    )
+    expected.add(
+        "local",
+        "8c7dd922ad47494fc02c388e12c00eac",
+        os.path.join("dir", "subdir", "file"),
+    )
+
+    with dvc.state:
+        used_cache = dvc.used_cache([path])
+        assert (
+            used_cache._items == expected._items
+            and used_cache.external == expected.external
+        )


### PR DESCRIPTION
Using output path or a subdir/subfile path within an output now works
with `dvc push/pull/fetch/status -c` commands. Other commands don't
support the same logic for now, as there are some questions about what
should commands like `dvc remove` do when given a specific output path.

Example:
    dvc add data
    dvc pull data/subdir # will only pull files within data/subdir

Related to #2458

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

https://github.com/iterative/dvc.org/issues/886

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

