### PR TITLE
dvc: replace flatten_dict with flatten_json

### DIFF
--- a/dvc/repo/metrics/diff.py
+++ b/dvc/repo/metrics/diff.py
@@ -1,7 +1,7 @@
 import json
 from collections import defaultdict
 
-from flatten_dict import flatten
+from flatten_json import flatten
 
 from dvc.exceptions import NoMetricsError
 
@@ -34,25 +34,18 @@ def _diff_vals(old, new):
     return res
 
 
-# dot_reducer is not released yet (flatten-dict > 0.2.0)
-def _dot(k1, k2):
-    if k1 is None:
-        return k2
-    return "{0}.{1}".format(k1, k2)
-
-
 def _diff_dicts(old_dict, new_dict):
     old_default = None
     new_default = None
 
     if isinstance(new_dict, dict):
-        new = flatten(new_dict, reducer=_dot)
+        new = flatten(new_dict, ".")
     else:
         new = defaultdict(lambda: "not a dict")
         new_default = "unable to parse"
 
     if isinstance(old_dict, dict):
-        old = flatten(old_dict, reducer=_dot)
+        old = flatten(old_dict, ".")
     else:
         old = defaultdict(lambda: "not a dict")
         old_default = "unable to parse"

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ install_requires = [
     "networkx>=2.1,<2.4",
     "speedcopy>=2.0.1",
     "pyfastcopy>=1.0.3",
-    "flatten-dict>=0.2.0",
+    "flatten_json>=0.1.6",
     "texttable>=0.5.2",
 ]
 


### PR DESCRIPTION
flatten_json has a conda package, while flatten_dict doesn't and I'm not
willing to maintain yet another conda package :)

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

