### PR TITLE
params: use dpath for xpaths

### DIFF
--- a/dvc/dependency/param.py
+++ b/dvc/dependency/param.py
@@ -2,9 +2,8 @@ import os
 import yaml
 from collections import defaultdict
 
+import dpath.util
 from voluptuous import Any
-from funcy import select_keys
-from flatten_json import flatten
 
 from dvc.compat import fspath_py35
 from dvc.dependency.local import DependencyLOCAL
@@ -87,9 +86,10 @@ class DependencyPARAMS(DependencyLOCAL):
                     "Unable to read parameters from '{}'".format(self)
                 ) from exc
 
-        config = flatten(config, ".")
-
-        return select_keys(lambda key: key in self.params, config)
+        ret = {}
+        for param in self.params:
+            ret[param] = dpath.util.get(config, param, separator=".")
+        return ret
 
     def save_info(self):
         info = self._get_info()

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ install_requires = [
     "flatten_json>=0.1.6",
     "texttable>=0.5.2",
     "pygtrie==2.3.2",
+    "dpath>=2.0.1,<3",
 ]
 
 

--- a/tests/unit/dependency/test_params.py
+++ b/tests/unit/dependency/test_params.py
@@ -70,9 +70,11 @@ def test_get_info_unsupported_format(tmp_dir, dvc):
 
 
 def test_get_info_nested(tmp_dir, dvc):
-    tmp_dir.gen("params.yaml", yaml.dump({"some": {"path": {"foo": "val"}}}))
+    tmp_dir.gen(
+        "params.yaml", yaml.dump({"some": {"path": {"foo": ["val1", "val2"]}}})
+    )
     dep = DependencyPARAMS(Stage(dvc), None, ["some.path.foo"])
-    assert dep._get_info() == {"some.path.foo": "val"}
+    assert dep._get_info() == {"some.path.foo": ["val1", "val2"]}
 
 
 def test_save_info_missing_params(dvc):


### PR DESCRIPTION
Currently `dvc run -p angles` is broken when you use it with `params.yaml`
that looks like this:

```
angles:
    - 2
    - 3
    - 100
    - 3.2
    - 36.2
    - 3.6
```

because we are incorrectly using `flatten` instead of simply using some
xpath-like library to access params that are specified.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
