### PR TITLE
tests: replace spy() with pytest-mock spy

### DIFF
--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -9,7 +9,7 @@ import colorama
 import pytest
 from mock import patch
 
-import dvc
+import dvc as dvc_module
 from dvc.cache import Cache
 from dvc.exceptions import DvcException
 from dvc.exceptions import RecursiveAddingWhileUsingFilename
@@ -28,8 +28,6 @@ from dvc.utils.fs import path_isin
 from dvc.utils.stage import load_stage_file
 from tests.basic_env import TestDvc
 from tests.utils import get_gitignore_content
-
-dvc_module = dvc  # to disambiguate between the module and the fixture
 
 
 def test_add(tmp_dir, dvc):
@@ -244,12 +242,6 @@ class TestDoubleAddUnchanged(TestDvc):
 
         ret = main(["add", self.DATA_DIR])
         self.assertEqual(ret, 0)
-
-
-class TestDvcWithMocker(TestDvc):
-    @pytest.fixture(autouse=True)
-    def use_mocker(self, mocker):
-        self.mocker = mocker
 
 
 def test_should_update_state_entry_for_file_after_add(mocker, dvc, tmp_dir):

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -253,63 +253,62 @@ class TestDvcWithMocker(TestDvc):
 class TestShouldUpdateStateEntryForFileAfterAdd(TestDvcWithMocker):
     def test(self):
         file_md5_counter = self.mocker.spy(dvc.remote.local, "file_md5")
-        with patch.object(dvc.remote.local, "file_md5", file_md5_counter):
-            ret = main(["config", "cache.type", "copy"])
-            self.assertEqual(ret, 0)
 
-            ret = main(["add", self.FOO])
-            self.assertEqual(ret, 0)
-            self.assertEqual(file_md5_counter.mock.call_count, 1)
+        ret = main(["config", "cache.type", "copy"])
+        self.assertEqual(ret, 0)
 
-            ret = main(["status"])
-            self.assertEqual(ret, 0)
-            self.assertEqual(file_md5_counter.mock.call_count, 1)
+        ret = main(["add", self.FOO])
+        self.assertEqual(ret, 0)
+        self.assertEqual(file_md5_counter.mock.call_count, 1)
 
-            ret = main(["run", "-d", self.FOO, "echo foo"])
-            self.assertEqual(ret, 0)
-            self.assertEqual(file_md5_counter.mock.call_count, 1)
+        ret = main(["status"])
+        self.assertEqual(ret, 0)
+        self.assertEqual(file_md5_counter.mock.call_count, 1)
 
-            os.rename(self.FOO, self.FOO + ".back")
-            ret = main(["checkout"])
-            self.assertEqual(ret, 0)
-            self.assertEqual(file_md5_counter.mock.call_count, 1)
+        ret = main(["run", "-d", self.FOO, "echo foo"])
+        self.assertEqual(ret, 0)
+        self.assertEqual(file_md5_counter.mock.call_count, 1)
 
-            ret = main(["status"])
-            self.assertEqual(ret, 0)
-            self.assertEqual(file_md5_counter.mock.call_count, 1)
+        os.rename(self.FOO, self.FOO + ".back")
+        ret = main(["checkout"])
+        self.assertEqual(ret, 0)
+        self.assertEqual(file_md5_counter.mock.call_count, 1)
+
+        ret = main(["status"])
+        self.assertEqual(ret, 0)
+        self.assertEqual(file_md5_counter.mock.call_count, 1)
 
 
 class TestShouldUpdateStateEntryForDirectoryAfterAdd(TestDvcWithMocker):
     def test(self):
         file_md5_counter = self.mocker.spy(dvc.remote.local, "file_md5")
-        with patch.object(dvc.remote.local, "file_md5", file_md5_counter):
 
-            ret = main(["config", "cache.type", "copy"])
-            self.assertEqual(ret, 0)
+        ret = main(["config", "cache.type", "copy"])
+        self.assertEqual(ret, 0)
 
-            ret = main(["add", self.DATA_DIR])
-            self.assertEqual(ret, 0)
-            self.assertEqual(file_md5_counter.mock.call_count, 3)
+        ret = main(["add", self.DATA_DIR])
+        self.assertEqual(ret, 0)
+        self.assertEqual(file_md5_counter.mock.call_count, 3)
 
-            ret = main(["status"])
-            self.assertEqual(ret, 0)
-            self.assertEqual(file_md5_counter.mock.call_count, 3)
+        ret = main(["status"])
+        self.assertEqual(ret, 0)
+        self.assertEqual(file_md5_counter.mock.call_count, 3)
 
-            ls = "dir" if os.name == "nt" else "ls"
-            ret = main(
-                ["run", "-d", self.DATA_DIR, "{} {}".format(ls, self.DATA_DIR)]
-            )
-            self.assertEqual(ret, 0)
-            self.assertEqual(file_md5_counter.mock.call_count, 3)
+        ls = "dir" if os.name == "nt" else "ls"
+        ret = main(
+            ["run", "-d", self.DATA_DIR, "{} {}".format(ls, self.DATA_DIR)]
+        )
+        self.assertEqual(ret, 0)
+        self.assertEqual(file_md5_counter.mock.call_count, 3)
 
-            os.rename(self.DATA_DIR, self.DATA_DIR + ".back")
-            ret = main(["checkout"])
-            self.assertEqual(ret, 0)
-            self.assertEqual(file_md5_counter.mock.call_count, 3)
+        os.rename(self.DATA_DIR, self.DATA_DIR + ".back")
+        ret = main(["checkout"])
+        self.assertEqual(ret, 0)
+        self.assertEqual(file_md5_counter.mock.call_count, 3)
 
-            ret = main(["status"])
-            self.assertEqual(ret, 0)
-            self.assertEqual(file_md5_counter.mock.call_count, 3)
+        ret = main(["status"])
+        self.assertEqual(ret, 0)
+        self.assertEqual(file_md5_counter.mock.call_count, 3)
 
 
 class TestAddCommit(TestDvc):
@@ -327,22 +326,17 @@ class TestAddCommit(TestDvc):
 
 class TestShouldCollectDirCacheOnlyOnce(TestDvcWithMocker):
     def test(self):
-        from dvc.remote.local import RemoteLOCAL
-
         get_dir_checksum_counter = self.mocker.spy(
             RemoteLOCAL, "get_dir_checksum"
         )
-        with patch.object(
-            RemoteLOCAL, "get_dir_checksum", get_dir_checksum_counter
-        ):
-            ret = main(["add", self.DATA_DIR])
-            self.assertEqual(0, ret)
+        ret = main(["add", self.DATA_DIR])
+        self.assertEqual(0, ret)
 
-            ret = main(["status"])
-            self.assertEqual(0, ret)
+        ret = main(["status"])
+        self.assertEqual(0, ret)
 
-            ret = main(["status"])
-            self.assertEqual(0, ret)
+        ret = main(["status"])
+        self.assertEqual(0, ret)
         self.assertEqual(1, get_dir_checksum_counter.mock.call_count)
 
 
@@ -488,9 +482,8 @@ class TestShouldNotTrackGitInternalFiles(TestDvcWithMocker):
     def test(self):
         stage_creator_spy = self.mocker.spy(dvc.repo.add, "_create_stages")
 
-        with patch.object(dvc.repo.add, "_create_stages", stage_creator_spy):
-            ret = main(["add", "-R", self.dvc.root_dir])
-            self.assertEqual(0, ret)
+        ret = main(["add", "-R", self.dvc.root_dir])
+        self.assertEqual(0, ret)
 
         created_stages_filenames = stage_creator_spy.mock.call_args[0][1]
         for fname in created_stages_filenames:
@@ -580,7 +573,6 @@ def test_readding_dir_should_not_unprotect_all(tmp_dir, dvc, mocker):
     tmp_dir.gen("dir/new_file", "new_file_content")
 
     unprotect_spy = mocker.spy(RemoteLOCAL, "unprotect")
-    mocker.patch.object(RemoteLOCAL, "unprotect", unprotect_spy)
     dvc.add("dir")
 
     assert not unprotect_spy.mock.called
@@ -595,7 +587,6 @@ def test_should_not_checkout_when_adding_cached_copy(tmp_dir, dvc, mocker):
     shutil.copy("bar", "foo")
 
     copy_spy = mocker.spy(dvc.cache.local, "copy")
-    mocker.patch.object(dvc.cache.local, "copy", copy_spy)
 
     dvc.add("foo")
 

--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -583,27 +583,21 @@ class TestRecursiveSyncOperations(Local, TestDataCloudBase):
         self._test_recursive_pull()
 
 
-class TestCheckSumRecalculation(TestDvc):
-    @pytest.fixture(autouse=True)
-    def use_mocker(self, mocker):
-        self.mocker = mocker
-
-    def test(self):
-        test_get_file_checksum = self.mocker.spy(
-            RemoteLOCAL, "get_file_checksum"
-        )
-        url = Local.get_url()
-        ret = main(["remote", "add", "-d", TEST_REMOTE, url])
-        self.assertEqual(ret, 0)
-        ret = main(["config", "cache.type", "hardlink"])
-        self.assertEqual(ret, 0)
-        ret = main(["add", self.FOO])
-        self.assertEqual(ret, 0)
-        ret = main(["push"])
-        self.assertEqual(ret, 0)
-        ret = main(["run", "-d", self.FOO, "echo foo"])
-        self.assertEqual(ret, 0)
-        self.assertEqual(test_get_file_checksum.mock.call_count, 1)
+def test_checksum_recalculation(mocker, dvc, tmp_dir):
+    tmp_dir.gen({"foo": "foo"})
+    test_get_file_checksum = mocker.spy(RemoteLOCAL, "get_file_checksum")
+    url = Local.get_url()
+    ret = main(["remote", "add", "-d", TEST_REMOTE, url])
+    assert ret == 0
+    ret = main(["config", "cache.type", "hardlink"])
+    assert ret == 0
+    ret = main(["add", "foo"])
+    assert ret == 0
+    ret = main(["push"])
+    assert ret == 0
+    ret = main(["run", "-d", "foo", "echo foo"])
+    assert ret == 0
+    assert test_get_file_checksum.mock.call_count == 1
 
 
 class TestShouldWarnOnNoChecksumInLocalAndRemoteCache(TestDvc):

--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -28,7 +28,6 @@ from dvc.utils import file_md5
 from dvc.utils.stage import dump_stage_file
 from dvc.utils.stage import load_stage_file
 from tests.basic_env import TestDvc
-from tests.utils import spy
 
 from tests.remotes import (
     Azure,
@@ -586,8 +585,14 @@ class TestRecursiveSyncOperations(Local, TestDataCloudBase):
 
 
 class TestCheckSumRecalculation(TestDvc):
+    @pytest.fixture(autouse=True)
+    def use_mocker(self, mocker):
+        self.mocker = mocker
+
     def test(self):
-        test_get_file_checksum = spy(RemoteLOCAL.get_file_checksum)
+        test_get_file_checksum = self.mocker.spy(
+            RemoteLOCAL, "get_file_checksum"
+        )
         with patch.object(
             RemoteLOCAL, "get_file_checksum", test_get_file_checksum
         ):

--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -6,7 +6,6 @@ import uuid
 from unittest import SkipTest
 
 import pytest
-from mock import patch
 
 from dvc.cache import NamedCache
 from dvc.config import Config
@@ -593,20 +592,17 @@ class TestCheckSumRecalculation(TestDvc):
         test_get_file_checksum = self.mocker.spy(
             RemoteLOCAL, "get_file_checksum"
         )
-        with patch.object(
-            RemoteLOCAL, "get_file_checksum", test_get_file_checksum
-        ):
-            url = Local.get_url()
-            ret = main(["remote", "add", "-d", TEST_REMOTE, url])
-            self.assertEqual(ret, 0)
-            ret = main(["config", "cache.type", "hardlink"])
-            self.assertEqual(ret, 0)
-            ret = main(["add", self.FOO])
-            self.assertEqual(ret, 0)
-            ret = main(["push"])
-            self.assertEqual(ret, 0)
-            ret = main(["run", "-d", self.FOO, "echo foo"])
-            self.assertEqual(ret, 0)
+        url = Local.get_url()
+        ret = main(["remote", "add", "-d", TEST_REMOTE, url])
+        self.assertEqual(ret, 0)
+        ret = main(["config", "cache.type", "hardlink"])
+        self.assertEqual(ret, 0)
+        ret = main(["add", self.FOO])
+        self.assertEqual(ret, 0)
+        ret = main(["push"])
+        self.assertEqual(ret, 0)
+        ret = main(["run", "-d", self.FOO, "echo foo"])
+        self.assertEqual(ret, 0)
         self.assertEqual(test_get_file_checksum.mock.call_count, 1)
 
 

--- a/tests/func/test_import_url.py
+++ b/tests/func/test_import_url.py
@@ -8,7 +8,6 @@ import dvc
 from dvc.main import main
 from dvc.utils.fs import makedirs
 from tests.basic_env import TestDvc
-from tests.utils import spy
 
 
 class TestCmdImport(TestDvc):
@@ -42,6 +41,10 @@ class TestDefaultOutput(TestDvc):
 
 
 class TestShouldRemoveOutsBeforeImport(TestDvc):
+    @pytest.fixture(autouse=True)
+    def use_mocker(self, mocker):
+        self.mocker = mocker
+
     def setUp(self):
         super().setUp()
         tmp_dir = self.mkdtemp()
@@ -50,7 +53,9 @@ class TestShouldRemoveOutsBeforeImport(TestDvc):
             fobj.write("content")
 
     def test(self):
-        remove_outs_call_counter = spy(dvc.stage.Stage.remove_outs)
+        remove_outs_call_counter = self.mocker.spy(
+            dvc.stage.Stage, "remove_outs"
+        )
         with patch.object(
             dvc.stage.Stage, "remove_outs", remove_outs_call_counter
         ):

--- a/tests/func/test_import_url.py
+++ b/tests/func/test_import_url.py
@@ -2,7 +2,6 @@ import os
 from uuid import uuid4
 
 import pytest
-from mock import patch
 
 import dvc
 from dvc.main import main
@@ -56,11 +55,8 @@ class TestShouldRemoveOutsBeforeImport(TestDvc):
         remove_outs_call_counter = self.mocker.spy(
             dvc.stage.Stage, "remove_outs"
         )
-        with patch.object(
-            dvc.stage.Stage, "remove_outs", remove_outs_call_counter
-        ):
-            ret = main(["import-url", self.external_source])
-            self.assertEqual(0, ret)
+        ret = main(["import-url", self.external_source])
+        self.assertEqual(0, ret)
 
         self.assertEqual(1, remove_outs_call_counter.mock.call_count)
 

--- a/tests/func/test_import_url.py
+++ b/tests/func/test_import_url.py
@@ -4,9 +4,12 @@ from uuid import uuid4
 import pytest
 
 import dvc
+from dvc.stage import Stage
 from dvc.main import main
 from dvc.utils.fs import makedirs
+from dvc.compat import fspath
 from tests.basic_env import TestDvc
+from tests.dir_helpers import TmpDir
 
 
 class TestCmdImport(TestDvc):
@@ -59,6 +62,17 @@ class TestShouldRemoveOutsBeforeImport(TestDvc):
         self.assertEqual(0, ret)
 
         self.assertEqual(1, remove_outs_call_counter.mock.call_count)
+
+
+def test_should_remove_outs_before_import(mocker, dvc, tmp_path_factory):
+    import_dir = TmpDir(tmp_path_factory.mktemp("import"))
+    import_dir.gen({"foo": "foo"})
+
+    remove_outs_call_counter = mocker.spy(Stage, "remove_outs")
+    ret = main(["import-url", fspath(import_dir / "foo")])
+
+    assert ret == 0
+    assert remove_outs_call_counter.mock.call_count == 1
 
 
 class TestImportFilename(TestDvc):

--- a/tests/func/test_import_url.py
+++ b/tests/func/test_import_url.py
@@ -3,13 +3,11 @@ from uuid import uuid4
 
 import pytest
 
-import dvc
 from dvc.stage import Stage
 from dvc.main import main
 from dvc.utils.fs import makedirs
 from dvc.compat import fspath
 from tests.basic_env import TestDvc
-from tests.dir_helpers import TmpDir
 
 
 class TestCmdImport(TestDvc):
@@ -42,34 +40,11 @@ class TestDefaultOutput(TestDvc):
             self.assertEqual(fd.read(), "content")
 
 
-class TestShouldRemoveOutsBeforeImport(TestDvc):
-    @pytest.fixture(autouse=True)
-    def use_mocker(self, mocker):
-        self.mocker = mocker
-
-    def setUp(self):
-        super().setUp()
-        tmp_dir = self.mkdtemp()
-        self.external_source = os.path.join(tmp_dir, "file")
-        with open(self.external_source, "w") as fobj:
-            fobj.write("content")
-
-    def test(self):
-        remove_outs_call_counter = self.mocker.spy(
-            dvc.stage.Stage, "remove_outs"
-        )
-        ret = main(["import-url", self.external_source])
-        self.assertEqual(0, ret)
-
-        self.assertEqual(1, remove_outs_call_counter.mock.call_count)
-
-
-def test_should_remove_outs_before_import(mocker, dvc, tmp_path_factory):
-    import_dir = TmpDir(tmp_path_factory.mktemp("import"))
-    import_dir.gen({"foo": "foo"})
+def test_should_remove_outs_before_import(mocker, erepo_dir):
+    erepo_dir.gen({"foo": "foo"})
 
     remove_outs_call_counter = mocker.spy(Stage, "remove_outs")
-    ret = main(["import-url", fspath(import_dir / "foo")])
+    ret = main(["import-url", fspath(erepo_dir / "foo")])
 
     assert ret == 0
     assert remove_outs_call_counter.mock.call_count == 1

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -78,17 +78,14 @@ class TestContainsLink(TestCase):
         contains_symlink_spy = self.mocker.spy(
             dvc.utils.fs, "contains_symlink_up_to"
         )
-        with patch.object(
-            dvc.utils.fs, "contains_symlink_up_to", contains_symlink_spy
-        ):
 
-            # call from full path to match contains_symlink_spy patch path
-            self.assertFalse(
-                dvc.utils.fs.contains_symlink_up_to(
-                    os.path.join("foo", "path"), "foo"
-                )
+        # call from full path to match contains_symlink_spy patch path
+        self.assertFalse(
+            dvc.utils.fs.contains_symlink_up_to(
+                os.path.join("foo", "path"), "foo"
             )
-            self.assertEqual(2, contains_symlink_spy.mock.call_count)
+        )
+        self.assertEqual(2, contains_symlink_spy.mock.call_count)
 
     @patch.object(System, "is_symlink", return_value=True)
     def test_should_return_false_when_base_path_is_symlink(self, _):

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -22,7 +22,6 @@ from dvc.utils.fs import path_isin, remove
 from dvc.utils.fs import makedirs
 from dvc.utils.fs import walk_files
 from tests.basic_env import TestDir
-from tests.utils import spy
 
 
 class TestMtimeAndSize(TestDir):
@@ -45,6 +44,10 @@ class TestMtimeAndSize(TestDir):
 
 
 class TestContainsLink(TestCase):
+    @pytest.fixture(autouse=True)
+    def use_mocker(self, mocker):
+        self.mocker = mocker
+
     def test_should_raise_exception_on_base_path_not_in_path(self):
         with self.assertRaises(BasePathNotInCheckedPathException):
             contains_symlink_up_to(os.path.join("foo", "path"), "bar")
@@ -72,7 +75,9 @@ class TestContainsLink(TestCase):
 
     @patch.object(System, "is_symlink", return_value=False)
     def test_should_call_recursive_on_no_condition_matched(self, _):
-        contains_symlink_spy = spy(contains_symlink_up_to)
+        contains_symlink_spy = self.mocker.spy(
+            dvc.utils.fs, "contains_symlink_up_to"
+        )
         with patch.object(
             dvc.utils.fs, "contains_symlink_up_to", contains_symlink_spy
         ):

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -2,20 +2,7 @@ import os
 from contextlib import contextmanager
 from filecmp import dircmp
 
-from mock import MagicMock
-
 from dvc.scm import Git
-
-
-def spy(method_to_decorate):
-    mock = MagicMock()
-
-    def wrapper(self, *args, **kwargs):
-        mock(*args, **kwargs)
-        return method_to_decorate(self, *args, **kwargs)
-
-    wrapper.mock = mock
-    return wrapper
 
 
 def get_gitignore_content():


### PR DESCRIPTION
After I'd started, @pared pointed out that it would be best to convert the tests to plain functions as opposed to classes, to better utilise the `mocker` fixture. I ended up having to create a bunch of wrappers just to use this fixture. Let me know if you'd like me to go ahead and convert all of the classes that were using spy into plain pytest function tests.

Fixes #3198

-------

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

