### PR TITLE
ui: don't show exception for "Too many files" error

### DIFF
--- a/dvc/logger.py
+++ b/dvc/logger.py
@@ -62,7 +62,7 @@ class ColorFormatter(logging.Formatter):
             return record.msg
 
         if record.levelname == "ERROR" or record.levelname == "CRITICAL":
-            exception, stack_trace = self._parse_exc(record.exc_info)
+            exception, stack_trace = self._parse_exc(record)
 
             return (
                 "{color}{levelname}{nc}: {description}" "{stack_trace}\n"
@@ -122,13 +122,15 @@ class ColorFormatter(logging.Formatter):
 
         return exc_list, tb_list
 
-    def _parse_exc(self, exc_info):
-        if not exc_info:
+    def _parse_exc(self, record):
+        tb_only = getattr(record, "tb_only", False)
+
+        if not record.exc_info:
             return (None, "")
 
-        exc_list, tb_list = self._walk_exc(exc_info)
+        exc_list, tb_list = self._walk_exc(record.exc_info)
 
-        exception = ": ".join(exc_list)
+        exception = None if tb_only else ": ".join(exc_list)
 
         if self._current_level() == logging.DEBUG:
             stack_trace = (

--- a/dvc/main.py
+++ b/dvc/main.py
@@ -60,7 +60,8 @@ def main(argv=None):
     except Exception as exc:  # pylint: disable=broad-except
         if isinstance(exc, OSError) and exc.errno == errno.EMFILE:
             logger.exception(
-                "too many open files, please increase your `ulimit`"
+                "too many open files, please increase your `ulimit`",
+                extra={"tb_only": True},
             )
         else:
             logger.exception("unexpected error")

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -102,6 +102,25 @@ class TestColorFormatter:
 
             assert expected == formatter.format(caplog.records[0])
 
+    def test_tb_only(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger="dvc"):
+            try:
+                raise Exception("description")
+            except Exception:
+                stack_trace = traceback.format_exc()
+                logger.exception("something", extra={"tb_only": True})
+
+            expected = (
+                "{red}ERROR{nc}: something\n"
+                "{red}{line}{nc}\n"
+                "{stack_trace}"
+                "{red}{line}{nc}\n".format(
+                    line="-" * 60, stack_trace=stack_trace, **colors
+                )
+            )
+
+            assert expected == formatter.format(caplog.records[0])
+
     def test_nested_exceptions(self, caplog):
         with caplog.at_level(logging.DEBUG, logger="dvc"):
             try:


### PR DESCRIPTION
https://github.com/iterative/dvc.org/pull/875#discussion_r362920851

Stops showing the exception in non-verbose mode, but shows full
traceback in verbose mode.

Introducing our custom parameter `tb_only` through standard `extra`
logging parameter.

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

