### PR TITLE
get: implement --show-url to display only url/path to remote

### DIFF
--- a/dvc/api.py
+++ b/dvc/api.py
@@ -10,7 +10,7 @@ import ruamel.yaml
 from voluptuous import Schema, Required, Invalid
 
 from dvc.repo import Repo
-from dvc.exceptions import DvcException
+from dvc.exceptions import DvcException, NotDvcRepoError
 from dvc.external_repo import external_repo
 
 
@@ -43,13 +43,27 @@ class SummonError(DvcException):
     pass
 
 
+class UrlNotDvcRepoError(DvcException):
+    """Thrown if given url is not a DVC repository.
+
+    Args:
+        url (str): url to the repository.
+    """
+
+    def __init__(self, url):
+        super().__init__("URL '{}' is not a dvc repository.".format(url))
+
+
 def get_url(path, repo=None, rev=None, remote=None):
     """Returns an url of a resource specified by path in repo"""
-    with _make_repo(repo, rev=rev) as _repo:
-        abspath = os.path.join(_repo.root_dir, path)
-        out, = _repo.find_outs_by_path(abspath)
-        remote_obj = _repo.cloud.get_remote(remote)
-        return str(remote_obj.checksum_to_path_info(out.checksum))
+    try:
+        with _make_repo(repo, rev=rev) as _repo:
+            abspath = os.path.join(_repo.root_dir, path)
+            out, = _repo.find_outs_by_path(abspath)
+            remote_obj = _repo.cloud.get_remote(remote)
+            return str(remote_obj.checksum_to_path_info(out.checksum))
+    except NotDvcRepoError:
+        raise UrlNotDvcRepoError(repo)
 
 
 def open(path, repo=None, rev=None, remote=None, mode="r", encoding=None):

--- a/dvc/command/get.py
+++ b/dvc/command/get.py
@@ -3,7 +3,7 @@ import logging
 
 from .base import append_doc_link
 from .base import CmdBaseNoRepo
-from dvc.exceptions import DvcException, NotDvcRepoError
+from dvc.exceptions import DvcException
 
 
 logger = logging.getLogger(__name__)
@@ -18,23 +18,8 @@ class CmdGet(CmdBaseNoRepo):
                 self.args.path, repo=self.args.url, rev=self.args.rev
             )
             logger.info(url)
-        except NotDvcRepoError:
-            # NOTE: there's no way to get direct links to files inside
-            # git repository.
-            logger.exception(
-                "Could not show url for '{}' from '{}'. ".format(
-                    self.args.path, self.args.url
-                )
-                + "Only DVC repository is supported currently.",
-                exc_info=None,
-            )
-            return 1
         except DvcException:
-            logger.exception(
-                "failed to show url for '{}' from '{}'".format(
-                    self.args.path, self.args.url
-                )
-            )
+            logger.exception("failed to show url")
             return 1
 
         return 0

--- a/dvc/command/get.py
+++ b/dvc/command/get.py
@@ -10,7 +10,28 @@ logger = logging.getLogger(__name__)
 
 
 class CmdGet(CmdBaseNoRepo):
+    def _run_get_url(self):
+        from dvc.api import get_url
+
+        try:
+            url = get_url(
+                self.args.path, repo=self.args.url, rev=self.args.rev
+            )
+            logger.info("{} {}".format(self.args.path, url))
+        except DvcException:
+            logger.exception(
+                "failed to show url for '{}' from '{}'".format(
+                    self.args.path, self.args.url
+                )
+            )
+            return 1
+        return 0
+
     def run(self):
+
+        if self.args.show_url:
+            return self._run_get_url()
+
         from dvc.repo import Repo
 
         try:
@@ -54,5 +75,10 @@ def add_parser(subparsers, parent_parser):
     )
     get_parser.add_argument(
         "--rev", nargs="?", help="Git revision (e.g. branch, tag, SHA)"
+    )
+    get_parser.add_argument(
+        "--show-url",
+        action="store_true",
+        help="Returns path/url to the location in remote for specified path",
     )
     get_parser.set_defaults(func=CmdGet)

--- a/tests/func/test_api.py
+++ b/tests/func/test_api.py
@@ -57,7 +57,8 @@ def test_get_url_git_only_repo_throws_exception(tmp_dir, scm):
     with pytest.raises(UrlNotDvcRepoError) as exc_info:
         api.get_url("foo", fspath(tmp_dir))
 
-    assert fspath(tmp_dir) in str(exc_info)
+    # On windows, `exc_info` has path escaped, eg: `C:\\\\Users\\\\travis`
+    assert fspath(tmp_dir) in str(exc_info).replace("\\\\", "\\")
 
 
 @pytest.mark.parametrize("remote_url", all_remote_params, indirect=True)

--- a/tests/func/test_api.py
+++ b/tests/func/test_api.py
@@ -6,7 +6,7 @@ import ruamel.yaml
 import pytest
 
 from dvc import api
-from dvc.api import SummonError
+from dvc.api import SummonError, UrlNotDvcRepoError
 from dvc.compat import fspath
 from dvc.exceptions import FileMissingError
 from dvc.main import main
@@ -49,6 +49,15 @@ def test_get_url_external(erepo_dir, remote_url):
     repo_url = "file://{}".format(erepo_dir)
     expected_url = URLInfo(remote_url) / "ac/bd18db4cc2f85cedef654fccc4a4d8"
     assert api.get_url("foo", repo=repo_url) == expected_url
+
+
+def test_get_url_git_only_repo_throws_exception(tmp_dir, scm):
+    tmp_dir.scm_gen({"foo": "foo"}, commit="initial")
+
+    with pytest.raises(UrlNotDvcRepoError) as exc_info:
+        api.get_url("foo", fspath(tmp_dir))
+
+    assert fspath(tmp_dir) in str(exc_info)
 
 
 @pytest.mark.parametrize("remote_url", all_remote_params, indirect=True)

--- a/tests/func/test_get.py
+++ b/tests/func/test_get.py
@@ -203,7 +203,7 @@ def test_get_url_not_existing(tmp_dir, erepo_dir, caplog):
             main(["get", fspath(erepo_dir), "not-existing-file", "--show-url"])
             == 1
         )
-        assert "failed to show url for 'not-existing-file'" in caplog.text
+        assert "failed to show url" in caplog.text
 
 
 def test_get_url_git_only_repo(tmp_dir, scm, caplog):
@@ -211,4 +211,4 @@ def test_get_url_git_only_repo(tmp_dir, scm, caplog):
 
     with caplog.at_level(logging.ERROR):
         assert main(["get", fspath(tmp_dir), "foo", "--show-url"]) == 1
-        assert "Only DVC repository is supported currently" in caplog.text
+        assert "failed to show url" in caplog.text

--- a/tests/func/test_get.py
+++ b/tests/func/test_get.py
@@ -5,6 +5,7 @@ import pytest
 
 from dvc.cache import Cache
 from dvc.config import Config
+from dvc.main import main
 from dvc.repo.get import GetDVCFileError, PathMissingError
 from dvc.repo import Repo
 from dvc.system import System
@@ -184,3 +185,15 @@ def test_get_from_non_dvc_master(tmp_dir, erepo_dir, caplog):
 
     assert caplog.text == ""
     assert (tmp_dir / dst).read_text() == "some_contents"
+
+
+def test_get_url(tmp_dir, erepo_dir):
+    with erepo_dir.chdir():
+        erepo_dir.dvc_gen("foo", "foo")
+        assert main(["get", ".", "foo", "--show-url"]) == 0
+
+
+def test_get_url_not_existing(tmp_dir, erepo_dir):
+    with erepo_dir.chdir():
+        erepo_dir.dvc_gen("foo", "foo")
+        assert main(["get", ".", "food", "--show-url"]) == 1

--- a/tests/unit/command/test_get.py
+++ b/tests/unit/command/test_get.py
@@ -23,10 +23,9 @@ def test_get_url(mocker, caplog):
     assert cli_args.func == CmdGet
 
     cmd = cli_args.func(cli_args)
-    m = mocker.patch("dvc.api.get_url")
-    m.return_value = "url"
+    m = mocker.patch("dvc.api.get_url", return_value="resource_url")
 
     assert cmd.run() == 0
-    assert "url" in caplog.text
+    assert "resource_url" in caplog.text
 
     m.assert_called_once_with("src", repo="repo_url", rev="version")

--- a/tests/unit/command/test_get.py
+++ b/tests/unit/command/test_get.py
@@ -24,6 +24,7 @@ def test_get_url(mocker):
 
     cmd = cli_args.func(cli_args)
     m = mocker.patch("dvc.api.get_url")
+    m.return_value = "url"
 
     assert cmd.run() == 0
 

--- a/tests/unit/command/test_get.py
+++ b/tests/unit/command/test_get.py
@@ -16,7 +16,7 @@ def test_get(mocker):
     m.assert_called_once_with("repo_url", path="src", out="out", rev="version")
 
 
-def test_get_url(mocker):
+def test_get_url(mocker, caplog):
     cli_args = parse_args(
         ["get", "repo_url", "src", "--rev", "version", "--show-url"]
     )
@@ -27,5 +27,6 @@ def test_get_url(mocker):
     m.return_value = "url"
 
     assert cmd.run() == 0
+    assert "url" in caplog.text
 
     m.assert_called_once_with("src", repo="repo_url", rev="version")

--- a/tests/unit/command/test_get.py
+++ b/tests/unit/command/test_get.py
@@ -14,3 +14,17 @@ def test_get(mocker):
     assert cmd.run() == 0
 
     m.assert_called_once_with("repo_url", path="src", out="out", rev="version")
+
+
+def test_get_url(mocker):
+    cli_args = parse_args(
+        ["get", "repo_url", "src", "--rev", "version", "--show-url"]
+    )
+    assert cli_args.func == CmdGet
+
+    cmd = cli_args.func(cli_args)
+    m = mocker.patch("dvc.api.get_url")
+
+    assert cmd.run() == 0
+
+    m.assert_called_once_with("src", repo="repo_url", rev="version")


### PR DESCRIPTION
Closes #2994. 

From the product requirements, it deviates on the following issue:
1. For now, it does not support showing URLs for multiple paths.
   So, we can only do `dvc get <url> <path> --show-url` for a single path, so as 
   to make it compatible with `dvc get`.
2. It also does not support specifying remote at the moment, so as to not introduce new flags.
3. It does not work with the file inside of a directory (i.e. `dir/file`). Limitation of `dvc.api.get_url()`. Requires adding directory granularity support.
	```sh
	➜ dvc get . dir/file --show-url
	ERROR: failed to show url - unable to find DVC-file with output 'dir/file'
	```
4. How to show path/URL to the directory? Currently, it only shows `.dir` file.
	```sh
	➜ dvc get . dir --show-url
    ../tmp.fKEyzBMWge/12/11325135bf45fe5f67efa975110a57.dir
	```
   Same is the case with `dvc get` (cc @jorgeorpinel for docs regarding `dvc.api.get_url()`).
   
5. It does not work with non-dvc repos (i.e. git only repos). So, the following won't work:
   ```sh
   ➜ dvc get https://github.com/schacon/cowsay install.sh --show-url 
   ERROR: failed to show url - URL 'https://github.com/schacon/cowsay' is not a dvc repository.
   ```
6. Custom revision does not work for the local repo.
   Not fixing at the moment. Will create a separate issue for this.
	```sh
	➜ dvc get . foo --rev=HEAD@{5.days.ago} # works
	➜ dvc get . foo --rev=HEAD@{5.days.ago} --show-url
	ERROR: unexpected error - Custom revision is not supported for local repo
   ```


### Example Usage
```sh
➜ dvc get . foo --show-url
../tmp.uJVvn5ZaLY/d3/b07384d113edec49eaa6238ad5ff00
➜ dvc get https://github.com/iterative/dataset-registry.git get-started/data.xml --rev=HEAD@{5.days.ago} --show-url
https://remote.dvc.org/dataset-registry/a3/04afb96060aad90176268345e10355
```
EDIT: Made changes to format from `<path> <url>` previously to just `<url>`. 

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [ ] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

---

### TODO
#### Edgecases
- [x] https://github.com/iterative/dvc/pull/3156#discussion_r366942056
     
