### PR TITLE
CLI: Fixed cmds help strings

### DIFF
--- a/dvc/command/data_sync.py
+++ b/dvc/command/data_sync.py
@@ -195,8 +195,10 @@ def add_parser(subparsers, _parent_parser):
     push_parser.set_defaults(func=CmdDataPush)
 
     # Fetch
-    FETCH_HELP = "Get tracked files or directories from remote storage"
-    " into the cache."
+    FETCH_HELP = (
+        "Get tracked files or directories from remote storage"
+        " into the cache."
+    )
 
     fetch_parser = subparsers.add_parser(
         "fetch",

--- a/dvc/command/diff.py
+++ b/dvc/command/diff.py
@@ -121,7 +121,7 @@ class CmdDiff(CmdBase):
 def add_parser(subparsers, parent_parser):
     DIFF_DESCRIPTION = (
         "Show changes between commits in the DVC repository,"
-        " or between a commit and the workspace."
+        " or between a commit and the workspace. "
         "Prints the list of paths added, modified, or deleted."
     )
     diff_parser = subparsers.add_parser(

--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -57,8 +57,9 @@ class CmdRepro(CmdBase):
 
 
 def add_parser(subparsers, parent_parser):
-    REPRO_HELP = "Reproduce complete or partial pipelines"
-    " by executing their stages."
+    REPRO_HELP = (
+        "Reproduce complete or partial pipelines by executing their stages."
+    )
     repro_parser = subparsers.add_parser(
         "repro",
         parents=[parent_parser],

--- a/dvc/command/version.py
+++ b/dvc/command/version.py
@@ -142,9 +142,9 @@ def _get_dvc_repo_info(repo):
 
 
 def add_parser(subparsers, parent_parser):
-    VERSION_HELP = "Display the DVC version"
-    " and system/environment information."
-
+    VERSION_HELP = (
+        "Display the DVC version and system/environment information."
+    )
     version_parser = subparsers.add_parser(
         "version",
         parents=[parent_parser],


### PR DESCRIPTION
This fixes a few command help string outputs that were cut short because of a typo: 

```
COMMAND_HELP = "Substring one, "
"substring two."
```

This resulted in the CLI rendering only the first substring in the help section of the root `dvc` command.  

Since this is a small change that doesn't even change the CLI help messages, but rather fixes the existing ones, I haven't created an issue upfront.
I've walked through all the commands one by one, fixed the help strings where I noticed the bug.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏