### PR TITLE
py3: deprecate 2.7

### DIFF
--- a/scripts/ci/before_install.sh
+++ b/scripts/ci/before_install.sh
@@ -44,16 +44,9 @@ if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Test" ]]; then
 fi
 
 if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
-    if [[ -n "$PY2" ]]; then
-        $scriptdir/retry.sh choco install python2
-        echo 'PATH="/c/Python27:/c/Python27/Scripts:$PATH"' >> env.sh
-    else
-        $scriptdir/retry.sh choco install python --version 3.7.5
-        echo 'PATH="/c/Python37:/c/Python37/Scripts:$PATH"' >> env.sh
-    fi
+    $scriptdir/retry.sh choco install python --version 3.7.5
+    echo 'PATH="/c/Python37:/c/Python37/Scripts:$PATH"' >> env.sh
 elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    if [[ ! -n "$PY2" ]]; then
-        ln -s -f /usr/local/bin/python3 /usr/local/bin/python
-        ln -s -f /usr/local/bin/pip3 /usr/local/bin/pip
-    fi
+    ln -s -f /usr/local/bin/python3 /usr/local/bin/python
+    ln -s -f /usr/local/bin/pip3 /usr/local/bin/pip
 fi

--- a/scripts/ci/check_python.sh
+++ b/scripts/ci/check_python.sh
@@ -12,12 +12,7 @@ else
 fi
 
 py_ver="$(python -c 'import sys; print(sys.version[0])')"
-if [[ -n "$PY2" ]]; then
-    if [[ "$py_ver" != "2" ]]; then
-        exit 1
-    fi
-else
-    if [[ "$py_ver" != "3" ]]; then
-        exit 1
-    fi
+
+if [[ "$py_ver" != 3 ]]; then
+  exit 1
 fi

--- a/scripts/ci/deploy_condition.sh
+++ b/scripts/ci/deploy_condition.sh
@@ -2,13 +2,6 @@
 
 set -e
 
-python_ver="$(python -c 'import sys; print(sys.version_info[0])')"
-
-if [[ $python_ver != "2" ]]; then
-    echo false
-    exit 0
-fi
-
 if [[ $TRAVIS_OS_NAME == "osx" && $TRAVIS_OSX_IMAGE != "xcode8.3" ]]; then
     echo false
     exit 0

--- a/scripts/ci/script.sh
+++ b/scripts/ci/script.sh
@@ -6,8 +6,7 @@ set -e
 python -mtests
 
 if [[ "$TRAVIS_PULL_REQUEST" == "false" && \
-      "$TRAVIS_SECURE_ENV_VARS" == "true" && \
-      "$(python -c 'import sys; print(sys.version_info[0])')" == '2' ]]; then
+      "$TRAVIS_SECURE_ENV_VARS" == "true" ]]; then
 	pip install codecov
 	codecov
 fi

--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,23 @@
+import importlib.util
 import os
 import sys
 
-from setuptools import find_packages
-from setuptools import setup
+from setuptools import find_packages, setup
 from setuptools.command.build_py import build_py as _build_py
-
-import fastentrypoints  # noqa: F401
 
 # Prevents pkg_resources import in entry point script,
 # see https://github.com/ninjaaron/fast-entry_points.
 # This saves about 200 ms on startup time for non-wheel installs.
+import fastentrypoints  # noqa: F401
 
 
-# https://packaging.python.org/guides/single-sourcing-package-version/
+# Read package meta-data from version.py
+# see https://packaging.python.org/guides/single-sourcing-package-version/
 pkg_dir = os.path.dirname(os.path.abspath(__file__))
 version_path = os.path.join(pkg_dir, "dvc", "version.py")
-if sys.version_info[0] == 2:
-    import imp
-
-    dvc_version = imp.load_source("dvc.version", version_path)
-else:
-    import importlib.util
-
-    spec = importlib.util.spec_from_file_location("dvc.version", version_path)
-    dvc_version = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(dvc_version)
-
+spec = importlib.util.spec_from_file_location("dvc.version", version_path)
+dvc_version = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(dvc_version)
 version = dvc_version.__version__  # noqa: F821
 
 
@@ -80,6 +72,7 @@ install_requires = [
     "tqdm>=4.40.0,<5",
     "packaging>=19.0",
     "zc.lockfile>=1.2.1",
+    "flufl.lock>=3.2",
     "win-unicode-console>=0.5; sys_platform == 'win32'",
     "pywin32>=225; sys_platform == 'win32'",
 ]
@@ -100,17 +93,13 @@ s3 = ["boto3>=1.9.201"]
 azure = ["azure-storage-blob==2.1.0"]
 oss = ["oss2==2.6.1"]
 ssh = ["paramiko>=2.5.0"]
+hdfs = ["pyarrow==0.15.1"]
 # gssapi should not be included in all_remotes, because it doesn't have wheels
 # for linux and mac, so it will fail to compile if user doesn't have all the
 # requirements, including kerberos itself. Once all the wheels are available,
 # we can start shipping it by default.
 ssh_gssapi = ["paramiko[gssapi]>=2.5.0"]
-hdfs = ["pyarrow==0.15.1"]
-all_remotes = gs + s3 + azure + ssh + oss + gdrive
-
-if os.name != "nt" or sys.version_info[0] != 2:
-    # NOTE: there are no pyarrow wheels for python2 on windows
-    all_remotes += hdfs
+all_remotes = gs + s3 + azure + ssh + oss + gdrive + hdfs
 
 # Extra dependecies to run tests
 tests_requirements = [
@@ -163,9 +152,6 @@ setup(
         "ssh": ssh,
         "ssh_gssapi": ssh_gssapi,
         "hdfs": hdfs,
-        # NOTE: https://github.com/inveniosoftware/troubleshooting/issues/1
-        ":python_version=='2.7'": ["futures", "pathlib2", "contextlib2"],
-        ":python_version>='3.0'": ["flufl.lock>=3.2"],
         "tests": tests_requirements,
     },
     keywords="data science, data version control, machine learning",

--- a/setup.py
+++ b/setup.py
@@ -169,11 +169,9 @@ setup(
         "tests": tests_requirements,
     },
     keywords="data science, data version control, machine learning",
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+    python_requires=">=3.5",
     classifiers=[
         "Development Status :: 4 - Beta",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
* Modify `python_requires`, _explicit version classifiers_, and imports in `setup.py`
* Cleanup `ci/scripts` 

Related: https://github.com/iterative/dvc/issues/1818