### PR TITLE
analytics: ignore request.post errors

### DIFF
--- a/dvc/analytics.py
+++ b/dvc/analytics.py
@@ -76,7 +76,10 @@ def send(report):
     headers = {"content-type": "application/json"}
 
     with open(report, "rb") as fobj:
-        requests.post(url, data=fobj, headers=headers, timeout=5)
+        try:
+            requests.post(url, data=fobj, headers=headers, timeout=5)
+        except requests.exceptions.RequestException:
+            logger.debug("failed to send analytics report", exc_info=True)
 
     os.remove(report)
 

--- a/tests/unit/test_analytics.py
+++ b/tests/unit/test_analytics.py
@@ -61,16 +61,19 @@ def test_runtime_info(tmp_global_config):
 
 @mock.patch("requests.post")
 def test_send(mock_post, tmp_path):
+    import requests
+
     url = "https://analytics.dvc.org"
     report = {"name": "dummy report"}
-    fname = str(tmp_path / "report")
+    report_file = tmp_path / "report"
 
-    with open(fname, "w") as fobj:
-        json.dump(report, fobj)
+    report_file.write_text(json.dumps(report))
+    mock_post.side_effect = requests.exceptions.RequestException
 
-    analytics.send(fname)
+    analytics.send(str(report_file))
     assert mock_post.called
     assert mock_post.call_args.args[0] == url
+    assert not report_file.exists()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Users have been complaining about dvc analytics errors when they are not
connected to the internet.

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
