### PR TITLE
remotes.http: Support dvc push for http remotes

### DIFF
--- a/dvc/config.py
+++ b/dvc/config.py
@@ -103,7 +103,7 @@ LOCAL_COMMON = {
 }
 HTTP_COMMON = {
     "auth": All(Lower, Choices("basic", "digest", "custom")),
-    "custom_header": str,
+    "custom_auth_header": str,
     "user": str,
     "password": str,
     "ask_password": Bool,

--- a/dvc/config.py
+++ b/dvc/config.py
@@ -101,6 +101,13 @@ LOCAL_COMMON = {
     "shared": All(Lower, Choices("group")),
     Optional("slow_link_warning", default=True): Bool,
 }
+HTTP_COMMON = {
+    "basic_auth": Bool,
+    "digest_auth": Bool,
+    "user": str,
+    "password": str,
+    "ask_password": Bool,
+}
 SCHEMA = {
     "core": {
         "remote": Lower,
@@ -169,8 +176,8 @@ SCHEMA = {
                     "gdrive_user_credentials_file": str,
                     **REMOTE_COMMON,
                 },
-                "http": REMOTE_COMMON,
-                "https": REMOTE_COMMON,
+                "http": {**HTTP_COMMON, **REMOTE_COMMON},
+                "https": {**HTTP_COMMON, **REMOTE_COMMON},
                 "remote": {str: object},  # Any of the above options are valid
             }
         )

--- a/dvc/config.py
+++ b/dvc/config.py
@@ -102,8 +102,8 @@ LOCAL_COMMON = {
     Optional("slow_link_warning", default=True): Bool,
 }
 HTTP_COMMON = {
-    "basic_auth": Bool,
-    "digest_auth": Bool,
+    "auth": All(Lower, Choices("basic", "digest", "custom")),
+    "custom_header": str,
     "user": str,
     "password": str,
     "ask_password": Bool,

--- a/dvc/remote/http.py
+++ b/dvc/remote/http.py
@@ -90,7 +90,7 @@ class RemoteHTTP(RemoteBASE):
                         yield chunk
 
             response = self._request("POST", to_info.url, data=chunks())
-            if response.status_code != 200:
+            if response.status_code not in (200, 201):
                 raise HTTPError(response.status_code, response.reason)
 
     def exists(self, path_info):
@@ -131,9 +131,9 @@ class RemoteHTTP(RemoteBASE):
                 self.password = ask_password(host, user)
             if self.auth == "basic":
                 return HTTPBasicAuth(path_info.user, self.password)
-            elif self.auth == "digest":
+            if self.auth == "digest":
                 return HTTPDigestAuth(path_info.user, self.password)
-            elif self.auth == "custom" and self.custom_auth_header:
+            if self.auth == "custom" and self.custom_auth_header:
                 self.headers.update({self.custom_auth_header: self.password})
         return None
 

--- a/dvc/remote/http.py
+++ b/dvc/remote/http.py
@@ -50,7 +50,7 @@ class RemoteHTTP(RemoteBASE):
             )
 
         self.auth = config.get("auth", None)
-        self.custom_header = config.get("custom_header", None)
+        self.custom_auth_header = config.get("custom_auth_header", None)
         self.password = config.get("password", None)
         self.ask_password = config.get("ask_password", False)
         self.headers = {}
@@ -133,8 +133,8 @@ class RemoteHTTP(RemoteBASE):
                 return HTTPBasicAuth(path_info.user, self.password)
             elif self.auth == "digest":
                 return HTTPDigestAuth(path_info.user, self.password)
-            elif self.auth == "custom" and self.custom_header:
-                self.headers.update({self.custom_header: self.password})
+            elif self.auth == "custom" and self.custom_auth_header:
+                self.headers.update({self.custom_auth_header: self.password})
         return None
 
     @wrap_prop(threading.Lock())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import mockssh
 import pytest
 
 from dvc.remote.ssh.connection import SSHConnection
-from tests.utils.httpd import TempFileServer
+from tests.utils.httpd import PushRequestHandler, StaticFileServer
 from .dir_helpers import *  # noqa
 
 
@@ -61,6 +61,6 @@ def _close_pools():
 
 
 @pytest.fixture
-def http_server():
-    with TempFileServer() as httpd:
+def http_server(tmp_dir):
+    with StaticFileServer(handler_class=PushRequestHandler) as httpd:
         yield httpd

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import mockssh
 import pytest
 
 from dvc.remote.ssh.connection import SSHConnection
+from tests.utils.httpd import TempFileServer
 from .dir_helpers import *  # noqa
 
 
@@ -57,3 +58,9 @@ def _close_pools():
 
     yield
     close_pools()
+
+
+@pytest.fixture
+def http_server():
+    with TempFileServer() as httpd:
+        yield httpd

--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -30,6 +30,7 @@ from tests.remotes import (
     GCP,
     GDrive,
     HDFS,
+    HTTP,
     Local,
     S3,
     SSHMocked,
@@ -288,6 +289,20 @@ class TestRemoteSSHMocked(SSHMocked, TestDataCloudBase):
 class TestRemoteHDFS(HDFS, TestDataCloudBase):
     def _get_cloud_class(self):
         return RemoteHDFS
+
+
+@pytest.mark.usefixtures("http_server")
+class TestRemoteHTTP(HTTP, TestDataCloudBase):
+    @pytest.fixture(autouse=True)
+    def setup_method_fixture(self, request, http_server):
+        self.http_server = http_server
+        self.method_name = request.function.__name__
+
+    def get_url(self):
+        return super().get_url(self.http_server.server_port)
+
+    def _get_cloud_class(self):
+        return RemoteHTTP
 
 
 class TestDataCloudCLIBase(TestDvc):

--- a/tests/remotes.py
+++ b/tests/remotes.py
@@ -275,3 +275,11 @@ class HDFS:
         return "hdfs://{}@127.0.0.1{}".format(
             getpass.getuser(), Local.get_storagepath()
         )
+
+
+class HTTP:
+    should_test = always_test
+
+    @staticmethod
+    def get_url(port):
+        return "http://127.0.0.1:{}".format(port)

--- a/tests/unit/remote/test_http.py
+++ b/tests/unit/remote/test_http.py
@@ -83,13 +83,13 @@ def test_digest_auth_method(dvc):
 
 
 def test_custom_auth_method(dvc):
-    header = "Custom Header"
+    header = "Custom-Header"
     password = "password"
     config = {
         "url": "http://example.com/",
         "path_info": "file.html",
         "auth": "custom",
-        "custom_header": header,
+        "custom_auth_header": header,
         "password": password,
     }
 

--- a/tests/unit/remote/test_http.py
+++ b/tests/unit/remote/test_http.py
@@ -51,9 +51,9 @@ def test_basic_auth_method(dvc):
     config = {
         "url": "http://example.com/",
         "path_info": "file.html",
+        "auth": "basic",
         "user": user,
         "password": password,
-        "basic_auth": True,
     }
 
     remote = RemoteHTTP(dvc, config)
@@ -71,12 +71,30 @@ def test_digest_auth_method(dvc):
     config = {
         "url": "http://example.com/",
         "path_info": "file.html",
+        "auth": "digest",
         "user": user,
         "password": password,
-        "digest_auth": True,
     }
 
     remote = RemoteHTTP(dvc, config)
 
     assert remote.auth_method() == auth
     assert isinstance(remote.auth_method(), HTTPDigestAuth)
+
+
+def test_custom_auth_method(dvc):
+    header = "Custom Header"
+    password = "password"
+    config = {
+        "url": "http://example.com/",
+        "path_info": "file.html",
+        "auth": "custom",
+        "custom_header": header,
+        "password": password,
+    }
+
+    remote = RemoteHTTP(dvc, config)
+
+    assert remote.auth_method() is None
+    assert header in remote.headers
+    assert remote.headers[header] == password

--- a/tests/unit/remote/test_http.py
+++ b/tests/unit/remote/test_http.py
@@ -27,3 +27,56 @@ def test_download_fails_on_error_code(dvc):
 
         with pytest.raises(HTTPError):
             remote._download(URLInfo(url) / "missing.txt", "missing.txt")
+
+
+def test_public_auth_method(dvc):
+    config = {
+        "url": "http://example.com/",
+        "path_info": "file.html",
+        "user": "",
+        "password": "",
+    }
+
+    remote = RemoteHTTP(dvc, config)
+
+    assert remote.auth_method() is None
+
+
+def test_basic_auth_method(dvc):
+    from requests.auth import HTTPBasicAuth
+
+    user = "username"
+    password = "password"
+    auth = HTTPBasicAuth(user, password)
+    config = {
+        "url": "http://example.com/",
+        "path_info": "file.html",
+        "user": user,
+        "password": password,
+        "basic_auth": True,
+    }
+
+    remote = RemoteHTTP(dvc, config)
+
+    assert remote.auth_method() == auth
+    assert isinstance(remote.auth_method(), HTTPBasicAuth)
+
+
+def test_digest_auth_method(dvc):
+    from requests.auth import HTTPDigestAuth
+
+    user = "username"
+    password = "password"
+    auth = HTTPDigestAuth(user, password)
+    config = {
+        "url": "http://example.com/",
+        "path_info": "file.html",
+        "user": user,
+        "password": password,
+        "digest_auth": True,
+    }
+
+    remote = RemoteHTTP(dvc, config)
+
+    assert remote.auth_method() == auth
+    assert isinstance(remote.auth_method(), HTTPDigestAuth)

--- a/tests/utils/httpd.py
+++ b/tests/utils/httpd.py
@@ -1,9 +1,6 @@
 import hashlib
 import os
-import shutil
-import tempfile
 import threading
-from functools import partial
 from http import HTTPStatus
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 from RangeHTTPServer import RangeRequestHandler
@@ -52,7 +49,7 @@ class PushRequestHandler(SimpleHTTPRequestHandler):
 
     def do_POST(self):
         chunked = self.headers.get("Transfer-Encoding", "") == "chunked"
-        path = os.path.join(self.directory, self.translate_path(self.path))
+        path = self.translate_path(self.path)
         try:
             os.makedirs(os.path.dirname(path), exist_ok=True)
             with open(path, "wb") as fd:
@@ -62,7 +59,7 @@ class PushRequestHandler(SimpleHTTPRequestHandler):
                 else:
                     size = int(self.headers.get("Content-Length", 0))
                     fd.write(self.rfile.read(size))
-        except Exception as e:
+        except (IOError, OSError) as e:
             self.send_error(HTTPStatus.INTERNAL_SERVER_ERROR, str(e))
         self.send_response(HTTPStatus.OK)
         self.end_headers()
@@ -87,17 +84,3 @@ class StaticFileServer:
         self._httpd.shutdown()
         self._httpd.server_close()
         self._lock.release()
-
-
-class TempFileServer(StaticFileServer):
-    def __init__(self):
-        self.directory = tempfile.mkdtemp()
-        handler_class = partial(PushRequestHandler, directory=self.directory)
-        super().__init__(handler_class=handler_class)
-
-    def __exit__(self, *args):
-        super().__exit__(*args)
-        self.cleanup()
-
-    def cleanup(self):
-        shutil.rmtree(self.directory)

--- a/tests/utils/httpd.py
+++ b/tests/utils/httpd.py
@@ -59,7 +59,7 @@ class PushRequestHandler(SimpleHTTPRequestHandler):
                 else:
                     size = int(self.headers.get("Content-Length", 0))
                     fd.write(self.rfile.read(size))
-        except (IOError, OSError) as e:
+        except OSError as e:
             self.send_error(HTTPStatus.INTERNAL_SERVER_ERROR, str(e))
         self.send_response(HTTPStatus.OK)
         self.end_headers()


### PR DESCRIPTION
* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.
  iterative/dvc.org/pull/1006

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

WIP PR for #3247 

* Adds support for POST uploads to http remotes
* Adds support for HTTP Basic and Digest authentication methods (for both upload and download operations)
    * `basic_auth` and `digest_auth` boolean options added to the http(s) remote configurations (digest takes precedence if both are set to true)
    * When no auth method is specified (or both are set to false), existing behavior is used (no auth method, assumes all HTTP endpoints are public for both upload and download)
    * Username/password combinations can be configured in the same way as ssh remotes
    * Password can be set in config or prompted on command line via `ask_password` config option

Still TODO:

* [x] Add functional/remote tests
* [x] Docs PR