### PR TITLE
erepo: cache all read only external repos by hexsha

### DIFF
--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -8,14 +8,9 @@ from pathspec.patterns import GitWildMatchPattern
 
 from dvc.exceptions import GitHookAlreadyExistsError
 from dvc.scm.base import Base
-from dvc.scm.base import CloneError
-from dvc.scm.base import FileNotInRepoError
-from dvc.scm.base import RevError
-from dvc.scm.base import SCMError
+from dvc.scm.base import CloneError, FileNotInRepoError, RevError, SCMError
 from dvc.scm.git.tree import GitTree
-from dvc.utils import fix_env
-from dvc.utils import is_binary
-from dvc.utils import relpath
+from dvc.utils import fix_env, is_binary, relpath
 from dvc.utils.fs import path_isin
 
 logger = logging.getLogger(__name__)
@@ -93,6 +88,12 @@ class Git(Base):
                 ) from exc
 
         return repo
+
+    @staticmethod
+    def is_sha(rev):
+        import git
+
+        return rev and git.Repo.re_hexsha_shortened.search(rev)
 
     @staticmethod
     def is_repo(root_dir):
@@ -211,14 +212,16 @@ class Git(Base):
             self.repo.git.checkout(branch)
 
     def pull(self):
-        info, = self.repo.remote().pull()
-        if info.flags & info.ERROR:
-            raise SCMError("pull failed: {}".format(info.note))
+        infos = self.repo.remote().pull()
+        for info in infos:
+            if info.flags & info.ERROR:
+                raise SCMError("pull failed: {}".format(info.note))
 
     def push(self):
-        info, = self.repo.remote().push()
-        if info.flags & info.ERROR:
-            raise SCMError("push failed: {}".format(info.summary))
+        infos = self.repo.remote().push()
+        for info in infos:
+            if info.flags & info.ERROR:
+                raise SCMError("push failed: {}".format(info.summary))
 
     def branch(self, branch):
         self.repo.git.branch(branch)
@@ -324,15 +327,30 @@ class Git(Base):
         return GitTree(self.repo, self.resolve_rev(rev))
 
     def get_rev(self):
-        return self.repo.git.rev_parse("HEAD")
+        return self.repo.rev_parse("HEAD").hexsha
 
     def resolve_rev(self, rev):
-        from git.exc import GitCommandError
+        from git.exc import BadName, GitCommandError
+        from contextlib import suppress
 
+        names = [rev] + ([] if Git.is_sha(rev) else ["origin/" + rev])
+        for name in names:
+            with suppress(BadName, GitCommandError):
+                try:
+                    # Try python implementation of rev-parse first, it's faster
+                    return self.repo.rev_parse(name).hexsha
+                except NotImplementedError:
+                    # Fall back to `git rev-parse` for advanced features
+                    return self.repo.git.rev_parse(name)
+
+        raise RevError("unknown Git revision '{}'".format(rev))
+
+    def has_rev(self, rev):
         try:
-            return self.repo.git.rev_parse(rev)
-        except GitCommandError:
-            raise RevError("unknown Git revision '{}'".format(rev))
+            self.resolve_rev(rev)
+            return True
+        except RevError:
+            return False
 
     def close(self):
         self.repo.close()


### PR DESCRIPTION
So we have 3 things cached now separately:
- clean clones, to not ask for creds repatedly
- cache dirs, also shared between erepos with same origin
- checked out clones if they are read only, addressed by (url, hexsha)

Several additions to `Git` along the way:
- Git.is_sha() static method
- .pull() and .push() work with multiple returned records correctly
- .get_rev() and .resolve_rev() work faster
- .resolve_rev() looks for remote branches
- .has_rev()

Fixes #3280.