### PR TITLE
version: fix bug when .git dir is removed, show more info regarding repo

### DIFF
--- a/dvc/command/version.py
+++ b/dvc/command/version.py
@@ -15,6 +15,7 @@ from dvc.utils import is_binary, relpath
 from dvc.command.base import CmdBaseNoRepo, append_doc_link
 from dvc.version import __version__
 from dvc.exceptions import DvcException, NotDvcRepoError
+from dvc.scm.base import SCMError
 from dvc.system import System
 from dvc.utils.pkg import PKG
 
@@ -34,7 +35,11 @@ class CmdVersion(CmdBaseNoRepo):
         ]
 
         try:
-            repo = Repo()
+            try:
+                repo = Repo()
+            except SCMError:
+                repo = Repo(no_scm=True)
+
             root_directory = repo.root_dir
 
             # cache_dir might not exist yet (e.g. after `dvc init`), and we

--- a/dvc/command/version.py
+++ b/dvc/command/version.py
@@ -15,6 +15,7 @@ from dvc.utils import is_binary, relpath
 from dvc.command.base import CmdBaseNoRepo, append_doc_link
 from dvc.version import __version__
 from dvc.exceptions import DvcException, NotDvcRepoError
+from dvc.scm import NoSCM
 from dvc.scm.base import SCMError
 from dvc.system import System
 from dvc.utils.pkg import PKG
@@ -39,6 +40,8 @@ class CmdVersion(CmdBaseNoRepo):
                 repo = Repo()
             except SCMError:
                 repo = Repo(no_scm=True)
+
+            info.append("Repo: " + _get_dvc_repo_info(repo))
 
             root_directory = repo.root_dir
 
@@ -116,6 +119,19 @@ class CmdVersion(CmdBaseNoRepo):
         os.remove(src)
 
         return ", ".join(cache)
+
+
+def _get_dvc_repo_info(repo):
+    if repo.config.get("core", {}).get("no_scm", False):
+        return "dvc (no_scm)"
+
+    if isinstance(repo.scm, NoSCM):
+        return "dvc, git (broken)"
+
+    if repo.root_dir != repo.scm.root_dir:
+        return "dvc (subdir), git"
+
+    return "dvc, git"
 
 
 def add_parser(subparsers, parent_parser):

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -60,7 +60,7 @@ class Repo(object):
     from dvc.repo.get_url import get_url
     from dvc.repo.update import update
 
-    def __init__(self, root_dir=None):
+    def __init__(self, root_dir=None, no_scm=False):
         from dvc.state import State
         from dvc.lock import make_lock
         from dvc.scm import SCM
@@ -78,7 +78,7 @@ class Repo(object):
 
         self.config = Config(self.dvc_dir)
 
-        no_scm = self.config["core"].get("no_scm", False)
+        no_scm = no_scm or self.config["core"].get("no_scm", False)
         self.scm = SCM(self.root_dir, no_scm=no_scm)
 
         self.tree = WorkingTree(self.root_dir)

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -60,7 +60,7 @@ class Repo(object):
     from dvc.repo.get_url import get_url
     from dvc.repo.update import update
 
-    def __init__(self, root_dir=None, no_scm=False):
+    def __init__(self, root_dir=None):
         from dvc.state import State
         from dvc.lock import make_lock
         from dvc.scm import SCM
@@ -78,7 +78,7 @@ class Repo(object):
 
         self.config = Config(self.dvc_dir)
 
-        no_scm = no_scm or self.config["core"].get("no_scm", False)
+        no_scm = self.config["core"].get("no_scm", False)
         self.scm = SCM(self.root_dir, no_scm=no_scm)
 
         self.tree = WorkingTree(self.root_dir)

--- a/tests/func/test_version.py
+++ b/tests/func/test_version.py
@@ -49,6 +49,8 @@ def test_info_in_broken_git_repo(tmp_dir, dvc, scm, caplog):
     shutil.rmtree(dvc.scm.dir)
     assert main(["version"]) == 0
 
+    assert "Repo: dvc, git (broken)" in caplog.text
+
 
 @pytest.mark.skipif(psutil is None, reason="No psutil.")
 def test_fs_info_in_repo(tmp_dir, dvc, caplog):

--- a/tests/func/test_version.py
+++ b/tests/func/test_version.py
@@ -1,5 +1,6 @@
 import os
 import re
+import shutil
 
 import pytest
 
@@ -7,9 +8,12 @@ from dvc.command.version import psutil
 from dvc.main import main
 
 
-def test_info_in_repo(tmp_dir, dvc, caplog):
+@pytest.mark.parametrize("scm_init", [True, False])
+def test_info_in_repo(scm_init, tmp_dir, caplog):
+    tmp_dir.init(scm=scm_init, dvc=True)
     # Create `.dvc/cache`, that is needed to check supported link types.
-    os.mkdir(dvc.cache.local.cache_dir)
+    os.mkdir(tmp_dir.dvc.cache.local.cache_dir)
+
     assert main(["version"]) == 0
 
     assert re.search(r"DVC version: \d+\.\d+\.\d+", caplog.text)
@@ -20,6 +24,11 @@ def test_info_in_repo(tmp_dir, dvc, caplog):
     assert re.search(
         r"(Cache: (.*link - (not )?supported(,\s)?){3})", caplog.text
     )
+
+
+def test_info_in_broken_git_repo(tmp_dir, dvc, scm, caplog):
+    shutil.rmtree(dvc.scm.dir)
+    assert main(["version"]) == 0
 
 
 @pytest.mark.skipif(psutil is None, reason="No psutil.")
@@ -40,6 +49,7 @@ def test_info_outside_of_repo(tmp_dir, caplog):
     assert re.search(r"Binary: (True|False)", caplog.text)
     assert re.search(r"Package: .*", caplog.text)
     assert not re.search(r"(Cache: (.*link - (not )?(,\s)?){3})", caplog.text)
+    assert "Repo:" not in caplog.text
 
 
 @pytest.mark.skipif(psutil is None, reason="No psutil.")

--- a/tests/func/test_version.py
+++ b/tests/func/test_version.py
@@ -25,6 +25,25 @@ def test_info_in_repo(scm_init, tmp_dir, caplog):
         r"(Cache: (.*link - (not )?supported(,\s)?){3})", caplog.text
     )
 
+    if scm_init:
+        assert "Repo: dvc, git" in caplog.text
+    else:
+        assert "Repo: dvc (no_scm)" in caplog.text
+
+
+def test_info_in_subdir(tmp_dir, scm, caplog):
+    dvc_subdir = tmp_dir / "subdir"
+    dvc_subdir.mkdir()
+
+    with dvc_subdir.chdir():
+        dvc_subdir.init(scm=False, dvc=True)
+        with dvc_subdir.dvc.config.edit() as conf:
+            del conf["core"]["no_scm"]
+
+        assert main(["version"]) == 0
+
+    assert "Repo: dvc (subdir), git" in caplog.text
+
 
 def test_info_in_broken_git_repo(tmp_dir, dvc, scm, caplog):
     shutil.rmtree(dvc.scm.dir)


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Fixes https://github.com/iterative/dvc/issues/3461

08cfa4f implements the fix when `.git` dir is removed. This PR tries to show information as much as possible, so, if `.git` dir is removed, it tries to open it as non-git dvc repository.

65184a5 implements additional output format if the cwd is a path to `dvc` repo. Examples:
1. When the repo is a subdir:
```sh
DVC version: 0.89.0+65184a
Python version: 3.6.6
Platform: Linux-5.5.2-arch1-1-x86_64-with-arch
Binary: False
Package: None
Repo: dvc (subdir), git
Filesystem type (workspace): ('tmpfs', 'tmpfs')
```

2. When the .git dir is broken, or cannot use `git` operations by dvc:
```sh
DVC version: 0.89.0+65184a
Python version: 3.6.6
Platform: Linux-5.5.2-arch1-1-x86_64-with-arch
Binary: False
Package: None
Repo: dvc, git (broken)
Cache: reflink - not supported, hardlink - supported, symlink - supported
Filesystem type (cache directory): ('tmpfs', 'tmpfs')
Filesystem type (workspace): ('tmpfs', 'tmpfs')
```

3. Git + DVC repo
```
DVC version: 0.89.0+65184a
Python version: 3.6.6
Platform: Linux-5.5.2-arch1-1-x86_64-with-arch
Binary: False
Package: None
Repo: dvc, git
Filesystem type (workspace): ('ext4', '/dev/sda9')
```

4. DVC no_scm:
```
DVC version: 0.89.0+65184a
Python version: 3.6.6
Platform: Linux-5.5.2-arch1-1-x86_64-with-arch
Binary: False
Package: None
Repo: dvc (no_scm)
Filesystem type (workspace): ('tmpfs', 'tmpfs')
```

5. If not a dvc repo at all:
```
DVC version: 0.89.0+65184a
Python version: 3.6.6
Platform: Linux-5.5.2-arch1-1-x86_64-with-arch
Binary: False
Package: None
Filesystem type (workspace): ('ext4', '/dev/sda9')
```