### PR TITLE
check root .gitignore in '_ignored'

### DIFF
--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -18,7 +18,6 @@ from dvc.utils import is_binary
 from dvc.utils import relpath
 from dvc.utils.fs import path_isin
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -135,23 +134,22 @@ class Git(Base):
 
     def _ignored(self, entry, gitignore_path):
 
-        # We want to check first if `entry` is already being ignored by the .gitignore file in the root dir.
+        # We want to check first if `entry` is already being ignored
+        # by the .gitignore file in the root dir.
+
+        entry = (
+            entry[1:] if entry[0] == "/" else entry
+        )  # make sure that joining the paths works
         entry_path = os.path.join(os.path.dirname(gitignore_path), entry)
         from git.exc import GitCommandError
+
         try:
             self.repo.git.check_ignore(entry_path)
             return True
         except GitCommandError:
-            # If none of the paths passed to `check_ignore` are ignored, GitPython annoyingly raises an Exception
-            pass
-
-        if os.path.exists(gitignore_path):
-            with open(gitignore_path, "r") as fobj:
-                ignore_list = fobj.readlines()
-            return any(
-                filter(lambda x: x.strip() == entry.strip(), ignore_list)
-            )
-        return False
+            # If none of the paths passed to `check_ignore` are ignored,
+            # GitPython annoyingly raises an Exception
+            return False
 
     def ignore(self, path):
         entry, gitignore = self._get_gitignore(path)

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -132,19 +132,14 @@ class Git(Base):
 
         return entry, gitignore
 
-    def _ignored(self, entry, gitignore_path):
+    def _ignored(self, path):
 
         # We want to check first if `entry` is already being ignored
         # by the .gitignore file in the root dir.
-
-        entry = (
-            entry[1:] if entry[0] == "/" else entry
-        )  # make sure that joining the paths works
-        entry_path = os.path.join(os.path.dirname(gitignore_path), entry)
         from git.exc import GitCommandError
 
         try:
-            self.repo.git.check_ignore(entry_path)
+            self.repo.git.check_ignore(path)
             return True
         except GitCommandError:
             # If none of the paths passed to `check_ignore` are ignored,
@@ -154,7 +149,7 @@ class Git(Base):
     def ignore(self, path):
         entry, gitignore = self._get_gitignore(path)
 
-        if self._ignored(entry, gitignore):
+        if self._ignored(path):
             return
 
         msg = "Adding '{}' to '{}'.".format(relpath(path), relpath(gitignore))

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -133,17 +133,12 @@ class Git(Base):
         return entry, gitignore
 
     def _ignored(self, path):
-
-        # We want to check first if `path` is already being ignored
-        # by the .gitignore file in the root dir.
         from git.exc import GitCommandError
 
         try:
             self.repo.git.check_ignore(path)
             return True
         except GitCommandError:
-            # If none of the paths passed to `check_ignore` are ignored,
-            # GitPython annoyingly raises an Exception
             return False
 
     def ignore(self, path):

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -133,8 +133,18 @@ class Git(Base):
 
         return entry, gitignore
 
-    @staticmethod
-    def _ignored(entry, gitignore_path):
+    def _ignored(self, entry, gitignore_path):
+
+        # We want to check first if `entry` is already being ignored by the .gitignore file in the root dir.
+        entry_path = os.path.join(os.path.dirname(gitignore_path), entry)
+        from git.exc import GitCommandError
+        try:
+            self.repo.git.check_ignore(entry_path)
+            return True
+        except GitCommandError:
+            # If none of the paths passed to `check_ignore` are ignored, GitPython annoyingly raises an Exception
+            pass
+
         if os.path.exists(gitignore_path):
             with open(gitignore_path, "r") as fobj:
                 ignore_list = fobj.readlines()

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -134,7 +134,7 @@ class Git(Base):
 
     def _ignored(self, path):
 
-        # We want to check first if `entry` is already being ignored
+        # We want to check first if `path` is already being ignored
         # by the .gitignore file in the root dir.
         from git.exc import GitCommandError
 

--- a/tests/dir_helpers.py
+++ b/tests/dir_helpers.py
@@ -45,6 +45,7 @@ from global repo template to creating everything inplace, which:
 
 import os
 import pathlib
+import logging
 from contextlib import contextmanager
 
 import pytest
@@ -63,6 +64,11 @@ __all__ = [
     "erepo_dir",
     "git_dir",
 ]
+
+
+# see https://github.com/iterative/dvc/issues/3167
+git_logger = logging.getLogger("git")
+git_logger.setLevel(logging.CRITICAL)
 
 
 class TmpDir(pathlib.Path):

--- a/tests/func/test_get.py
+++ b/tests/func/test_get.py
@@ -163,11 +163,7 @@ def test_get_from_non_dvc_master(tmp_dir, git_dir, caplog):
 
     caplog.clear()
 
-    # removing `git` import in conftest resulted in unexpected logs from
-    # that package, see https://github.com/iterative/dvc/issues/3167
-    with caplog.at_level(logging.INFO, logger="git"), caplog.at_level(
-        logging.INFO, logger="dvc"
-    ):
+    with caplog.at_level(logging.INFO, logger="dvc"):
         Repo.get(fspath(git_dir), "some_file", out="some_dst", rev="branch")
 
     assert caplog.text == ""

--- a/tests/func/test_scm.py
+++ b/tests/func/test_scm.py
@@ -83,6 +83,14 @@ def test_ignore(tmp_dir, scm):
     assert _count_gitignore_entries(target) == 0
 
 
+def test_ignored(tmp_dir, scm):
+    tmp_dir.gen({"dir1": {"file1.jpg": "cont", "file2.txt": "cont"}})
+    tmp_dir.gen({".gitignore": "dir1/*.jpg"})
+
+    assert scm._ignored("file1.jpg", fspath(tmp_dir / "dir1" / ".gitignore"))
+    assert not scm._ignored("file2.txt", fspath(tmp_dir / "dir1" / ".gitignore"))
+
+
 def test_get_gitignore(tmp_dir, scm):
     tmp_dir.gen({"file1": "contents", "dir": {}})
 

--- a/tests/func/test_scm.py
+++ b/tests/func/test_scm.py
@@ -87,8 +87,8 @@ def test_ignored(tmp_dir, scm):
     tmp_dir.gen({"dir1": {"file1.jpg": "cont", "file2.txt": "cont"}})
     tmp_dir.gen({".gitignore": "dir1/*.jpg"})
 
-    assert scm._ignored("file1.jpg", fspath(tmp_dir / "dir1" / ".gitignore"))
-    assert not scm._ignored("file2.txt", fspath(tmp_dir / "dir1" / ".gitignore"))
+    assert scm._ignored(fspath(tmp_dir / "dir1" / "file1.jpg"))
+    assert not scm._ignored(fspath(tmp_dir / "dir1" / "file2.txt"))
 
 
 def test_get_gitignore(tmp_dir, scm):


### PR DESCRIPTION
* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

git: check if files are handled by root-dir `.gitignore`

When a file is already ignored through the root-dir `.gitignore` file, we don't want to add it to the "local" `.gitignore` file created by dvc

Fixes #1714 

