### PR TITLE
Remove usage of google-api-python-client deps

### DIFF
--- a/dvc/remote/gdrive.py
+++ b/dvc/remote/gdrive.py
@@ -33,12 +33,11 @@ class GDriveMissedCredentialKeyError(DvcException):
 
 @decorator
 def _wrap_pydrive_retriable(call):
-    from apiclient import errors
     from pydrive2.files import ApiRequestError
 
     try:
         result = call()
-    except (ApiRequestError, errors.HttpError) as exception:
+    except ApiRequestError as exception:
         retry_codes = ["403", "500", "502", "503", "504"]
         if any(
             "HttpError {}".format(code) in str(exception)
@@ -210,6 +209,7 @@ class RemoteGDrive(RemoteBASE):
             GoogleAuth.DEFAULT_SETTINGS["get_refresh_token"] = True
             GoogleAuth.DEFAULT_SETTINGS["oauth_scope"] = [
                 "https://www.googleapis.com/auth/drive",
+                # drive.appdata grants access to appDataFolder GDrive directory
                 "https://www.googleapis.com/auth/drive.appdata",
             ]
 


### PR DESCRIPTION
Related to #2865 

Since PyDrive2 was [updated to newer version](https://github.com/iterative/dvc/commit/2f1224b27b240d0806b927664b99273c384f1573) the usage of `errors.HttpError` is not needed anymore according to https://github.com/iterative/PyDrive2/pull/5