### PR TITLE
tests: fix typo on gdrive_client_secret

### DIFF
--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -193,7 +193,7 @@ def setup_gdrive_cloud(remote_url, dvc):
     config["remote"][TEST_REMOTE] = {
         "url": remote_url,
         "gdrive_client_id": TEST_GDRIVE_CLIENT_ID,
-        "grdive_client_secret": TEST_GDRIVE_CLIENT_SECRET,
+        "gdrive_client_secret": TEST_GDRIVE_CLIENT_SECRET,
     }
 
     dvc.config = config
@@ -428,7 +428,7 @@ class TestRemoteGDriveCLI(GDrive, TestDataCloudCLIBase):
                 "remote",
                 "modify",
                 TEST_REMOTE,
-                "grdive_client_secret",
+                "gdrive_client_secret",
                 TEST_GDRIVE_CLIENT_SECRET,
             ]
         )


### PR DESCRIPTION
Client secrets had a typo on tests which were failing CI.

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
