### PR TITLE
install: fix post-checkout hook

### DIFF
--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -275,9 +275,10 @@ class Git(Base):
             [
                 # checking out some reference and not specific file.
                 '[ "$3" = "1" ]',
-                # check that we are on some branch/tag and not in detached HEAD
-                # state, so we don't accidentally break a rebase.
-                '[ "$(git rev-parse --abbrev-ref HEAD)" != "HEAD" ]',
+                # make sure we are not in the middle of a rebase/merge, so we
+                # don't accidentally break it with an unsuccessful checkout.
+                # Note that git hooks are always running in repo root.
+                "[ ! -d .git/rebase-merge ]",
             ],
             "checkout",
         )


### PR DESCRIPTION
We should skip running post-checkout hook on rebases and merges to not
accidentally break them in the middle of the process. Git doesn't
provide any native mechanisms for hooks to know whether or not this is a
rebase/merge that we are going through, but we can use
`.git/rebase-merge` existance as a marker.

Previous approach has only accounted for branches and was causing issues
when checking-out tags.

Fixes #3241

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

