### PR TITLE
repo: raise exception if root_dir is not a directory path

### DIFF
--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -112,18 +112,7 @@ class MoveNotDataSourceError(DvcException):
 
 
 class NotDvcRepoError(DvcException):
-    """Thrown if a directory is not a DVC repo.
-
-    Args:
-        root (str): path to the directory.
-    """
-
-    def __init__(self, root, msg=None):
-        msg = msg or (
-            "you are not inside of a DVC repository "
-            "(checked up to mount point '{}')"
-        )
-        super().__init__(msg.format(root))
+    """Thrown if a directory is not a DVC repo"""
 
 
 class DvcParserError(DvcException):

--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -118,8 +118,8 @@ class NotDvcRepoError(DvcException):
         root (str): path to the directory.
     """
 
-    def __init__(self, root):
-        msg = (
+    def __init__(self, root, msg=None):
+        msg = msg or (
             "you are not inside of a DVC repository "
             "(checked up to mount point '{}')"
         )

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -129,10 +129,10 @@ class Repo(object):
 
     @classmethod
     def find_root(cls, root=None):
-        root_dir = os.path.abspath(os.path.realpath(root or os.getcwd()))
+        root_dir = os.path.realpath(root or os.curdir)
 
         if not os.path.isdir(root_dir):
-            raise NotDvcRepoError(root, msg="folder {} does not exist")
+            raise NotDvcRepoError("directory '{}' does not exist".format(root))
 
         while True:
             dvc_dir = os.path.join(root_dir, cls.DVC_DIR)
@@ -141,7 +141,12 @@ class Repo(object):
             if os.path.ismount(root_dir):
                 break
             root_dir = os.path.dirname(root_dir)
-        raise NotDvcRepoError(root_dir)
+
+        message = (
+            "you are not inside of a DVC repository "
+            "(checked up to mount point '{}')"
+        ).format(root_dir)
+        raise NotDvcRepoError(message)
 
     @classmethod
     def find_dvc_dir(cls, root=None):

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -129,19 +129,19 @@ class Repo(object):
 
     @classmethod
     def find_root(cls, root=None):
-        if root is None:
-            root = os.getcwd()
-        else:
-            root = os.path.abspath(os.path.realpath(root))
+        root_dir = os.path.abspath(os.path.realpath(root or os.getcwd()))
+
+        if not os.path.isdir(root_dir):
+            raise NotDvcRepoError(root, msg="folder {} does not exist")
 
         while True:
-            dvc_dir = os.path.join(root, cls.DVC_DIR)
+            dvc_dir = os.path.join(root_dir, cls.DVC_DIR)
             if os.path.isdir(dvc_dir):
-                return root
-            if os.path.ismount(root):
+                return root_dir
+            if os.path.ismount(root_dir):
                 break
-            root = os.path.dirname(root)
-        raise NotDvcRepoError(root)
+            root_dir = os.path.dirname(root_dir)
+        raise NotDvcRepoError(root_dir)
 
     @classmethod
     def find_dvc_dir(cls, root=None):


### PR DESCRIPTION
When Repo is instantiated with invalid urls such as 'http://github.com/iterative/dvc.git',
it does os.path.realpath which is not intelligent enough and just concatenates with current
working directory, which is then traversed outward. It might happen that the outward folder
is a dvc directory which is not really what we want.

So, a check for root to be a directory is added. Otherwise, NotDvcRepoError is thrown with
a custom message.

**TLDR**: `Repo("https://github.com")` and `Repo("not existing directory")` should throw `NotDvcRepoError` even if dvc repo exists outward.

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
