### PR TITLE
import-url: allow queries in URL

### DIFF
--- a/dvc/path_info.py
+++ b/dvc/path_info.py
@@ -112,7 +112,7 @@ class URLInfo(_BasePath):
 
     def __init__(self, url):
         p = urlparse(url)
-        assert not p.params and not p.fragment
+        assert not p.query and not p.params and not p.fragment
         assert p.password is None
 
         self.fill_parts(p.scheme, p.hostname, p.username, p.port, p.path)

--- a/dvc/path_info.py
+++ b/dvc/path_info.py
@@ -241,3 +241,47 @@ class CloudURLInfo(URLInfo):
     @property
     def path(self):
         return self._spath.lstrip("/")
+
+
+class HTTPURLInfo(URLInfo):
+    def __init__(self, url):
+        p = urlparse(url)
+        stripped = p._replace(params=None, query=None, fragment=None)
+        super().__init__(stripped.geturl())
+        self.params = p.params
+        self.query = p.query
+        self.fragment = p.fragment
+
+    @classmethod
+    def from_parts(
+        cls,
+        scheme=None,
+        host=None,
+        user=None,
+        port=None,
+        path="",
+        netloc=None,
+        params=None,
+        query=None,
+        fragment=None,
+    ):
+        assert bool(host) ^ bool(netloc)
+
+        if netloc is not None:
+            return cls(
+                "{}://{}{}{}{}{}".format(
+                    scheme,
+                    netloc,
+                    path,
+                    (";" + params) if params else "",
+                    ("?" + query) if query else "",
+                    ("#" + fragment) if fragment else "",
+                )
+            )
+
+        obj = cls.__new__(cls)
+        obj.fill_parts(scheme, host, user, port, path)
+        obj.params = params
+        obj.query = query
+        obj.fragment = fragment
+        return obj

--- a/dvc/path_info.py
+++ b/dvc/path_info.py
@@ -285,3 +285,32 @@ class HTTPURLInfo(URLInfo):
         obj.query = query
         obj.fragment = fragment
         return obj
+
+    @property
+    def _extra_parts(self):
+        return (self.params, self.query, self.fragment)
+
+    @property
+    def parts(self):
+        return self._base_parts + self._path.parts + self._extra_parts
+
+    @cached_property
+    def url(self):
+        return "{}://{}{}{}{}{}".format(
+            self.scheme,
+            self.netloc,
+            self._spath,
+            (";" + self.params) if self.params else "",
+            ("?" + self.query) if self.query else "",
+            ("#" + self.fragment) if self.fragment else "",
+        )
+
+    def __eq__(self, other):
+        if isinstance(other, (str, bytes)):
+            other = self.__class__(other)
+        return (
+            self.__class__ == other.__class__
+            and self._base_parts == other._base_parts
+            and self._path == other._path
+            and self._extra_parts == other._extra_parts
+        )

--- a/dvc/path_info.py
+++ b/dvc/path_info.py
@@ -112,7 +112,7 @@ class URLInfo(_BasePath):
 
     def __init__(self, url):
         p = urlparse(url)
-        assert not p.query and not p.params and not p.fragment
+        assert not p.params and not p.fragment
         assert p.password is None
 
         self.fill_parts(p.scheme, p.hostname, p.username, p.port, p.path)

--- a/dvc/path_info.py
+++ b/dvc/path_info.py
@@ -314,3 +314,6 @@ class HTTPURLInfo(URLInfo):
             and self._path == other._path
             and self._extra_parts == other._extra_parts
         )
+
+    def __hash__(self):
+        return hash(self.parts)

--- a/dvc/remote/http.py
+++ b/dvc/remote/http.py
@@ -4,6 +4,7 @@ import threading
 
 from funcy import cached_property, memoize, wrap_prop, wrap_with
 
+from dvc.path_info import HTTPURLInfo
 import dvc.prompt as prompt
 from dvc.config import ConfigError
 from dvc.exceptions import DvcException, HTTPError
@@ -25,6 +26,7 @@ def ask_password(host, user):
 
 class RemoteHTTP(RemoteBASE):
     scheme = Schemes.HTTP
+    path_cls = HTTPURLInfo
     SESSION_RETRIES = 5
     SESSION_BACKOFF_FACTOR = 0.1
     REQUEST_TIMEOUT = 10

--- a/tests/unit/test_path_info.py
+++ b/tests/unit/test_path_info.py
@@ -52,10 +52,9 @@ def test_url_info_deepcopy(cls):
     assert u1 == u2
 
 
-@pytest.mark.parametrize("cls", [HTTPURLInfo])
-def test_https_url_info_str(cls):
+def test_https_url_info_str():
     url = "https://user@test.com/test1;p=par?q=quer#frag"
-    u = cls("https://user@test.com/test1;p=par?q=quer#frag")
+    u = HTTPURLInfo(url)
     assert u.url == url
     assert str(u) == u.url
 

--- a/tests/unit/test_path_info.py
+++ b/tests/unit/test_path_info.py
@@ -4,6 +4,7 @@ import pathlib
 import pytest
 
 from dvc.path_info import CloudURLInfo
+from dvc.path_info import HTTPURLInfo
 from dvc.path_info import PathInfo
 from dvc.path_info import URLInfo
 
@@ -44,11 +45,19 @@ def test_url_info_parents(cls):
     ]
 
 
-@pytest.mark.parametrize("cls", [URLInfo, CloudURLInfo])
+@pytest.mark.parametrize("cls", [URLInfo, CloudURLInfo, HTTPURLInfo])
 def test_url_info_deepcopy(cls):
     u1 = cls("ssh://user@test.com:/test1/test2/test3")
     u2 = copy.deepcopy(u1)
     assert u1 == u2
+
+
+@pytest.mark.parametrize("cls", [HTTPURLInfo])
+def test_https_url_info_str(cls):
+    url = "https://user@test.com/test1;p=par?q=quer#frag"
+    u = cls("https://user@test.com/test1;p=par?q=quer#frag")
+    assert u.url == url
+    assert str(u) == u.url
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_path_info.py
+++ b/tests/unit/test_path_info.py
@@ -57,6 +57,9 @@ def test_https_url_info_str():
     u = HTTPURLInfo(url)
     assert u.url == url
     assert str(u) == u.url
+    assert u.params == "p=par"
+    assert u.query == "q=quer"
+    assert u.fragment == "frag"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Looks like disallowing URLs containing queries happened in b83564d (#2707), i.e. `dvc>0.66.1`... Not sure why. Seems fine to me to remove the `assert not p.query` restriction.

- [x] fix `URLInfo` for http URLs (via  subclass `HTTPURLInfo(URLInfo)`)
  + [x] add support for params
  + [x] add support for queries
    * fixes #3424 `dvc import-url -v https://www.dropbox.com/?test data`
  + [x] add support for fragments
- [x] add tests