### PR TITLE
test: check that no remote backend modules are loaded by default

### DIFF
--- a/tests/unit/test_imports.py
+++ b/tests/unit/test_imports.py
@@ -1,0 +1,19 @@
+import subprocess
+
+
+def test_no_remote_imports():
+    remote_modules = {
+        "boto3",
+        "botocore",
+        "google.cloud.storage",
+        "azure.storage.blob",
+        "oss2",
+        "pydrive2",
+        "paramiko",
+        "pyarrow",
+    }
+
+    code = "import dvc.main, sys; print(' '.join(sys.modules))"
+    res = subprocess.run(["python", "-c", code], stdout=subprocess.PIPE)
+    modules = res.stdout.decode().split()
+    assert not set(modules) & remote_modules


### PR DESCRIPTION
We had this missed out repeatedly over time, so I added a check that we don't import any remote related deps on initial load.

Examples of related issues are #3399 and #2445.