### PR TITLE
dvc: update gc to remove unpacked dir

### DIFF
--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -697,6 +697,8 @@ class RemoteBASE(object):
             if checksum in used:
                 continue
             path_info = self.checksum_to_path_info(checksum)
+            if self.is_dir_checksum(checksum):
+                self._remove_unpacked_dir(checksum)
             self.remove(path_info)
             removed = True
         return removed
@@ -1008,4 +1010,7 @@ class RemoteBASE(object):
         return True
 
     def _update_unpacked_dir(self, checksum):
+        pass
+
+    def _remove_unpacked_dir(self, checksum):
         pass

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -464,6 +464,10 @@ class RemoteLOCAL(RemoteBASE):
         info = self.checksum_to_path_info(checksum)
         return info.with_name(info.name + self.UNPACKED_DIR_SUFFIX)
 
+    def _remove_unpacked_dir(self, checksum):
+        path_info = self._get_unpacked_dir_path_info(checksum)
+        self.remove(path_info)
+
     def _path_info_changed(self, path_info):
         if self.exists(path_info) and self.state.get(path_info):
             return False

--- a/tests/func/test_gc.py
+++ b/tests/func/test_gc.py
@@ -7,6 +7,7 @@ from git import Repo
 from dvc.exceptions import CollectCacheError
 from dvc.main import main
 from dvc.repo import Repo as DvcRepo
+from dvc.remote.local import RemoteLOCAL
 from tests.basic_env import TestDir, TestDvcGit
 
 
@@ -204,3 +205,18 @@ def test_gc_no_dir_cache(tmp_dir, dvc, repo_template):
 
 def _count_files(path):
     return sum(len(files) for _, _, files in os.walk(path))
+
+
+def test_gc_no_unpacked_dir(tmp_dir, dvc, repo_template):
+    dir_stages = dvc.add("dir")
+    dvc.status()
+
+    os.remove("dir.dvc")
+    unpackeddir = (
+        dir_stages[0].outs[0].cache_path + RemoteLOCAL.UNPACKED_DIR_SUFFIX
+    )
+
+    assert os.path.exists(unpackeddir)
+
+    dvc.gc(force=True)
+    assert not os.path.exists(unpackeddir)


### PR DESCRIPTION
In local remote its found that gc does not
remove the unpacked dir. This change set
helps to remove it.

Signed-off-by: Sujith H <sujith.h@gmail.com>

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

- Fixes https://github.com/iterative/dvc/issues/2946

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

