### PR TITLE
[WIP] remote: locally index list of checksums available on cloud remotes

### DIFF
--- a/dvc/command/data_sync.py
+++ b/dvc/command/data_sync.py
@@ -30,6 +30,7 @@ class CmdDataPull(CmdDataBase):
                 with_deps=self.args.with_deps,
                 force=self.args.force,
                 recursive=self.args.recursive,
+                drop_index=self.args.drop_index,
             )
             log_summary(stats)
         except (CheckoutError, DvcException) as exc:
@@ -53,6 +54,7 @@ class CmdDataPush(CmdDataBase):
                 all_commits=self.args.all_commits,
                 with_deps=self.args.with_deps,
                 recursive=self.args.recursive,
+                drop_index=self.args.drop_index,
             )
         except DvcException:
             logger.exception("failed to push data to the cloud")
@@ -158,6 +160,12 @@ def add_parser(subparsers, _parent_parser):
         default=False,
         help="Pull cache for subdirectories of the specified directory.",
     )
+    pull_parser.add_argument(
+        "--drop-index",
+        action="store_true",
+        default=False,
+        help="Drop local index for the specified remote cache.",
+    )
     pull_parser.set_defaults(func=CmdDataPull)
 
     # Push
@@ -206,6 +214,12 @@ def add_parser(subparsers, _parent_parser):
         action="store_true",
         default=False,
         help="Push cache for subdirectories of specified directory.",
+    )
+    push_parser.add_argument(
+        "--drop-index",
+        action="store_true",
+        default=False,
+        help="Drop local index for the specified remote cache.",
     )
     push_parser.set_defaults(func=CmdDataPush)
 
@@ -323,5 +337,11 @@ def add_parser(subparsers, _parent_parser):
         action="store_true",
         default=False,
         help="Show status for all dependencies of the specified target.",
+    )
+    status_parser.add_argument(
+        "--drop-index",
+        action="store_true",
+        default=False,
+        help="Drop local index for the specified remote cache.",
     )
     status_parser.set_defaults(func=CmdDataStatus)

--- a/dvc/command/data_sync.py
+++ b/dvc/command/data_sync.py
@@ -164,7 +164,7 @@ def add_parser(subparsers, _parent_parser):
         "--drop-index",
         action="store_true",
         default=False,
-        help="Drop local index for the specified remote cache.",
+        help="Drop local index for the specified remote.",
     )
     pull_parser.set_defaults(func=CmdDataPull)
 

--- a/dvc/command/data_sync.py
+++ b/dvc/command/data_sync.py
@@ -219,7 +219,7 @@ def add_parser(subparsers, _parent_parser):
         "--drop-index",
         action="store_true",
         default=False,
-        help="Drop local index for the specified remote cache.",
+        help="Drop local index for the remote.",
     )
     push_parser.set_defaults(func=CmdDataPush)
 
@@ -342,6 +342,6 @@ def add_parser(subparsers, _parent_parser):
         "--drop-index",
         action="store_true",
         default=False,
-        help="Drop local index for the specified remote cache.",
+        help="Drop local index for the remote.",
     )
     status_parser.set_defaults(func=CmdDataStatus)

--- a/dvc/command/status.py
+++ b/dvc/command/status.py
@@ -49,6 +49,7 @@ class CmdDataStatus(CmdDataBase):
                 all_tags=self.args.all_tags,
                 all_commits=self.args.all_commits,
                 with_deps=self.args.with_deps,
+                drop_index=self.args.drop_index,
             )
             if st:
                 if self.args.quiet:

--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -66,6 +66,7 @@ class DataCloud(object):
                 By default remote from core.remote config option is used.
             show_checksums (bool): show checksums instead of file names in
                 information messages.
+            drop_index (bool): clear local index for the remote
         """
         return self.repo.cache.local.push(
             caches,
@@ -93,6 +94,7 @@ class DataCloud(object):
                 By default remote from core.remote config option is used.
             show_checksums (bool): show checksums instead of file names in
                 information messages.
+            drop_index (bool): clear local index for the remote
         """
         remote = self.get_remote(remote, "pull")
         downloaded_items_num = self.repo.cache.local.pull(
@@ -143,6 +145,7 @@ class DataCloud(object):
                 is used.
             show_checksums (bool): show checksums instead of file names in
                 information messages.
+            drop_index (bool): clear local index for the remote
         """
         remote = self.get_remote(remote, "status")
         return self.repo.cache.local.status(

--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -48,7 +48,14 @@ class DataCloud(object):
     def _init_remote(self, remote):
         return Remote(self.repo, name=remote)
 
-    def push(self, caches, jobs=None, remote=None, show_checksums=False):
+    def push(
+        self,
+        caches,
+        jobs=None,
+        remote=None,
+        show_checksums=False,
+        drop_index=False,
+    ):
         """Push data items in a cloud-agnostic way.
 
         Args:
@@ -65,9 +72,17 @@ class DataCloud(object):
             jobs=jobs,
             remote=self.get_remote(remote, "push"),
             show_checksums=show_checksums,
+            drop_index=drop_index,
         )
 
-    def pull(self, caches, jobs=None, remote=None, show_checksums=False):
+    def pull(
+        self,
+        caches,
+        jobs=None,
+        remote=None,
+        show_checksums=False,
+        drop_index=False,
+    ):
         """Pull data items in a cloud-agnostic way.
 
         Args:
@@ -81,7 +96,11 @@ class DataCloud(object):
         """
         remote = self.get_remote(remote, "pull")
         downloaded_items_num = self.repo.cache.local.pull(
-            caches, jobs=jobs, remote=remote, show_checksums=show_checksums
+            caches,
+            jobs=jobs,
+            remote=remote,
+            show_checksums=show_checksums,
+            drop_index=drop_index,
         )
 
         if not remote.verify:
@@ -105,7 +124,14 @@ class DataCloud(object):
                     # (see `RemoteBASE.download()`)
                     self.repo.state.save(cache_file, checksum)
 
-    def status(self, caches, jobs=None, remote=None, show_checksums=False):
+    def status(
+        self,
+        caches,
+        jobs=None,
+        remote=None,
+        show_checksums=False,
+        drop_index=False,
+    ):
         """Check status of data items in a cloud-agnostic way.
 
         Args:
@@ -120,5 +146,9 @@ class DataCloud(object):
         """
         remote = self.get_remote(remote, "status")
         return self.repo.cache.local.status(
-            caches, jobs=jobs, remote=remote, show_checksums=show_checksums
+            caches,
+            jobs=jobs,
+            remote=remote,
+            show_checksums=show_checksums,
+            drop_index=drop_index,
         )

--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -104,7 +104,7 @@ class ExternalRepo(Repo):
 
             # Only pull unless all needed cache is present
             if out.changed_cache(filter_info=src):
-                self.cloud.pull(out.get_used_cache(filter_info=src))
+                self.cloud.pull([out.get_used_cache(filter_info=src)])
 
             try:
                 out.checkout(filter_info=src)

--- a/dvc/output/base.py
+++ b/dvc/output/base.py
@@ -363,8 +363,9 @@ class OutputBase(object):
 
         if self.cache.changed_cache_file(self.checksum):
             try:
+                cache = NamedCache.make("local", self.checksum, str(self))
                 self.repo.cloud.pull(
-                    NamedCache.make("local", self.checksum, str(self)),
+                    [(None, cache)],
                     jobs=jobs,
                     remote=remote,
                     show_checksums=False,

--- a/dvc/output/base.py
+++ b/dvc/output/base.py
@@ -401,16 +401,22 @@ class OutputBase(object):
 
         In case that the given output is a directory, it will also
         include the `info` of its files.
+
+        Returns:
+            2-tuple of NamedCache objects in the form of
+            (directory `info`, file `info`).
+            If the given output is not a directory, the first tuple entry will
+            be None.
         """
 
         if not self.use_cache:
-            return NamedCache()
+            return None, NamedCache()
 
         if self.stage.is_repo_import:
             cache = NamedCache()
             (dep,) = self.stage.deps
             cache.external[dep.repo_pair].add(dep.def_path)
-            return cache
+            return None, cache
 
         if not self.checksum:
             msg = (
@@ -429,16 +435,14 @@ class OutputBase(object):
                     )
                 )
             logger.warning(msg)
-            return NamedCache()
+            return None, NamedCache()
 
         ret = NamedCache.make(self.scheme, self.checksum, str(self))
 
         if not self.is_dir_checksum:
-            return ret
+            return None, ret
 
-        ret.update(self._collect_used_dir_cache(**kwargs))
-
-        return ret
+        return ret, self._collect_used_dir_cache(**kwargs)
 
     @classmethod
     def _validate_output_path(cls, path):

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -115,7 +115,7 @@ class RemoteBASE(object):
 
         url = config.get("url")
         if url:
-            index_name = hashlib.md5(url.encode("utf-8")).hexdigest()
+            index_name = hashlib.sha256(url.encode("utf-8")).hexdigest()
         else:
             index_name = None
         self.index = RemoteIndex(self.repo, index_name)

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -897,7 +897,6 @@ class RemoteBASE(object):
             remote_checksums = self._cache_object_exists(checksums, jobs, name)
             if remote_checksums:
                 self.index.update(remote_checksums)
-                self.index.save()
             return list(indexed_checksums) + remote_checksums
 
         # Max remote size allowed for us to use traverse method
@@ -936,7 +935,6 @@ class RemoteBASE(object):
             )
         )
         self.index.replace(remote_checksums)
-        self.index.save()
         return list(indexed_checksums) + list(
             checksums & set(remote_checksums)
         )

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -118,7 +118,9 @@ class RemoteBASE(object):
             index_name = hashlib.sha256(url.encode("utf-8")).hexdigest()
         else:
             index_name = None
-        self.index = RemoteIndex(self.repo, index_name)
+        self.index = RemoteIndex(
+            self.repo, index_name, self.CHECKSUM_DIR_SUFFIX
+        )
 
     @classmethod
     def get_missing_deps(cls):

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -740,12 +740,15 @@ class RemoteBASE(object):
             remote_size, remote_checksums, jobs, name
         )
 
-    def gc(self, named_cache, jobs=None):
-        logger.debug("named_cache: {} jobs: {}".format(named_cache, jobs))
-        used = self.extract_used_local_checksums(named_cache)
+    def gc(self, named_caches, jobs=None):
+        logger.debug("named_caches: {} jobs: {}".format(named_caches, jobs))
+        used = self.extract_used_local_checksums(named_caches)
 
         if self.scheme != "":
-            used.update(named_cache[self.scheme])
+            for dir_cache, file_cache in named_caches:
+                if dir_cache:
+                    used.update(dir_cache[self.scheme])
+                used.update(file_cache[self.scheme])
 
         removed = False
         for checksum in self.all(jobs, str(self.path_info)):
@@ -1275,8 +1278,12 @@ class RemoteBASE(object):
     def _get_unpacked_dir_names(self, checksums):
         return set()
 
-    def extract_used_local_checksums(self, named_cache):
-        used = set(named_cache["local"])
+    def extract_used_local_checksums(self, named_caches):
+        used = set()
+        for dir_cache, file_cache in named_caches:
+            if dir_cache:
+                used.update(dir_cache["local"])
+            used.update(file_cache["local"])
         unpacked = self._get_unpacked_dir_names(used)
         return used | unpacked
 

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -763,7 +763,6 @@ class RemoteBASE(object):
             path_info = self.checksum_to_path_info(checksum)
             if self.is_dir_checksum(checksum):
                 self._remove_unpacked_dir(checksum)
-            self.index.remove(checksum)
             self.remove(path_info)
             removed = True
         if removed:
@@ -898,7 +897,7 @@ class RemoteBASE(object):
         if len(checksums) == 1 or not self.CAN_TRAVERSE:
             remote_checksums = self._cache_object_exists(checksums, jobs, name)
             if remote_checksums:
-                self.index.update(remote_checksums)
+                self.index.update_all(remote_checksums)
             return list(indexed_checksums) + remote_checksums
 
         # Max remote size allowed for us to use traverse method
@@ -936,7 +935,7 @@ class RemoteBASE(object):
                 remote_size, remote_checksums, jobs, name
             )
         )
-        self.index.replace(remote_checksums)
+        self.index.replace_all(remote_checksums)
         return list(indexed_checksums) + list(
             checksums & set(remote_checksums)
         )

--- a/dvc/remote/index.py
+++ b/dvc/remote/index.py
@@ -1,5 +1,5 @@
 import logging
-import pathlib
+import os
 import pickle
 
 logger = logging.getLogger(__name__)
@@ -20,8 +20,8 @@ class RemoteIndex(object):
 
     def __init__(self, repo, name=None):
         if name:
-            self.path = pathlib.Path(repo.index_dir).joinpath(
-                "{}{}".format(name, self.INDEX_SUFFIX)
+            self.path = os.path.join(
+                repo.index_dir, "{}{}".format(name, self.INDEX_SUFFIX)
             )
         else:
             self.path = None
@@ -37,7 +37,7 @@ class RemoteIndex(object):
 
     def load(self):
         """(Re)load this index from disk."""
-        if self.path and self.path.is_file():
+        if self.path and os.path.isfile(self.path):
             try:
                 with open(self.path, "rb") as fobj:
                     self._checksums = pickle.load(fobj)
@@ -62,8 +62,8 @@ class RemoteIndex(object):
     def invalidate(self):
         """Invalidate this index (to force re-indexing later)."""
         self._checksums.clear()
-        if self.path and self.path.exists():
-            self.path.unlink()
+        if self.path and os.path.isfile(self.path):
+            os.unlink(self.path)
 
     def remove(self, checksum):
         if checksum in self._checksums:

--- a/dvc/remote/index.py
+++ b/dvc/remote/index.py
@@ -38,13 +38,13 @@ def _verify_protocol(protocol=None):
         protocol = DEFAULT_PROTOCOL
     if protocol not in SUPPORTED_PROTOCOLS:
         raise DvcException(
-            "unsupported remote index protocol version: {}".format(protocol)
+            "unsupported remote index protocol version: '{}'".format(protocol)
         )
     return protocol
 
 
 def dump(dir_checksums, file_checksums, fobj, protocol=None):
-    """Write specified checksums to the open file object ``fobj``."""
+    """Write specified checksums to the specified open file object"""
     protocol = _verify_protocol(protocol)
     _dump_v1(dir_checksums, file_checksums, fobj)
 
@@ -70,7 +70,7 @@ def _dump_v1(dir_checksums, file_checksums, fobj):
 
 
 def load(fobj, protocol=None, dir_suffix=".dir"):
-    """Read index checksums from the open file object ``fobj``.
+    """Read index checksums from the specified open file object.
 
     Returns a 2-tuple of (dir_checksums, file_checksums).
     """
@@ -87,7 +87,7 @@ def _load_v1(fobj, dir_suffix=""):
             fobj.read(_header_v1.size)
         )
     except struct.error as exc:
-        raise DvcException("Invalid v1 remote index file: {}".format(exc))
+        raise DvcException("Invalid v1 remote index file: '{}'".format(exc))
     dir_checksums = set()
     file_checksums = set()
     crc = 0
@@ -166,7 +166,7 @@ class RemoteIndex(object):
             except IOError as exc:
                 logger.error(
                     "Failed to load remote index file '{}'. "
-                    "Remote will be re-indexed: {}".format(self.path, exc)
+                    "Remote will be re-indexed: '{}'".format(self.path, exc)
                 )
             finally:
                 self.lock.release()

--- a/dvc/remote/index.py
+++ b/dvc/remote/index.py
@@ -1,0 +1,78 @@
+import logging
+import pathlib
+import pickle
+
+logger = logging.getLogger(__name__)
+
+
+class RemoteIndex(object):
+    """Class for locally indexing remote checksums.
+
+    Args:
+        repo: repo for this remote
+    """
+
+    INDEX_SUFFIX = ".idx"
+
+    def __init__(self, repo, name):
+        if repo and hasattr(repo, "index_dir") and name:
+            self.path = pathlib.Path(repo.index_dir).joinpath(
+                "{}{}".format(name, self.INDEX_SUFFIX)
+            )
+        else:
+            self.path = None
+        self._checksums = set()
+        self.load()
+
+    def __iter__(self):
+        return iter(self._checksums)
+
+    @property
+    def checksums(self):
+        return self._checksums
+
+    def load(self):
+        """(Re)load this index from disk."""
+        if self.path and self.path.exists():
+            try:
+                with open(self.path, "rb") as fd:
+                    self._checksums = pickle.load(fd)
+            except IOError:
+                logger.error(
+                    "Failed to load remote index from '{}'".format(self.path)
+                )
+
+    def save(self):
+        """Save this index to disk."""
+        if self.path:
+            try:
+                with open(self.path, "wb") as fd:
+                    pickle.dump(self._checksums, fd)
+            except IOError:
+                logger.error(
+                    "Failed to save remote index to '{}'".format(self.path)
+                )
+
+    def invalidate(self):
+        """Invalidate this index (to force re-indexing later)."""
+        self._checksums.clear()
+        if self.path and self.path.exists():
+            self.path.unlink()
+
+    def remove(self, checksum):
+        if checksum in self._checksums:
+            self._checksums.remove(checksum)
+
+    def replace(self, checksums):
+        """Replace the full contents of this index with ``checksums``.
+
+        Changes to the index will not be written to disk.
+        """
+        self._checksums = set(checksums)
+
+    def update(self, *checksums):
+        """Update this index, adding elements from ``checksums``.
+
+        Changes to the index will not be written to disk.
+        """
+        self._checksums.update(*checksums)

--- a/dvc/remote/index.py
+++ b/dvc/remote/index.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import pickle
+import threading
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +26,9 @@ class RemoteIndex(object):
             )
         else:
             self.path = None
+        self.lock = threading.Lock()
         self._checksums = set()
+        self.modified = False
         self.load()
 
     def __iter__(self):
@@ -38,47 +41,75 @@ class RemoteIndex(object):
     def load(self):
         """(Re)load this index from disk."""
         if self.path and os.path.isfile(self.path):
+            self.lock.acquire()
             try:
                 with open(self.path, "rb") as fobj:
                     self._checksums = pickle.load(fobj)
-            except PermissionError:
+                self.modified = False
+            except IOError as exc:
                 logger.error(
-                    "Insufficient permissions to read index file "
-                    "'{}'".format(self.path)
+                    "Failed to load remote index file '{}'. "
+                    "Remote will be re-indexed: {}".format(self.path, exc)
                 )
+            finally:
+                self.lock.release()
 
     def save(self):
         """Save this index to disk."""
-        if self.path:
+        if self.path and self.modified:
+            self.lock.acquire()
             try:
                 with open(self.path, "wb") as fobj:
                     pickle.dump(self._checksums, fobj)
-            except PermissionError:
+                self.modified = False
+            except IOError as exc:
                 logger.error(
-                    "Insufficient permissions to write index file "
-                    "'{}'".format(self.path)
+                    "Failed to save remote index file '{}': {}".format(
+                        self.path, exc
+                    )
                 )
+            finally:
+                self.lock.release()
 
     def invalidate(self):
         """Invalidate this index (to force re-indexing later)."""
+        self.lock.acquire()
         self._checksums.clear()
+        self.modified = True
         if self.path and os.path.isfile(self.path):
-            os.unlink(self.path)
+            try:
+                os.unlink(self.path)
+            except IOError as exc:
+                logger.error(
+                    "Failed to remove remote index file '{}': {}".format(
+                        self.path, exc
+                    )
+                )
+        self.lock.release()
 
     def remove(self, checksum):
         if checksum in self._checksums:
+            self.lock.acquire()
             self._checksums.remove(checksum)
+            self.modified = True
+            self.lock.release()
 
     def replace(self, checksums):
         """Replace the full contents of this index with ``checksums``.
 
         Changes to the index will not be written to disk.
         """
+        self.lock.acquire()
         self._checksums = set(checksums)
+        self.modified = True
+        self.lock.release()
 
     def update(self, *checksums):
         """Update this index, adding elements from ``checksums``.
 
         Changes to the index will not be written to disk.
         """
+        self.lock.acquire()
         self._checksums.update(*checksums)
+        self.modified = True
+        self.lock.release()

--- a/dvc/remote/index.py
+++ b/dvc/remote/index.py
@@ -1,9 +1,140 @@
 import logging
 import os
-import pickle
+import struct
 import threading
+import zlib
+from binascii import unhexlify
+
+from funcy import chunks, concat, split, split_at
+
+from dvc.exceptions import DvcException
 
 logger = logging.getLogger(__name__)
+
+
+DEFAULT_PROTOCOL = 1
+SUPPORTED_PROTOCOLS = [1]
+
+# Index format (v1) is the following:
+#
+# (all integer types are little-endian)
+#
+# Header
+# ------
+#   protocol_version (32-bit uint): index file protocol version
+#   dir_checksum_count (64-bit uint): number of .dir checksums in data section
+#   file_checksum_count (64-bit uint): number of file checksums in data section
+#   compressed_len (64-bit uint): length of data section
+#   crc - 32-bit CRC32 checksum of uncompressed data
+#
+# Data (zlib compressed)
+# ----------------------
+#   array of <dir_checksum_count> 128-bit MD5 .dir checksums
+#   array of <file_checksum_count> 128-bit MD5 file checksums
+_header_v1 = struct.Struct("<IQQ")
+_compress_crc_v1 = struct.Struct("<QI")
+
+
+def _verify_protocol(protocol=None):
+    if protocol is None:
+        protocol = DEFAULT_PROTOCOL
+    if protocol not in SUPPORTED_PROTOCOLS:
+        raise DvcException(
+            "unsupported remote index protocol version: {}".format(protocol)
+        )
+    return protocol
+
+
+def dump(dir_checksums, file_checksums, fobj, protocol=None):
+    """Write specified checksums to the open file object ``fobj``."""
+    protocol = _verify_protocol(protocol)
+    _dump_v1(dir_checksums, file_checksums, fobj)
+
+
+def _dump_v1(dir_checksums, file_checksums, fobj):
+    pos = fobj.tell()
+    # write header
+    fobj.write(
+        _header_v1.pack(1, len(dir_checksums), len(file_checksums))
+        + _compress_crc_v1.pack(0, 0)
+    )
+    # compress 1024 MD5 checksums (16kB chunks) at a time
+    compress = zlib.compressobj()
+    compress_len = 0
+    crc = 0
+    data_checksums = concat(
+        (csum[:32] for csum in dir_checksums), file_checksums
+    )
+    for checksums in chunks(1024, data_checksums):
+        data = unhexlify("".join(checksums))
+        crc = zlib.crc32(data, crc)
+        compress_len += fobj.write(compress.compress(data))
+    compress_len += fobj.write(compress.flush())
+    endpos = fobj.tell()
+    fobj.seek(pos + _header_v1.size)
+    fobj.write(_compress_crc_v1.pack(compress_len, crc))
+    fobj.seek(endpos)
+
+
+def load(fobj, protocol=None, dir_suffix=".dir"):
+    """Read index checksums from the open file object ``fobj``.
+
+    Returns a 2-tuple of (dir_checksums, file_checksums).
+    """
+    data = fobj.read(4)
+    (protocol,) = struct.unpack("<I", data)
+    _verify_protocol(protocol)
+    fobj.seek(0)
+    return _load_v1(fobj, dir_suffix)
+
+
+def _load_v1(fobj, dir_suffix=""):
+    try:
+        protocol, dir_count, file_count = _header_v1.unpack(
+            fobj.read(_header_v1.size)
+        )
+        compress_len, file_crc = _compress_crc_v1.unpack(
+            fobj.read(_compress_crc_v1.size)
+        )
+    except struct.error as exc:
+        raise DvcException("Invalid v1 remote index file: {}".format(exc))
+    dir_checksums = set()
+    file_checksums = set()
+
+    def read_chunks():
+        # decompress 4kB chunks at a time and return uncompressed data aligned
+        # to a 4-byte (checksum length) boundary
+        decompress = zlib.decompressobj()
+        bytes_read = 0
+        unconsumed = b""
+        extra = b""
+        crc = 0
+        while bytes_read < compress_len:
+            compress_data = fobj.read(4096)
+            bytes_read += len(compress_data)
+            data = extra + decompress.decompress(unconsumed + compress_data)
+            unconsumed = decompress.unconsumed_tail
+            extra_count = len(data) % 4
+            extra = data[len(data) - extra_count :]
+            data = data[: len(data) - extra_count]
+            crc = zlib.crc32(data, crc)
+            yield data
+        data = extra + decompress.flush()
+        crc = zlib.crc32(data, crc)
+        if crc != file_crc:
+            raise DvcException("Remote index file failed CRC check")
+        return data
+
+    for data in read_chunks():
+        checksums = chunks(32, data.hex())
+        if len(dir_checksums) < dir_count:
+            dirs, files = split_at(dir_count - len(dir_checksums), checksums)
+            dir_checksums.update(checksum + dir_suffix for checksum in dirs)
+            file_checksums.update(files)
+        else:
+            file_checksums.update(checksums)
+
+    return dir_checksums, file_checksums
 
 
 class RemoteIndex(object):
@@ -19,24 +150,29 @@ class RemoteIndex(object):
 
     INDEX_SUFFIX = ".idx"
 
-    def __init__(self, repo, name=None):
+    def __init__(self, repo, name=None, dir_suffix=".dir"):
         if name:
             self.path = os.path.join(
                 repo.index_dir, "{}{}".format(name, self.INDEX_SUFFIX)
             )
         else:
             self.path = None
-        self.lock = threading.Lock()
-        self._checksums = set()
+        self.dir_suffix = dir_suffix
+        self.lock = threading.RLock()
+        self._dir_checksums = set()
+        self._file_checksums = set()
         self.modified = False
         self.load()
 
     def __iter__(self):
-        return iter(self._checksums)
+        return iter(self.checksums)
 
     @property
     def checksums(self):
-        return self._checksums
+        return self._dir_checksums | self._file_checksums
+
+    def is_dir_checksum(self, checksum):
+        return checksum.endswith(self.dir_suffix)
 
     def load(self):
         """(Re)load this index from disk."""
@@ -44,7 +180,9 @@ class RemoteIndex(object):
             self.lock.acquire()
             try:
                 with open(self.path, "rb") as fobj:
-                    self._checksums = pickle.load(fobj)
+                    self._dir_checksums, self._file_checksums = load(
+                        fobj, dir_suffix=self.dir_suffix
+                    )
                 self.modified = False
             except IOError as exc:
                 logger.error(
@@ -60,7 +198,7 @@ class RemoteIndex(object):
             self.lock.acquire()
             try:
                 with open(self.path, "wb") as fobj:
-                    pickle.dump(self._checksums, fobj)
+                    dump(self._dir_checksums, self._file_checksums, fobj)
                 self.modified = False
             except IOError as exc:
                 logger.error(
@@ -74,7 +212,8 @@ class RemoteIndex(object):
     def invalidate(self):
         """Invalidate this index (to force re-indexing later)."""
         self.lock.acquire()
-        self._checksums.clear()
+        self._dir_checksums.clear()
+        self._file_checksums.clear()
         self.modified = True
         if self.path and os.path.isfile(self.path):
             try:
@@ -100,8 +239,9 @@ class RemoteIndex(object):
         Changes to the index will not be written to disk.
         """
         self.lock.acquire()
-        self._checksums = set(checksums)
-        self.modified = True
+        self._dir_checksums = set()
+        self._file_checksums = set()
+        self.update(checksums)
         self.lock.release()
 
     def update(self, *checksums):
@@ -109,7 +249,9 @@ class RemoteIndex(object):
 
         Changes to the index will not be written to disk.
         """
+        dir_checksums, file_checksums = split(self.is_dir_checksum, *checksums)
         self.lock.acquire()
-        self._checksums.update(*checksums)
+        self._dir_checksums.update(dir_checksums)
+        self._file_checksums.update(file_checksums)
         self.modified = True
         self.lock.release()

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -501,12 +501,9 @@ class RemoteLOCAL(RemoteBASE):
             if future.result():
                 # do not upload this .dir file if any file in this
                 # directory failed to upload
-                logger.debug(
-                    "failed to upload full contents of '{}', "
-                    "aborting .dir file upload".format(name)
-                )
                 logger.error(
-                    "failed to upload '{}' to '{}'".format(from_info, to_info)
+                    "one or more files failed while uploading "
+                    "'{}' to '{}'".format(from_info, to_info)
                 )
                 return 1
         return func(from_info, to_info, name)

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -369,8 +369,18 @@ class RemoteLOCAL(RemoteBASE):
 
         if fails:
             if download:
+                remote.index.invalidate()
                 raise DownloadError(fails)
             raise UploadError(fails)
+        elif not download:
+            pushed_checksums = list(map(self.path_to_checksum, plans[0]))
+            logger.debug(
+                "Adding {} pushed checksums to index".format(
+                    len(pushed_checksums)
+                )
+            )
+            remote.index.update(pushed_checksums)
+            remote.index.save()
 
         return len(plans[0])
 

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -484,15 +484,18 @@ class RemoteLOCAL(RemoteBASE):
                 raise DownloadError(fails)
             raise UploadError(fails)
         elif not download:
-            pushed_checksums = list(
-                map(self.path_to_checksum, dir_plans[0] + file_plans[0])
+            pushed_dir_checksums = list(
+                map(self.path_to_checksum, dir_plans[0])
+            )
+            pushed_file_checksums = list(
+                map(self.path_to_checksum, file_plans[0])
             )
             logger.debug(
                 "Adding {} pushed checksums to index".format(
-                    len(pushed_checksums)
+                    len(pushed_dir_checksums) + len(pushed_file_checksums)
                 )
             )
-            remote.index.update(pushed_checksums)
+            remote.index.update(pushed_dir_checksums, pushed_file_checksums)
             remote.index.save()
 
         return len(dir_plans[0]) + len(file_plans[0])

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -269,6 +269,7 @@ class RemoteLOCAL(RemoteBASE):
             download=download,
             drop_index=drop_index,
         )
+        remote.index.save()
         return dict(dir_status, **file_status)
 
     def _status(

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -85,6 +85,8 @@ class Repo(object):
 
         self.tmp_dir = os.path.join(self.dvc_dir, "tmp")
         makedirs(self.tmp_dir, exist_ok=True)
+        self.index_dir = os.path.join(self.dvc_dir, "index")
+        makedirs(self.index_dir, exist_ok=True)
 
         hardlink_lock = self.config["core"].get("hardlink_lock", False)
         self.lock = make_lock(

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -296,7 +296,8 @@ class Repo(object):
                         used_file.update(file_cache, suffix=suffix)
                         used_caches.append((used_dir, used_file))
 
-        used_caches.append((None, file_caches))
+        if file_caches._items or file_caches.external:
+            used_caches.append((None, file_caches))
         return used_caches
 
     def _collect_graph(self, stages=None):

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -84,8 +84,7 @@ class Repo(object):
         self.tree = WorkingTree(self.root_dir)
 
         self.tmp_dir = os.path.join(self.dvc_dir, "tmp")
-        makedirs(self.tmp_dir, exist_ok=True)
-        self.index_dir = os.path.join(self.dvc_dir, "index")
+        self.index_dir = os.path.join(self.tmp_dir, "index")
         makedirs(self.index_dir, exist_ok=True)
 
         hardlink_lock = self.config["core"].get("hardlink_lock", False)

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -21,6 +21,7 @@ def _fetch(
     all_tags=False,
     recursive=False,
     all_commits=False,
+    drop_index=False,
 ):
     """Download data items from a cloud and imported repositories
 
@@ -51,7 +52,11 @@ def _fetch(
 
     try:
         downloaded += self.cloud.pull(
-            used, jobs, remote=remote, show_checksums=show_checksums
+            used,
+            jobs,
+            remote=remote,
+            show_checksums=show_checksums,
+            drop_index=drop_index,
         )
     except NoRemoteError:
         if not used.external and used["local"]:

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -59,7 +59,19 @@ def _fetch(
             drop_index=drop_index,
         )
     except NoRemoteError:
-        if not used.external and used["local"]:
+        external = False
+        local = False
+        for dir_cache, file_cache in used:
+            if dir_cache:
+                if dir_cache.external:
+                    external = True
+                if dir_cache["local"]:
+                    local = True
+            if file_cache.external:
+                external = True
+            if file_cache["local"]:
+                local = True
+        if not external and local:
             raise
     except DownloadError as exc:
         failed += exc.amount

--- a/dvc/repo/gc.py
+++ b/dvc/repo/gc.py
@@ -1,7 +1,6 @@
 import logging
 
 from . import locked
-from dvc.cache import NamedCache
 from dvc.exceptions import InvalidArgumentError
 
 
@@ -60,9 +59,9 @@ def gc(
             stack.enter_context(repo.lock)
             stack.enter_context(repo.state)
 
-        used = NamedCache()
+        used = []
         for repo in all_repos + [self]:
-            used.update(
+            used.extend(
                 repo.used_cache(
                     all_branches=all_branches,
                     with_deps=with_deps,

--- a/dvc/repo/pull.py
+++ b/dvc/repo/pull.py
@@ -18,6 +18,7 @@ def pull(
     force=False,
     recursive=False,
     all_commits=False,
+    drop_index=False,
 ):
     processed_files_count = self._fetch(
         targets,
@@ -28,6 +29,7 @@ def pull(
         all_commits=all_commits,
         with_deps=with_deps,
         recursive=recursive,
+        drop_index=drop_index,
     )
     stats = self._checkout(
         targets=targets, with_deps=with_deps, force=force, recursive=recursive

--- a/dvc/repo/push.py
+++ b/dvc/repo/push.py
@@ -12,6 +12,7 @@ def push(
     all_tags=False,
     recursive=False,
     all_commits=False,
+    drop_index=False,
 ):
     used = self.used_cache(
         targets,
@@ -24,4 +25,4 @@ def push(
         jobs=jobs,
         recursive=recursive,
     )
-    return self.cloud.push(used, jobs, remote=remote)
+    return self.cloud.push(used, jobs, remote=remote, drop_index=drop_index)

--- a/dvc/repo/status.py
+++ b/dvc/repo/status.py
@@ -45,6 +45,7 @@ def _cloud_status(
     with_deps=False,
     all_tags=False,
     all_commits=False,
+    drop_index=False,
 ):
     """Returns a dictionary with the files that are new or deleted.
 
@@ -86,7 +87,9 @@ def _cloud_status(
     )
 
     ret = {}
-    status_info = self.cloud.status(used, jobs, remote=remote)
+    status_info = self.cloud.status(
+        used, jobs, remote=remote, drop_index=drop_index
+    )
     for info in status_info.values():
         name = info["name"]
         status = info["status"]
@@ -111,6 +114,7 @@ def status(
     with_deps=False,
     all_tags=False,
     all_commits=False,
+    drop_index=False,
 ):
     if cloud or remote:
         return _cloud_status(
@@ -122,6 +126,7 @@ def status(
             remote=remote,
             all_tags=all_tags,
             all_commits=all_commits,
+            drop_index=drop_index,
         )
 
     ignored = list(

--- a/dvc/stage.py
+++ b/dvc/stage.py
@@ -1059,10 +1059,9 @@ class Stage(object):
         )
 
     def get_used_cache(self, *args, **kwargs):
-        from .cache import NamedCache
 
-        cache = NamedCache()
+        ret = []
         for out in self._filter_outs(kwargs.get("filter_info")):
-            cache.update(out.get_used_cache(*args, **kwargs))
+            ret.append(out.get_used_cache(*args, **kwargs))
 
-        return cache
+        return ret

--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -112,7 +112,7 @@ class TestDataCloudBase(TestDvc):
         out = stage.outs[0]
         cache = out.cache_path
         md5 = out.checksum
-        info = out.get_used_cache()
+        info = [out.get_used_cache()]
 
         stages = self.dvc.add(self.DATA_DIR)
         self.assertEqual(len(stages), 1)
@@ -122,7 +122,9 @@ class TestDataCloudBase(TestDvc):
         cache_dir = out_dir.cache_path
         name_dir = str(out_dir)
         md5_dir = out_dir.checksum
-        info_dir = NamedCache.make(out_dir.scheme, md5_dir, name_dir)
+        info_dir = [
+            (NamedCache.make(out_dir.scheme, md5_dir, name_dir), NamedCache())
+        ]
 
         with self.cloud.repo.state:
             # Check status

--- a/tests/unit/command/test_data_sync.py
+++ b/tests/unit/command/test_data_sync.py
@@ -54,6 +54,7 @@ def test_pull(mocker):
             "--with-deps",
             "--force",
             "--recursive",
+            "--drop-index",
         ]
     )
     assert cli_args.func == CmdDataPull
@@ -73,6 +74,7 @@ def test_pull(mocker):
         with_deps=True,
         force=True,
         recursive=True,
+        drop_index=True,
     )
 
 
@@ -91,6 +93,7 @@ def test_push(mocker):
             "--all-commits",
             "--with-deps",
             "--recursive",
+            "--drop-index",
         ]
     )
     assert cli_args.func == CmdDataPush
@@ -109,4 +112,5 @@ def test_push(mocker):
         all_commits=True,
         with_deps=True,
         recursive=True,
+        drop_index=True,
     )

--- a/tests/unit/command/test_status.py
+++ b/tests/unit/command/test_status.py
@@ -17,6 +17,7 @@ def test_cloud_status(mocker):
             "--all-tags",
             "--all-commits",
             "--with-deps",
+            "--drop-index",
         ]
     )
     assert cli_args.func == CmdDataStatus
@@ -35,4 +36,5 @@ def test_cloud_status(mocker):
         all_tags=True,
         all_commits=True,
         with_deps=True,
+        drop_index=True,
     )

--- a/tests/unit/output/test_output.py
+++ b/tests/unit/output/test_output.py
@@ -86,5 +86,8 @@ def test_get_used_cache(exists, expected_message, mocker, caplog):
     ).return_value = exists
 
     with caplog.at_level(logging.WARNING, logger="dvc"):
-        assert isinstance(output.get_used_cache(), NamedCache)
+        used = output.get_used_cache()
+        assert isinstance(used, tuple)
+        assert used[0] is None
+        assert isinstance(used[1], NamedCache)
     assert first(caplog.messages) == expected_message

--- a/tests/unit/remote/test_base.py
+++ b/tests/unit/remote/test_base.py
@@ -52,7 +52,7 @@ def test_cache_exists(object_exists, traverse, dvc):
     with mock.patch.object(
         remote, "cache_checksums", return_value=list(range(256))
     ):
-        checksums = list(range(1000))
+        checksums = set(range(1000))
         remote.cache_exists(checksums)
         object_exists.assert_called_with(checksums, None, None)
         traverse.assert_not_called()

--- a/tests/unit/remote/test_index.py
+++ b/tests/unit/remote/test_index.py
@@ -1,7 +1,23 @@
-import pickle
 import os.path
 
-from dvc.remote.index import RemoteIndex
+from dvc.remote.index import dump, load, RemoteIndex
+
+
+def test_protocol_v1_roundtrip(tmp_dir):
+    tmpfile = os.path.join(tmp_dir, "foo.idx")
+
+    expected_dir = frozenset(["0123456789abcdef0123456789abcdef.dir"])
+    expected_file = frozenset(map(_to_checksum, range(2000)))
+    with open(tmpfile, "wb") as fobj:
+        dump(expected_dir, expected_file, fobj)
+    with open(tmpfile, "rb") as fobj:
+        dir_checksums, file_checksums = load(fobj, dir_suffix=".dir")
+    assert dir_checksums == expected_dir
+    assert not expected_file ^ file_checksums
+
+
+def _to_checksum(n):
+    return "{:032}".format(n)
 
 
 def test_init(dvc):
@@ -9,28 +25,21 @@ def test_init(dvc):
     assert str(index.path) == os.path.join(dvc.index_dir, "foo.idx")
 
 
-def test_load(dvc):
-    checksums = {1, 2, 3}
-    path = os.path.join(dvc.index_dir, "foo.idx")
-    with open(path, "wb") as fd:
-        pickle.dump(checksums, fd)
+def test_roundtrip(dvc):
+    expected_dir = frozenset(["0123456789abcdef0123456789abcdef.dir"])
+    expected_file = frozenset(["fedcba9876543210fedcba9876543210"])
     index = RemoteIndex(dvc, "foo")
-    assert index.checksums == checksums
-
-
-def test_save(dvc):
-    index = RemoteIndex(dvc, "foo")
-    index.replace({4, 5, 6})
+    index.replace(expected_dir | expected_file)
     index.save()
-    path = os.path.join(dvc.index_dir, "foo.idx")
-    with open(path, "rb") as fd:
-        checksums = pickle.load(fd)
-    assert index.checksums == checksums
+    index.load()
+    assert index._dir_checksums == expected_dir
+    assert index._file_checksums == expected_file
+    assert index.checksums == expected_dir | expected_file
 
 
 def test_invalidate(dvc):
     index = RemoteIndex(dvc, "foo")
-    index.replace({1, 2, 3})
+    index.replace({_to_checksum(n) for n in (1, 2, 3)})
     index.save()
     index.invalidate()
     assert not index.checksums

--- a/tests/unit/remote/test_index.py
+++ b/tests/unit/remote/test_index.py
@@ -7,7 +7,7 @@ def test_protocol_v1_roundtrip(tmp_dir):
     tmpfile = os.path.join(tmp_dir, "foo.idx")
 
     expected_dir = frozenset(["0123456789abcdef0123456789abcdef.dir"])
-    expected_file = frozenset(map(_to_checksum, range(2000)))
+    expected_file = frozenset(map(_to_checksum, range(10000)))
     with open(tmpfile, "wb") as fobj:
         dump(expected_dir, expected_file, fobj)
     with open(tmpfile, "rb") as fobj:

--- a/tests/unit/remote/test_index.py
+++ b/tests/unit/remote/test_index.py
@@ -34,4 +34,4 @@ def test_invalidate(dvc):
     index.save()
     index.invalidate()
     assert not index.checksums
-    assert not index.path.exists()
+    assert not os.path.exists(index.path)

--- a/tests/unit/remote/test_index.py
+++ b/tests/unit/remote/test_index.py
@@ -2,35 +2,36 @@ import pickle
 import os.path
 
 from dvc.remote.index import RemoteIndex
-from tests.basic_env import TestDvc
 
 
-class TestRemoteIndex(TestDvc):
-    def test_init(self):
-        index = RemoteIndex(self.dvc, "foo")
-        assert str(index.path) == os.path.join(self.dvc.index_dir, "foo.idx")
+def test_init(dvc):
+    index = RemoteIndex(dvc, "foo")
+    assert str(index.path) == os.path.join(dvc.index_dir, "foo.idx")
 
-    def test_load(self):
-        checksums = {1, 2, 3}
-        path = os.path.join(self.dvc.index_dir, "foo.idx")
-        with open(path, "wb") as fd:
-            pickle.dump(checksums, fd)
-        index = RemoteIndex(self.dvc, "foo")
-        assert index.checksums == checksums
 
-    def test_save(self):
-        index = RemoteIndex(self.dvc, "foo")
-        index.replace({4, 5, 6})
-        index.save()
-        path = os.path.join(self.dvc.index_dir, "foo.idx")
-        with open(path, "rb") as fd:
-            checksums = pickle.load(fd)
-        assert index.checksums == checksums
+def test_load(dvc):
+    checksums = {1, 2, 3}
+    path = os.path.join(dvc.index_dir, "foo.idx")
+    with open(path, "wb") as fd:
+        pickle.dump(checksums, fd)
+    index = RemoteIndex(dvc, "foo")
+    assert index.checksums == checksums
 
-    def test_invalidate(self):
-        index = RemoteIndex(self.dvc, "foo")
-        index.replace({1, 2, 3})
-        index.save()
-        index.invalidate()
-        assert not index.checksums
-        assert not index.path.exists()
+
+def test_save(dvc):
+    index = RemoteIndex(dvc, "foo")
+    index.replace({4, 5, 6})
+    index.save()
+    path = os.path.join(dvc.index_dir, "foo.idx")
+    with open(path, "rb") as fd:
+        checksums = pickle.load(fd)
+    assert index.checksums == checksums
+
+
+def test_invalidate(dvc):
+    index = RemoteIndex(dvc, "foo")
+    index.replace({1, 2, 3})
+    index.save()
+    index.invalidate()
+    assert not index.checksums
+    assert not index.path.exists()

--- a/tests/unit/remote/test_index.py
+++ b/tests/unit/remote/test_index.py
@@ -1,0 +1,36 @@
+import pickle
+import os.path
+
+from dvc.remote.index import RemoteIndex
+from tests.basic_env import TestDvc
+
+
+class TestRemoteIndex(TestDvc):
+    def test_init(self):
+        index = RemoteIndex(self.dvc, "foo")
+        assert str(index.path) == os.path.join(self.dvc.index_dir, "foo.idx")
+
+    def test_load(self):
+        checksums = {1, 2, 3}
+        path = os.path.join(self.dvc.index_dir, "foo.idx")
+        with open(path, "wb") as fd:
+            pickle.dump(checksums, fd)
+        index = RemoteIndex(self.dvc, "foo")
+        assert index.checksums == checksums
+
+    def test_save(self):
+        index = RemoteIndex(self.dvc, "foo")
+        index.replace({4, 5, 6})
+        index.save()
+        path = os.path.join(self.dvc.index_dir, "foo.idx")
+        with open(path, "rb") as fd:
+            checksums = pickle.load(fd)
+        assert index.checksums == checksums
+
+    def test_invalidate(self):
+        index = RemoteIndex(self.dvc, "foo")
+        index.replace({1, 2, 3})
+        index.save()
+        index.invalidate()
+        assert not index.checksums
+        assert not index.path.exists()

--- a/tests/unit/remote/test_local.py
+++ b/tests/unit/remote/test_local.py
@@ -26,7 +26,7 @@ def test_status_download_optimization(mocker):
     other_remote.url = "other_remote"
     other_remote.cache_exists.return_value = []
 
-    remote.status(infos, other_remote, download=True)
+    remote.status([(None, infos)], other_remote, download=True)
 
     assert other_remote.cache_exists.call_count == 0
 

--- a/tests/unit/repo/test_repo.py
+++ b/tests/unit/repo/test_repo.py
@@ -37,10 +37,10 @@ def test_used_cache(tmp_dir, dvc, path):
     from dvc.cache import NamedCache
 
     tmp_dir.dvc_gen({"dir": {"subdir": {"file": "file"}, "other": "other"}})
-    expected = NamedCache.make(
+    expected_dir = NamedCache.make(
         "local", "70922d6bf66eb073053a82f77d58c536.dir", "dir"
     )
-    expected.add(
+    expected_file = NamedCache.make(
         "local",
         "8c7dd922ad47494fc02c388e12c00eac",
         os.path.join("dir", "subdir", "file"),
@@ -48,9 +48,16 @@ def test_used_cache(tmp_dir, dvc, path):
 
     with dvc.state:
         used_cache = dvc.used_cache([path])
+        assert isinstance(used_cache, list)
+        assert len(used_cache) == 1
+        assert isinstance(used_cache[0], tuple)
+        used_dir = used_cache[0][0]
+        used_file = used_cache[0][1]
         assert (
-            used_cache._items == expected._items
-            and used_cache.external == expected.external
+            used_dir._items == expected_dir._items
+            and used_dir.external == expected_dir.external
+            and used_file._items == expected_file._items
+            and used_file.external == expected_file.external
         )
 
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Related to #2147.

### New behavior

* Checksums available on the remote are indexed (cached) locally in `.dvc/tmp/index/<filename>.idx` where `filename` will be the SHA256 digest of the remote URL.
* On any dvc command which queries remote status (`status -c`/`push`/`pull`/`fetch`/`gc -c`) index will be updated to include any new checksums which are found on the remote (or are pushed successfully to the remote)
* `--drop-index` can be used to delete the index for the remote (and force re-indexing)

### Implementation details

* `remote.cache_exists()`
    1. Validate our index by querying for .dir checksums on the remote. If a .dir checksum is in our index, but not the remote (i.e. someone else has run `gc -c`), clear the entire index.
    2. Look for checksums in the index - If all of the checksums being queried are already in the local index, the remote will not be queried at all.
    3. Any checksums which are not in the local index will be queried on the remote as usual, and the local index will be updated to include any new remote cache entries. (So doing a full list/traverse of the remote will is the same as (re)indexing the entire remote)
* `pull`/`fetch`: If any index related mismatch/error occurs (i.e. trying to download a file that is in our index but not on the remote), clear the entire index.
* `gc -c`: Queries and re-indexes the entire remote, regardless of what was in the index before running `gc -c`.
* Index file will be read once at the start of relevant dvc commands, and written to once at most (only if the index was modified during the dvc command)
* `RemoteIndex` class/module can be easily extended/modified in the future to support any other protocols which support the usual `dump()`/`load()` interface (pickle, json, msgpack, etc)

### Todo
* [ ] Figure out an actual storage solution (currently written in flat binary file format)
* [x] add `--drop-index` CLI option to `push/pull/status` so user can force re-indexing
* [x] Use `.dir` checksum existence on remote to validate/invalidate index
* [x] `push`: push .dir checksums last
* [x] `gc`: remove .dir checksums first
* [x] unit tests for index module
* [ ] functional tests for new behavior
* [ ] docs

### Other ideas:

* Only index .dir checksums to keep local size to a minimum? This was discussed in #2147, if we modify `push` behavior for `.dir` checksums to push the directory file contents first, and the actual `.dir` checksum last, we can treat the dir checksum as an index on its own - if the .dir checksum is on exists on the remote, it follows that the directory contents is also on the remote
* Index file size as well as checksums? (also related to #3568)