### PR TITLE
dvc: use pydrive2 instead of pydrive

### DIFF
--- a/dvc/remote/gdrive.py
+++ b/dvc/remote/gdrive.py
@@ -34,7 +34,7 @@ class GDriveMissedCredentialKeyError(DvcException):
 @decorator
 def _wrap_pydrive_retriable(call):
     from apiclient import errors
-    from pydrive.files import ApiRequestError
+    from pydrive2.files import ApiRequestError
 
     try:
         result = call()
@@ -61,7 +61,7 @@ gdrive_retry = compose(
 class RemoteGDrive(RemoteBASE):
     scheme = Schemes.GDRIVE
     path_cls = CloudURLInfo
-    REQUIRES = {"pydrive": "pydrive"}
+    REQUIRES = {"pydrive2": "pydrive2"}
     GDRIVE_USER_CREDENTIALS_DATA = "GDRIVE_USER_CREDENTIALS_DATA"
     DEFAULT_USER_CREDENTIALS_FILE = "gdrive-user-credentials.json"
 
@@ -177,11 +177,11 @@ class RemoteGDrive(RemoteBASE):
     @property
     @wrap_with(threading.RLock())
     def drive(self):
-        from pydrive.auth import RefreshError
+        from pydrive2.auth import RefreshError
 
         if not hasattr(self, "_gdrive"):
-            from pydrive.auth import GoogleAuth
-            from pydrive.drive import GoogleDrive
+            from pydrive2.auth import GoogleAuth
+            from pydrive2.drive import GoogleDrive
 
             if os.getenv(RemoteGDrive.GDRIVE_USER_CREDENTIALS_DATA):
                 with open(
@@ -227,7 +227,7 @@ class RemoteGDrive(RemoteBASE):
                         self.gdrive_user_credentials_path, str(exc)
                     )
                 )
-            # Handle pydrive.auth.AuthenticationError and others auth failures
+            # Handle pydrive2.auth.AuthenticationError and others auth failures
             except Exception as exc:
                 raise DvcException(
                     "Google Drive authentication failed"

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ gs = ["google-cloud-storage==1.19.0"]
 # google-api-python-client is internal dependency of pydrive. After merge of
 # https://github.com/gsuitedevs/PyDrive/pull/180 into pydrive's master,
 # usage of google-api-python-client can be removed from DVC.
-gdrive = ["pydrive>=1.3.1", "google-api-python-client>=1.2"]
+gdrive = ["pydrive2>=1.4.0", "google-api-python-client>=1.2"]
 s3 = ["boto3>=1.9.201"]
 azure = ["azure-storage-blob==2.1.0"]
 oss = ["oss2==2.6.1"]


### PR DESCRIPTION
PyDrive2 is our maintained fork.

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

