### PR TITLE
external: refactor external_repo() and its users

### DIFF
--- a/dvc/api.py
+++ b/dvc/api.py
@@ -109,7 +109,7 @@ def read(path, repo=None, rev=None, remote=None, mode="r", encoding=None):
 
 @contextmanager
 def _make_repo(repo_url, rev=None):
-    if not repo_url or os.path.exists(repo_url):
+    if rev is None and (not repo_url or os.path.exists(repo_url)):
         yield Repo(repo_url)
     else:
         with external_repo(url=repo_url, rev=rev) as repo:

--- a/dvc/api.py
+++ b/dvc/api.py
@@ -10,7 +10,7 @@ import ruamel.yaml
 from voluptuous import Schema, Required, Invalid
 
 from dvc.repo import Repo
-from dvc.exceptions import DvcException, NotDvcRepoError
+from dvc.exceptions import DvcException
 from dvc.external_repo import external_repo
 
 
@@ -43,7 +43,7 @@ class SummonError(DvcException):
     pass
 
 
-class UrlNotDvcRepoError(NotDvcRepoError):
+class UrlNotDvcRepoError(DvcException):
     """Thrown if given url is not a DVC repository.
 
     Args:

--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -227,6 +227,7 @@ class ETagMismatchError(DvcException):
 
 class FileMissingError(DvcException):
     def __init__(self, path):
+        self.path = path
         super().__init__(
             "Can't find '{}' neither locally nor on remote".format(path)
         )

--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -3,25 +3,27 @@ import tempfile
 from contextlib import contextmanager
 from distutils.dir_util import copy_tree
 
-from funcy import retry
+from funcy import retry, suppress, memoize, cached_property
 
-from dvc.config import NoRemoteError, ConfigError
+from dvc.compat import fspath
+from dvc.repo import Repo
+from dvc.config import Config, NoRemoteError, NotDvcRepoError
 from dvc.exceptions import NoRemoteInExternalRepoError
+from dvc.exceptions import OutputNotFoundError, NoOutputInExternalRepoError
+from dvc.exceptions import FileMissingError, PathMissingError
 from dvc.remote import RemoteConfig
-from dvc.exceptions import NoOutputInExternalRepoError
-from dvc.exceptions import OutputNotFoundError
-from dvc.utils.fs import remove
-
-
-REPO_CACHE = {}
+from dvc.utils.fs import remove, fs_copy
+from dvc.scm import SCM
 
 
 @contextmanager
-def external_repo(url=None, rev=None, rev_lock=None, cache_dir=None):
-    from dvc.repo import Repo
+def external_repo(url, rev=None):
+    path = _cached_clone(url, rev)
+    try:
+        repo = ExternalRepo(path, url)
+    except NotDvcRepoError:
+        repo = ExternalGitRepo(path, url)
 
-    path = _external_repo(url=url, rev=rev_lock or rev, cache_dir=cache_dir)
-    repo = Repo(path)
     try:
         yield repo
     except NoRemoteError:
@@ -30,28 +32,121 @@ def external_repo(url=None, rev=None, rev_lock=None, cache_dir=None):
         if exc.repo is repo:
             raise NoOutputInExternalRepoError(exc.output, repo.root_dir, url)
         raise
-    repo.close()
+    except FileMissingError as exc:
+        raise PathMissingError(exc.path, url)
+    finally:
+        repo.close()
 
 
-def cached_clone(url, rev=None, **_ignored_kwargs):
+def clean_repos():
+    # Outside code should not see cache while we are removing
+    repo_paths = list(_cached_clone.memory.values())
+    _cached_clone.memory.clear()
+
+    for path in repo_paths:
+        _remove(path)
+
+
+class ExternalRepo(Repo):
+    def __init__(self, root_dir, url):
+        super().__init__(root_dir)
+        self.url = url
+        self._set_upstream()
+
+    def pull_to(self, path, to_info):
+        try:
+            out = None
+            with suppress(OutputNotFoundError):
+                out = self.find_out_by_relpath(path)
+
+            if out and out.use_cache:
+                self._pull_cached(out, to_info)
+                return
+
+            # Git handled files can't have absolute path
+            if os.path.isabs(path):
+                raise FileNotFoundError
+
+            fs_copy(os.path.join(self.root_dir, path), fspath(to_info))
+        except FileNotFoundError:
+            raise PathMissingError(path, self.url)
+
+    def _pull_cached(self, out, to_info):
+        with self.state:
+            self.cloud.pull(out.get_used_cache())
+            out.path_info = to_info
+            failed = out.checkout()
+            # This might happen when pull haven't really pulled all the files
+            if failed:
+                raise FileNotFoundError
+
+    def _set_upstream(self):
+        # check if the URL is local and no default remote is present
+        # add default remote pointing to the original repo's cache location
+        if os.path.isdir(self.url):
+            rconfig = RemoteConfig(self.config)
+            if not rconfig.has_default():
+                src_repo = Repo(self.url)
+                try:
+                    rconfig.add(
+                        "auto-generated-upstream",
+                        src_repo.cache.local.cache_dir,
+                        default=True,
+                        level=Config.LEVEL_LOCAL,
+                    )
+                finally:
+                    src_repo.close()
+
+
+class ExternalGitRepo:
+    def __init__(self, root_dir, url):
+        self.root_dir = root_dir
+        self.url = url
+
+    @cached_property
+    def scm(self):
+        return SCM(self.root_dir)
+
+    def close(self):
+        if "scm" in self.__dict__:
+            self.scm.close()
+
+    def find_out_by_relpath(self, path):
+        raise OutputNotFoundError(path, self)
+
+    def pull_to(self, path, to_info):
+        try:
+            # Git handled files can't have absolute path
+            if os.path.isabs(path):
+                raise FileNotFoundError
+
+            fs_copy(os.path.join(self.root_dir, path), fspath(to_info))
+        except FileNotFoundError:
+            raise PathMissingError(path, self.url)
+
+    @contextmanager
+    def open_by_relpath(self, path, mode="r", encoding=None):
+        try:
+            abs_path = os.path.join(self.root_dir, path)
+            with open(abs_path, mode, encoding) as fd:
+                yield fd
+        except FileNotFoundError:
+            raise PathMissingError(path, self.url)
+
+
+@memoize
+def _cached_clone(url, rev):
     """Clone an external git repo to a temporary directory.
 
     Returns the path to a local temporary directory with the specified
     revision checked out.
-
-    Uses the REPO_CACHE to avoid accessing the remote server again if
-    cloning from the same URL twice in the same session.
-
     """
-
     new_path = tempfile.mkdtemp("dvc-erepo")
 
-    # Copy and adjust existing clean clone
-    if (url, None, None) in REPO_CACHE:
-        old_path = REPO_CACHE[url, None, None]
-
+    if url in _cached_clone.memory:
+        # Copy and an existing clean clone
         # This one unlike shutil.copytree() works with an existing dir
-        copy_tree(old_path, new_path)
+        copy_tree(_cached_clone.memory[url], new_path)
     else:
         # Create a new clone
         _clone_repo(url, new_path)
@@ -59,52 +154,12 @@ def cached_clone(url, rev=None, **_ignored_kwargs):
         # Save clean clone dir so that we will have access to a default branch
         clean_clone_path = tempfile.mkdtemp("dvc-erepo")
         copy_tree(new_path, clean_clone_path)
-        REPO_CACHE[url, None, None] = clean_clone_path
+        _cached_clone.memory[url] = clean_clone_path
 
     # Check out the specified revision
     if rev is not None:
         _git_checkout(new_path, rev)
 
-    return new_path
-
-
-def _external_repo(url=None, rev=None, cache_dir=None):
-    from dvc.config import Config
-    from dvc.cache import CacheConfig
-    from dvc.repo import Repo
-
-    key = (url, rev, cache_dir)
-    if key in REPO_CACHE:
-        return REPO_CACHE[key]
-
-    new_path = cached_clone(url, rev=rev)
-
-    repo = Repo(new_path)
-    try:
-        # check if the URL is local and no default remote is present
-        # add default remote pointing to the original repo's cache location
-        if os.path.isdir(url):
-            rconfig = RemoteConfig(repo.config)
-            if not _default_remote_set(rconfig):
-                original_repo = Repo(url)
-                try:
-                    rconfig.add(
-                        "auto-generated-upstream",
-                        original_repo.cache.local.cache_dir,
-                        default=True,
-                        level=Config.LEVEL_LOCAL,
-                    )
-                finally:
-                    original_repo.close()
-
-        if cache_dir is not None:
-            cache_config = CacheConfig(repo.config)
-            cache_config.set_dir(cache_dir, level=Config.LEVEL_LOCAL)
-    finally:
-        # Need to close/reopen repo to force config reread
-        repo.close()
-
-    REPO_CACHE[key] = new_path
     return new_path
 
 
@@ -116,15 +171,6 @@ def _git_checkout(repo_path, revision):
         git.checkout(revision)
     finally:
         git.close()
-
-
-def clean_repos():
-    # Outside code should not see cache while we are removing
-    repo_paths = list(REPO_CACHE.values())
-    REPO_CACHE.clear()
-
-    for path in repo_paths:
-        _remove(path)
 
 
 def _remove(path):
@@ -141,19 +187,3 @@ def _clone_repo(url, path):
 
     git = Git.clone(url, path)
     git.close()
-
-
-def _default_remote_set(rconfig):
-    """
-    Checks if default remote config is present.
-    Args:
-        rconfig: a remote config
-
-    Returns:
-        True if the default remote config is set, else False
-    """
-    try:
-        rconfig.get_default()
-        return True
-    except ConfigError:
-        return False

--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -73,7 +73,10 @@ class ExternalRepo(Repo):
 
     def _pull_cached(self, out, to_info):
         with self.state:
-            self.cloud.pull(out.get_used_cache())
+            # Only pull unless all needed cache is present
+            if out.changed_cache():
+                self.cloud.pull(out.get_used_cache())
+
             out.path_info = to_info
             failed = out.checkout()
             # This might happen when pull haven't really pulled all the files

--- a/dvc/remote/config.py
+++ b/dvc/remote/config.py
@@ -157,3 +157,7 @@ class RemoteConfig(object):
         return self.config.get(
             Config.SECTION_CORE, Config.SECTION_CORE_REMOTE, level=level
         )
+
+    def has_default(self):
+        core = self.config.config[Config.SECTION_CORE]
+        return bool(core.get(Config.SECTION_CORE_REMOTE))

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -61,7 +61,7 @@ class RemoteLOCAL(RemoteBASE):
             cwd = config[Config.PRIVATE_CWD]
             cache_dir = os.path.abspath(os.path.join(cwd, cache_dir))
 
-        self.path_info = PathInfo(cache_dir) if cache_dir else None
+        self.cache_dir = cache_dir
         self._dir_info = {}
 
     @property
@@ -71,6 +71,10 @@ class RemoteLOCAL(RemoteBASE):
     @property
     def cache_dir(self):
         return self.path_info.fspath if self.path_info else None
+
+    @cache_dir.setter
+    def cache_dir(self, value):
+        self.path_info = PathInfo(value) if value else None
 
     @classmethod
     def supported(cls, config):

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -4,7 +4,6 @@ from dvc.cache import NamedCache
 from dvc.config import NoRemoteError
 from dvc.exceptions import DownloadError
 from dvc.exceptions import OutputNotFoundError
-from dvc.external_repo import external_repo
 from dvc.scm.base import CloneError
 
 
@@ -70,11 +69,13 @@ def _fetch(
 
 
 def _fetch_external(self, repo_url, repo_rev, files):
-    failed = 0
+    from dvc.external_repo import external_repo
 
-    cache_dir = self.cache.local.cache_dir
+    failed = 0
     try:
-        with external_repo(repo_url, repo_rev, cache_dir=cache_dir) as repo:
+        with external_repo(repo_url, repo_rev) as repo:
+            repo.cache.local.cache_dir = self.cache.local.cache_dir
+
             with repo.state:
                 cache = NamedCache()
                 for name in files:

--- a/tests/func/test_api.py
+++ b/tests/func/test_api.py
@@ -6,9 +6,9 @@ import ruamel.yaml
 import pytest
 
 from dvc import api
-from dvc.api import SummonError, NotDvcRepoError, UrlNotDvcRepoError
+from dvc.api import SummonError, UrlNotDvcRepoError
 from dvc.compat import fspath
-from dvc.exceptions import FileMissingError
+from dvc.exceptions import FileMissingError, NotDvcRepoError
 from dvc.main import main
 from dvc.path_info import URLInfo
 from dvc.remote.config import RemoteConfig

--- a/tests/func/test_api.py
+++ b/tests/func/test_api.py
@@ -6,7 +6,7 @@ import ruamel.yaml
 import pytest
 
 from dvc import api
-from dvc.api import SummonError, UrlNotDvcRepoError
+from dvc.api import SummonError, NotDvcRepoError, UrlNotDvcRepoError
 from dvc.compat import fspath
 from dvc.exceptions import FileMissingError
 from dvc.main import main
@@ -51,14 +51,14 @@ def test_get_url_external(erepo_dir, remote_url):
     assert api.get_url("foo", repo=repo_url) == expected_url
 
 
-def test_get_url_git_only_repo_throws_exception(tmp_dir, scm):
+def test_get_url_requires_dvc(tmp_dir, scm):
     tmp_dir.scm_gen({"foo": "foo"}, commit="initial")
 
-    with pytest.raises(UrlNotDvcRepoError) as exc_info:
-        api.get_url("foo", fspath(tmp_dir))
+    with pytest.raises(NotDvcRepoError, match="not inside of a dvc repo"):
+        api.get_url("foo", repo=fspath(tmp_dir))
 
-    # On windows, `exc_info` has path escaped, eg: `C:\\\\Users\\\\travis`
-    assert fspath(tmp_dir) in str(exc_info).replace("\\\\", "\\")
+    with pytest.raises(UrlNotDvcRepoError):
+        api.get_url("foo", repo="file://{}".format(tmp_dir))
 
 
 @pytest.mark.parametrize("remote_url", all_remote_params, indirect=True)

--- a/tests/func/test_external_repo.py
+++ b/tests/func/test_external_repo.py
@@ -1,11 +1,8 @@
-import os
-
 from mock import patch
+from dvc.compat import fspath
 
 from dvc.external_repo import external_repo
 from dvc.scm.git import Git
-from dvc.compat import fspath
-from dvc.utils.fs import path_isin
 
 
 def test_external_repo(erepo_dir):
@@ -15,20 +12,14 @@ def test_external_repo(erepo_dir):
         erepo_dir.dvc_gen("file", "master", commit="create file on master")
 
     url = fspath(erepo_dir)
-    # We will share cache dir, to fetch version file
-    cache_dir = erepo_dir.dvc.cache.local.cache_dir
 
     with patch.object(Git, "clone", wraps=Git.clone) as mock:
-        with external_repo(url, cache_dir=cache_dir) as repo:
-            with repo.open(os.path.join(repo.root_dir, "file")) as fd:
+        with external_repo(url) as repo:
+            with repo.open_by_relpath("file") as fd:
                 assert fd.read() == "master"
 
-        with external_repo(url, rev="branch", cache_dir=cache_dir) as repo:
-            with repo.open(os.path.join(repo.root_dir, "file")) as fd:
+        with external_repo(url, rev="branch") as repo:
+            with repo.open_by_relpath("file") as fd:
                 assert fd.read() == "branch"
-
-        # Check cache_dir is unset
-        with external_repo(url) as repo:
-            assert path_isin(repo.cache.local.cache_dir, repo.root_dir)
 
         assert mock.call_count == 1

--- a/tests/func/test_get.py
+++ b/tests/func/test_get.py
@@ -6,7 +6,8 @@ import pytest
 from dvc.cache import Cache
 from dvc.config import Config
 from dvc.main import main
-from dvc.repo.get import GetDVCFileError, PathMissingError
+from dvc.exceptions import PathMissingError
+from dvc.repo.get import GetDVCFileError
 from dvc.repo import Repo
 from dvc.system import System
 from dvc.utils.fs import makedirs

--- a/tests/func/test_import.py
+++ b/tests/func/test_import.py
@@ -1,20 +1,18 @@
 import filecmp
 import os
 import shutil
+from dvc.compat import fspath
 
 import pytest
 from mock import patch
 
 from dvc.cache import Cache
 from dvc.config import Config
-from dvc.exceptions import DownloadError
-from dvc.exceptions import PathMissingError
-from dvc.exceptions import NoOutputInExternalRepoError
+from dvc.exceptions import DownloadError, PathMissingError
 from dvc.config import NoRemoteError
 from dvc.stage import Stage
 from dvc.system import System
 from dvc.utils.fs import makedirs
-from dvc.compat import fspath
 import dvc.data_cloud as cloud
 from tests.utils import trees_equal
 
@@ -266,5 +264,5 @@ def test_import_non_existing(erepo_dir, tmp_dir, dvc):
         tmp_dir.dvc.imp(fspath(erepo_dir), "invalid_output")
 
     # https://github.com/iterative/dvc/pull/2837#discussion_r352123053
-    with pytest.raises(NoOutputInExternalRepoError):
+    with pytest.raises(PathMissingError):
         tmp_dir.dvc.imp(fspath(erepo_dir), "/root/", "root")

--- a/tests/func/test_status.py
+++ b/tests/func/test_status.py
@@ -33,9 +33,7 @@ def test_status_non_dvc_repo_import(tmp_dir, dvc, erepo_dir):
     with erepo_dir.branch("branch", new=True), erepo_dir.chdir():
         erepo_dir.scm.repo.index.remove([".dvc"], r=True)
         shutil.rmtree(".dvc")
-        erepo_dir.scm_gen("file", "first version")
-        erepo_dir.scm.add(["file"])
-        erepo_dir.scm.commit("first version")
+        erepo_dir.scm_gen("file", "first version", commit="first version")
 
     dvc.imp(fspath(erepo_dir), "file", "file", rev="branch")
 
@@ -49,8 +47,6 @@ def test_status_non_dvc_repo_import(tmp_dir, dvc, erepo_dir):
 
     with erepo_dir.branch("branch", new=False), erepo_dir.chdir():
         erepo_dir.scm_gen("file", "second_version", commit="update file")
-        erepo_dir.scm.add(["file"])
-        erepo_dir.scm.commit("first version")
 
     status, = dvc.status(["file.dvc"])["file.dvc"]
 
@@ -65,9 +61,7 @@ def test_status_before_and_after_dvc_init(tmp_dir, dvc, erepo_dir):
     with erepo_dir.chdir():
         erepo_dir.scm.repo.index.remove([".dvc"], r=True)
         shutil.rmtree(".dvc")
-        erepo_dir.scm_gen("file", "first version")
-        erepo_dir.scm.add(["file"])
-        erepo_dir.scm.commit("first version")
+        erepo_dir.scm_gen("file", "first version", commit="first verison")
         old_rev = erepo_dir.scm.get_rev()
 
     dvc.imp(fspath(erepo_dir), "file", "file")

--- a/tests/func/test_update.py
+++ b/tests/func/test_update.py
@@ -114,9 +114,7 @@ def test_update_before_and_after_dvc_init(tmp_dir, dvc, erepo_dir):
     with erepo_dir.chdir():
         erepo_dir.scm.repo.index.remove([".dvc"], r=True)
         shutil.rmtree(".dvc")
-        erepo_dir.scm_gen("file", "first version")
-        erepo_dir.scm.add(["file"])
-        erepo_dir.scm.commit("first version")
+        erepo_dir.scm_gen("file", "first version", commit="first version")
         old_rev = erepo_dir.scm.get_rev()
 
     stage = dvc.imp(fspath(erepo_dir), "file", "file")


### PR DESCRIPTION
Some things are fixed along the way:
- no cache shared between incompatible funcs
- some incosistent exceptions are now consistent
- import updates for git files now works both for dvc and git repos
- "auto-generated-upstream already exists" fixed
- api.open()/read() works with git repos now
- api funcs allow specifying `rev` for local repos now

Fixes #3124, fixes #2976, fixes #3179, and fixes #2824. Closes #3172.
