### PR TITLE
brancher: do not get tree if there's no revs

### DIFF
--- a/dvc/repo/brancher.py
+++ b/dvc/repo/brancher.py
@@ -42,8 +42,9 @@ def brancher(  # noqa: E302
             revs.extend(scm.list_tags())
 
     try:
-        for sha, names in group_by(scm.resolve_rev, revs).items():
-            self.tree = scm.get_tree(sha)
-            yield ", ".join(names)
+        if revs:
+            for sha, names in group_by(scm.resolve_rev, revs).items():
+                self.tree = scm.get_tree(sha)
+                yield ", ".join(names)
     finally:
         self.tree = saved_tree


### PR DESCRIPTION
From https://github.com/iterative/dvc/pull/3207#discussion_r369496309

When if it's a dvc only repo, brancher was failing as `NoSCM` does not have `resolve_rev`.
```sh
$ dvc init --no-scm
$ python -c '
from dvc.repo import Repo
repo = Repo(".")
print(list(repo.brancher(all_branches=True, all_commits=True, all_tags=True)))
'
Traceback (most recent call last):
  File "<string>", line 4, in <module>
  File "/home/saugat/repos/iterative/dvc/dvc/repo/brancher.py", line 45, in brancher
    for sha, names in group_by(scm.resolve_rev, revs).items():
AttributeError: 'NoSCM' object has no attribute 'resolve_rev'
```

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

