### PR TITLE
tests: remove use of mocker as context-manager

### DIFF
--- a/tests/func/test_ls.py
+++ b/tests/func/test_ls.py
@@ -79,9 +79,9 @@ def test_ls_repo_with_color(tmp_dir, dvc, scm, mocker, monkeypatch, caplog):
     cmd = cli_args.func(cli_args)
 
     caplog.clear()
-    with mocker.patch("sys.stdout.isatty", return_value=True):
-        with caplog.at_level(logging.INFO, logger="dvc.command.ls"):
-            assert cmd.run() == 0
+    mocker.patch("sys.stdout.isatty", return_value=True)
+    with caplog.at_level(logging.INFO, logger="dvc.command.ls"):
+        assert cmd.run() == 0
 
     assert caplog.records[-1].msg == "\n".join(
         [

--- a/tests/unit/command/test_imp_url.py
+++ b/tests/unit/command/test_imp_url.py
@@ -22,14 +22,12 @@ def test_failed_import_url(mocker, caplog):
     assert cli_args.func == CmdImportUrl
 
     cmd = cli_args.func(cli_args)
-    with mocker.patch.object(
-        cmd.repo, "imp_url", side_effect=DvcException("error")
-    ):
-        with caplog.at_level(logging.ERROR, logger="dvc"):
-            assert cmd.run() == 1
-            expected_error = (
-                "failed to import http://somesite.com/file_name. "
-                "You could also try downloading it manually, and "
-                "adding it with `dvc add`."
-            )
-            assert expected_error in caplog.text
+    mocker.patch.object(cmd.repo, "imp_url", side_effect=DvcException("error"))
+    with caplog.at_level(logging.ERROR, logger="dvc"):
+        assert cmd.run() == 1
+        expected_error = (
+            "failed to import http://somesite.com/file_name. "
+            "You could also try downloading it manually, and "
+            "adding it with `dvc add`."
+        )
+        assert expected_error in caplog.text

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -24,10 +24,10 @@ colors = {
 
 @pytest.fixture()
 def dt(mocker):
-    with mocker.patch(
+    mocker.patch(
         "time.time", return_value=time.mktime(datetime(2020, 2, 2).timetuple())
-    ):
-        yield "2020-02-02 00:00:00,000"
+    )
+    yield "2020-02-02 00:00:00,000"
 
 
 class TestColorFormatter:
@@ -195,32 +195,32 @@ class TestColorFormatter:
     def test_progress_awareness(self, mocker, capsys, caplog):
         from dvc.progress import Tqdm
 
-        with mocker.patch("sys.stdout.isatty", return_value=True):
-            with Tqdm(total=100, desc="progress") as pbar:
-                pbar.update()
+        mocker.patch("sys.stdout.isatty", return_value=True)
+        with Tqdm(total=100, desc="progress") as pbar:
+            pbar.update()
 
-                # logging an invisible message should not break
-                # the progress bar output
-                with caplog.at_level(logging.INFO, logger="dvc"):
-                    debug_record = logging.LogRecord(
-                        name="dvc",
-                        level=logging.DEBUG,
-                        pathname=__name__,
-                        lineno=1,
-                        msg="debug",
-                        args=(),
-                        exc_info=None,
-                    )
+            # logging an invisible message should not break
+            # the progress bar output
+            with caplog.at_level(logging.INFO, logger="dvc"):
+                debug_record = logging.LogRecord(
+                    name="dvc",
+                    level=logging.DEBUG,
+                    pathname=__name__,
+                    lineno=1,
+                    msg="debug",
+                    args=(),
+                    exc_info=None,
+                )
 
-                    formatter.format(debug_record)
-                    captured = capsys.readouterr()
-                    assert captured.out == ""
+                formatter.format(debug_record)
+                captured = capsys.readouterr()
+                assert captured.out == ""
 
-                #  when the message is actually visible
-                with caplog.at_level(logging.INFO, logger="dvc"):
-                    logger.info("some info")
-                    captured = capsys.readouterr()
-                    assert captured.out == ""
+            #  when the message is actually visible
+            with caplog.at_level(logging.INFO, logger="dvc"):
+                logger.info("some info")
+                captured = capsys.readouterr()
+                assert captured.out == ""
 
 
 def test_handlers():

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -125,7 +125,6 @@ def test_relpath():
     ],
 )
 def test_resolve_output(inp, out, is_dir, expected, mocker):
-    with mocker.patch("os.path.isdir", return_value=is_dir):
-        result = resolve_output(inp, out)
-
+    mocker.patch("os.path.isdir", return_value=is_dir)
+    result = resolve_output(inp, out)
     assert result == expected


### PR DESCRIPTION
`mocker` is not expected to work as a context-manager (https://github.com/pytest-dev/pytest-mock/issues/164), and raises a `ValueError` if done so.

Ref: https://github.com/pytest-dev/pytest-mock#note-about-usage-as-context-manager