### PR TITLE
Snap classic deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,14 @@ jobs:
     - sudo snapcraft --use-lxd
     after_failure:
     - sudo journalctl -u snapd
+    #uncomment after classic approval
+    #<>
+    #stage: deploy
+    #deploy:
+    #- provider: snap
+    #  snap: dvc_*.snap
+    #  channel: ${SOURCE_TAG:+stable}${SOURCE_TAG:-edge}
+    #  skip_cleanup: true
   # deploy jobs
   - name: "Pypi pkgs"
     if: tag is present

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,33 +75,6 @@ jobs:
     language: python
     python: 3.7
     script: ./scripts/build_package.sh
-  - name: Snapcraft snap
-    addons:
-     snaps:
-     - name: snapcraft
-       channel: stable
-       confinement: classic
-     - name: lxd
-       channel: stable
-    env:
-    - SNAPCRAFT_IMAGE_INFO: '{"build_url": "$TRAVIS_BUILD_URL"}'
-    before_install:
-    - sudo /snap/bin/lxd.migrate -yes
-    - sudo /snap/bin/lxd waitready
-    - sudo /snap/bin/lxd init --auto
-    install:
-    script:
-    - sudo snapcraft --use-lxd
-    after_failure:
-    - sudo journalctl -u snapd
-    #uncomment after classic approval
-    #<>
-    #stage: deploy
-    #deploy:
-    #- provider: snap
-    #  snap: dvc_*.snap
-    #  channel: ${SOURCE_TAG:+stable}${SOURCE_TAG:-edge}
-    #  skip_cleanup: true
   # deploy jobs
   - name: "Pypi pkgs"
     if: tag is present
@@ -124,6 +97,31 @@ jobs:
       on:
         tags: true
         repo: iterative/dvc
+  - name: Snapcraft snap
+    addons:
+     snaps:
+     - name: snapcraft
+       channel: stable
+       confinement: classic
+     - name: lxd
+       channel: stable
+    env:
+    - SNAPCRAFT_IMAGE_INFO: '{"build_url": "$TRAVIS_BUILD_URL"}'
+    before_install:
+    - sudo /snap/bin/lxd.migrate -yes
+    - sudo /snap/bin/lxd waitready
+    - sudo /snap/bin/lxd init --auto
+    install:
+    script:
+    - sudo snapcraft --use-lxd
+    after_failure:
+    - sudo journalctl -u snapd
+    stage: deploy
+    deploy:
+    - provider: snap
+      snap: dvc_*.snap
+      channel: ${SOURCE_TAG:+stable}${SOURCE_TAG:-edge}
+      skip_cleanup: true
 
 before_install:
   - bash ./scripts/ci/before_install.sh
@@ -144,7 +142,6 @@ deploy:
       - dvc*.deb
       - dvc*.pkg
       - dvc*.exe
-      - dvc*.snap
     skip_cleanup: true
     on:
       tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,6 @@ jobs:
     - sudo snapcraft --use-lxd
     after_failure:
     - sudo journalctl -u snapd
-    stage: deploy
     deploy:
     - provider: snap
       snap: dvc_*.snap

--- a/README.rst
+++ b/README.rst
@@ -153,17 +153,12 @@ Currently, this includes support for Python versions 2.7, 3.6 and 3.7.
 Snap (Snapcraft)
 ----------------
 
-Download the latest ``dvc_*.snap`` from the
-GitHub `releases page <https://github.com/iterative/dvc/releases>`_.
-
 .. code-block:: bash
 
-   snap install dvc_*.snap --dangerous --classic
+   snap install dvc --classic
 
-Once ``dvc`` is released on the snap store
-(`pending request <https://forum.snapcraft.io/t/classic-confinement-request-for-dvc/14124>`_)
-there will be no need to download ``dvc_*.snap`` or use ``--dangerous``
-(``snap install dvc --classic`` would suffice).
+This corresponds to the latest tagged release.
+Add ``--edge`` for the latest ``master`` version.
 
 Package
 -------


### PR DESCRIPTION
Finally have approval (https://forum.snapcraft.io/t/classic-confinement-request-for-dvc/14124/8) so can deploy snaps to the snapcraft store!

- [x] update CI to auto-deploy to snap store (https://snapcraft.io/dvc)
  + `--edge` <- `master`
  + `--stable` <- tags
- [x] manually release `0.80.0` from https://github.com/iterative/dvc/releases/download/0.80.0/dvc_0.80.0_amd64.snap to check that it works

Note from approval:

> This snap is using `classic` confinement. The publisher of this snap has been vetted (https://forum.snapcraft.io/t/classic-confinement-request-for-dvc/14124/7) and this snap is now granted use of `confinement: classic`. Note, future uploads may require the snap come from a build on our infrastructure (https://launchpad.net/bugs/1657825) so if you haven't done so already, please configure your builds at https://build.snapcraft.io