### PR TITLE
test: add @TmpDir.chdir()

### DIFF
--- a/tests/func/test_api.py
+++ b/tests/func/test_api.py
@@ -11,7 +11,6 @@ from dvc.exceptions import FileMissingError
 from dvc.main import main
 from dvc.path_info import URLInfo
 from dvc.remote.config import RemoteConfig
-from dvc.compat import fspath
 from tests.remotes import Azure, GCP, HDFS, Local, OSS, S3, SSH
 
 
@@ -130,7 +129,7 @@ def test_open_not_cached(dvc):
         api.read(metric_file)
 
 
-def test_summon(tmp_dir, erepo_dir, dvc, monkeypatch):
+def test_summon(tmp_dir, dvc, erepo_dir):
     objects = {
         "objects": [
             {
@@ -152,9 +151,7 @@ def test_summon(tmp_dir, erepo_dir, dvc, monkeypatch):
     dup_objects = copy.deepcopy(objects)
     dup_objects["objects"] *= 2
 
-    with monkeypatch.context() as m:
-        m.chdir(fspath(erepo_dir))
-
+    with erepo_dir.chdir():
         erepo_dir.dvc_gen("number", "100", commit="Add number.dvc")
         erepo_dir.scm_gen("dvcsummon.yaml", ruamel.yaml.dump(objects))
         erepo_dir.scm_gen("other.yaml", ruamel.yaml.dump(other_objects))

--- a/tests/func/test_get.py
+++ b/tests/func/test_get.py
@@ -14,9 +14,8 @@ from dvc.compat import fspath
 from tests.utils import trees_equal
 
 
-def test_get_repo_file(tmp_dir, erepo_dir, monkeypatch):
-    with monkeypatch.context() as m:
-        m.chdir(fspath(erepo_dir))
+def test_get_repo_file(tmp_dir, erepo_dir):
+    with erepo_dir.chdir():
         erepo_dir.dvc_gen("file", "contents", commit="create file")
 
     Repo.get(fspath(erepo_dir), "file", "file_imported")
@@ -25,9 +24,8 @@ def test_get_repo_file(tmp_dir, erepo_dir, monkeypatch):
     assert (tmp_dir / "file_imported").read_text() == "contents"
 
 
-def test_get_repo_dir(tmp_dir, erepo_dir, monkeypatch):
-    with monkeypatch.context() as m:
-        m.chdir(fspath(erepo_dir))
+def test_get_repo_dir(tmp_dir, erepo_dir):
+    with erepo_dir.chdir():
         erepo_dir.dvc_gen({"dir": {"file": "contents"}}, commit="create dir")
 
     Repo.get(fspath(erepo_dir), "dir", "dir_imported")
@@ -60,9 +58,8 @@ def test_get_git_dir(tmp_dir, erepo_dir):
     trees_equal(fspath(erepo_dir / src), fspath(tmp_dir / dst))
 
 
-def test_cache_type_is_properly_overridden(tmp_dir, erepo_dir, monkeypatch):
-    with monkeypatch.context() as m:
-        m.chdir(fspath(erepo_dir))
+def test_cache_type_is_properly_overridden(tmp_dir, erepo_dir):
+    with erepo_dir.chdir():
         erepo_dir.dvc.config.set(
             Config.SECTION_CACHE, Config.SECTION_CACHE_TYPE, "symlink"
         )
@@ -79,9 +76,8 @@ def test_cache_type_is_properly_overridden(tmp_dir, erepo_dir, monkeypatch):
     assert (tmp_dir / "file_imported").read_text() == "contents"
 
 
-def test_get_repo_rev(tmp_dir, erepo_dir, monkeypatch):
-    with monkeypatch.context() as m:
-        m.chdir(fspath(erepo_dir))
+def test_get_repo_rev(tmp_dir, erepo_dir):
+    with erepo_dir.chdir():
         erepo_dir.scm.checkout("new_branch", create_new=True)
         erepo_dir.dvc_gen("file", "contents", commit="create file on branch")
         erepo_dir.scm.checkout("master")
@@ -105,13 +101,12 @@ def test_get_a_dvc_file(tmp_dir, erepo_dir):
 
 
 # https://github.com/iterative/dvc/pull/2837#discussion_r352123053
-def test_get_full_dvc_path(tmp_dir, erepo_dir, tmp_path_factory, monkeypatch):
+def test_get_full_dvc_path(tmp_dir, erepo_dir, tmp_path_factory):
     path = tmp_path_factory.mktemp("ext")
     external_data = path / "ext_data"
     external_data.write_text("ext_data")
 
-    with monkeypatch.context() as m:
-        m.chdir(fspath(erepo_dir))
+    with erepo_dir.chdir():
         erepo_dir.dvc.add(fspath(external_data))
         erepo_dir.scm_add(["ext_data.dvc"], commit="add external data")
 
@@ -120,12 +115,11 @@ def test_get_full_dvc_path(tmp_dir, erepo_dir, tmp_path_factory, monkeypatch):
     assert (tmp_dir / "ext_data_imported").read_text() == "ext_data"
 
 
-def test_non_cached_output(tmp_dir, erepo_dir, monkeypatch):
+def test_non_cached_output(tmp_dir, erepo_dir):
     src = "non_cached_file"
     dst = src + "_imported"
 
-    with monkeypatch.context() as m:
-        m.chdir(fspath(erepo_dir))
+    with erepo_dir.chdir():
         erepo_dir.dvc.run(
             outs_no_cache=[src], cmd="echo hello > non_cached_file"
         )
@@ -151,9 +145,8 @@ def test_unknown_path(tmp_dir, erepo_dir):
 
 
 @pytest.mark.parametrize("dname", [".", "dir", "dir/subdir"])
-def test_get_to_dir(tmp_dir, erepo_dir, monkeypatch, dname):
-    with monkeypatch.context() as m:
-        m.chdir(fspath(erepo_dir))
+def test_get_to_dir(tmp_dir, erepo_dir, dname):
+    with erepo_dir.chdir():
         erepo_dir.dvc_gen("file", "contents", commit="create file")
 
     makedirs(dname, exist_ok=True)
@@ -164,11 +157,8 @@ def test_get_to_dir(tmp_dir, erepo_dir, monkeypatch, dname):
     assert (tmp_dir / dname / "file").read_text() == "contents"
 
 
-def test_get_from_non_dvc_master(
-    tmp_dir, erepo_dir, tmp_path, monkeypatch, caplog
-):
-    with monkeypatch.context() as m:
-        m.chdir(fspath(erepo_dir))
+def test_get_from_non_dvc_master(tmp_dir, erepo_dir, caplog):
+    with erepo_dir.chdir():
         erepo_dir.scm.checkout("new_branch", create_new=True)
         erepo_dir.scm_gen(
             {"some_file": "some_contents"}, commit="create some file"

--- a/tests/func/test_import.py
+++ b/tests/func/test_import.py
@@ -17,9 +17,8 @@ from dvc.compat import fspath
 from tests.utils import trees_equal
 
 
-def test_import(tmp_dir, scm, dvc, erepo_dir, monkeypatch):
-    with monkeypatch.context() as m:
-        m.chdir(fspath(erepo_dir))
+def test_import(tmp_dir, scm, dvc, erepo_dir):
+    with erepo_dir.chdir():
         erepo_dir.dvc_gen("foo", "foo content", commit="create foo")
 
     dvc.imp(fspath(erepo_dir), "foo", "foo_imported")
@@ -57,9 +56,8 @@ def test_import_git_dir(erepo_dir, tmp_dir, dvc, scm):
     assert tmp_dir.scm.repo.git.check_ignore(fspath(tmp_dir / dst))
 
 
-def test_import_dir(tmp_dir, scm, dvc, erepo_dir, monkeypatch):
-    with monkeypatch.context() as m:
-        m.chdir(fspath(erepo_dir))
+def test_import_dir(tmp_dir, scm, dvc, erepo_dir):
+    with erepo_dir.chdir():
         erepo_dir.dvc_gen({"dir": {"foo": "foo content"}}, commit="create dir")
 
     dvc.imp(fspath(erepo_dir), "dir", "dir_imported")
@@ -91,9 +89,8 @@ def test_import_non_cached(erepo_dir, tmp_dir, dvc, scm):
     assert tmp_dir.scm.repo.git.check_ignore(dst)
 
 
-def test_import_rev(tmp_dir, scm, dvc, erepo_dir, monkeypatch):
-    with monkeypatch.context() as m:
-        m.chdir(fspath(erepo_dir))
+def test_import_rev(tmp_dir, scm, dvc, erepo_dir):
+    with erepo_dir.chdir():
         erepo_dir.scm.checkout("new_branch", create_new=True)
         erepo_dir.dvc_gen("foo", "foo content", commit="create foo on branch")
         erepo_dir.scm.checkout("master")
@@ -104,9 +101,8 @@ def test_import_rev(tmp_dir, scm, dvc, erepo_dir, monkeypatch):
     assert scm.repo.git.check_ignore("foo_imported")
 
 
-def test_pull_imported_stage(tmp_dir, dvc, erepo_dir, monkeypatch):
-    with monkeypatch.context() as m:
-        m.chdir(fspath(erepo_dir))
+def test_pull_imported_stage(tmp_dir, dvc, erepo_dir):
+    with erepo_dir.chdir():
         erepo_dir.dvc_gen("foo", "foo content", commit="create foo")
     dvc.imp(fspath(erepo_dir), "foo", "foo_imported")
 
@@ -121,11 +117,8 @@ def test_pull_imported_stage(tmp_dir, dvc, erepo_dir, monkeypatch):
     assert os.path.isfile(dst_cache)
 
 
-def test_cache_type_is_properly_overridden(
-    tmp_dir, scm, dvc, erepo_dir, monkeypatch
-):
-    with monkeypatch.context() as m:
-        m.chdir(fspath(erepo_dir))
+def test_cache_type_is_properly_overridden(tmp_dir, scm, dvc, erepo_dir):
+    with erepo_dir.chdir():
         erepo_dir.dvc.config.set(
             Config.SECTION_CACHE, Config.SECTION_CACHE_TYPE, "symlink"
         )
@@ -144,9 +137,8 @@ def test_cache_type_is_properly_overridden(
     assert scm.repo.git.check_ignore("foo_imported")
 
 
-def test_pull_imported_directory_stage(tmp_dir, dvc, erepo_dir, monkeypatch):
-    with monkeypatch.context() as m:
-        m.chdir(fspath(erepo_dir))
+def test_pull_imported_directory_stage(tmp_dir, dvc, erepo_dir):
+    with erepo_dir.chdir():
         erepo_dir.dvc_gen({"dir": {"foo": "foo content"}}, commit="create dir")
 
     dvc.imp(fspath(erepo_dir), "dir", "dir_imported")
@@ -160,11 +152,8 @@ def test_pull_imported_directory_stage(tmp_dir, dvc, erepo_dir, monkeypatch):
     trees_equal(fspath(erepo_dir / "dir"), "dir_imported")
 
 
-def test_download_error_pulling_imported_stage(
-    tmp_dir, dvc, erepo_dir, monkeypatch
-):
-    with monkeypatch.context() as m:
-        m.chdir(fspath(erepo_dir))
+def test_download_error_pulling_imported_stage(tmp_dir, dvc, erepo_dir):
+    with erepo_dir.chdir():
         erepo_dir.dvc_gen("foo", "foo content", commit="create foo")
     dvc.imp(fspath(erepo_dir), "foo", "foo_imported")
 
@@ -181,11 +170,10 @@ def test_download_error_pulling_imported_stage(
 
 
 @pytest.mark.parametrize("dname", [".", "dir", "dir/subdir"])
-def test_import_to_dir(dname, tmp_dir, dvc, erepo_dir, monkeypatch):
+def test_import_to_dir(dname, tmp_dir, dvc, erepo_dir):
     makedirs(dname, exist_ok=True)
 
-    with monkeypatch.context() as m:
-        m.chdir(fspath(erepo_dir))
+    with erepo_dir.chdir():
         erepo_dir.dvc_gen("foo", "foo content", commit="create foo")
 
     stage = dvc.imp(fspath(erepo_dir), "foo", dname)
@@ -197,9 +185,8 @@ def test_import_to_dir(dname, tmp_dir, dvc, erepo_dir, monkeypatch):
     assert (tmp_dir / dst).read_text() == "foo content"
 
 
-def test_pull_non_workspace(tmp_dir, scm, dvc, erepo_dir, monkeypatch):
-    with monkeypatch.context() as m:
-        m.chdir(fspath(erepo_dir))
+def test_pull_non_workspace(tmp_dir, scm, dvc, erepo_dir):
+    with erepo_dir.chdir():
         erepo_dir.dvc_gen("foo", "master content", commit="create foo")
         erepo_dir.scm.checkout("new_branch", create_new=True)
         erepo_dir.dvc_gen("foo", "branch content", commit="modify foo")
@@ -219,6 +206,7 @@ def test_pull_non_workspace(tmp_dir, scm, dvc, erepo_dir, monkeypatch):
 def test_import_non_existing(erepo_dir, tmp_dir, dvc):
     with pytest.raises(PathMissingError):
         tmp_dir.dvc.imp(fspath(erepo_dir), "invalid_output")
+
     # https://github.com/iterative/dvc/pull/2837#discussion_r352123053
     with pytest.raises(NoOutputInExternalRepoError):
         tmp_dir.dvc.imp(fspath(erepo_dir), "/root/", "root")


### PR DESCRIPTION
Will simplify bootstrapping for `erepo_dir`. Closes https://github.com/iterative/dvc/issues/2967.