### PR TITLE
dvc: introduce local stage cache

### DIFF
--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -72,6 +72,7 @@ class Repo(object):
         from dvc.repo.params import Params
         from dvc.scm.tree import WorkingTree
         from dvc.utils.fs import makedirs
+        from dvc.stage.cache import StageCache
 
         root_dir = self.find_root(root_dir)
 
@@ -103,6 +104,8 @@ class Repo(object):
 
         self.cache = Cache(self)
         self.cloud = DataCloud(self)
+
+        self.stage_cache = StageCache(self.cache.local.cache_dir)
 
         self.metrics = Metrics(self)
         self.params = Params(self)

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -97,12 +97,7 @@ def reproduce(
 
 
 def _reproduce_stages(
-    G,
-    stages,
-    downstream=False,
-    ignore_build_cache=False,
-    single_item=False,
-    **kwargs
+    G, stages, downstream=False, single_item=False, **kwargs
 ):
     r"""Derive the evaluation of the given node for the given graph.
 
@@ -172,7 +167,7 @@ def _reproduce_stages(
         try:
             ret = _reproduce_stage(stage, **kwargs)
 
-            if len(ret) != 0 and ignore_build_cache:
+            if len(ret) != 0 and kwargs.get("ignore_build_cache", False):
                 # NOTE: we are walking our pipeline from the top to the
                 # bottom. If one stage is changed, it will be reproduced,
                 # which tells us that we should force reproducing all of

--- a/dvc/repo/run.py
+++ b/dvc/repo/run.py
@@ -68,6 +68,9 @@ def run(self, fname=None, no_exec=False, **kwargs):
         raise OutputDuplicationError(exc.output, set(exc.stages) - {stage})
 
     if not no_exec:
-        stage.run(no_commit=kwargs.get("no_commit", False))
+        stage.run(
+            no_commit=kwargs.get("no_commit", False),
+            ignore_build_cache=kwargs.get("ignore_build_cache", False),
+        )
     dvcfile.dump(stage, update_pipeline=True)
     return stage

--- a/dvc/stage/cache.py
+++ b/dvc/stage/cache.py
@@ -1,0 +1,124 @@
+import os
+import yaml
+import logging
+
+from voluptuous import Schema, Required, Invalid
+
+from dvc.utils.fs import makedirs
+from dvc.utils import relpath, dict_sha256
+
+logger = logging.getLogger(__name__)
+
+SCHEMA = Schema(
+    {
+        Required("cmd"): str,
+        Required("deps"): {str: str},
+        Required("outs"): {str: str},
+    }
+)
+
+
+def _get_cache_hash(cache, key=False):
+    return dict_sha256(
+        {
+            "cmd": cache["cmd"],
+            "deps": cache["deps"],
+            "outs": list(cache["outs"].keys()) if key else cache["outs"],
+        }
+    )
+
+
+def _get_stage_hash(stage):
+    if not stage.cmd or not stage.deps or not stage.outs:
+        return None
+
+    for dep in stage.deps:
+        if dep.scheme != "local" or not dep.def_path or not dep.get_checksum():
+            return None
+
+    for out in stage.outs:
+        if out.scheme != "local" or not out.def_path or out.persist:
+            return None
+
+    return _get_cache_hash(_create_cache(stage), key=True)
+
+
+def _create_cache(stage):
+    return {
+        "cmd": stage.cmd,
+        "deps": {dep.def_path: dep.get_checksum() for dep in stage.deps},
+        "outs": {out.def_path: out.get_checksum() for out in stage.outs},
+    }
+
+
+class StageCache:
+    def __init__(self, cache_dir):
+        self.cache_dir = os.path.join(cache_dir, "stages")
+
+    def _get_cache_dir(self, key):
+        return os.path.join(self.cache_dir, key[:2], key)
+
+    def _get_cache_path(self, key, value):
+        return os.path.join(self._get_cache_dir(key), value)
+
+    def _load_cache(self, key, value):
+        path = self._get_cache_path(key, value)
+
+        try:
+            with open(path, "r") as fobj:
+                return SCHEMA(yaml.safe_load(fobj))
+        except FileNotFoundError:
+            return None
+        except (yaml.error.YAMLError, Invalid):
+            logger.warning("corrupted cache file '%s'.", relpath(path))
+            os.unlink(path)
+            return None
+
+    def _load(self, stage):
+        key = _get_stage_hash(stage)
+        if not key:
+            return None
+
+        cache_dir = self._get_cache_dir(key)
+        if not os.path.exists(cache_dir):
+            return None
+
+        for value in os.listdir(cache_dir):
+            cache = self._load_cache(key, value)
+            if cache:
+                return cache
+
+        return None
+
+    def save(self, stage):
+        cache_key = _get_stage_hash(stage)
+        if not cache_key:
+            return
+
+        cache = _create_cache(stage)
+        cache_value = _get_cache_hash(cache)
+
+        if self._load_cache(cache_key, cache_value):
+            return
+
+        # sanity check
+        SCHEMA(cache)
+
+        path = self._get_cache_path(cache_key, cache_value)
+        dpath = os.path.dirname(path)
+        makedirs(dpath, exist_ok=True)
+        with open(path, "w+") as fobj:
+            yaml.dump(cache, fobj)
+
+    def restore(self, stage):
+        cache = self._load(stage)
+        if not cache:
+            return
+
+        deps = {dep.def_path: dep for dep in stage.deps}
+        for def_path, checksum in cache["deps"].items():
+            deps[def_path].checksum = checksum
+
+        outs = {out.def_path: out for out in stage.outs}
+        for def_path, checksum in cache["outs"].items():
+            outs[def_path].checksum = checksum

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -76,8 +76,8 @@ def file_md5(fname):
     return (None, None)
 
 
-def bytes_md5(byts):
-    hasher = hashlib.md5()
+def bytes_hash(byts, typ):
+    hasher = getattr(hashlib, typ)()
     hasher.update(byts)
     return hasher.hexdigest()
 
@@ -100,10 +100,18 @@ def dict_filter(d, exclude=()):
     return d
 
 
-def dict_md5(d, exclude=()):
+def dict_hash(d, typ, exclude=()):
     filtered = dict_filter(d, exclude)
     byts = json.dumps(filtered, sort_keys=True).encode("utf-8")
-    return bytes_md5(byts)
+    return bytes_hash(byts, typ)
+
+
+def dict_md5(d, **kwargs):
+    return dict_hash(d, "md5", **kwargs)
+
+
+def dict_sha256(d, **kwargs):
+    return dict_hash(d, "sha256", **kwargs)
 
 
 def _split(list_to_split, chunk_size):

--- a/tests/func/test_gc.py
+++ b/tests/func/test_gc.py
@@ -1,4 +1,5 @@
 import logging
+import shutil
 import os
 
 import configobj
@@ -341,6 +342,7 @@ def test_gc_not_collect_pipeline_tracked_files(tmp_dir, dvc, run_copy):
     tmp_dir.gen("bar", "bar")
 
     run_copy("foo", "foo2", name="copy")
+    shutil.rmtree(dvc.stage_cache.cache_dir)
     assert _count_files(dvc.cache.local.cache_dir) == 1
     dvc.gc(workspace=True, force=True)
     assert _count_files(dvc.cache.local.cache_dir) == 1

--- a/tests/func/test_repro.py
+++ b/tests/func/test_repro.py
@@ -1295,7 +1295,9 @@ class TestReproNoCommit(TestRepro):
             ["repro", self._get_stage_target(self.stage), "--no-commit"]
         )
         self.assertEqual(ret, 0)
-        self.assertFalse(os.path.exists(self.dvc.cache.local.cache_dir))
+        self.assertEqual(
+            os.listdir(self.dvc.cache.local.cache_dir), ["stages"]
+        )
 
 
 class TestReproAlreadyCached(TestRepro):

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -6,6 +6,7 @@ import pytest
 from dvc.path_info import PathInfo
 from dvc.utils import (
     file_md5,
+    dict_sha256,
     resolve_output,
     fix_env,
     relpath,
@@ -155,3 +156,28 @@ def test_hint_on_lockfile():
     with pytest.raises(Exception) as exc:
         assert parse_target("pipelines.lock:name")
     assert "pipelines.yaml:name" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "d,sha",
+    [
+        (
+            {
+                "cmd": "echo content > out",
+                "deps": {"dep": "2254342becceafbd04538e0a38696791"},
+                "outs": {"out": "f75b8179e4bbe7e2b4a074dcef62de95"},
+            },
+            "f472eda60f09660a4750e8b3208cf90b3a3b24e5f42e0371d829710e9464d74a",
+        ),
+        (
+            {
+                "cmd": "echo content > out",
+                "deps": {"dep": "2254342becceafbd04538e0a38696791"},
+                "outs": ["out"],
+            },
+            "a239b67073bd58affcdb81fff3305d1726c6e7f9c86f3d4fca0e92e8147dc7b0",
+        ),
+    ],
+)
+def test_dict_sha256(d, sha):
+    assert dict_sha256(d) == sha


### PR DESCRIPTION
This patch introduces `.dvc/cache/stages` that is used to store previous
runs and their results, which could then be reused later when we stumble
upon the same command with the same deps and outs.

Format of build cache entries is single-line json, which is readable by
humans and might also be used for lock files discussed in #1871.

Related to #1871
Local part of #1234

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
