### PR TITLE
get: handle non-DVC repositories

### DIFF
--- a/dvc/command/get.py
+++ b/dvc/command/get.py
@@ -31,7 +31,7 @@ class CmdGet(CmdBaseNoRepo):
 
 
 def add_parser(subparsers, parent_parser):
-    GET_HELP = "Download/copy files or directories from Git repository."
+    GET_HELP = "Download a file or directory from any DVC project or Git repository"
     get_parser = subparsers.add_parser(
         "get",
         parents=[parent_parser],

--- a/dvc/command/get.py
+++ b/dvc/command/get.py
@@ -50,10 +50,7 @@ def add_parser(subparsers, parent_parser):
         help="Path to a file or directory within the project or repository",
     )
     get_parser.add_argument(
-        "-o",
-        "--out",
-        nargs="?",
-        help="Destination path to download files to",
+        "-o", "--out", nargs="?", help="Destination path to download files to"
     )
     get_parser.add_argument(
         "--rev", nargs="?", help="Git revision (e.g. branch, tag, SHA)"

--- a/dvc/command/get.py
+++ b/dvc/command/get.py
@@ -43,7 +43,7 @@ def add_parser(subparsers, parent_parser):
         "url", help="URL of Git repository to download from."
     )
     get_parser.add_argument(
-        "path", help="Path to a file or directory within the repository."
+        "path", help="Path to a file or directory within the project or repository"
     )
     get_parser.add_argument(
         "-o",

--- a/dvc/command/get.py
+++ b/dvc/command/get.py
@@ -40,7 +40,7 @@ def add_parser(subparsers, parent_parser):
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     get_parser.add_argument(
-        "url", help="URL of Git repository to download from."
+        "url", help="Location of DVC project or Git repository to download from"
     )
     get_parser.add_argument(
         "path", help="Path to a file or directory within the project or repository"

--- a/dvc/command/get.py
+++ b/dvc/command/get.py
@@ -31,7 +31,9 @@ class CmdGet(CmdBaseNoRepo):
 
 
 def add_parser(subparsers, parent_parser):
-    GET_HELP = "Download a file or directory from any DVC project or Git repository"
+    GET_HELP = (
+        "Download a file or directory from any DVC project or Git repository"
+    )
     get_parser = subparsers.add_parser(
         "get",
         parents=[parent_parser],
@@ -40,10 +42,12 @@ def add_parser(subparsers, parent_parser):
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     get_parser.add_argument(
-        "url", help="Location of DVC project or Git repository to download from"
+        "url",
+        help="Location of DVC project or Git repository to download from.",
     )
     get_parser.add_argument(
-        "path", help="Path to a file or directory within the project or repository"
+        "path",
+        help="Path to a file or directory within the project or repository",
     )
     get_parser.add_argument(
         "-o",

--- a/dvc/command/get.py
+++ b/dvc/command/get.py
@@ -31,7 +31,7 @@ class CmdGet(CmdBaseNoRepo):
 
 
 def add_parser(subparsers, parent_parser):
-    GET_HELP = "Download/copy files or directories from DVC repository."
+    GET_HELP = "Download/copy files or directories from git repository."
     get_parser = subparsers.add_parser(
         "get",
         parents=[parent_parser],
@@ -40,10 +40,10 @@ def add_parser(subparsers, parent_parser):
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     get_parser.add_argument(
-        "url", help="URL of Git repository with DVC project to download from."
+        "url", help="URL of Git repository to download from."
     )
     get_parser.add_argument(
-        "path", help="Path to a file or directory within a DVC repository."
+        "path", help="Path to a file or directory within the repository."
     )
     get_parser.add_argument(
         "-o",
@@ -52,6 +52,6 @@ def add_parser(subparsers, parent_parser):
         help="Destination path to copy/download files to.",
     )
     get_parser.add_argument(
-        "--rev", nargs="?", help="DVC repository git revision."
+        "--rev", nargs="?", help="Repository git revision."
     )
     get_parser.set_defaults(func=CmdGet)

--- a/dvc/command/get.py
+++ b/dvc/command/get.py
@@ -52,6 +52,6 @@ def add_parser(subparsers, parent_parser):
         help="Destination path to copy/download files to.",
     )
     get_parser.add_argument(
-        "--rev", nargs="?", help="Repository git revision."
+        "--rev", nargs="?", help="Git revision (e.g. branch, tag, SHA)"
     )
     get_parser.set_defaults(func=CmdGet)

--- a/dvc/command/get.py
+++ b/dvc/command/get.py
@@ -31,7 +31,7 @@ class CmdGet(CmdBaseNoRepo):
 
 
 def add_parser(subparsers, parent_parser):
-    GET_HELP = "Download/copy files or directories from git repository."
+    GET_HELP = "Download/copy files or directories from Git repository."
     get_parser = subparsers.add_parser(
         "get",
         parents=[parent_parser],

--- a/dvc/command/get.py
+++ b/dvc/command/get.py
@@ -32,7 +32,7 @@ class CmdGet(CmdBaseNoRepo):
 
 def add_parser(subparsers, parent_parser):
     GET_HELP = (
-        "Download a file or directory from any DVC project or Git repository"
+        "Download a file or directory from any DVC project or Git repository."
     )
     get_parser = subparsers.add_parser(
         "get",
@@ -43,7 +43,7 @@ def add_parser(subparsers, parent_parser):
     )
     get_parser.add_argument(
         "url",
-        help="Location of DVC project or Git repository to download from.",
+        help="Location of DVC project or Git repository to download from",
     )
     get_parser.add_argument(
         "path",
@@ -53,7 +53,7 @@ def add_parser(subparsers, parent_parser):
         "-o",
         "--out",
         nargs="?",
-        help="Destination path to copy/download files to.",
+        help="Destination path to download files to",
     )
     get_parser.add_argument(
         "--rev", nargs="?", help="Git revision (e.g. branch, tag, SHA)"

--- a/dvc/command/imp.py
+++ b/dvc/command/imp.py
@@ -30,8 +30,8 @@ class CmdImport(CmdBase):
 
 def add_parser(subparsers, parent_parser):
     IMPORT_HELP = (
-        "Download a file or directory from any DVC project or Git repository and take it under "
-        "DVC control."
+        "Download a file or directory from any DVC project or Git repository"
+        "and take it under DVC control."
     )
 
     import_parser = subparsers.add_parser(
@@ -45,7 +45,10 @@ def add_parser(subparsers, parent_parser):
         "url",
         help="Location of DVC project or Git repository to download from",
     )
-    import_parser.add_argument("path", help="Path to a file or directory within the project or repository")
+    import_parser.add_argument(
+        "path",
+        help="Path to a file or directory within the project or repository",
+    )
     import_parser.add_argument(
         "-o", "--out", nargs="?", help="Destination path to download files to"
     )

--- a/dvc/command/imp.py
+++ b/dvc/command/imp.py
@@ -30,7 +30,8 @@ class CmdImport(CmdBase):
 
 def add_parser(subparsers, parent_parser):
     IMPORT_HELP = (
-        "Download data from DVC repository and take it under DVC control."
+        "Download data from DVC project or Git repository and take it under "
+        "DVC control."
     )
 
     import_parser = subparsers.add_parser(
@@ -41,13 +42,12 @@ def add_parser(subparsers, parent_parser):
         formatter_class=argparse.RawTextHelpFormatter,
     )
     import_parser.add_argument(
-        "url", help="URL of Git repository with DVC project to download from."
+        "url",
+        help="Location of Git repository with DVC project to download from.",
     )
+    import_parser.add_argument("path", help="Path to data within DVC project.")
     import_parser.add_argument(
-        "path", help="Path to data within DVC repository."
-    )
-    import_parser.add_argument(
-        "-o", "--out", nargs="?", help="Destination path to put data to."
+        "-o", "--out", nargs="?", help="Destination path to put data in."
     )
     import_parser.add_argument(
         "--rev", nargs="?", help="DVC repository git revision."

--- a/dvc/command/imp.py
+++ b/dvc/command/imp.py
@@ -30,7 +30,7 @@ class CmdImport(CmdBase):
 
 def add_parser(subparsers, parent_parser):
     IMPORT_HELP = (
-        "Download data from DVC project or Git repository and take it under "
+        "Download a file or directory from any DVC project or Git repository and take it under "
         "DVC control."
     )
 
@@ -43,13 +43,13 @@ def add_parser(subparsers, parent_parser):
     )
     import_parser.add_argument(
         "url",
-        help="Location of Git repository with DVC project to download from.",
+        help="Location of DVC project or Git repository to download from",
     )
-    import_parser.add_argument("path", help="Path to data within DVC project.")
+    import_parser.add_argument("path", help="Path to a file or directory within the project or repository")
     import_parser.add_argument(
-        "-o", "--out", nargs="?", help="Destination path to put data in."
+        "-o", "--out", nargs="?", help="Destination path to download files to"
     )
     import_parser.add_argument(
-        "--rev", nargs="?", help="DVC repository git revision."
+        "--rev", nargs="?", help="Git revision (e.g. branch, tag, SHA)"
     )
     import_parser.set_defaults(func=CmdImport)

--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -240,11 +240,6 @@ class DvcIgnoreInCollectedDirError(DvcException):
         )
 
 
-class UrlNotDvcRepoError(DvcException):
-    def __init__(self, url):
-        super().__init__("URL '{}' is not a dvc repository.".format(url))
-
-
 class GitHookAlreadyExistsError(DvcException):
     def __init__(self, hook_name):
         super().__init__(

--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -33,7 +33,7 @@ def external_repo(url=None, rev=None, rev_lock=None, cache_dir=None):
     repo.close()
 
 
-def cached_clone(url, rev=None, **_ignored_kwargs):
+def cached_clone(url, rev=None, clone_path=None, **_ignored_kwargs):
     """Clone an external git repo to a temporary directory.
 
     Returns the path to a local temporary directory with the specified
@@ -44,7 +44,7 @@ def cached_clone(url, rev=None, **_ignored_kwargs):
 
     """
 
-    new_path = tempfile.mkdtemp("dvc-erepo")
+    new_path = clone_path or tempfile.mkdtemp("dvc-erepo")
 
     # Copy and adjust existing clean clone
     if (url, None, None) in REPO_CACHE:

--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -33,7 +33,7 @@ def external_repo(url=None, rev=None, rev_lock=None, cache_dir=None):
     repo.close()
 
 
-def cached_clone(url, rev=None, clone_path=None, **_ignored_kwargs):
+def cached_clone(url, rev=None, **_ignored_kwargs):
     """Clone an external git repo to a temporary directory.
 
     Returns the path to a local temporary directory with the specified
@@ -44,7 +44,7 @@ def cached_clone(url, rev=None, clone_path=None, **_ignored_kwargs):
 
     """
 
-    new_path = clone_path or tempfile.mkdtemp("dvc-erepo")
+    new_path = tempfile.mkdtemp("dvc-erepo")
 
     # Copy and adjust existing clean clone
     if (url, None, None) in REPO_CACHE:

--- a/dvc/repo/get.py
+++ b/dvc/repo/get.py
@@ -70,7 +70,6 @@ def get(url, path, out=None, rev=None):
 
             output = repo.find_out_by_relpath(path)
             if output.use_cache:
-                # Catch this below and go for a plain old fs_copy
                 _get_cached(repo, output, out)
                 return
 

--- a/dvc/repo/get.py
+++ b/dvc/repo/get.py
@@ -27,6 +27,11 @@ class GetDVCFileError(DvcException):
         )
 
 
+def _forbid_absolute_path(path):
+    if os.path.isabs(path):
+        raise FileNotFoundError
+
+
 @staticmethod
 def get(url, path, out=None, rev=None):
     out = resolve_output(path, out)
@@ -66,8 +71,7 @@ def get(url, path, out=None, rev=None):
                     return
 
                 # Either an uncached out with absolute path or a user error
-                if os.path.isabs(path):
-                    raise FileNotFoundError
+                _forbid_absolute_path(path)
 
                 fs_copy(os.path.join(repo.root_dir, path), out)
                 return
@@ -76,6 +80,7 @@ def get(url, path, out=None, rev=None):
             # Not a DVC repository, continue below and copy from git
             pass
 
+        _forbid_absolute_path(path)
         raw_git_dir = cached_clone(url, rev=rev)
         fs_copy(os.path.join(raw_git_dir, path), out)
     except (OutputNotFoundError, FileNotFoundError):

--- a/dvc/repo/get.py
+++ b/dvc/repo/get.py
@@ -3,6 +3,8 @@ import os
 
 import shortuuid
 
+from dvc.cache import CacheConfig
+from dvc.config import Config
 from dvc.exceptions import (
     DvcException,
     NotDvcRepoError,
@@ -49,9 +51,11 @@ def get(url, path, out=None, rev=None):
     dpath = os.path.dirname(os.path.abspath(out))
     tmp_dir = os.path.join(dpath, "." + str(shortuuid.uuid()))
     try:
-        cached_clone(url, rev=rev, clone_path=tmp_dir)
+        clone_dir = cached_clone(url, rev=rev)
         try:
-            repo = Repo(tmp_dir)
+            repo = Repo(clone_dir)
+            cache_config = CacheConfig(repo.config)
+            cache_config.set_dir(tmp_dir, level=Config.LEVEL_LOCAL)
 
             # Try any links possible to avoid data duplication.
             #
@@ -78,12 +82,13 @@ def get(url, path, out=None, rev=None):
         if os.path.isabs(path):
             raise FileNotFoundError
 
-        fs_copy(os.path.join(tmp_dir, path), out)
+        fs_copy(os.path.join(clone_dir, path), out)
 
     except (OutputNotFoundError, FileNotFoundError):
         raise PathMissingError(path, url)
     finally:
         remove(tmp_dir)
+        remove(clone_dir)
 
 
 def _get_cached(repo, output, out):

--- a/dvc/repo/get.py
+++ b/dvc/repo/get.py
@@ -27,11 +27,6 @@ class GetDVCFileError(DvcException):
         )
 
 
-# Dummy exception raised to signal a plain file copy is needed
-class _DoPlainCopy(DvcException):
-    pass
-
-
 @staticmethod
 def get(url, path, out=None, rev=None):
     from dvc.repo import Repo

--- a/dvc/repo/get.py
+++ b/dvc/repo/get.py
@@ -46,7 +46,6 @@ def get(url, path, out=None, rev=None):
     # and won't work with reflink/hardlink.
     dpath = os.path.dirname(os.path.abspath(out))
     tmp_dir = os.path.join(dpath, "." + str(shortuuid.uuid()))
-    raw_git_dir = None
     try:
         try:
             with external_repo(cache_dir=tmp_dir, url=url, rev=rev) as repo:
@@ -87,8 +86,6 @@ def get(url, path, out=None, rev=None):
         raise PathMissingError(path, url)
     finally:
         remove(tmp_dir)
-        if raw_git_dir:
-            remove(raw_git_dir)
 
 
 def _get_cached(repo, output, out):

--- a/dvc/repo/get.py
+++ b/dvc/repo/get.py
@@ -66,7 +66,6 @@ def get(url, path, out=None, rev=None):
                     return
 
                 # Either an uncached out with absolute path or a user error
-
                 if os.path.isabs(path):
                     raise FileNotFoundError
 

--- a/tests/func/test_get.py
+++ b/tests/func/test_get.py
@@ -136,6 +136,14 @@ def test_absolute_file_outside_repo(tmp_dir, erepo_dir):
         Repo.get(fspath(erepo_dir), "/root/")
 
 
+def test_absolute_file_outside_git_repo(tmp_dir, erepo_dir):
+    erepo_dir.scm.repo.index.remove([erepo_dir.dvc.dvc_dir], r=True)
+    erepo_dir.scm.commit("remove dvc")
+
+    with pytest.raises(PathMissingError):
+        Repo.get(fspath(erepo_dir), "/root/")
+
+
 def test_unknown_path(tmp_dir, erepo_dir):
     with pytest.raises(PathMissingError):
         Repo.get(fspath(erepo_dir), "a_non_existing_file")


### PR DESCRIPTION
Allows us to `dvc get` from non-DVC source repositories.

Fixes #3089
Closes #3077

Will send PR for doc site tomorrow. Just need to change some parts which imply that the remote repository needs to be DVC-enabled.

----

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

docs: https://github.com/iterative/dvc.org/issues/911

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏