### PR TITLE
test: Merge _should_test_azure and _get_azure_url inside Azure test helper

### DIFF
--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -32,12 +32,12 @@ from tests.utils import spy
 
 from tests.remotes import (
     _should_test_aws,
-    _should_test_azure,
     _should_test_gcp,
     _should_test_gdrive,
     _should_test_hdfs,
     _should_test_oss,
     _should_test_ssh,
+    Azure,
     TEST_CONFIG,
     TEST_SECTION,
     TEST_GCP_CREDS_FILE,
@@ -45,7 +45,6 @@ from tests.remotes import (
     TEST_GDRIVE_CLIENT_SECRET,
     TEST_REMOTE,
     get_aws_url,
-    get_azure_url,
     get_gcp_url,
     get_gdrive_url,
     get_hdfs_url,
@@ -264,10 +263,10 @@ class TestRemoteGS(TestDataCloudBase):
 
 class TestRemoteAZURE(TestDataCloudBase):
     def _should_test(self):
-        return _should_test_azure()
+        return Azure.should_test()
 
     def _get_url(self):
-        return get_azure_url()
+        return Azure.get_url()
 
     def _get_cloud_class(self):
         return RemoteAZURE
@@ -535,10 +534,10 @@ class TestRemoteGSCLI(TestDataCloudCLIBase):
 
 class TestRemoteAZURECLI(TestDataCloudCLIBase):
     def _should_test(self):
-        return _should_test_azure()
+        return Azure.should_test()
 
     def _test(self):
-        url = get_azure_url()
+        url = Azure.get_url()
 
         self.main(["remote", "add", TEST_REMOTE, url])
 

--- a/tests/remotes.py
+++ b/tests/remotes.py
@@ -84,16 +84,6 @@ def _should_test_gcp():
     return True
 
 
-def _should_test_azure():
-    do_test = env2bool("DVC_TEST_AZURE", undefined=None)
-    if do_test is not None:
-        return do_test
-
-    return os.getenv("AZURE_STORAGE_CONTAINER_NAME") and os.getenv(
-        "AZURE_STORAGE_CONNECTION_STRING"
-    )
-
-
 def _should_test_oss():
     do_test = env2bool("DVC_TEST_OSS", undefined=None)
     if do_test is not None:
@@ -205,12 +195,6 @@ def get_gcp_url():
     return "gs://" + get_gcp_storagepath()
 
 
-def get_azure_url():
-    container_name = os.getenv("AZURE_STORAGE_CONTAINER_NAME")
-    assert container_name is not None
-    return "azure://{}/{}".format(container_name, str(uuid.uuid4()))
-
-
 def get_oss_storagepath():
     return "{}/{}".format(TEST_OSS_REPO_BUCKET, (uuid.uuid4()))
 
@@ -271,8 +255,21 @@ class GCP:
 
 
 class Azure:
-    should_test = staticmethod(_should_test_azure)
-    get_url = staticmethod(get_azure_url)
+    @staticmethod
+    def should_test():
+        do_test = env2bool("DVC_TEST_AZURE", undefined=None)
+        if do_test is not None:
+            return do_test
+
+        return os.getenv("AZURE_STORAGE_CONTAINER_NAME") and os.getenv(
+            "AZURE_STORAGE_CONNECTION_STRING"
+        )
+
+    @staticmethod
+    def get_url():
+        container_name = os.getenv("AZURE_STORAGE_CONTAINER_NAME")
+        assert container_name is not None
+        return "azure://{}/{}".format(container_name, str(uuid.uuid4()))
 
 
 class OSS:


### PR DESCRIPTION
I tried doing this in a single PR, but, it became fairly large. So, I'm just making a PR with a single change.

After merging all the functions inside `tests/remotes.py`, we could use the {Azure, S3, GCP, etc.} classes as mixins on the `TestCase`s.

Related to #2878.

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

