### PR TITLE
gc: make it safer by only activating by use of certain flags

### DIFF
--- a/dvc/command/gc.py
+++ b/dvc/command/gc.py
@@ -12,6 +12,16 @@ logger = logging.getLogger(__name__)
 
 class CmdGC(CmdBase):
     def run(self):
+        from dvc.repo.gc import _raise_error_if_all_disabled
+
+        _raise_error_if_all_disabled(
+            all_branches=self.args.all_branches,
+            all_tags=self.args.all_tags,
+            all_commits=self.args.all_commits,
+            workspace=self.args.workspace,
+            cloud=self.args.cloud,
+        )
+
         msg = "This will remove all cache except items used in "
 
         msg += "the working tree"
@@ -47,6 +57,7 @@ class CmdGC(CmdBase):
             force=self.args.force,
             jobs=self.args.jobs,
             repos=self.args.repos,
+            workspace=self.args.workspace,
         )
         return 0
 
@@ -63,6 +74,13 @@ def add_parser(subparsers, parent_parser):
         description=append_doc_link(GC_DESCRIPTION, "gc"),
         help=GC_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    gc_parser.add_argument(
+        "-w",
+        "--workspace",
+        action="store_true",
+        default=False,
+        help="Keep data files used in the current workspace.",
     )
     gc_parser.add_argument(
         "-a",

--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -7,6 +7,10 @@ class DvcException(Exception):
     """Base class for all dvc exceptions."""
 
 
+class InvalidArgumentError(ValueError, DvcException):
+    """Thrown if arguments are invalid."""
+
+
 class OutputDuplicationError(DvcException):
     """Thrown if a file/directory is specified as an output in more than one
     stage.

--- a/tests/func/test_repro.py
+++ b/tests/func/test_repro.py
@@ -949,7 +949,7 @@ class TestReproExternalBase(TestDvc):
         self.assertEqual(self.dvc.status([cmd_stage.path]), {})
 
         self.assertEqual(self.dvc.status(), {})
-        self.dvc.gc()
+        self.dvc.gc(workspace=True)
         self.assertEqual(self.dvc.status(), {})
 
         self.dvc.remove(cmd_stage.path, outs_only=True)


### PR DESCRIPTION
Previous plain `gc` is now not supported. The same behavior can be trigger by
`gc -w` or `gc --workspace`. When `--all-{tags, commits, branches}` are
specified, it will work as if `-w` is also specified (same as before).

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

https://github.com/iterative/dvc.org/issues/1013

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Related to #2325