### PR TITLE
utils: more robust text file detection on checksum

### DIFF
--- a/dvc/istextfile.py
+++ b/dvc/istextfile.py
@@ -7,15 +7,11 @@
 TEXT_CHARS = bytes(range(32, 127)) + b"\n\r\t\f\b"
 
 
-def istextfile(fname, blocksize=512):
-    """ Uses heuristics to guess whether the given file is text or binary,
-        by reading a single block of bytes from the file.
-        If more than 30% of the chars in the block are non-text, or there
-        are NUL ('\x00') bytes in the block, assume this is a binary file.
+def istext(block):
+    """ Uses heuristics to guess whether the given block of bytes is text or
+    binary. If more than 30% of the chars in the block are non-text, or there
+    are NUL ('\x00') bytes in the block, assume this is a binary file.
     """
-    with open(fname, "rb") as fobj:
-        block = fobj.read(blocksize)
-
     if not block:
         # An empty file is considered a valid text file
         return True
@@ -28,3 +24,11 @@ def istextfile(fname, blocksize=512):
     # occurrences of TEXT_CHARS from the block
     nontext = block.translate(None, TEXT_CHARS)
     return float(len(nontext)) / len(block) <= 0.30
+
+
+def istextfile(fname, blocksize=2048):
+    """ Uses heuristics on the first 'blocksize' bytes in a file to guess
+    whether the given file is text or binary.
+    """
+    with open(fname, "rb") as fobj:
+        return istext(fobj.read(blocksize))

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -32,13 +32,13 @@ def dos2unix(data):
 def file_md5(fname):
     """ get the (md5 hexdigest, md5 digest) of a file """
     from dvc.progress import Tqdm
-    from dvc.istextfile import istextfile
+    from dvc.istextfile import istext
 
     fname = fspath_py35(fname)
 
     if os.path.exists(fname):
         hash_md5 = hashlib.md5()
-        binary = not istextfile(fname)
+        is_file_binary = None
         size = os.path.getsize(fname)
         no_progress_bar = True
         if size >= LARGE_FILE_SIZE:
@@ -62,7 +62,10 @@ def file_md5(fname):
                     if not data:
                         break
 
-                    if binary:
+                    if is_file_binary is None:
+                        is_file_binary = not istext(data)
+
+                    if is_file_binary:
                         chunk = data
                     else:
                         chunk = dos2unix(data)


### PR DESCRIPTION
In the case where binary files have a large text header, the current
checksum routine will treat said files as text files and normalize
line-endings before performing the checksum. Not only is it dangerous to
manipulate binary files like this, it also doubles the runtime of the
checksum routine, as every block of data must be read twice. This patch
makes the process for detecting text files more robust by increasing the
number of bytes interrogated by DVC used to classify the file.

**Note:** In my team's case, this will invalidate our DVC cache and remote, as the checksums for most of our corpus were incorrectly calculated. We can, of course, fix this by re-`dvc add`ing all of our files, but I want to make sure you (the maintainers) are aware of the ramifications for others.

This doesn't outright fix #3261, but it was a result of that issue.

Fixes #3364 

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

