### PR TITLE
test: refactor tmp_dir/erepo_dir

### DIFF
--- a/tests/dir_helpers.py
+++ b/tests/dir_helpers.py
@@ -237,10 +237,6 @@ def run_copy(tmp_dir, dvc):
         "import sys, shutil\nshutil.copyfile(sys.argv[1], sys.argv[2])",
     )
 
-    # Do we need this?
-    if hasattr(tmp_dir, "scm"):
-        tmp_dir.scm_add("copy.py", commit="add copy.py")
-
     def run_copy(src, dst, **run_kwargs):
         return dvc.run(
             cmd="python copy.py {} {}".format(src, dst),

--- a/tests/dir_helpers.py
+++ b/tests/dir_helpers.py
@@ -54,15 +54,7 @@ from dvc.utils.fs import makedirs
 from dvc.compat import fspath, fspath_py35
 
 
-__all__ = ["tmp_dir", "scm", "dvc", "repo_template", "run_copy", "erepo_dir"]
-REPO_TEMPLATE = {
-    "foo": "foo",
-    "bar": "bar",
-    "dir": {
-        "data": "dir/data text",
-        "subdir": {"subdata": "dir/subdir/subdata text"},
-    },
-}
+__all__ = ["tmp_dir", "scm", "dvc", "run_copy", "erepo_dir"]
 
 
 class TmpDir(pathlib.Path):
@@ -234,11 +226,6 @@ def dvc(tmp_dir, request):
         yield dvc
     finally:
         dvc.close()
-
-
-@pytest.fixture
-def repo_template(tmp_dir):
-    tmp_dir.gen(REPO_TEMPLATE)
 
 
 @pytest.fixture

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -463,7 +463,9 @@ class TestAddFilename(TestDvc):
         self.assertFalse(os.path.exists("foo.dvc"))
 
 
-def test_should_cleanup_after_failed_add(tmp_dir, scm, dvc, repo_template):
+def test_failed_add_cleanup(tmp_dir, scm, dvc):
+    tmp_dir.gen({"foo": "foo", "bar": "bar"})
+
     # Add and corrupt a stage file
     dvc.add("foo")
     tmp_dir.gen("foo.dvc", "- broken\nyaml")

--- a/tests/func/test_gc.py
+++ b/tests/func/test_gc.py
@@ -189,9 +189,9 @@ def test_all_commits(tmp_dir, scm, dvc):
     assert _count_files(dvc.cache.local.cache_dir) == n - 1
 
 
-def test_gc_no_dir_cache(tmp_dir, dvc, repo_template):
-    dvc.add(["foo", "bar"])
-    dir_stage, = dvc.add("dir")
+def test_gc_no_dir_cache(tmp_dir, dvc):
+    tmp_dir.dvc_gen({"foo": "foo", "bar": "bar"})
+    dir_stage, = tmp_dir.dvc_gen({"dir": {"x": "x", "subdir": {"y": "y"}}})
 
     os.unlink(dir_stage.outs[0].cache_path)
 
@@ -207,8 +207,8 @@ def _count_files(path):
     return sum(len(files) for _, _, files in os.walk(path))
 
 
-def test_gc_no_unpacked_dir(tmp_dir, dvc, repo_template):
-    dir_stages = dvc.add("dir")
+def test_gc_no_unpacked_dir(tmp_dir, dvc):
+    dir_stages = tmp_dir.dvc_gen({"dir": {"file": "text"}})
     dvc.status()
 
     os.remove("dir.dvc")


### PR DESCRIPTION
Provides `make_tmp_dir` fixture. A base for simplifying tests where we now remove `.dvc` in erepo. 

Cleaning up that code will conflict with #3190, so waiting for that.