### PR TITLE
pull: treat HTTP redirects without Location header as error

### DIFF
--- a/dvc/remote/http.py
+++ b/dvc/remote/http.py
@@ -103,7 +103,13 @@ class RemoteHTTP(RemoteBASE):
         try:
             res = self._session.request(method, url, **kwargs)
 
-            if kwargs["allow_redirects"] and res.status_code in (301, 302):
+            redirect_no_location = (
+                kwargs["allow_redirects"]
+                and res.status_code in (301, 302)
+                and "location" not in res.headers
+            )
+
+            if redirect_no_location:
                 # AWS s3 doesn't like to add a location header to its redirects
                 # from https://s3.amazonaws.com/<bucket name>/* type URLs.
                 # This should be treated as an error

--- a/dvc/remote/http.py
+++ b/dvc/remote/http.py
@@ -103,7 +103,7 @@ class RemoteHTTP(RemoteBASE):
         try:
             res = self._session.request(method, url, **kwargs)
 
-            if kwargs["allow_redirects"] and res.is_redirect:
+            if kwargs["allow_redirects"] and res.status_code in (301, 302):
                 # AWS s3 doesn't like to add a location header to its redirects
                 # from https://s3.amazonaws.com/<bucket name>/* type URLs.
                 # This should be treated as an error

--- a/dvc/remote/http.py
+++ b/dvc/remote/http.py
@@ -109,6 +109,8 @@ class RemoteHTTP(RemoteBASE):
                 # This should be treated as an error
                 raise requests.exceptions.RequestException
 
+            return res
+
         except requests.exceptions.RequestException:
             raise DvcException("could not perform a {} request".format(method))
 

--- a/dvc/remote/http.py
+++ b/dvc/remote/http.py
@@ -101,7 +101,14 @@ class RemoteHTTP(RemoteBASE):
         kwargs.setdefault("timeout", self.REQUEST_TIMEOUT)
 
         try:
-            return self._session.request(method, url, **kwargs)
+            res = self._session.request(method, url, **kwargs)
+
+            if kwargs["allow_redirects"] and res.is_redirect:
+                # AWS s3 doesn't like to add a location header to its redirects
+                # from https://s3.amazonaws.com/<bucket name>/* type URLs.
+                # This should be treated as an error
+                raise requests.exceptions.RequestException
+
         except requests.exceptions.RequestException:
             raise DvcException("could not perform a {} request".format(method))
 


### PR DESCRIPTION
The reason for this problem is a 301 without a Location header. In our HTTP remote we can treat this as an error, since we don't know where to actually find the data.

Fixes #2963

-------

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

