### PR TITLE
py3: use yield from where appropriate

### DIFF
--- a/dvc/remote/s3.py
+++ b/dvc/remote/s3.py
@@ -194,11 +194,7 @@ class RemoteS3(RemoteBASE):
         }
         paginator = self.s3.get_paginator(self.list_objects_api)
         for page in paginator.paginate(**kwargs):
-            contents = page.get("Contents", None)
-            if not contents:
-                continue
-            for item in contents:
-                yield item
+            yield from page.get("Contents", ())
 
     def _list_paths(self, path_info, max_items=None):
         return (

--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -260,8 +260,7 @@ class RemoteSSH(RemoteBASE):
     def list_cache_paths(self):
         with self.ssh(self.path_info) as ssh:
             # If we simply return an iterator then with above closes instantly
-            for path in ssh.walk_files(self.path_info.path):
-                yield path
+            yield from ssh.walk_files(self.path_info.path)
 
     def walk_files(self, path_info):
         with self.ssh(path_info) as ssh:

--- a/dvc/remote/ssh/connection.py
+++ b/dvc/remote/ssh/connection.py
@@ -139,8 +139,7 @@ class SSHConnection:
 
         for dname in dirs:
             newpath = posixpath.join(directory, dname)
-            for entry in self.walk(newpath, topdown=topdown):
-                yield entry
+            yield from self.walk(newpath, topdown=topdown)
 
         if not topdown:
             yield directory, dirs, nondirs

--- a/dvc/scm/git/tree.py
+++ b/dvc/scm/git/tree.py
@@ -128,8 +128,7 @@ class GitTree(BaseTree):
             yield os.path.normpath(tree.abspath), dirs, nondirs
 
         for i in dirs:
-            for x in self._walk(tree[i], topdown=True):
-                yield x
+            yield from self._walk(tree[i], topdown=topdown)
 
         if not topdown:
             yield os.path.normpath(tree.abspath), dirs, nondirs
@@ -146,5 +145,4 @@ class GitTree(BaseTree):
         if tree is None:
             raise IOError(errno.ENOENT, "No such file")
 
-        for x in self._walk(tree, topdown):
-            yield x
+        yield from self._walk(tree, topdown=topdown)

--- a/tests/remotes.py
+++ b/tests/remotes.py
@@ -238,8 +238,7 @@ class S3Mocked:
     @contextmanager
     def remote(cls):
         with mock_s3():
-            remote = RemoteS3(None, {"url": cls.get_url()})
-            yield remote
+            yield RemoteS3(None, {"url": cls.get_url()})
 
     @staticmethod
     def put_objects(remote, objects):
@@ -259,8 +258,7 @@ class GCP:
     @classmethod
     @contextmanager
     def remote(cls):
-        remote = RemoteGS(None, {"url": cls.get_url()})
-        yield remote
+        yield RemoteGS(None, {"url": cls.get_url()})
 
     @staticmethod
     def put_objects(remote, objects):


### PR DESCRIPTION
Fixed a bug in `GitTree._walk()` not passing `topdown` flag properly along the way.