### PR TITLE
fix snap stable & edge release errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,7 +135,7 @@ deploy:
       stage: build
   - provider: snap
     snap: dvc_*.snap
-    channel: $SNAP_CHANNEL
+    channel: $RELEASE_SNAP_CHANNEL
     skip_cleanup: true
     on:
       all_branches: true

--- a/scripts/ci/before_install.sh
+++ b/scripts/ci/before_install.sh
@@ -52,7 +52,7 @@ elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
 fi
 
 if [[ -n "$TRAVIS_TAG" ]]; then
-    echo "export SNAP_CHANNEL=stable" >> env.sh
+    echo "export RELEASE_SNAP_CHANNEL=stable" >> env.sh
 else
-    echo "export SNAP_CHANNEL=edge" >> env.sh
+    echo "export RELEASE_SNAP_CHANNEL=edge" >> env.sh
 fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,10 +27,12 @@ parts:
     - git
     override-pull: |
         snapcraftctl pull
-        echo 'PKG = "snap"' > $SNAPCRAFT_PART_SRC/dvc/utils/build.py
         snapcraftctl set-version `cd $SNAPCRAFT_PART_SRC && git describe --tags`
+        echo 'PKG = "snap"' > $SNAPCRAFT_PART_SRC/dvc/utils/build.py
         # install all optional extras
         sed -ri 's/(=install_requires)/\1+all_remotes+hdfs/' $SNAPCRAFT_PART_SRC/setup.py
+        sed -rn 's/^(_BASE_VERSION = .*)$/__version__ = \1/p' $SNAPCRAFT_PART_SRC/dvc/version.py > $SNAPCRAFT_PART_SRC/dvc/version.py.new
+        mv $SNAPCRAFT_PART_SRC/dvc/version.py.new $SNAPCRAFT_PART_SRC/dvc/version.py
     override-build: |
         snapcraftctl build
         cp $SNAPCRAFT_PART_BUILD/scripts/completion/dvc.bash $SNAPCRAFT_PART_INSTALL/completion.sh

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,11 +28,12 @@ parts:
     override-pull: |
         snapcraftctl pull
         snapcraftctl set-version `cd $SNAPCRAFT_PART_SRC && git describe --tags`
+        git diff --quiet || error_dirty_build
         echo 'PKG = "snap"' > $SNAPCRAFT_PART_SRC/dvc/utils/build.py
         # install all optional extras
         sed -ri 's/(=install_requires)/\1+all_remotes+hdfs/' $SNAPCRAFT_PART_SRC/setup.py
-        sed -rn 's/^(_BASE_VERSION = .*)$/__version__ = \1/p' $SNAPCRAFT_PART_SRC/dvc/version.py > $SNAPCRAFT_PART_SRC/dvc/version.py.new
-        mv $SNAPCRAFT_PART_SRC/dvc/version.py.new $SNAPCRAFT_PART_SRC/dvc/version.py
+        # ensure dvc knows the state isn't really dirty
+        sed -rin 's/.*git.*diff.*--quiet.*//' $SNAPCRAFT_PART_SRC/dvc/version.py
     override-build: |
         snapcraftctl build
         cp $SNAPCRAFT_PART_BUILD/scripts/completion/dvc.bash $SNAPCRAFT_PART_INSTALL/completion.sh


### PR DESCRIPTION
- [x] `master`/`edge`: fix `SNAP_CHANNEL` env var automatically being picked up the `provider: snap` and used incorrectly https://travis-ci.com/iterative/dvc/jobs/278042607#L2168
  + really it should be automatically picked up and used *correctly*: https://docs.travis-ci.com/user/deployment-v2/providers/snap/#environment-variables. Looks like a travis bug.
- [x] `tag`/`stable`: fix version mismatch tag https://travis-ci.com/iterative/dvc/jobs/277748053#L2143
  + `dvc --version` => `<tag>+<hash>.mod` rather than `<tag>`
  + because of making tweaks to source while building the snap package? https://github.com/iterative/dvc/blob/aa86eab2cc4acbfc34279312eaa5cf1b8f30558e/snap/snapcraft.yaml#L30-L33
- continues #3173, #3158 <- (re) fixes #3152
- continues #2956 <- (re) fixes #2954