### PR TITLE
remote: use progress bar when paginating

### DIFF
--- a/dvc/remote/azure.py
+++ b/dvc/remote/azure.py
@@ -97,10 +97,9 @@ class RemoteAZURE(RemoteBASE):
                 bucket, prefix=prefix, marker=next_marker
             )
 
-            if progress_callback:
-                progress_callback(len(blobs))
-
             for blob in blobs:
+                if progress_callback:
+                    progress_callback()
                 yield blob.name
 
             if not blobs.next_marker:

--- a/dvc/remote/azure.py
+++ b/dvc/remote/azure.py
@@ -29,6 +29,7 @@ class RemoteAZURE(RemoteBASE):
     REQUIRES = {"azure-storage-blob": "azure.storage.blob"}
     PARAM_CHECKSUM = "etag"
     COPY_POLL_SECONDS = 5
+    LIST_OBJECT_PAGE_SIZE = 5000
 
     def __init__(self, repo, config):
         super().__init__(repo, config)
@@ -88,13 +89,16 @@ class RemoteAZURE(RemoteBASE):
         logger.debug("Removing {}".format(path_info))
         self.blob_service.delete_blob(path_info.bucket, path_info.path)
 
-    def _list_paths(self, bucket, prefix):
+    def _list_paths(self, bucket, prefix, progress_callback=None):
         blob_service = self.blob_service
         next_marker = None
         while True:
             blobs = blob_service.list_blobs(
                 bucket, prefix=prefix, marker=next_marker
             )
+
+            if progress_callback:
+                progress_callback(len(blobs))
 
             for blob in blobs:
                 yield blob.name
@@ -104,14 +108,16 @@ class RemoteAZURE(RemoteBASE):
 
             next_marker = blobs.next_marker
 
-    def list_cache_paths(self, prefix=None):
+    def list_cache_paths(self, prefix=None, progress_callback=None):
         if prefix:
             prefix = posixpath.join(
                 self.path_info.path, prefix[:2], prefix[2:]
             )
         else:
             prefix = self.path_info.path
-        return self._list_paths(self.path_info.bucket, prefix)
+        return self._list_paths(
+            self.path_info.bucket, prefix, progress_callback
+        )
 
     def _upload(
         self, from_file, to_info, name=None, no_progress_bar=False, **_kwargs

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -850,15 +850,14 @@ class RemoteBASE(object):
         with Tqdm(
             desc="Estimating size of "
             + ("cache in '{}'".format(name) if name else "remote cache"),
-            bar_format=Tqdm.BAR_FMT_NOTOTAL,
-            unit="objects",
+            unit="file",
         ) as pbar:
             remote_checksums = set(
                 map(
                     self.path_to_checksum,
                     self.list_cache_paths(
                         prefix=prefix,
-                        progress_callback=lambda n: pbar.update(
+                        progress_callback=lambda n=1: pbar.update(
                             n * total_prefixes
                         ),
                     ),

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -847,9 +847,23 @@ class RemoteBASE(object):
         checksums = frozenset(checksums)
         prefix = "0" * self.TRAVERSE_PREFIX_LEN
         total_prefixes = pow(16, self.TRAVERSE_PREFIX_LEN)
-        remote_checksums = set(
-            map(self.path_to_checksum, self.list_cache_paths(prefix=prefix))
-        )
+        with Tqdm(
+            desc="Estimating size of "
+            + ("cache in '{}'".format(name) if name else "remote cache"),
+            bar_format=Tqdm.BAR_FMT_NOTOTAL,
+            unit="objects",
+        ) as pbar:
+            remote_checksums = set(
+                map(
+                    self.path_to_checksum,
+                    self.list_cache_paths(
+                        prefix=prefix,
+                        progress_callback=lambda n: pbar.update(
+                            n * total_prefixes
+                        ),
+                    ),
+                )
+            )
         if remote_checksums:
             remote_size = total_prefixes * len(remote_checksums)
         else:

--- a/dvc/remote/gs.py
+++ b/dvc/remote/gs.py
@@ -134,15 +134,12 @@ class RemoteGS(RemoteBASE):
             prefix = posixpath.join(path_info.path, prefix[:2], prefix[2:])
         else:
             prefix = path_info.path
-        for page in (
-            self.gs.bucket(path_info.bucket)
-            .list_blobs(prefix=path_info.path, max_results=max_items)
-            .pages
+        for blob in self.gs.bucket(path_info.bucket).list_blobs(
+            prefix=path_info.path, max_results=max_items
         ):
             if progress_callback:
-                progress_callback.update(page.num_items)
-            for blob in page:
-                yield blob.name
+                progress_callback()
+            yield blob.name
 
     def list_cache_paths(self, prefix=None, progress_callback=None):
         return self._list_paths(

--- a/dvc/remote/hdfs.py
+++ b/dvc/remote/hdfs.py
@@ -153,7 +153,7 @@ class RemoteHDFS(RemoteBASE):
                 raise FileNotFoundError(*e.args)
             raise
 
-    def list_cache_paths(self, prefix=None):
+    def list_cache_paths(self, prefix=None, progress_callback=None):
         if not self.exists(self.path_info):
             return
 
@@ -166,7 +166,10 @@ class RemoteHDFS(RemoteBASE):
         with self.hdfs(self.path_info) as hdfs:
             while dirs:
                 try:
-                    for entry in hdfs.ls(dirs.pop(), detail=True):
+                    entries = hdfs.ls(dirs.pop(), detail=True)
+                    if progress_callback:
+                        progress_callback.update(len(entries))
+                    for entry in entries:
                         if entry["kind"] == "directory":
                             dirs.append(urlparse(entry["name"]).path)
                         elif entry["kind"] == "file":

--- a/dvc/remote/hdfs.py
+++ b/dvc/remote/hdfs.py
@@ -172,7 +172,7 @@ class RemoteHDFS(RemoteBASE):
                             dirs.append(urlparse(entry["name"]).path)
                         elif entry["kind"] == "file":
                             if progress_callback:
-                                progress_callback.update()
+                                progress_callback()
                             yield urlparse(entry["name"]).path
                 except IOError as e:
                     # When searching for a specific prefix pyarrow raises an

--- a/dvc/remote/hdfs.py
+++ b/dvc/remote/hdfs.py
@@ -167,12 +167,12 @@ class RemoteHDFS(RemoteBASE):
             while dirs:
                 try:
                     entries = hdfs.ls(dirs.pop(), detail=True)
-                    if progress_callback:
-                        progress_callback.update(len(entries))
                     for entry in entries:
                         if entry["kind"] == "directory":
                             dirs.append(urlparse(entry["name"]).path)
                         elif entry["kind"] == "file":
+                            if progress_callback:
+                                progress_callback.update()
                             yield urlparse(entry["name"]).path
                 except IOError as e:
                     # When searching for a specific prefix pyarrow raises an

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -59,7 +59,12 @@ class RemoteLOCAL(RemoteBASE):
     def list_cache_paths(self, prefix=None, progress_callback=None):
         assert prefix is None
         assert self.path_info is not None
-        return walk_files(self.path_info)
+        if progress_callback:
+            for path in walk_files(self.path_info):
+                progress_callback()
+                yield path
+        else:
+            yield from walk_files(self.path_info)
 
     def get(self, md5):
         if not md5:

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -56,7 +56,7 @@ class RemoteLOCAL(RemoteBASE):
     def supported(cls, config):
         return True
 
-    def list_cache_paths(self, prefix=None):
+    def list_cache_paths(self, prefix=None, progress_callback=None):
         assert prefix is None
         assert self.path_info is not None
         return walk_files(self.path_info)

--- a/dvc/remote/oss.py
+++ b/dvc/remote/oss.py
@@ -94,16 +94,10 @@ class RemoteOSS(RemoteBASE):
     def _list_paths(self, prefix, progress_callback=None):
         import oss2
 
-        # oss2.ObjectIterator lacks any convenient way to iterate over pages
-        # instead of the flattened list of blobs
-        count = 0
-        iterator = oss2.ObjectIterator(self.oss_service, prefix=prefix)
-        for blob in iterator:
-            yield blob.key
+        for blob in oss2.ObjectIterator(self.oss_service, prefix=prefix):
             if progress_callback:
-                count = (count + 1) % iterator.max_keys
-                if count == 0:
-                    progress_callback(iterator.max_keys)
+                progress_callback()
+            yield blob.key
 
     def list_cache_paths(self, prefix=None, progress_callback=None):
         if prefix:

--- a/dvc/remote/oss.py
+++ b/dvc/remote/oss.py
@@ -38,6 +38,7 @@ class RemoteOSS(RemoteBASE):
     REQUIRES = {"oss2": "oss2"}
     PARAM_CHECKSUM = "etag"
     COPY_POLL_SECONDS = 5
+    LIST_OBJECT_PAGE_SIZE = 100
 
     def __init__(self, repo, config):
         super().__init__(repo, config)
@@ -90,20 +91,28 @@ class RemoteOSS(RemoteBASE):
         logger.debug("Removing oss://{}".format(path_info))
         self.oss_service.delete_object(path_info.path)
 
-    def _list_paths(self, prefix):
+    def _list_paths(self, prefix, progress_callback=None):
         import oss2
 
-        for blob in oss2.ObjectIterator(self.oss_service, prefix=prefix):
+        # oss2.ObjectIterator lacks any convenient way to iterate over pages
+        # instead of the flattened list of blobs
+        count = 0
+        iterator = oss2.ObjectIterator(self.oss_service, prefix=prefix)
+        for blob in iterator:
             yield blob.key
+            if progress_callback:
+                count = (count + 1) % iterator.max_keys
+                if count == 0:
+                    progress_callback(iterator.max_keys)
 
-    def list_cache_paths(self, prefix=None):
+    def list_cache_paths(self, prefix=None, progress_callback=None):
         if prefix:
             prefix = posixpath.join(
                 self.path_info.path, prefix[:2], prefix[2:]
             )
         else:
             prefix = self.path_info.path
-        return self._list_paths(prefix)
+        return self._list_paths(prefix, progress_callback)
 
     def _upload(
         self, from_file, to_info, name=None, no_progress_bar=False, **_kwargs

--- a/dvc/remote/s3.py
+++ b/dvc/remote/s3.py
@@ -206,8 +206,11 @@ class RemoteS3(RemoteBASE):
         for page in paginator.paginate(**kwargs):
             contents = page.get("Contents", ())
             if progress_callback:
-                progress_callback(len(contents))
-            yield from contents
+                for item in contents:
+                    progress_callback()
+                    yield item
+            else:
+                yield from contents
 
     def _list_paths(
         self, path_info, max_items=None, prefix=None, progress_callback=None

--- a/dvc/remote/s3.py
+++ b/dvc/remote/s3.py
@@ -191,7 +191,9 @@ class RemoteS3(RemoteBASE):
         logger.debug("Removing {}".format(path_info))
         self.s3.delete_object(Bucket=path_info.bucket, Key=path_info.path)
 
-    def _list_objects(self, path_info, max_items=None, prefix=None):
+    def _list_objects(
+        self, path_info, max_items=None, prefix=None, progress_callback=None
+    ):
         """ Read config for list object api, paginate through list objects."""
         kwargs = {
             "Bucket": path_info.bucket,
@@ -202,16 +204,25 @@ class RemoteS3(RemoteBASE):
             kwargs["Prefix"] = posixpath.join(path_info.path, prefix[:2])
         paginator = self.s3.get_paginator(self.list_objects_api)
         for page in paginator.paginate(**kwargs):
-            yield from page.get("Contents", ())
+            contents = page.get("Contents", ())
+            if progress_callback:
+                progress_callback(len(contents))
+            yield from contents
 
-    def _list_paths(self, path_info, max_items=None, prefix=None):
+    def _list_paths(
+        self, path_info, max_items=None, prefix=None, progress_callback=None
+    ):
         return (
             item["Key"]
-            for item in self._list_objects(path_info, max_items, prefix)
+            for item in self._list_objects(
+                path_info, max_items, prefix, progress_callback
+            )
         )
 
-    def list_cache_paths(self, prefix=None):
-        return self._list_paths(self.path_info, prefix=prefix)
+    def list_cache_paths(self, prefix=None, progress_callback=None):
+        return self._list_paths(
+            self.path_info, prefix=prefix, progress_callback=progress_callback
+        )
 
     def isfile(self, path_info):
         from botocore.exceptions import ClientError

--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -253,7 +253,12 @@ class RemoteSSH(RemoteBASE):
         assert prefix is None
         with self.ssh(self.path_info) as ssh:
             # If we simply return an iterator then with above closes instantly
-            yield from ssh.walk_files(self.path_info.path)
+            if progress_callback:
+                for path in ssh.walk_files(self.path_info.path):
+                    progress_callback()
+                    yield path
+            else:
+                yield from ssh.walk_files(self.path_info.path)
 
     def walk_files(self, path_info):
         with self.ssh(path_info) as ssh:

--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -249,7 +249,7 @@ class RemoteSSH(RemoteBASE):
             else:
                 yield io.TextIOWrapper(fd, encoding=encoding)
 
-    def list_cache_paths(self, prefix=None):
+    def list_cache_paths(self, prefix=None, progress_callback=None):
         assert prefix is None
         with self.ssh(self.path_info) as ssh:
             # If we simply return an iterator then with above closes instantly

--- a/tests/unit/remote/test_base.py
+++ b/tests/unit/remote/test_base.py
@@ -82,7 +82,7 @@ def test_cache_exists(path_to_checksum, object_exists, traverse):
         remote.cache_exists(checksums)
         object_exists.assert_not_called()
         traverse.assert_called_with(
-            frozenset(checksums), set(range(256)), None, None
+            frozenset(checksums), set(range(256)), mock.ANY, None, None
         )
 
     # default traverse
@@ -105,8 +105,12 @@ def test_cache_exists(path_to_checksum, object_exists, traverse):
 def test_cache_exists_traverse(path_to_checksum, list_cache_paths):
     remote = RemoteBASE(None, {})
     remote.path_info = PathInfo("foo")
-    remote._cache_exists_traverse({0}, set())
+    remote._cache_exists_traverse({0}, set(), 4096)
     for i in range(1, 16):
-        list_cache_paths.assert_any_call(prefix="{:03x}".format(i))
+        list_cache_paths.assert_any_call(
+            prefix="{:03x}".format(i), progress_callback=mock.ANY
+        )
     for i in range(1, 256):
-        list_cache_paths.assert_any_call(prefix="{:02x}".format(i))
+        list_cache_paths.assert_any_call(
+            prefix="{:02x}".format(i), progress_callback=mock.ANY
+        )

--- a/tests/unit/remote/test_base.py
+++ b/tests/unit/remote/test_base.py
@@ -8,6 +8,16 @@ from dvc.remote.base import RemoteCmdError
 from dvc.remote.base import RemoteMissingDepsError
 
 
+class _CallableOrNone(object):
+    """Helper for testing if object is callable() or None."""
+
+    def __eq__(self, other):
+        return True if other is None else callable(other)
+
+
+CallableOrNone = _CallableOrNone()
+
+
 class TestRemoteBASE(object):
     REMOTE_CLS = RemoteBASE
 
@@ -82,7 +92,11 @@ def test_cache_exists(path_to_checksum, object_exists, traverse):
         remote.cache_exists(checksums)
         object_exists.assert_not_called()
         traverse.assert_called_with(
-            frozenset(checksums), set(range(256)), mock.ANY, None, None
+            frozenset(checksums),
+            set(range(256)),
+            256 * pow(16, remote.TRAVERSE_PREFIX_LEN),
+            None,
+            None,
         )
 
     # default traverse
@@ -108,9 +122,9 @@ def test_cache_exists_traverse(path_to_checksum, list_cache_paths):
     remote._cache_exists_traverse({0}, set(), 4096)
     for i in range(1, 16):
         list_cache_paths.assert_any_call(
-            prefix="{:03x}".format(i), progress_callback=mock.ANY
+            prefix="{:03x}".format(i), progress_callback=CallableOrNone
         )
     for i in range(1, 256):
         list_cache_paths.assert_any_call(
-            prefix="{:02x}".format(i), progress_callback=mock.ANY
+            prefix="{:02x}".format(i), progress_callback=CallableOrNone
         )

--- a/tests/unit/remote/test_base.py
+++ b/tests/unit/remote/test_base.py
@@ -12,7 +12,7 @@ class _CallableOrNone(object):
     """Helper for testing if object is callable() or None."""
 
     def __eq__(self, other):
-        return True if other is None else callable(other)
+        return other is None or callable(other)
 
 
 CallableOrNone = _CallableOrNone()


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

* During size estimation, status is displayed via `BAR_FMT_NOTOTAL` progress bar, as current # of estimated total remote size
* During threaded traverse, status is displayed via a single progress bar, as # of objects fetched out of the estimated total remote size

Will close #3526 