### PR TITLE
ui: fix missing progress & tidy

### DIFF
--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -234,7 +234,7 @@ class RemoteBASE(object):
 
         from_info = PathInfo(tmp)
         to_info = self.cache.path_info / tmp_fname("")
-        self.cache.upload(from_info, to_info, no_progress_bar=False)
+        self.cache.upload(from_info, to_info, no_progress_bar=True)
 
         checksum = self.get_file_checksum(to_info) + self.CHECKSUM_DIR_SUFFIX
         return checksum, to_info

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -234,7 +234,7 @@ class RemoteBASE(object):
 
         from_info = PathInfo(tmp)
         to_info = self.cache.path_info / tmp_fname("")
-        self.cache.upload(from_info, to_info, no_progress_bar=True)
+        self.cache.upload(from_info, to_info, no_progress_bar=False)
 
         checksum = self.get_file_checksum(to_info) + self.CHECKSUM_DIR_SUFFIX
         return checksum, to_info

--- a/dvc/remote/gdrive.py
+++ b/dvc/remote/gdrive.py
@@ -246,7 +246,7 @@ class RemoteGDrive(RemoteBASE):
         self,
         parent_id,
         title,
-        no_progress_bar=True,
+        no_progress_bar=False,
         from_file="",
         progress_name="",
     ):

--- a/dvc/remote/gs.py
+++ b/dvc/remote/gs.py
@@ -51,7 +51,7 @@ def _upload_to_bucket(
     to_info,
     chunk_size=None,
     name=None,
-    no_progress_bar=True,
+    no_progress_bar=False,
 ):
     blob = bucket.blob(to_info.path, chunk_size=chunk_size)
     with io.open(from_file, mode="rb") as fobj:
@@ -166,7 +166,7 @@ class RemoteGS(RemoteBASE):
         """
         return self.isfile(path_info) or self.isdir(path_info)
 
-    def _upload(self, from_file, to_info, name=None, no_progress_bar=True):
+    def _upload(self, from_file, to_info, name=None, no_progress_bar=False):
         bucket = self.gs.bucket(to_info.bucket)
         _upload_to_bucket(
             bucket,
@@ -176,7 +176,7 @@ class RemoteGS(RemoteBASE):
             no_progress_bar=no_progress_bar,
         )
 
-    def _download(self, from_info, to_file, name=None, no_progress_bar=True):
+    def _download(self, from_info, to_file, name=None, no_progress_bar=False):
         bucket = self.gs.bucket(from_info.bucket)
         blob = bucket.get_blob(from_info.path)
         with io.open(to_file, mode="wb") as fobj:


### PR DESCRIPTION
make `no_progress_bar=False` rather than `True`

- [x] `remote.gdrive.RemoteGDrive.gdrive_upload_file()`
- [x] `remote.base.RemoteBASE._get_dir_info_checksum():self.cache.upload()`
- [x] `remote.gs.RemoteGDrive.RemoteGS._upload()` and `_download()`

----

- fixes #3332
- replaces/closes #3334
- depends on #3316