### PR TITLE
remote: ADD sock attribute and pass it to SSHConnection constructor

### DIFF
--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -89,6 +89,7 @@ class RemoteSSH(RemoteBASE):
         self.gss_auth = config.get("gss_auth", False)
         proxy_command = user_ssh_config.get("proxycommand", False)
         if proxy_command:
+            import paramiko
             self.sock = paramiko.ProxyCommand(proxy_command)
         else:
             self.sock = None

--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -88,6 +88,7 @@ class RemoteSSH(RemoteBASE):
         proxy_command = user_ssh_config.get("proxycommand", False)
         if proxy_command:
             import paramiko
+
             self.sock = paramiko.ProxyCommand(proxy_command)
         else:
             self.sock = None

--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -99,6 +99,8 @@ class RemoteSSH(RemoteBASE):
 
     @staticmethod
     def _load_user_ssh_config(hostname):
+        import paramiko
+
         user_config_file = RemoteSSH.ssh_config_filename()
         user_ssh_config = {}
         if hostname and os.path.exists(user_config_file):

--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -33,8 +33,6 @@ def ask_password(host, user, port):
 
 
 class RemoteSSH(RemoteBASE):
-    import paramiko
-
     scheme = Schemes.SSH
     REQUIRES = {"paramiko": "paramiko"}
 

--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -10,7 +10,6 @@ from contextlib import closing, contextmanager
 from urllib.parse import urlparse
 
 from funcy import memoize, wrap_with, silent, first
-import paramiko
 
 import dvc.prompt as prompt
 from dvc.progress import Tqdm
@@ -34,6 +33,8 @@ def ask_password(host, user, port):
 
 
 class RemoteSSH(RemoteBASE):
+    import paramiko
+
     scheme = Schemes.SSH
     REQUIRES = {"paramiko": "paramiko"}
 


### PR DESCRIPTION
The sock attribute is set to a `paramiko.ProxyCommand` object
if 'ProxyCommand' exists in config to `None` other-wise
(which is the default option in `paramiko.client.SSHClient.connect()`).

FIXES #3560

No tests added, but passes all current tests.
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
