### PR TITLE
metrics: diff: fix float precision formatting

### DIFF
--- a/dvc/command/metrics.py
+++ b/dvc/command/metrics.py
@@ -121,6 +121,9 @@ def _show_diff(diff):
 
     table = Texttable()
 
+    # disable automatic formatting
+    table.set_cols_dtype(["t", "t", "t", "t"])
+
     # remove borders to make it easier for users to copy stuff
     table.set_chars(("", "", "", ""))
     table.set_deco(0)

--- a/tests/unit/command/test_metrics.py
+++ b/tests/unit/command/test_metrics.py
@@ -119,3 +119,12 @@ def test_metrics_show(dvc, mocker):
         all_branches=True,
         all_commits=True,
     )
+
+
+def test_metrics_diff_prec():
+    assert _show_diff(
+        {"other.json": {"a.b": {"old": 0.0042, "new": 0.0043, "diff": 0.0001}}}
+    ) == (
+        "   Path      Metric   Value    Change\n"
+        "other.json   a.b      0.0043   0.0001"
+    )


### PR DESCRIPTION
Texttable will try to detect the column type automatically, which
results in a low precision of the float that it is showing. We need to
disable that auto-formatting and just use `str(val)` instead.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
