### PR TITLE
logger: use py3 methods to display the exception

### DIFF
--- a/dvc/logger.py
+++ b/dvc/logger.py
@@ -59,13 +59,11 @@ class ColorFormatter(logging.Formatter):
 
         if record.exc_info:
             _, exception, _ = record.exc_info
-            cause = exception.__cause__
 
-            info = "{message}{separator}{exception}{cause}".format(
+            info = "{message}{separator}{exception}".format(
                 message=record.msg or "",
                 separator=" - " if record.msg and exception.args else "",
-                exception=exception,
-                cause=": " + str(cause) if cause else "",
+                exception=": ".join(self._causes(exception)),
             )
 
             if self._current_level() == logging.DEBUG:
@@ -91,6 +89,11 @@ class ColorFormatter(logging.Formatter):
             nc=colorama.Fore.RESET,
             info=info,
         )
+
+    def _causes(self, exc):
+        while exc:
+            yield str(exc)
+            exc = exc.__cause__
 
     def _current_level(self):
         return logging.getLogger("dvc").getEffectiveLevel()

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -107,21 +107,26 @@ class TestColorFormatter:
             except Exception as exc:
                 try:
                     raise DvcException("second") from exc
-                except DvcException:
-                    stack_trace = traceback.format_exc()
-                    logger.exception("message")
+                except DvcException as exc:
+                    try:
+                        raise ValueError("third") from exc
+                    except ValueError:
+                        stack_trace = traceback.format_exc()
+                        logger.exception("message")
 
             expected = (
-                "{red}ERROR{nc}: message - second: first\n"
+                "{red}ERROR{nc}: message - third: second: first\n"
                 "{red}{line}{nc}\n"
                 "{stack_trace}"
                 "{red}{line}{nc}".format(
                     line="-" * 60, stack_trace=stack_trace, **colors
                 )
             )
+
             assert expected == formatter.format(caplog.records[0])
             assert "Exception: first" in stack_trace
             assert "dvc.exceptions.DvcException: second" in stack_trace
+            assert "ValueError: third" in stack_trace
 
     def test_progress_awareness(self, mocker, capsys, caplog):
         from dvc.progress import Tqdm

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -44,7 +44,7 @@ class TestColorFormatter:
         with caplog.at_level(logging.INFO, logger="dvc"):
             logger.error("message")
 
-            expected = "{red}ERROR{nc}: message\n".format(**colors)
+            expected = "{red}ERROR{nc}: message".format(**colors)
 
             assert expected == formatter.format(caplog.records[0])
 
@@ -55,7 +55,7 @@ class TestColorFormatter:
             except Exception:
                 logger.exception("message")
 
-            expected = "{red}ERROR{nc}: message\n".format(**colors)
+            expected = "{red}ERROR{nc}: message".format(**colors)
 
             assert expected == formatter.format(caplog.records[0])
 
@@ -66,7 +66,7 @@ class TestColorFormatter:
             except Exception:
                 logger.exception("")
 
-            expected = "{red}ERROR{nc}: description\n".format(**colors)
+            expected = "{red}ERROR{nc}: description".format(**colors)
 
             assert expected == formatter.format(caplog.records[0])
 
@@ -77,9 +77,7 @@ class TestColorFormatter:
             except Exception:
                 logger.exception("message")
 
-            expected = "{red}ERROR{nc}: message - description\n".format(
-                **colors
-            )
+            expected = "{red}ERROR{nc}: message - description".format(**colors)
 
             assert expected == formatter.format(caplog.records[0])
 
@@ -95,7 +93,7 @@ class TestColorFormatter:
                 "{red}ERROR{nc}: description\n"
                 "{red}{line}{nc}\n"
                 "{stack_trace}"
-                "{red}{line}{nc}\n".format(
+                "{red}{line}{nc}".format(
                     line="-" * 60, stack_trace=stack_trace, **colors
                 )
             )
@@ -117,7 +115,7 @@ class TestColorFormatter:
                 "{red}ERROR{nc}: message - second: first\n"
                 "{red}{line}{nc}\n"
                 "{stack_trace}"
-                "{red}{line}{nc}\n".format(
+                "{red}{line}{nc}".format(
                     line="-" * 60, stack_trace=stack_trace, **colors
                 )
             )


### PR DESCRIPTION
Related: #1818 

Did the best that I could. `formatException` and `formatStack` doesn't work for us because of the way we are displaying the traceback and manipulating the title of the exception.