### PR TITLE
dvc: support Python3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,20 @@ jobs:
     install:
     script: ./scripts/ci/check_patch.sh
   # test jobs
+  - name: "3.8 on Windows"
+    stage: test
+    os: windows           # Windows 10.0.17134 N/A Build 17134
+    language: shell       # 'language: python' is an error on Travis CI Windows
+    env:
+      - PYTHON_VERSION=3.8.0
+      - PATH=/c/Python38:/c/Python38/Scripts:$PATH
   - name: "3.7 on Windows"
     stage: test
     os: windows           # Windows 10.0.17134 N/A Build 17134
     language: shell       # 'language: python' is an error on Travis CI Windows
+    env:
+      - PYTHON_VERSION=3.7.5
+      - PATH=/c/Python37:/c/Python37/Scripts:$PATH
   - name: "3.5 on Linux"
     language: python
     python: 3.5
@@ -46,6 +56,9 @@ jobs:
   - name: "3.7 on Linux"
     language: python
     python: 3.7
+  - name: "3.8 on Linux"
+    language: python
+    python: 3.8
   - name: "3.7 on Mac"
     os: osx
     osx_image: xcode11.3
@@ -65,17 +78,17 @@ jobs:
     script: ./scripts/build_windows.cmd
   - name: "Linux pkgs"
     language: python
-    python: 3.7
+    python: 3.8
     before_install:
     install:
     script: ./scripts/build_posix.sh
   - name: "PyPI pkgs"
     language: python
-    python: 3.7
+    python: 3.8
     script: ./scripts/build_package.sh
   - name: Snapcraft snap
     language: python
-    python: 3.7
+    python: 3.8
     addons:
      snaps:
      - name: snapcraft

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,9 +76,12 @@ jobs:
     language: shell
     install:
     script: ./scripts/build_windows.cmd
+    env:
+      - PYTHON_VERSION=3.7.5
+      - PATH=/c/Python37:/c/Python37/Scripts:$PATH
   - name: "Linux pkgs"
     language: python
-    python: 3.8
+    python: 3.7
     before_install:
     install:
     script: ./scripts/build_posix.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,13 +33,6 @@ jobs:
     install:
     script: ./scripts/ci/check_patch.sh
   # test jobs
-  - name: "3.8 on Windows"
-    stage: test
-    os: windows           # Windows 10.0.17134 N/A Build 17134
-    language: shell       # 'language: python' is an error on Travis CI Windows
-    env:
-      - PYTHON_VERSION=3.8.0
-      - PATH=/c/Python38:/c/Python38/Scripts:$PATH
   - name: "3.7 on Windows"
     stage: test
     os: windows           # Windows 10.0.17134 N/A Build 17134
@@ -47,6 +40,12 @@ jobs:
     env:
       - PYTHON_VERSION=3.7.5
       - PATH=/c/Python37:/c/Python37/Scripts:$PATH
+  - name: "3.8 on Windows"
+    os: windows           # Windows 10.0.17134 N/A Build 17134
+    language: shell       # 'language: python' is an error on Travis CI Windows
+    env:
+      - PYTHON_VERSION=3.8.0
+      - PATH=/c/Python38:/c/Python38/Scripts:$PATH
   - name: "3.5 on Linux"
     language: python
     python: 3.5

--- a/dvc/system.py
+++ b/dvc/system.py
@@ -3,13 +3,14 @@ import logging
 import os
 import platform
 import shutil
+import sys
 
 from dvc.compat import fspath
 from dvc.exceptions import DvcException
 
 logger = logging.getLogger(__name__)
 
-if platform.system() == "Windows":
+if platform.system() == "Windows" and sys.version_info < (3, 8):
     try:
         import speedcopy
 

--- a/scripts/ci/before_install.sh
+++ b/scripts/ci/before_install.sh
@@ -44,8 +44,8 @@ if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Test" ]]; then
 fi
 
 if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
-  $scriptdir/retry.sh choco install python --version 3.7.5
-  echo 'PATH="/c/Python37:/c/Python37/Scripts:$PATH"' >>env.sh
+  $scriptdir/retry.sh choco install python --version $PYTHON_VERSION
+  echo "PATH='$PATH'" >>env.sh
 elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   ln -s -f /usr/local/bin/python3 /usr/local/bin/python
   ln -s -f /usr/local/bin/pip3 /usr/local/bin/pip

--- a/scripts/ci/install_hadoop.sh
+++ b/scripts/ci/install_hadoop.sh
@@ -23,6 +23,13 @@ echo "export HADOOP_COMMON_HOME=/usr/local/hadoop" >>env.sh
 echo "export HADOOP_HDFS_HOME=/usr/local/hadoop" >>env.sh
 echo "export YARN_HOME=/usr/local/hadoop" >>env.sh
 echo "export HADOOP_COMMON_LIB_NATIVE_DIR=/usr/local/hadoop/lib/native" >>env.sh
+
+# regression on PyArrow==0.16.0: https://issues.apache.org/jira/browse/ARROW-7841
+# it tries to retrieve native library from $HADOOP_HOME directory, instead of
+# `$HADOOP_HOME/lib/native`.
+# force it to search for `libhdfs.so` inside `$HADOOP_HOME/lib/native`
+echo "export ARROW_LIBHDFS_DIR=/usr/local/hadoop/lib/native" >> env.sh
+
 echo "export JAVA_HOME=/usr/" >>env.sh
 echo "export PATH=\$PATH:/usr/local/hadoop/sbin:/usr/local/hadoop/bin:$JAVA_PATH/bin" >>env.sh
 

--- a/scripts/ci/install_hadoop.sh
+++ b/scripts/ci/install_hadoop.sh
@@ -24,10 +24,11 @@ echo "export HADOOP_HDFS_HOME=/usr/local/hadoop" >>env.sh
 echo "export YARN_HOME=/usr/local/hadoop" >>env.sh
 echo "export HADOOP_COMMON_LIB_NATIVE_DIR=/usr/local/hadoop/lib/native" >>env.sh
 
-# regression on PyArrow==0.16.0: https://issues.apache.org/jira/browse/ARROW-7841
-# it tries to retrieve native library from $HADOOP_HOME directory, instead of
+# PyArrow==0.16.0 regression https://issues.apache.org/jira/browse/ARROW-7841
+# retrieves native library from $HADOOP_HOME directory instead of
 # `$HADOOP_HOME/lib/native`.
-# force it to search for `libhdfs.so` inside `$HADOOP_HOME/lib/native`
+# Fix: force search for `libhdfs.so` inside `$HADOOP_HOME/lib/native`.
+# Note: not needed for PyArrow==0.17.0.
 echo "export ARROW_LIBHDFS_DIR=/usr/local/hadoop/lib/native" >> env.sh
 
 echo "export JAVA_HOME=/usr/" >>env.sh

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ install_requires = [
     "pywin32>=225; sys_platform == 'win32'",
     "networkx>=2.1,<2.4",
     "pydot>=1.2.4",
-    "speedcopy>=2.0.1; sys_platform == 'win32'",
+    "speedcopy>=2.0.1; python_version < '3.8' and sys_platform == 'win32'",
     "flatten_json>=0.1.6",
     "texttable>=0.5.2",
     "pygtrie==2.3.2",
@@ -89,7 +89,12 @@ s3 = ["boto3>=1.9.201"]
 azure = ["azure-storage-blob==2.1.0"]
 oss = ["oss2==2.6.1"]
 ssh = ["paramiko>=2.5.0"]
-hdfs = ["pyarrow==0.15.1"]
+hdfs = [
+    # pyarrow-0.16.0 import fails on 3.5 and 3.7 (works on 3.6 though)
+    # due to: https://issues.apache.org/jira/browse/ARROW-7852
+    "pyarrow==0.15.1; python_version < '3.8'",
+    "pyarrow==0.16.0; python_version == '3.8'",
+]
 # gssapi should not be included in all_remotes, because it doesn't have wheels
 # for linux and mac, so it will fail to compile if user doesn't have all the
 # requirements, including kerberos itself. Once all the wheels are available,
@@ -157,6 +162,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,

--- a/tests/func/test_checkout.py
+++ b/tests/func/test_checkout.py
@@ -436,10 +436,10 @@ class TestCheckoutMovedCacheDirWithSymlinks(TestDvc):
         self.assertEqual(ret, 0)
 
         self.assertTrue(System.is_symlink(self.FOO))
-        old_foo_link = os.readlink(self.FOO)
+        old_foo_link = os.path.realpath(self.FOO)
 
         self.assertTrue(System.is_symlink(self.DATA))
-        old_data_link = os.readlink(self.DATA)
+        old_data_link = os.path.realpath(self.DATA)
 
         old_cache_dir = self.dvc.cache.local.cache_dir
         new_cache_dir = old_cache_dir + "_new"
@@ -452,10 +452,10 @@ class TestCheckoutMovedCacheDirWithSymlinks(TestDvc):
         self.assertEqual(ret, 0)
 
         self.assertTrue(System.is_symlink(self.FOO))
-        new_foo_link = os.readlink(self.FOO)
+        new_foo_link = os.path.realpath(self.FOO)
 
         self.assertTrue(System.is_symlink(self.DATA))
-        new_data_link = os.readlink(self.DATA)
+        new_data_link = os.path.realpath(self.DATA)
 
         self.assertEqual(
             relpath(old_foo_link, old_cache_dir),


### PR DESCRIPTION
Fixes #3033

PyInstaller does not support Python3.8 yet: https://github.com/pyinstaller/pyinstaller/issues/4311 

* [x] ❗ Have you followed the guidelines in the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) list?

* [x] 📖 Check this box if this PR **does not** require [documentation](https://dvc.org/doc) updates, or if it does **and** you have created a separate PR in [dvc.org](https://github.com/iterative/dvc.org) with such updates (or at least opened an issue about it in that repo). Please link below to your PR (or issue) in the [dvc.org](https://github.com/iterative/dvc.org) repo.

* [x] ❌ Have you checked DeepSource, CodeClimate, and other sanity checks below? We consider their findings recommendatory and don't expect everything to be addressed. Please review them carefully and fix those that actually improve code or fix bugs.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

#### TODO
- [x] Cherry-pick 625de04 to see if this makes 3.8 tests pass.
- ~~Try to update pyarrow to 0.16.0 for other versions of Python and make them pass.~~
      Not possible due to https://issues.apache.org/jira/browse/ARROW-7852.
- [x] Enable 3.8 on Windows ~~and Mac~~.
- [ ] Run formattings on 3.8. (Not necessary).
- [x] Build wheels for 3.8 as well, and advertise on `classifiers` in setup.py.
- [x] Removing cherrypick after #3480 is merged. Code cleanups.

### Future discussions
We should try to be ahead of the `PyArrow` regarding releases. So, we should at-least be able to release non-hdfs packages before/on release of new python versions. We can run tests on `3.9-dev`   without `PyArrow`.

Do we need to support Python3.5? [The number of downloads are already low](https://pypistats.org/packages/dvc) (and, numpy/conda does not support this version at all).