### PR TITLE
update: handle imported files from non-DVC git repositories

### DIFF
--- a/dvc/dependency/repo.py
+++ b/dvc/dependency/repo.py
@@ -142,5 +142,10 @@ class DependencyREPO(DependencyLOCAL):
             )
 
     def update(self):
-        with self._make_repo(rev_lock=None) as repo:
-            self.def_repo[self.PARAM_REV_LOCK] = repo.scm.get_rev()
+        try:
+            with self._make_repo(rev_lock=None) as repo:
+                rev = repo.scm.get_rev()
+        except NotDvcRepoError:
+            clone_path = cached_clone(**self.def_repo)
+            rev = SCM(clone_path).get_rev()
+        self.def_repo[self.PARAM_REV_LOCK] = rev

--- a/tests/dir_helpers.py
+++ b/tests/dir_helpers.py
@@ -61,7 +61,7 @@ __all__ = [
     "repo_template",
     "run_copy",
     "erepo_dir",
-    "git_dir",
+    "external_git_dir",
 ]
 REPO_TEMPLATE = {
     "foo": "foo",
@@ -296,10 +296,10 @@ def erepo_dir(tmp_path_factory, monkeypatch):
 
 
 @pytest.fixture
-def git_dir(tmp_path_factory, monkeypatch):
+def external_git_dir(tmp_path_factory, monkeypatch):
     from dvc.scm.git import Git
 
-    path = TmpDir(fspath_py35(tmp_path_factory.mktemp("git_dir")))
+    path = TmpDir(fspath_py35(tmp_path_factory.mktemp("external_git_dir")))
 
     # Create git repo
     with path.chdir():

--- a/tests/dir_helpers.py
+++ b/tests/dir_helpers.py
@@ -307,6 +307,7 @@ def git_dir(tmp_path_factory, monkeypatch):
 
     try:
         path.scm = Git(fspath(path))
+        path.scm.commit("initial commit to create the master branch")
         yield path
     finally:
         path.scm.close()

--- a/tests/dir_helpers.py
+++ b/tests/dir_helpers.py
@@ -54,7 +54,15 @@ from dvc.utils.fs import makedirs
 from dvc.compat import fspath, fspath_py35
 
 
-__all__ = ["tmp_dir", "scm", "dvc", "repo_template", "run_copy", "erepo_dir"]
+__all__ = [
+    "tmp_dir",
+    "scm",
+    "dvc",
+    "repo_template",
+    "run_copy",
+    "erepo_dir",
+    "git_dir",
+]
 REPO_TEMPLATE = {
     "foo": "foo",
     "bar": "bar",
@@ -285,3 +293,20 @@ def erepo_dir(tmp_path_factory, monkeypatch):
         path.dvc.close()
 
     return path
+
+
+@pytest.fixture
+def git_dir(tmp_path_factory, monkeypatch):
+    from dvc.scm.git import Git
+
+    path = TmpDir(fspath_py35(tmp_path_factory.mktemp("git_dir")))
+
+    # Create git repo
+    with path.chdir():
+        _git_init()
+
+    try:
+        path.scm = Git(fspath(path))
+        yield path
+    finally:
+        path.scm.close()

--- a/tests/func/test_status.py
+++ b/tests/func/test_status.py
@@ -61,23 +61,25 @@ def test_status_non_dvc_repo_import(tmp_dir, dvc, erepo_dir):
     }
 
 
-def test_status_before_and_after_dvc_init(tmp_dir, dvc, git_dir):
-    with git_dir.chdir():
-        git_dir.scm_gen("file", "first version", commit="first version")
-        old_rev = git_dir.scm.get_rev()
+def test_status_before_and_after_dvc_init(tmp_dir, dvc, external_git_dir):
+    with external_git_dir.chdir():
+        external_git_dir.scm_gen(
+            "file", "first version", commit="first version"
+        )
+        old_rev = external_git_dir.scm.get_rev()
 
-    dvc.imp(fspath(git_dir), "file", "file")
+    dvc.imp(fspath(external_git_dir), "file", "file")
 
     assert dvc.status(["file.dvc"]) == {}
 
-    with git_dir.chdir():
-        git_dir.dvc = Repo.init()
-        git_dir.scm.repo.index.remove(["file"])
+    with external_git_dir.chdir():
+        external_git_dir.dvc = Repo.init()
+        external_git_dir.scm.repo.index.remove(["file"])
         os.remove("file")
-        git_dir.dvc_gen("file", "second version")
-        git_dir.scm.add([".dvc", "file.dvc"])
-        git_dir.scm.commit("version with dvc")
-        new_rev = git_dir.scm.get_rev()
+        external_git_dir.dvc_gen("file", "second version")
+        external_git_dir.scm.add([".dvc", "file.dvc"])
+        external_git_dir.scm.commit("version with dvc")
+        new_rev = external_git_dir.scm.get_rev()
 
     assert old_rev != new_rev
 
@@ -89,6 +91,6 @@ def test_status_before_and_after_dvc_init(tmp_dir, dvc, git_dir):
 
     assert status == {
         "changed deps": {
-            "file ({})".format(fspath(git_dir)): "update available"
+            "file ({})".format(fspath(external_git_dir)): "update available"
         }
     }

--- a/tests/func/test_status.py
+++ b/tests/func/test_status.py
@@ -61,27 +61,23 @@ def test_status_non_dvc_repo_import(tmp_dir, dvc, erepo_dir):
     }
 
 
-def test_status_before_and_after_dvc_init(tmp_dir, dvc, erepo_dir):
-    with erepo_dir.chdir():
-        erepo_dir.scm.repo.index.remove([".dvc"], r=True)
-        shutil.rmtree(".dvc")
-        erepo_dir.scm_gen("file", "first version")
-        erepo_dir.scm.add(["file"])
-        erepo_dir.scm.commit("first version")
-        old_rev = erepo_dir.scm.get_rev()
+def test_status_before_and_after_dvc_init(tmp_dir, dvc, git_dir):
+    with git_dir.chdir():
+        git_dir.scm_gen("file", "first version", commit="first version")
+        old_rev = git_dir.scm.get_rev()
 
-    dvc.imp(fspath(erepo_dir), "file", "file")
+    dvc.imp(fspath(git_dir), "file", "file")
 
     assert dvc.status(["file.dvc"]) == {}
 
-    with erepo_dir.chdir():
-        Repo.init()
-        erepo_dir.scm.repo.index.remove(["file"])
+    with git_dir.chdir():
+        git_dir.dvc = Repo.init()
+        git_dir.scm.repo.index.remove(["file"])
         os.remove("file")
-        erepo_dir.dvc_gen("file", "second version")
-        erepo_dir.scm.add([".dvc", "file.dvc"])
-        erepo_dir.scm.commit("version with dvc")
-        new_rev = erepo_dir.scm.get_rev()
+        git_dir.dvc_gen("file", "second version")
+        git_dir.scm.add([".dvc", "file.dvc"])
+        git_dir.scm.commit("version with dvc")
+        new_rev = git_dir.scm.get_rev()
 
     assert old_rev != new_rev
 
@@ -93,6 +89,6 @@ def test_status_before_and_after_dvc_init(tmp_dir, dvc, erepo_dir):
 
     assert status == {
         "changed deps": {
-            "file ({})".format(fspath(erepo_dir)): "update available"
+            "file ({})".format(fspath(git_dir)): "update available"
         }
     }

--- a/tests/func/test_update.py
+++ b/tests/func/test_update.py
@@ -190,17 +190,12 @@ def test_update_git_tracked(tmp_dir, dvc, erepo_dir):
     assert (tmp_dir / "file").read_text() == "first version"
 
     with erepo_dir.chdir():
-        erepo_dir.scm.repo.index.remove(["file"])
-        os.remove("file")
-        erepo_dir.scm_gen("file", "second version")
-        erepo_dir.scm.add(["file"])
-        erepo_dir.scm.commit("x")
+        erepo_dir.scm_gen("file", "second version", commit="update file")
 
     # Caching in external repos doesn't see upstream updates within single
     # cli call, so we need to clean the caches to see the changes.
     clean_repos()
 
-    dvc.update(stage.path)
+    dvc.update("file.dvc")
 
     assert (tmp_dir / "file").read_text() == "second version"
-    assert dvc.status([stage.path]) == {}

--- a/tests/func/test_update.py
+++ b/tests/func/test_update.py
@@ -174,28 +174,24 @@ def test_update_import_url(tmp_dir, dvc, tmp_path_factory):
     assert dst.read_text() == "updated file content"
 
 
-def test_update_git_tracked(tmp_dir, dvc, erepo_dir):
-    with erepo_dir.chdir():
-        erepo_dir.scm.repo.index.remove([".dvc"], r=True)
-        shutil.rmtree(".dvc")
-        erepo_dir.scm_gen("file", "first version")
-        erepo_dir.scm.add(["file"])
-        erepo_dir.scm.commit("first version")
+def test_update_git_tracked(tmp_dir, dvc, git_dir):
+    with git_dir.chdir():
+        git_dir.scm_gen("file", "first version", commit="create")
 
-    stage = dvc.imp(fspath(erepo_dir), "file", "file")
+    tmp_dir.dvc.imp(fspath(git_dir), "file", "file")
 
     # Just to make sure it doesn't crash
-    dvc.update(stage.path)
+    tmp_dir.dvc.update("file.dvc")
 
     assert (tmp_dir / "file").read_text() == "first version"
 
-    with erepo_dir.chdir():
-        erepo_dir.scm_gen("file", "second version", commit="update file")
+    with git_dir.chdir():
+        git_dir.scm_gen("file", "second version", commit="update file")
 
     # Caching in external repos doesn't see upstream updates within single
     # cli call, so we need to clean the caches to see the changes.
     clean_repos()
 
-    dvc.update("file.dvc")
+    tmp_dir.dvc.update("file.dvc")
 
     assert (tmp_dir / "file").read_text() == "second version"

--- a/tests/func/test_update.py
+++ b/tests/func/test_update.py
@@ -174,19 +174,21 @@ def test_update_import_url(tmp_dir, dvc, tmp_path_factory):
     assert dst.read_text() == "updated file content"
 
 
-def test_update_git_tracked(tmp_dir, dvc, git_dir):
-    with git_dir.chdir():
-        git_dir.scm_gen("file", "first version", commit="create")
+def test_update_git_tracked(tmp_dir, dvc, external_git_dir):
+    with external_git_dir.chdir():
+        external_git_dir.scm_gen("file", "first version", commit="create")
 
-    tmp_dir.dvc.imp(fspath(git_dir), "file", "file")
+    tmp_dir.dvc.imp(fspath(external_git_dir), "file", "file")
 
     # Just to make sure it doesn't crash
     tmp_dir.dvc.update("file.dvc")
 
     assert (tmp_dir / "file").read_text() == "first version"
 
-    with git_dir.chdir():
-        git_dir.scm_gen("file", "second version", commit="update file")
+    with external_git_dir.chdir():
+        external_git_dir.scm_gen(
+            "file", "second version", commit="update file"
+        )
 
     # Caching in external repos doesn't see upstream updates within single
     # cli call, so we need to clean the caches to see the changes.


### PR DESCRIPTION
This makes `dvc update` update files from git repositories. git-tracked imported files were actually already handled.

Fixes #2976

-----

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

