### PR TITLE
logger: remote: use lazy formatting

### DIFF
--- a/dvc/logger.py
+++ b/dvc/logger.py
@@ -58,8 +58,10 @@ class ColorFormatter(logging.Formatter):
     }
 
     def format(self, record):
+        msg = record.msg.format(*record.args) if record.args else record.msg
+
         if record.levelname == "INFO":
-            return record.msg
+            return msg
 
         if record.levelname == "ERROR" or record.levelname == "CRITICAL":
             exception, stack_trace = self._parse_exc(record)
@@ -70,8 +72,8 @@ class ColorFormatter(logging.Formatter):
                 color=self.color_code.get(record.levelname, ""),
                 nc=colorama.Fore.RESET,
                 levelname=record.levelname,
-                description=self._description(record.msg, exception),
-                msg=record.msg,
+                description=self._description(msg, exception),
+                msg=msg,
                 stack_trace=stack_trace,
             )
 
@@ -79,7 +81,7 @@ class ColorFormatter(logging.Formatter):
             color=self.color_code.get(record.levelname, ""),
             nc=colorama.Fore.RESET,
             levelname=record.levelname,
-            msg=record.msg,
+            msg=msg,
         )
 
     def _current_level(self):

--- a/dvc/rwlock.py
+++ b/dvc/rwlock.py
@@ -9,7 +9,7 @@ from funcy.py3 import lmap, lfilter, lmapcat
 
 from .exceptions import DvcException
 from .lock import LockError
-from .utils.fs import relpath
+from .utils import relpath
 
 INFO_SCHEMA = {"pid": int, "cmd": str}
 

--- a/dvc/state.py
+++ b/dvc/state.py
@@ -141,7 +141,7 @@ class State(object):  # pylint: disable=too-many-instance-attributes
 
     def _fetchall(self):
         ret = self.cursor.fetchall()
-        logger.debug("fetched: {}".format(ret))
+        logger.debug("fetched: {}", ret)
         return ret
 
     def _to_sqlite(self, num):
@@ -181,11 +181,12 @@ class State(object):  # pylint: disable=too-many-instance-attributes
                     __version__, self.VERSION, version
                 )
             elif version < self.VERSION:
-                msg = (
+                logger.warning(
                     "State file version '{}' is too old. "
-                    "Reformatting to the current version '{}'."
+                    "Reformatting to the current version '{}'.",
+                    version,
+                    self.VERSION,
                 )
-                logger.warning(msg.format(version, self.VERSION))
                 cmd = "DROP TABLE IF EXISTS {};"
                 self._execute(cmd.format(self.STATE_TABLE))
                 self._execute(cmd.format(self.STATE_INFO_TABLE))
@@ -466,7 +467,7 @@ class State(object):  # pylint: disable=too-many-instance-attributes
             actual_mtime, _ = get_mtime_and_size(path, self.repo.tree)
 
             if inode == actual_inode and mtime == actual_mtime:
-                logger.debug("Removing '{}' as unused link.".format(path))
+                logger.debug("Removing '{}' as unused link.", path)
                 remove(path)
                 unused.append(relpath)
 

--- a/dvc/utils/fs.py
+++ b/dvc/utils/fs.py
@@ -13,7 +13,6 @@ from dvc.system import System
 from dvc.utils import dict_md5
 from dvc.utils import fspath
 from dvc.utils import fspath_py35
-from dvc.utils import relpath
 
 
 logger = logging.getLogger(__name__)
@@ -30,7 +29,7 @@ def fs_copy(src, dst):
 
 def get_inode(path):
     inode = System.inode(path)
-    logger.debug("Path {} inode {}".format(path, inode))
+    logger.debug("Path {} inode {}", path, inode)
     return inode
 
 
@@ -131,10 +130,9 @@ def _chmod(func, p, excinfo):
 
 
 def remove(path):
+    logger.debug("Removing '{}'", path)
+
     path = fspath_py35(path)
-
-    logger.debug("Removing '{}'".format(relpath(path)))
-
     try:
         if os.path.isdir(path):
             shutil.rmtree(path, onerror=_chmod)


### PR DESCRIPTION
Part of #1843 , related to https://github.com/iterative/dvc/issues/3177

As our previous investigations showed, path stringification and stuff
like relpath are taking a very large chunk of time when working with
giant directories. This patch removes `format()`s and uses lazy
formatting provided by logger instead, so stuff like path_info is not
stringified until actually needed (e.g. on `-v`).

Benchmark results coming soon

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

