### PR TITLE
logger: allow exc_info in all record types

### DIFF
--- a/dvc/logger.py
+++ b/dvc/logger.py
@@ -51,7 +51,6 @@ class ColorFormatter(logging.Formatter):
 
     color_code = {
         "DEBUG": colorama.Fore.BLUE,
-        "INFO": "",
         "WARNING": colorama.Fore.YELLOW,
         "ERROR": colorama.Fore.RED,
         "CRITICAL": colorama.Fore.RED,
@@ -59,29 +58,21 @@ class ColorFormatter(logging.Formatter):
 
     def format(self, record):
         msg = record.msg.format(*record.args) if record.args else record.msg
+        exception, stack_trace = self._parse_exc(record)
+        return ("{prefix}{description}{stack_trace}").format(
+            prefix=self._prefix(record),
+            description=self._description(msg, exception),
+            stack_trace=stack_trace,
+        )
 
+    def _prefix(self, record):
         if record.levelname == "INFO":
-            return msg
+            return ""
 
-        if record.levelname == "ERROR" or record.levelname == "CRITICAL":
-            exception, stack_trace = self._parse_exc(record)
-
-            return (
-                "{color}{levelname}{nc}: {description}" "{stack_trace}\n"
-            ).format(
-                color=self.color_code.get(record.levelname, ""),
-                nc=colorama.Fore.RESET,
-                levelname=record.levelname,
-                description=self._description(msg, exception),
-                msg=msg,
-                stack_trace=stack_trace,
-            )
-
-        return "{color}{levelname}{nc}: {msg}".format(
+        return "{color}{levelname}{nc}: ".format(
             color=self.color_code.get(record.levelname, ""),
-            nc=colorama.Fore.RESET,
             levelname=record.levelname,
-            msg=msg,
+            nc=colorama.Fore.RESET,
         )
 
     def _current_level(self):

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -44,7 +44,7 @@ class TestColorFormatter:
         with caplog.at_level(logging.INFO, logger="dvc"):
             logger.error("message")
 
-            expected = "{red}ERROR{nc}: message\n".format(**colors)
+            expected = "{red}ERROR{nc}: message".format(**colors)
 
             assert expected == formatter.format(caplog.records[0])
 
@@ -55,7 +55,7 @@ class TestColorFormatter:
             except Exception:
                 logger.exception("message")
 
-            expected = "{red}ERROR{nc}: message\n".format(**colors)
+            expected = "{red}ERROR{nc}: message".format(**colors)
 
             assert expected == formatter.format(caplog.records[0])
 
@@ -66,7 +66,7 @@ class TestColorFormatter:
             except Exception:
                 logger.exception("")
 
-            expected = "{red}ERROR{nc}: description\n".format(**colors)
+            expected = "{red}ERROR{nc}: description".format(**colors)
 
             assert expected == formatter.format(caplog.records[0])
 
@@ -77,9 +77,7 @@ class TestColorFormatter:
             except Exception:
                 logger.exception("message")
 
-            expected = "{red}ERROR{nc}: message - description\n".format(
-                **colors
-            )
+            expected = "{red}ERROR{nc}: message - description".format(**colors)
 
             assert expected == formatter.format(caplog.records[0])
 
@@ -95,7 +93,7 @@ class TestColorFormatter:
                 "{red}ERROR{nc}: description\n"
                 "{red}{line}{nc}\n"
                 "{stack_trace}"
-                "{red}{line}{nc}\n".format(
+                "{red}{line}{nc}".format(
                     line="-" * 60, stack_trace=stack_trace, **colors
                 )
             )
@@ -114,7 +112,7 @@ class TestColorFormatter:
                 "{red}ERROR{nc}: something\n"
                 "{red}{line}{nc}\n"
                 "{stack_trace}"
-                "{red}{line}{nc}\n".format(
+                "{red}{line}{nc}".format(
                     line="-" * 60, stack_trace=stack_trace, **colors
                 )
             )
@@ -136,7 +134,7 @@ class TestColorFormatter:
                 "{red}ERROR{nc}: message - second: first\n"
                 "{red}{line}{nc}\n"
                 "{stack_trace}"
-                "{red}{line}{nc}\n".format(
+                "{red}{line}{nc}".format(
                     line="-" * 60, stack_trace=stack_trace, **colors
                 )
             )


### PR DESCRIPTION
This better reflects the original logger formatter and is neede for further improvements in the following PRs.

This also fixes annoying redundant newline between traceback and "need
any help" footer.

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
