### PR TITLE
setup: use older dpath

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ install_requires = [
     "flatten_json>=0.1.6",
     "texttable>=0.5.2",
     "pygtrie==2.3.2",
-    "dpath>=2.0.1,<3",
+    "dpath>=1.4.2",
 ]
 
 


### PR DESCRIPTION
Doing this to check if conda package would be alright with older dpath, since there are no 2.x packages released there right now.

* [ ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [ ] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
