### PR TITLE
hooks: checkout: fix incorrect dvc repo detection

### DIFF
--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -250,7 +250,7 @@ class Git(Base):
     def _install_hook(self, name, cmd):
         command = (
             '[ "$3" = "0" ]'
-            ' || [ -z "$(git ls-files .dvc)" ]'
+            ' || [ -z "$(git ls-files --full-name .dvc)" ]'
             " || exec dvc {}".format(cmd)
         )
 


### PR DESCRIPTION
When running from non-root directory `git ls-files .dvc` will treat it
as a relative path to the current location, so if you run `git checkout`
from a directory that is not a git/dvc root, our hook will think that
it is being run in a non-dvc repo and will do nothing. To fix that, [need
to use `--full-name` flag](https://git-scm.com/docs/git-ls-files#Documentation/git-ls-files.txt---full-name).

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

