### PR TITLE
get/import: --rev BRANCH: shallow clone

### DIFF
--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -248,7 +248,7 @@ def _clone_default_branch(url, rev):
         else:
             logger.debug("erepo: git clone %s to a temporary dir", url)
             clone_path = tempfile.mkdtemp("dvc-clone")
-            git = Git.clone(url, clone_path)
+            git = Git.clone(url, clone_path, rev=rev)
             CLONES[url] = clone_path
     finally:
         if git:

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -90,8 +90,8 @@ class Git(Base):
                 tmp_repo = clone_from()
             except git.exc.GitCommandError as exc:
                 raise CloneError(url, to_path) from exc
-        else:
-            tmp_repo.close()
+
+        tmp_repo.close()
 
         # NOTE: using our wrapper to make sure that env is fixed in __init__
         repo = Git(to_path)

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -76,7 +76,9 @@ class Git(Base):
                 url,
                 to_path,
                 env=env,  # needed before we can fix it in __init__
-                no_single_branch=True,
+                branch=rev,
+                single_branch=True,
+                depth=1,
             )
             tmp_repo.close()
         except git.exc.GitCommandError as exc:

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -77,7 +77,7 @@ class Git(Base):
                 to_path,
                 env=env,  # needed before we can fix it in __init__
                 branch=rev,
-                single_branch=True,
+                no_single_branch=True,
                 depth=1,
             )
             tmp_repo.close()

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -88,7 +88,7 @@ class Git(Base):
                 logger.debug("full clone")
                 tmp_repo = clone_from()
         except git.exc.GitCommandError as exc:
-            if not rev or f"Remote branch {rev} not found" not in str(exc):
+            if not rev or ("Remote branch %s not found" % rev) not in str(exc):
                 raise CloneError(url, to_path) from exc
             try:
                 logger.debug("not a branch - performing full clone")

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -81,12 +81,17 @@ class Git(Base):
         )
 
         try:
-            tmp_repo = clone_from(branch=rev, depth=1)
+            if rev:
+                logger.debug("attempting shallow clone of branch %s", rev)
+                tmp_repo = clone_from(branch=rev, depth=1)
+            else:
+                logger.debug("full clone")
+                tmp_repo = clone_from()
         except git.exc.GitCommandError as exc:
-            if f"Remote branch {rev} not found" not in str(exc):
+            if not rev or f"Remote branch {rev} not found" not in str(exc):
                 raise CloneError(url, to_path) from exc
             try:
-                # not a branch - need to do full clone
+                logger.debug("not a branch - performing full clone")
                 tmp_repo = clone_from()
             except git.exc.GitCommandError as exc:
                 raise CloneError(url, to_path) from exc


### PR DESCRIPTION
`dvc <get|import> REPO --rev BRANCH` should clone with `--single-branch --branch BRANCH` rather than cloning the full repo.

We could also add `--depth 1` to avoid getting the full commit history.

Alternatively we could do `--branch BRANCH --no-single-branch --depth 1` to get all heads without history.

- [x] pass `--rev BRANCH` to `git clone --branch BRANCH`
  - [x] add `--depth=1`
    + [ ] expose `--depth` option?
- [x] fallback to full clone so that this doesn't break with other types of `--rev`
- [ ] depends on #3496
  + [ ] can fallback on `--unshallow` once we have a proper global cache
- fixes #3473