### PR TITLE
fix snap deploy stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,7 +123,7 @@ jobs:
       channel: ${SOURCE_TAG:+stable}${SOURCE_TAG:-edge}
       skip_cleanup: true
       on:
-        tags: true
+        branch: master
         repo: iterative/dvc
 
 before_install:


### PR DESCRIPTION
- [x] fix `snapcraft` deploy authentication (https://travis-ci.com/iterative/dvc/jobs/272673458#L2100)
  + ~~seems this is similar to upstream https://github.com/travis-ci/dpl/pull/1122~~ just regenerated the auth token
  + [x] restart & sucessfully complete https://travis-ci.com/iterative/dvc/jobs/272673458
- [x] make `snap` CI builds appear in the `deploy` stage as intended
  + seems like because the previous job doesn't run on non-tagged master branch builds, its `stage: deploy` doesn't propagate
- continues #3063 