### PR TITLE
version: decode correctly commands output

### DIFF
--- a/dvc/version.py
+++ b/dvc/version.py
@@ -49,7 +49,7 @@ def _is_release(dir_path, base_version):
             ["git", "describe", "--tags", "--exact-match"],
             cwd=dir_path,
             stderr=subprocess.STDOUT,
-        )
+        ).decode("utf-8")
         tag = output.strip()
         return tag == base_version
     except subprocess.CalledProcessError:

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -12,10 +12,10 @@ def test_is_release():
         assert ret is False
 
         m.side_effect = None
-        m.return_value = dvc.version._BASE_VERSION
+        m.return_value = dvc.version._BASE_VERSION.encode("ascii")
         ret = dvc.version._is_release(None, dvc.version._BASE_VERSION)
         assert ret
 
-        m.return_value = "630d1741c2d5dd89a3176bd15b63121b905d35c9"
+        m.return_value = b"630d1741c2d5dd89a3176bd15b63121b905d35c9"
         ret = dvc.version._is_release(None, dvc.version._BASE_VERSION)
         assert ret is False


### PR DESCRIPTION
By default, `check_output` returns the data as encoded bytes.
We need to decode it properly to compare them with strings.

Using `bytes` as the return value of `check_output` mock will reflect the behavior correctly.

Close #3127