### PR TITLE
rwlock: flush and fsync

### DIFF
--- a/dvc/rwlock.py
+++ b/dvc/rwlock.py
@@ -50,6 +50,9 @@ def _edit_rwlock(lock_dir):
     yield lock
     with open(path, "w+") as fobj:
         json.dump(lock, fobj)
+        # NOTE: flush and fsync to ensure that rwlock contents are saved
+        fobj.flush()
+        os.fsync(fobj.fileno())
 
 
 def _infos_to_str(infos):


### PR DESCRIPTION
It is important that we ensure that rwlocked contents are flushed to
disk, because otherwise other rwlock readers might get outdated state.

Kudos @shcheklein for catching this one.

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

