### PR TITLE
config: forbid setting core.no_scm outside repo

### DIFF
--- a/dvc/command/config.py
+++ b/dvc/command/config.py
@@ -48,6 +48,13 @@ class CmdConfig(CmdBaseNoRepo):
             msg = "option {} doesn't exist"
             raise ConfigError(msg.format(self.args.name))
 
+        if self.args.name == "core.no_scm" and self.args.level in [
+            "global",
+            "system",
+        ]:
+            msg = "{} not allowed on a {} level"
+            raise ConfigError(msg.format(self.args.name, self.args.level))
+
 
 parent_config_parser = argparse.ArgumentParser(add_help=False)
 parent_config_parser.add_argument(

--- a/tests/func/test_config.py
+++ b/tests/func/test_config.py
@@ -106,3 +106,10 @@ def test_merging_two_levels(dvc):
 def test_config_loads_without_error_for_non_dvc_repo(tmp_dir):
     # regression testing for https://github.com/iterative/dvc/issues/3328
     Config(validate=True)
+
+
+def test_no_scm(dvc):
+    assert 251 == main(["config", "--global", "core.no_scm", "true"])
+    assert 251 == main(["config", "--system", "core.no_scm", "true"])
+    assert 0 == main(["config", "--local", "core.no_scm", "true"])
+    assert 0 == main(["config", "core.no_scm", "true"])


### PR DESCRIPTION
Raise a `ConfigError` when setting `core.no_scm` on a global or system level.

Close #3427

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
