### PR TITLE
rwlock: check that .dvc/lock is locked

### DIFF
--- a/dvc/lock.py
+++ b/dvc/lock.py
@@ -68,6 +68,10 @@ class Lock(object):
         self._lock.close()
         self._lock = None
 
+    @property
+    def is_locked(self):
+        return bool(self._lock)
+
     def __enter__(self):
         self.lock()
 

--- a/dvc/repo/destroy.py
+++ b/dvc/repo/destroy.py
@@ -1,8 +1,15 @@
 from dvc.utils.fs import remove
+from . import locked
 
 
-def destroy(self):
-    for stage in self.stages:
+@locked
+def _destroy_stages(repo):
+    for stage in repo.stages:
         stage.remove(remove_outs=False)
 
-    remove(self.dvc_dir)
+
+# NOTE: not locking `destroy`, as `remove` will need to delete `.dvc` dir,
+# which will cause issues on Windows, as `.dvc/lock` will be busy.
+def destroy(repo):
+    _destroy_stages(repo)
+    remove(repo.dvc_dir)

--- a/dvc/stage.py
+++ b/dvc/stage.py
@@ -143,6 +143,8 @@ def rwlocked(call, read=None, write=None):
 
     stage = call._args[0]
 
+    assert stage.repo.lock.is_locked
+
     def _chain(names):
         return [
             item.path_info

--- a/tests/func/test_repro.py
+++ b/tests/func/test_repro.py
@@ -841,7 +841,7 @@ class TestReproExternalBase(TestDvc):
 
         patch_run = patch.object(stage, "_run", wraps=stage._run)
 
-        with self.dvc.state:
+        with self.dvc.lock, self.dvc.state:
             with patch_download as mock_download:
                 with patch_checkout as mock_checkout:
                     with patch_run as mock_run:

--- a/tests/func/test_run.py
+++ b/tests/func/test_run.py
@@ -655,7 +655,8 @@ def test_run_deterministic_overwrite(deterministic_run):
 
 
 def test_run_deterministic_callback(deterministic_run):
-    deterministic_run.stage.remove()
+    with deterministic_run.stage.repo.lock:
+        deterministic_run.stage.remove()
     deterministic_run.deps = []
     deterministic_run.run()
     with mock.patch("dvc.prompt.confirm", return_value=True):

--- a/tests/func/test_stage.py
+++ b/tests/func/test_stage.py
@@ -108,7 +108,7 @@ class TestDefaultWorkingDirectory(TestDvc):
         d = load_stage_file(stage.relpath)
         self.assertNotIn(Stage.PARAM_WDIR, d.keys())
 
-        with self.dvc.state:
+        with self.dvc.lock, self.dvc.state:
             stage = Stage.load(self.dvc, stage.relpath)
             self.assertFalse(stage.changed())
 

--- a/tests/unit/test_stage.py
+++ b/tests/unit/test_stage.py
@@ -111,5 +111,6 @@ def test_stage_run_ignore_sigint(dvc_repo, mocker):
 def test_always_changed(dvc_repo):
     stage = Stage(dvc_repo, "path", always_changed=True)
     stage.save()
-    assert stage.changed()
-    assert stage.status()["path"] == ["always changed"]
+    with dvc_repo.lock:
+        assert stage.changed()
+        assert stage.status()["path"] == ["always changed"]


### PR DESCRIPTION
Mostly a sanity check, but we did have a potential bug in `destroy`,
whcih this PR fixes along the way.

Kudos @shcheklein for catching this one.

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

