### PR TITLE
metrics: diff: don't print "No changes"

### DIFF
--- a/dvc/command/metrics.py
+++ b/dvc/command/metrics.py
@@ -109,7 +109,7 @@ def _show_diff(diff):
     from texttable import Texttable
 
     if not diff:
-        return "No changes."
+        return ""
 
     table = Texttable()
 

--- a/tests/unit/command/test_metrics.py
+++ b/tests/unit/command/test_metrics.py
@@ -64,7 +64,7 @@ def test_metrics_diff_no_diff():
 
 
 def test_metrics_diff_no_changes():
-    assert _show_diff({}) == "No changes."
+    assert _show_diff({}) == ""
 
 
 def test_metrics_diff_new_metric():


### PR DESCRIPTION
Makes it easier to use in shell scripts. E.g. `-z $(dvc metrics diff)`, which
has the same semantics as `git diff`. Also syncs up with the behaviour       
of `dvc diff`.                                                               

Fixes #3469

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
