### PR TITLE
status: implement support for imported files

### DIFF
--- a/dvc/dependency/repo.py
+++ b/dvc/dependency/repo.py
@@ -115,7 +115,6 @@ class DependencyREPO(DependencyLOCAL):
     def status(self):
         current_fileinfo = self._get_fileinfo(updated=False)
         updated_fileinfo = self._get_fileinfo(updated=True)
-        print("CURRENT", current_fileinfo, "UPDATED", updated_fileinfo)
 
         if current_fileinfo["checksum"] and updated_fileinfo["checksum"]:
             has_changed = (

--- a/dvc/dependency/repo.py
+++ b/dvc/dependency/repo.py
@@ -9,6 +9,7 @@ from dvc.external_repo import cached_clone
 from dvc.external_repo import external_repo
 from dvc.exceptions import NotDvcRepoError
 from dvc.exceptions import OutputNotFoundError
+from dvc.exceptions import NoOutputInExternalRepoError
 from dvc.exceptions import PathMissingError
 from dvc.utils.fs import fs_copy
 from dvc.path_info import PathInfo
@@ -55,8 +56,7 @@ class DependencyREPO(DependencyLOCAL):
         try:
             with self._make_repo(rev_lock=rev_lock) as repo:
                 return repo.find_out_by_relpath(self.def_path).info["md5"]
-
-        except (NotDvcRepoError, OutputNotFoundError):
+        except (NotDvcRepoError, NoOutputInExternalRepoError):
             # Fall through and clone
             pass
 

--- a/dvc/dependency/repo.py
+++ b/dvc/dependency/repo.py
@@ -54,20 +54,19 @@ class DependencyREPO(DependencyLOCAL):
 
         try:
             with self._make_repo(rev_lock=rev_lock) as repo:
-                try:
-                    return repo.find_out_by_relpath(self.def_path).info["md5"]
-                except OutputNotFoundError:
-                    # Fall through to after exception handler
-                    path = os.path.join(repo.root_dir, self.def_path)
+                return repo.find_out_by_relpath(self.def_path).info["md5"]
 
-        except NotDvcRepoError:
-            repo_path = cached_clone(
-                self.def_repo[self.PARAM_URL],
-                rev=rev_lock or self.def_repo.get(self.PARAM_REV),
-            )
-            path = os.path.join(repo_path, self.def_path)
+        except (NotDvcRepoError, OutputNotFoundError):
+            # Fall through and clone
+            pass
 
-        return self.repo.cache.local.get_checksum(PathInfo(path))
+        repo_path = cached_clone(
+            self.def_repo[self.PARAM_URL],
+            rev=rev_lock or self.def_repo.get(self.PARAM_REV),
+        )
+        path = PathInfo(os.path.join(repo_path, self.def_path))
+
+        return self.repo.cache.local.get_checksum(path)
 
     def status(self):
         current_checksum = self._get_checksum(updated=False)

--- a/dvc/repo/status.py
+++ b/dvc/repo/status.py
@@ -19,7 +19,7 @@ def _local_status(self, targets=None, with_deps=False):
         stages = self.collect(None, with_deps=with_deps)
 
     for stage in stages:
-        if stage.locked:
+        if stage.locked and not stage.is_repo_import:
             logger.warning(
                 "DVC-file '{path}' is locked. Its dependencies are"
                 " not going to be shown in the status output.".format(
@@ -27,7 +27,7 @@ def _local_status(self, targets=None, with_deps=False):
                 )
             )
 
-        status.update(stage.status())
+        status.update(stage.status(for_status_command=True))
 
     return status
 

--- a/dvc/repo/status.py
+++ b/dvc/repo/status.py
@@ -10,13 +10,8 @@ from . import locked
 logger = logging.getLogger(__name__)
 
 
-def _local_status(self, targets=None, with_deps=False):
+def _joint_status(stages):
     status = {}
-
-    if targets:
-        stages = cat(self.collect(t, with_deps=with_deps) for t in targets)
-    else:
-        stages = self.collect(None, with_deps=with_deps)
 
     for stage in stages:
         if stage.locked and not stage.is_repo_import:
@@ -30,6 +25,15 @@ def _local_status(self, targets=None, with_deps=False):
         status.update(stage.status(for_status_command=True))
 
     return status
+
+
+def _local_status(self, targets=None, with_deps=False):
+    if targets:
+        stages = cat(self.collect(t, with_deps=with_deps) for t in targets)
+    else:
+        stages = self.collect(None, with_deps=with_deps)
+
+    return _joint_status(stages)
 
 
 def _cloud_status(

--- a/dvc/repo/status.py
+++ b/dvc/repo/status.py
@@ -22,7 +22,7 @@ def _joint_status(stages):
                 )
             )
 
-        status.update(stage.status(for_status_command=True))
+        status.update(stage.status(check_updates=True))
 
     return status
 

--- a/dvc/stage.py
+++ b/dvc/stage.py
@@ -1006,10 +1006,10 @@ class Stage(object):
         return ret
 
     @rwlocked(read=["deps", "outs"])
-    def status(self, for_status_command=False):
+    def status(self, check_updates=False):
         ret = []
 
-        show_import = self.is_repo_import and for_status_command
+        show_import = self.is_repo_import and check_updates
 
         if not self.locked or show_import:
             deps_status = self._status(self.deps)

--- a/dvc/stage.py
+++ b/dvc/stage.py
@@ -1006,10 +1006,12 @@ class Stage(object):
         return ret
 
     @rwlocked(read=["deps", "outs"])
-    def status(self):
+    def status(self, for_status_command=False):
         ret = []
 
-        if not self.locked:
+        show_import = self.is_repo_import and for_status_command
+
+        if not self.locked or show_import:
             deps_status = self._status(self.deps)
             if deps_status:
                 ret.append({"changed deps": deps_status})

--- a/tests/func/test_status.py
+++ b/tests/func/test_status.py
@@ -1,9 +1,12 @@
 import os
+import shutil
 
 from mock import patch
 
 from dvc.main import main
+from dvc.compat import fspath
 from tests.basic_env import TestDvc
+from dvc.external_repo import clean_repos
 
 
 class TestStatus(TestDvc):
@@ -23,3 +26,35 @@ class TestStatus(TestDvc):
     def test_implied_cloud(self, mock_status):
         main(["status", "--remote", "something"])
         mock_status.assert_called()
+
+
+def test_status_non_dvc_repo_import(tmp_dir, dvc, erepo_dir):
+    with erepo_dir.branch("branch", new=True), erepo_dir.chdir():
+        erepo_dir.scm.repo.index.remove([".dvc"], r=True)
+        shutil.rmtree(".dvc")
+        erepo_dir.scm_gen("file", "first version")
+        erepo_dir.scm.add(["file"])
+        erepo_dir.scm.commit("first version")
+
+    dvc.imp(fspath(erepo_dir), "file", "file", rev="branch")
+
+    status = dvc.status(["file.dvc"])
+
+    assert status == {}
+
+    # Caching in external repos doesn't see upstream updates within single
+    # cli call, so we need to clean the caches to see the changes.
+    clean_repos()
+
+    with erepo_dir.branch("branch", new=False), erepo_dir.chdir():
+        erepo_dir.scm_gen("file", "second_version", commit="update file")
+        erepo_dir.scm.add(["file"])
+        erepo_dir.scm.commit("first version")
+
+    status, = dvc.status(["file.dvc"])["file.dvc"]
+
+    assert status == {
+        "changed deps": {
+            "file ({})".format(fspath(erepo_dir)): "update available"
+        }
+    }

--- a/tests/func/test_status.py
+++ b/tests/func/test_status.py
@@ -3,6 +3,7 @@ import shutil
 
 from mock import patch
 
+from dvc.repo import Repo
 from dvc.main import main
 from dvc.compat import fspath
 from tests.basic_env import TestDvc
@@ -58,3 +59,36 @@ def test_status_non_dvc_repo_import(tmp_dir, dvc, erepo_dir):
             "file ({})".format(fspath(erepo_dir)): "update available"
         }
     }
+
+
+def test_status_before_and_after_dvc_init(tmp_dir, dvc, erepo_dir):
+    with erepo_dir.chdir():
+        erepo_dir.scm.repo.index.remove([".dvc"], r=True)
+        shutil.rmtree(".dvc")
+        erepo_dir.scm_gen("file", "first version")
+        erepo_dir.scm.add(["file"])
+        erepo_dir.scm.commit("first version")
+        old_rev = erepo_dir.scm.get_rev()
+
+    dvc.imp(fspath(erepo_dir), "file", "file")
+
+    assert dvc.status(["file.dvc"]) == {}
+
+    with erepo_dir.chdir():
+        Repo.init()
+        erepo_dir.scm.repo.index.remove(["file"])
+        os.remove("file")
+        erepo_dir.dvc_gen("file", "second version")
+        erepo_dir.scm.add([".dvc", "file.dvc"])
+        erepo_dir.scm.commit("version with dvc")
+        new_rev = erepo_dir.scm.get_rev()
+
+    assert old_rev != new_rev
+
+    # Caching in external repos doesn't see upstream updates within single
+    # cli call, so we need to clean the caches to see the changes.
+    clean_repos()
+
+    status = dvc.status(["file.dvc"])
+
+    print("STATUS", status)

--- a/tests/func/test_status.py
+++ b/tests/func/test_status.py
@@ -6,8 +6,8 @@ from mock import patch
 from dvc.repo import Repo
 from dvc.main import main
 from dvc.compat import fspath
-from tests.basic_env import TestDvc
 from dvc.external_repo import clean_repos
+from tests.basic_env import TestDvc
 
 
 class TestStatus(TestDvc):

--- a/tests/func/test_status.py
+++ b/tests/func/test_status.py
@@ -89,6 +89,10 @@ def test_status_before_and_after_dvc_init(tmp_dir, dvc, erepo_dir):
     # cli call, so we need to clean the caches to see the changes.
     clean_repos()
 
-    status = dvc.status(["file.dvc"])
+    status, = dvc.status(["file.dvc"])["file.dvc"]
 
-    print("STATUS", status)
+    assert status == {
+        "changed deps": {
+            "file ({})".format(fspath(erepo_dir)): "update available"
+        }
+    }

--- a/tests/func/test_update.py
+++ b/tests/func/test_update.py
@@ -19,8 +19,13 @@ def test_update_import(tmp_dir, dvc, erepo_dir):
     # cli call, so we need to clean the caches to see the changes.
     clean_repos()
 
-    assert dvc.status([stage.path]) == {}
+    status, = dvc.status([stage.path])["version.dvc"]
+    changed_dep, = list(status["changed deps"].items())
+    assert changed_dep[0].startswith("version ")
+    assert changed_dep[1] == "update available"
+
     dvc.update(stage.path)
+
     assert dvc.status([stage.path]) == {}
 
     assert imported.is_file()


### PR DESCRIPTION
This fix only works when the remote is located in your machine. For remote DVC projects, it doesn't work and I'm looking into why.

Also I'm having a lot of trouble writing a unit test for this. The CLI works fine but when I call `dvc.status(with_deps=True)` in the test it reports that nothing changed.

Fixes #2959

------

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [ ] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

:point_up: `dvc lock` docs imply that locked files are impervious to `dvc status`.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

:point_up: I changed some code which already had DeepSource antipatterns and it re-detected them.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

