### PR TITLE
dvc: add Repo(skip_checks) flag

### DIFF
--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -174,15 +174,18 @@ class Repo(object):
 
     def check_modified_graph(self, new_stages):
         """Generate graph including the new stage to check for errors"""
-        # Building graph might be costly for ones with many stages,
-        # we provide this non-documented hack to skip this for add and run.
-        # Can be used as:
+        # Building graph might be costly for the ones with many DVC-files,
+        # so we provide this undocumented hack to skip it. See [1] for
+        # more details. The hack can be used as:
         #
         #     repo = Repo(...)
         #     repo._skip_graph_checks = True
         #     repo.add(...)
         #
-        # A user should care about not duplicating outs and not adding cycles.
+        # A user should care about not duplicating outs and not adding cycles,
+        # otherwise DVC might have an undefined behaviour.
+        #
+        # [1] https://github.com/iterative/dvc/issues/2671
         if not getattr(self, "_skip_graph_checks", False):
             self._collect_graph(self.stages + new_stages)
 

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -174,6 +174,15 @@ class Repo(object):
 
     def check_modified_graph(self, new_stages):
         """Generate graph including the new stage to check for errors"""
+        # Building graph might be costly for ones with many stages,
+        # we provide this non-documented hack to skip this for add and run.
+        # Can be used as:
+        #
+        #     repo = Repo(...)
+        #     repo._skip_graph_checks = True
+        #     repo.add(...)
+        #
+        # A user should care about not duplicating outs and not adding cycles.
         if not getattr(self, "_skip_graph_checks", False):
             self._collect_graph(self.stages + new_stages)
 

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -174,7 +174,8 @@ class Repo(object):
 
     def check_modified_graph(self, new_stages):
         """Generate graph including the new stage to check for errors"""
-        self._collect_graph(self.stages + new_stages)
+        if not getattr(self, "_skip_graph_checks", False):
+            self._collect_graph(self.stages + new_stages)
 
     def collect(self, target, with_deps=False, recursive=False, graph=None):
         import networkx as nx

--- a/tests/unit/repo/test_repo.py
+++ b/tests/unit/repo/test_repo.py
@@ -85,15 +85,27 @@ def test_collect_optimization(tmp_dir, dvc, mocker):
 
 
 def test_skip_graph_checks(tmp_dir, dvc, mocker, run_copy):
-    (stage,) = tmp_dir.dvc_gen("foo", "foo text")
+    # See https://github.com/iterative/dvc/issues/2671 for more info
+    mock_collect_graph = mocker.patch("dvc.repo.Repo._collect_graph")
 
-    # Error out on graph collection and raise a skip graph checks flag
-    mocker.patch(
-        "dvc.repo.Repo._collect_graph",
-        side_effect=Exception("Should not collect"),
-    )
-    dvc._skip_graph_checks = True
-
+    # sanity check
     tmp_dir.gen("foo", "foo text")
     dvc.add("foo")
     run_copy("foo", "bar")
+    assert mock_collect_graph.called
+
+    # check that our hack can be enabled
+    mock_collect_graph.reset_mock()
+    dvc._skip_graph_checks = True
+    tmp_dir.gen("baz", "baz text")
+    dvc.add("baz")
+    run_copy("baz", "qux")
+    assert not mock_collect_graph.called
+
+    # check that our hack can be disabled
+    mock_collect_graph.reset_mock()
+    dvc._skip_graph_checks = False
+    tmp_dir.gen("quux", "quux text")
+    dvc.add("quux")
+    run_copy("quux", "quuz")
+    assert mock_collect_graph.called

--- a/tests/unit/repo/test_repo.py
+++ b/tests/unit/repo/test_repo.py
@@ -82,3 +82,18 @@ def test_collect_optimization(tmp_dir, dvc, mocker):
     # Should read stage directly instead of collecting the whole graph
     dvc.collect(stage.path)
     dvc.collect_granular(stage.path)
+
+
+def test_skip_graph_checks(tmp_dir, dvc, mocker, run_copy):
+    (stage,) = tmp_dir.dvc_gen("foo", "foo text")
+
+    # Error out on graph collection and raise a skip graph checks flag
+    mocker.patch(
+        "dvc.repo.Repo._collect_graph",
+        side_effect=Exception("Should not collect"),
+    )
+    dvc._skip_graph_checks = True
+
+    tmp_dir.gen("foo", "foo text")
+    dvc.add("foo")
+    run_copy("foo", "bar")


### PR DESCRIPTION
Will skip modified graph checks on add, run and import. The aim is to
avoid collecting stages and building graph on these commands.

The skip_checks flag is aimed to be private, but let people use dvc on
big repos without monkey patching or writing yaml files themselves.

Closes #2671. For the time being.