### PR TITLE
git: tree: use item.path instead of item.name

### DIFF
--- a/tests/unit/scm/test_git.py
+++ b/tests/unit/scm/test_git.py
@@ -1,5 +1,7 @@
 import os
 
+from dvc.compat import fspath
+
 from tests.basic_env import TestDvcGit
 
 
@@ -15,3 +17,23 @@ class TestGit(TestDvcGit):
     def test_belongs_to_scm_false(self):
         path = os.path.join("some", "non-.git", "file")
         self.assertFalse(self.dvc.scm.belongs_to_scm(path))
+
+
+def test_walk_with_submodules(tmp_dir, scm, git_dir):
+    git_dir.scm_gen(
+        {"foo": "foo", "bar": "bar", "dir": {"data": "data"}},
+        commit="add dir and files",
+    )
+    scm.repo.create_submodule("submodule", "submodule", url=fspath(git_dir))
+    scm.commit("added submodule")
+
+    files = []
+    dirs = []
+    tree = scm.get_tree("HEAD")
+    for _, dnames, fnames in tree.walk("."):
+        dirs.extend(dnames)
+        files.extend(fnames)
+
+    # currently we don't walk through submodules
+    assert not dirs
+    assert set(files) == {".gitmodules", "submodule"}


### PR DESCRIPTION
We are currently using this [0] hack to work around the fact that item.name
is not always a basename. Even though `IndexObject` has it defined that way
[1], but `Submodule` - doesn't [2]. So using `item.name` might cause issues
such as [3], because GitPython doesn't pass name parameter when simply
going through objects [4]. In other places, when working specifically with
submodules, it sets `_name` attribute explicitly [5].

Note that we still don't walk into submodules when walking through a git
repo. Might want to reconsider that later as for now we haven't heard
anything about it from actual users.

Fixes #3481

[0] https://github.com/iterative/dvc/blob/0.90.0/dvc/scm/git/tree.py#L15
[1] https://github.com/gitpython-developers/GitPython/blob/3.1.0/git/objects/base.py#L170
[2] https://github.com/gitpython-developers/GitPython/blob/3.1.0/git/objects/submodule/base.py#L1123
[3] https://github.com/gitpython-developers/GitPython/issues/597
[4] https://github.com/gitpython-developers/GitPython/blob/3.1.0/git/objects/tree.py#L237
[5] https://github.com/gitpython-developers/GitPython/blob/3.1.0/git/objects/submodule/base.py#L357

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
