### PR TITLE
get/import: they don't work with any DVC project, only DVC repos (as well as Git repos)

### DIFF
--- a/dvc/command/get.py
+++ b/dvc/command/get.py
@@ -51,7 +51,7 @@ class CmdGet(CmdBaseNoRepo):
 
 
 def add_parser(subparsers, parent_parser):
-    GET_HELP = "Download file or directory from any DVC or Git repository."
+    GET_HELP = "Download file or directory tracked by DVC or by Git."
     get_parser = subparsers.add_parser(
         "get",
         parents=[parent_parser],

--- a/dvc/command/get.py
+++ b/dvc/command/get.py
@@ -51,9 +51,7 @@ class CmdGet(CmdBaseNoRepo):
 
 
 def add_parser(subparsers, parent_parser):
-    GET_HELP = (
-        "Download file or directory from any DVC project or Git repository."
-    )
+    GET_HELP = "Download file or directory from any DVC or Git repository."
     get_parser = subparsers.add_parser(
         "get",
         parents=[parent_parser],
@@ -62,8 +60,7 @@ def add_parser(subparsers, parent_parser):
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     get_parser.add_argument(
-        "url",
-        help="Location of DVC project or Git repository to download from",
+        "url", help="Location of DVC or Git repository to download from"
     )
     get_parser.add_argument(
         "path",

--- a/dvc/command/get.py
+++ b/dvc/command/get.py
@@ -63,8 +63,7 @@ def add_parser(subparsers, parent_parser):
         "url", help="Location of DVC or Git repository to download from"
     )
     get_parser.add_argument(
-        "path",
-        help="Path to a file or directory within the project or repository",
+        "path", help="Path to a file or directory within the repository"
     )
     get_parser.add_argument(
         "-o", "--out", nargs="?", help="Destination path to download files to"

--- a/dvc/command/imp.py
+++ b/dvc/command/imp.py
@@ -30,7 +30,7 @@ class CmdImport(CmdBase):
 
 def add_parser(subparsers, parent_parser):
     IMPORT_HELP = (
-        "Download file or directory from any DVC project or Git repository "
+        "Download file or directory from any DVC or Git repository "
         "into the workspace, and track it."
     )
 
@@ -42,8 +42,7 @@ def add_parser(subparsers, parent_parser):
         formatter_class=argparse.RawTextHelpFormatter,
     )
     import_parser.add_argument(
-        "url",
-        help="Location of DVC project or Git repository to download from",
+        "url", help="Location of DVC or Git repository to download from"
     )
     import_parser.add_argument(
         "path",

--- a/dvc/command/imp.py
+++ b/dvc/command/imp.py
@@ -45,8 +45,7 @@ def add_parser(subparsers, parent_parser):
         "url", help="Location of DVC or Git repository to download from"
     )
     import_parser.add_argument(
-        "path",
-        help="Path to a file or directory within the project or repository",
+        "path", help="Path to a file or directory within the repository"
     )
     import_parser.add_argument(
         "-o", "--out", nargs="?", help="Destination path to download files to"

--- a/dvc/command/imp.py
+++ b/dvc/command/imp.py
@@ -30,7 +30,7 @@ class CmdImport(CmdBase):
 
 def add_parser(subparsers, parent_parser):
     IMPORT_HELP = (
-        "Download file or directory from any DVC or Git repository "
+        "Download file or directory tracked by DVC or by Git "
         "into the workspace, and track it."
     )
 


### PR DESCRIPTION
At least on v `0.82.6`. I created a `--no-scm` project and tried to `get` and `import` from it to other locations, getting:

```
ERROR: failed to get 'data' from '/Users/drbidibombom/DVC-repos/no-scm-aux' - Failed to clone repo '/Users/drbidibombom/DVC-repos/no-scm-aux' to '/var/folders/_c/3mt_xn_d4xl2ddsx2m98h_r40000gn/T/tmpy1o07ch5dvc-clone': Cmd('git') failed due to: exit code(128)
  cmdline: git clone --no-single-branch -v /Users/drbidibombom/DVC-repos/no-scm-aux /var/folders/_c/3mt_xn_d4xl2ddsx2m98h_r40000gn/T/tmpy1o07ch5dvc-clone
  stderr: 'fatal: repository '/Users/drbidibombom/DVC-repos/no-scm-aux' does not exist
'


Having any troubles? Hit us up at https://dvc.org/support, we are always happy to help!
```

---

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

  Docs update in iterative/dvc.org/pull/931 & iterative/dvc.org/pull/978

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
