### PR TITLE
pipeline: show: outs: eliminate extra edges in DAG

### DIFF
--- a/dvc/command/pipeline.py
+++ b/dvc/command/pipeline.py
@@ -31,7 +31,7 @@ class CmdPipelineShow(CmdBase):
             else:
                 logger.info(stage.path_in_repo)
 
-    def __build_graph(self, target, commands, outs):
+    def _build_graph(self, target, commands, outs):
         import networkx
         from dvc.stage import Stage
         from dvc.repo.graph import get_pipeline
@@ -74,7 +74,7 @@ class CmdPipelineShow(CmdBase):
     def _show_ascii(self, target, commands, outs):
         from dvc.dagascii import draw
 
-        nodes, edges, _ = self.__build_graph(target, commands, outs)
+        nodes, edges, _ = self._build_graph(target, commands, outs)
 
         if not nodes:
             return
@@ -84,7 +84,7 @@ class CmdPipelineShow(CmdBase):
     def _show_dependencies_tree(self, target, commands, outs):
         from treelib import Tree
 
-        nodes, edges, is_tree = self.__build_graph(target, commands, outs)
+        nodes, edges, is_tree = self._build_graph(target, commands, outs)
         if not nodes:
             return
         if not is_tree:
@@ -105,12 +105,12 @@ class CmdPipelineShow(CmdBase):
             observe_list.pop(0)
         tree.show()
 
-    def __write_dot(self, target, commands, outs):
+    def _write_dot(self, target, commands, outs):
         import io
         import networkx
         from networkx.drawing.nx_pydot import write_dot
 
-        _, edges, _ = self.__build_graph(target, commands, outs)
+        _, edges, _ = self._build_graph(target, commands, outs)
         edges = [edge[::-1] for edge in edges]
 
         simple_g = networkx.DiGraph()
@@ -131,9 +131,7 @@ class CmdPipelineShow(CmdBase):
                         target, self.args.commands, self.args.outs
                     )
                 elif self.args.dot:
-                    self.__write_dot(
-                        target, self.args.commands, self.args.outs
-                    )
+                    self._write_dot(target, self.args.commands, self.args.outs)
                 elif self.args.tree:
                     self._show_dependencies_tree(
                         target, self.args.commands, self.args.outs

--- a/dvc/command/pipeline.py
+++ b/dvc/command/pipeline.py
@@ -55,7 +55,7 @@ class CmdPipelineShow(CmdBase):
 
         edges = []
 
-        if outs and not commands:
+        if outs:
             for stage in networkx.dfs_preorder_nodes(G, target_stage):
                 for dep in stage.deps:
                     for out in stage.outs:

--- a/dvc/command/pipeline.py
+++ b/dvc/command/pipeline.py
@@ -36,8 +36,8 @@ class CmdPipelineShow(CmdBase):
         from dvc.stage import Stage
         from dvc.repo.graph import get_pipeline
 
-        stage = Stage.load(self.repo, target)
-        G = get_pipeline(self.repo.pipelines, stage)
+        target_stage = Stage.load(self.repo, target)
+        G = get_pipeline(self.repo.pipelines, target_stage)
 
         nodes = []
         for stage in G:
@@ -52,7 +52,7 @@ class CmdPipelineShow(CmdBase):
                 nodes.append(stage.relpath)
 
         edges = []
-        for from_stage, to_stage in G.edges():
+        for from_stage, to_stage in networkx.dfs_edges(G, target_stage):
             if commands:
                 if to_stage.cmd is None:
                     continue

--- a/dvc/command/pipeline.py
+++ b/dvc/command/pipeline.py
@@ -52,15 +52,16 @@ class CmdPipelineShow(CmdBase):
                 nodes.append(stage.relpath)
 
         edges = []
-        for from_stage, to_stage in networkx.dfs_edges(G, target_stage):
+        for from_stage, to_stage in G.edges():
             if commands:
                 if to_stage.cmd is None:
                     continue
                 edges.append((from_stage.cmd, to_stage.cmd))
             elif outs:
-                for from_out in from_stage.outs:
+                for from_dep in from_stage.deps:
                     for to_out in to_stage.outs:
-                        edges.append((str(from_out), str(to_out)))
+                        if from_dep.path_info == to_out.path_info:
+                            edges.append((str(from_dep), str(to_out)))
             else:
                 edges.append((from_stage.relpath, to_stage.relpath))
 

--- a/dvc/command/pipeline.py
+++ b/dvc/command/pipeline.py
@@ -40,7 +40,7 @@ class CmdPipelineShow(CmdBase):
         G = get_pipeline(self.repo.pipelines, target_stage)
 
         nodes = []
-        for stage in G:
+        for stage in networkx.preorder_nodes(G, target_stage):
             if commands:
                 if stage.cmd is None:
                     continue
@@ -48,6 +48,8 @@ class CmdPipelineShow(CmdBase):
             elif outs:
                 for out in stage.outs:
                     nodes.append(str(out))
+                for dep in stage.deps:
+                    nodes.append(str(dep))
             else:
                 nodes.append(stage.relpath)
 

--- a/dvc/command/pipeline.py
+++ b/dvc/command/pipeline.py
@@ -52,16 +52,15 @@ class CmdPipelineShow(CmdBase):
                 nodes.append(stage.relpath)
 
         edges = []
-        for from_stage, to_stage in G.edges():
+        for from_stage, to_stage in networkx.dfs_edges(G, target_stage):
             if commands:
                 if to_stage.cmd is None:
                     continue
                 edges.append((from_stage.cmd, to_stage.cmd))
             elif outs:
                 for from_dep in from_stage.deps:
-                    for to_out in to_stage.outs:
-                        if from_dep.path_info == to_out.path_info:
-                            edges.append((str(from_dep), str(to_out)))
+                    for from_out in from_stage.outs:
+                        edges.append((str(from_out), str(from_dep)))
             else:
                 edges.append((from_stage.relpath, to_stage.relpath))
 

--- a/tests/func/test_pipeline.py
+++ b/tests/func/test_pipeline.py
@@ -99,7 +99,7 @@ class TestPipelineShow(TestRepro):
         self.assertEqual(ret, 0)
 
 
-def test_disconnected_stage(tmp_dir, dvc, caplog):
+def test_disconnected_stage(tmp_dir, dvc):
     tmp_dir.dvc_gen({"base": "base"})
 
     dvc.add("base")
@@ -109,14 +109,13 @@ def test_disconnected_stage(tmp_dir, dvc, caplog):
         deps=["derived1"], outs=["final"], cmd="echo final > final"
     )
 
-    args = ["pipeline", "show", "--outs", "--dot", final_stage.path]
-    command = CmdPipelineShow(args)
+    command = CmdPipelineShow([])
     # Need to test __build_graph directly
     nodes, edges, is_tree = command._build_graph(
         final_stage.path, commands=False, outs=True
     )
 
-    assert set(nodes) == set(["final", "derived1", "base"])
+    assert set(nodes) == {"final", "derived1", "base"}
     assert edges == [("final", "derived1"), ("derived1", "base")]
     assert is_tree is True
 

--- a/tests/func/test_pipeline.py
+++ b/tests/func/test_pipeline.py
@@ -112,7 +112,7 @@ def test_disconnected_stage(tmp_dir, dvc, caplog):
     args = ["pipeline", "show", "--outs", "--dot", final_stage.path]
     command = CmdPipelineShow(args)
     # Need to test __build_graph directly
-    nodes, edges, is_tree = command._CmdPipelineShow__build_graph(
+    nodes, edges, is_tree = command._build_graph(
         final_stage.path, commands=False, outs=True
     )
 

--- a/tests/func/test_pipeline.py
+++ b/tests/func/test_pipeline.py
@@ -110,12 +110,11 @@ def test_disconnected_stage(tmp_dir, dvc, caplog):
     )
 
     args = ["pipeline", "show", "--outs", "--dot", final_stage.path]
-    with tmp_dir.chdir():
-        command = CmdPipelineShow(args)
-        # Need to test __build_graph directly
-        nodes, edges, is_tree = command._CmdPipelineShow__build_graph(
-            final_stage.path, commands=False, outs=True
-        )
+    command = CmdPipelineShow(args)
+    # Need to test __build_graph directly
+    nodes, edges, is_tree = command._CmdPipelineShow__build_graph(
+        final_stage.path, commands=False, outs=True
+    )
 
     assert set(nodes) == set(["final", "derived1", "base"])
     assert edges == [("final", "derived1"), ("derived1", "base")]


### PR DESCRIPTION
This fixes extra nodes edges appearing in `pipeline show --outs`, by using networkx to traverse the graph instead of listing all edges.

I spent a lot of time trying to figure out how to test this, so I thought I'd either leave it untested or take suggestions from the PR review.

Fixes #1744

----

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [ ] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

