### PR TITLE
CLI: redirect warnings to logger

### DIFF
--- a/dvc/__init__.py
+++ b/dvc/__init__.py
@@ -3,17 +3,8 @@ DVC
 ----
 Make your data science projects reproducible and shareable.
 """
-import warnings
-
 import dvc.logger
 from dvc.version import __version__  # noqa: F401
 
 
 dvc.logger.setup()
-
-# Ignore numpy's runtime warnings: https://github.com/numpy/numpy/pull/432.
-# We don't directly import numpy, but our dependency networkx does, causing
-# these warnings in some environments. Luckily these warnings are benign and
-# we can simply ignore them so that they don't show up when you are using dvc.
-warnings.filterwarnings("ignore", message="numpy.dtype size changed")
-warnings.filterwarnings("ignore", message="numpy.ufunc size changed")

--- a/dvc/logger.py
+++ b/dvc/logger.py
@@ -143,6 +143,7 @@ def _stack_trace(exc_info):
 
 
 def disable_other_loggers():
+    logging.captureWarnings(True)
     root = logging.root
     for (logger_name, logger) in root.manager.loggerDict.items():
         if logger_name != "dvc" and not logger_name.startswith("dvc."):

--- a/dvc/main.py
+++ b/dvc/main.py
@@ -33,7 +33,6 @@ def main(argv=None):
         int: command's return code.
     """
     args = None
-    cmd = None
     disable_other_loggers()
 
     outerLogLevel = logger.level


### PR DESCRIPTION
The `captureWarnings()` function can be used to integrate logging with the warnings module (that's what GDrive dependency libraries use to write this ugly message below).

We first use this function, then logger is silenced but since it has `py.` prefix.

Eventually, we should probably stop using loggers for the user interface and all WARNINGS should not be silenced, but be visible when I do `-v`? But we need to discuss this, may be we can introduce `-vvv` to show third party logger messages eventually.

- [x] Hide /Users/ivan/Projects/test-gdrive/.env/lib/python3.7/site-packages/oauth2client/_helpers.py:255: UserWarning: Cannot access /Users/ivan/Projects/test-gdrive/.dvc/tmp/gdrive-user-credentials.json: No such file or directory warnings.warn(_MISSING_FILE_MESSAGE.format(filename)) on the first auth. 

- [x] minor: unused var assignment

--------------------

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
