### PR TITLE
gdrive: support Google Service accounts

### DIFF
--- a/dvc/config.py
+++ b/dvc/config.py
@@ -172,9 +172,13 @@ SCHEMA = {
                     **REMOTE_COMMON,
                 },
                 "gdrive": {
+                    "gdrive_use_service_account": Bool,
                     "gdrive_client_id": str,
                     "gdrive_client_secret": str,
                     "gdrive_user_credentials_file": str,
+                    "gdrive_service_account_email": str,
+                    "gdrive_service_account_user_email": str,
+                    "gdrive_service_account_p12_file_path": str,
                     **REMOTE_COMMON,
                 },
                 "http": {**HTTP_COMMON, **REMOTE_COMMON},

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ install_requires = [
 # Extra dependencies for remote integrations
 
 gs = ["google-cloud-storage==1.19.0"]
-gdrive = ["pydrive2>=1.4.5"]
+gdrive = ["pydrive2>=1.4.6"]
 s3 = ["boto3>=1.9.201"]
 azure = ["azure-storage-blob==2.1.0"]
 oss = ["oss2==2.6.1"]

--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -37,8 +37,6 @@ from tests.remotes import (
     OSS,
     TEST_CONFIG,
     TEST_GCP_CREDS_FILE,
-    TEST_GDRIVE_CLIENT_ID,
-    TEST_GDRIVE_CLIENT_SECRET,
     TEST_REMOTE,
 )
 
@@ -193,8 +191,9 @@ def setup_gdrive_cloud(remote_url, dvc):
     config = copy.deepcopy(TEST_CONFIG)
     config["remote"][TEST_REMOTE] = {
         "url": remote_url,
-        "gdrive_client_id": TEST_GDRIVE_CLIENT_ID,
-        "gdrive_client_secret": TEST_GDRIVE_CLIENT_SECRET,
+        "gdrive_service_account_email": "test",
+        "gdrive_service_account_p12_file_path": "test.p12",
+        "gdrive_use_service_account": True,
     }
 
     dvc.config = config
@@ -434,8 +433,8 @@ class TestRemoteGDriveCLI(GDrive, TestDataCloudCLIBase):
                 "remote",
                 "modify",
                 TEST_REMOTE,
-                "gdrive_client_id",
-                TEST_GDRIVE_CLIENT_ID,
+                "gdrive_service_account_email",
+                "modified",
             ]
         )
         self.main(
@@ -443,8 +442,17 @@ class TestRemoteGDriveCLI(GDrive, TestDataCloudCLIBase):
                 "remote",
                 "modify",
                 TEST_REMOTE,
-                "gdrive_client_secret",
-                TEST_GDRIVE_CLIENT_SECRET,
+                "gdrive_service_account_p12_file_path",
+                "modified.p12",
+            ]
+        )
+        self.main(
+            [
+                "remote",
+                "modify",
+                TEST_REMOTE,
+                "gdrive_use_service_account",
+                "True",
             ]
         )
 

--- a/tests/remotes.py
+++ b/tests/remotes.py
@@ -35,11 +35,6 @@ TEST_GCP_CREDS_FILE = os.path.abspath(
 # Ensure that absolute path is used
 os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = TEST_GCP_CREDS_FILE
 
-TEST_GDRIVE_CLIENT_ID = (
-    "217948389181-rs7it4a635b3qrf8dnmklmoj2kimun9n.apps.googleusercontent.com"
-)
-TEST_GDRIVE_CLIENT_SECRET = "LNg9n_cK7bohI8gEHn4bUeMX"
-
 always_test = staticmethod(lambda: True)
 
 
@@ -146,7 +141,7 @@ class GCP:
 class GDrive:
     @staticmethod
     def should_test():
-        return os.getenv(RemoteGDrive.GDRIVE_USER_CREDENTIALS_DATA) is not None
+        return os.getenv(RemoteGDrive.GDRIVE_CREDENTIALS_DATA) is not None
 
     def get_url(self):
         if not getattr(self, "_remote_url", None):

--- a/tests/unit/remote/test_gdrive.py
+++ b/tests/unit/remote/test_gdrive.py
@@ -33,15 +33,15 @@ class TestRemoteGDrive(object):
     def test_drive(self):
         remote = RemoteGDrive(Repo(), self.CONFIG)
         os.environ[
-            RemoteGDrive.GDRIVE_USER_CREDENTIALS_DATA
+            RemoteGDrive.GDRIVE_CREDENTIALS_DATA
         ] = USER_CREDS_TOKEN_REFRESH_ERROR
         with pytest.raises(GDriveAccessTokenRefreshError):
             remote.drive
 
-        os.environ[RemoteGDrive.GDRIVE_USER_CREDENTIALS_DATA] = ""
+        os.environ[RemoteGDrive.GDRIVE_CREDENTIALS_DATA] = ""
         remote = RemoteGDrive(Repo(), self.CONFIG)
         os.environ[
-            RemoteGDrive.GDRIVE_USER_CREDENTIALS_DATA
+            RemoteGDrive.GDRIVE_CREDENTIALS_DATA
         ] = USER_CREDS_MISSED_KEY_ERROR
         with pytest.raises(GDriveMissedCredentialKeyError):
             remote.drive


### PR DESCRIPTION
https://github.com/iterative/PyDrive2/pull/7 should be merged first

Introduces `gdrive_service_account_email`, `gdrive_service_account_user_email` and `gdrive_service_account_p12_file_path` DVC config params to support authorization with Google Service accounts.

Introduced config params are independent from `client_id` and `client_secret` config params


Update:

https://github.com/iterative/PyDrive2/pull/11 should be merged first

Introduces  `gdrive_user_service_account` DVC config param disabled by default.