### PR TITLE
dvc: optimize building graph

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ install_requires = [
     "speedcopy>=2.0.1; sys_platform == 'win32'",
     "flatten_json>=0.1.6",
     "texttable>=0.5.2",
+    "pygtrie==2.3.2",
 ]
 
 


### PR DESCRIPTION
Use trie structure to efficiently check out, dep and stage paths being
prefixes of each other.

Will help with #2671.