### PR TITLE
api: fallback to external_repo if not a DVC repository

### DIFF
--- a/dvc/api.py
+++ b/dvc/api.py
@@ -108,8 +108,9 @@ def read(path, repo=None, rev=None, remote=None, mode="r", encoding=None):
 
 
 @contextmanager
-def _make_repo(repo_url, rev=None):
-    if rev is None and (not repo_url or os.path.exists(repo_url)):
+def _make_repo(repo_url=None, rev=None):
+    repo_url = repo_url or os.getcwd()
+    if rev is None and os.path.exists(repo_url):
         try:
             yield Repo(repo_url)
             return

--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -128,10 +128,10 @@ class ExternalGitRepo:
             raise PathMissingError(path, self.url)
 
     @contextmanager
-    def open_by_relpath(self, path, mode="r", encoding=None):
+    def open_by_relpath(self, path, mode="r", encoding=None, **kwargs):
         try:
             abs_path = os.path.join(self.root_dir, path)
-            with open(abs_path, mode, encoding) as fd:
+            with open(abs_path, mode, encoding=encoding) as fd:
                 yield fd
         except FileNotFoundError:
             raise PathMissingError(path, self.url)

--- a/tests/func/test_api.py
+++ b/tests/func/test_api.py
@@ -8,7 +8,7 @@ import pytest
 from dvc import api
 from dvc.api import SummonError, UrlNotDvcRepoError
 from dvc.compat import fspath
-from dvc.exceptions import FileMissingError, NotDvcRepoError
+from dvc.exceptions import FileMissingError
 from dvc.main import main
 from dvc.path_info import URLInfo
 from dvc.remote.config import RemoteConfig
@@ -54,7 +54,7 @@ def test_get_url_external(erepo_dir, remote_url):
 def test_get_url_requires_dvc(tmp_dir, scm):
     tmp_dir.scm_gen({"foo": "foo"}, commit="initial")
 
-    with pytest.raises(NotDvcRepoError, match="not inside of a DVC repo"):
+    with pytest.raises(UrlNotDvcRepoError, match="not a DVC repository"):
         api.get_url("foo", repo=fspath(tmp_dir))
 
     with pytest.raises(UrlNotDvcRepoError):


### PR DESCRIPTION
Fixes #3221. Now, it will just fallback to the `external_repo` if `Repo()` could not be instantiated.
Another idea would have been to check for the existence of `.dvc` directory, but, I went with this, as it feels correct and *robust*.

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

