### PR TITLE
stage: resolve stage path before creating the stage

### DIFF
--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -12,7 +12,7 @@ from ..output.base import OutputDoesNotExistError
 from ..progress import Tqdm
 from ..repo.scm_context import scm_context
 from ..stage import Stage
-from ..utils import LARGE_DIR_SIZE
+from ..utils import LARGE_DIR_SIZE, resolve_paths
 
 logger = logging.getLogger(__name__)
 
@@ -123,9 +123,8 @@ def _create_stages(repo, targets, fname, pbar=None):
         disable=len(targets) < LARGE_DIR_SIZE,
         unit="file",
     ):
-        stage = Stage.create(
-            repo, outs=[out], accompany_outs=True, fname=fname
-        )
+        path, wdir, out = resolve_paths(repo, out)
+        stage = Stage.create(repo, fname or path, wdir=wdir, outs=[out])
         repo._reset()
 
         if not stage:

--- a/dvc/repo/imp_url.py
+++ b/dvc/repo/imp_url.py
@@ -1,6 +1,9 @@
+import os
+
 from . import locked as locked_repo
 from dvc.repo.scm_context import scm_context
-from dvc.utils import resolve_output
+from dvc.utils import resolve_output, resolve_paths, relpath
+from dvc.utils.fs import path_isin
 
 
 @locked_repo
@@ -9,15 +12,14 @@ def imp_url(self, url, out=None, fname=None, erepo=None, locked=True):
     from dvc.stage import Stage
 
     out = resolve_output(url, out)
+    path, wdir, out = resolve_paths(self, out)
+
+    # NOTE: when user is importing something from within his own repository
+    if os.path.exists(url) and path_isin(os.path.abspath(url), self.root_dir):
+        url = relpath(url, wdir)
 
     stage = Stage.create(
-        self,
-        cmd=None,
-        deps=[url],
-        outs=[out],
-        fname=fname,
-        erepo=erepo,
-        accompany_outs=True,
+        self, fname or path, wdir=wdir, deps=[url], outs=[out], erepo=erepo,
     )
 
     if stage is None:

--- a/dvc/repo/run.py
+++ b/dvc/repo/run.py
@@ -1,14 +1,30 @@
+import os
+
 from . import locked
 from .scm_context import scm_context
 
 
 @locked
 @scm_context
-def run(self, no_exec=False, **kwargs):
+def run(self, fname=None, no_exec=False, **kwargs):
     from dvc.stage import Stage
 
-    stage = Stage.create(self, **kwargs)
+    outs = (
+        kwargs.get("outs", [])
+        + kwargs.get("outs_no_cache", [])
+        + kwargs.get("metrics", [])
+        + kwargs.get("metrics_no_cache", [])
+        + kwargs.get("outs_persist", [])
+        + kwargs.get("outs_persist_no_cache", [])
+    )
 
+    if outs:
+        base = os.path.basename(os.path.normpath(outs[0]))
+        path = base + Stage.STAGE_FILE_SUFFIX
+    else:
+        path = Stage.STAGE_FILE
+
+    stage = Stage.create(self, fname or path, **kwargs)
     if stage is None:
         return None
 

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -344,6 +344,32 @@ def resolve_output(inp, out):
     return out
 
 
+def resolve_paths(repo, out):
+    from ..stage import Stage
+    from ..path_info import PathInfo
+    from .fs import contains_symlink_up_to
+
+    abspath = os.path.abspath(out)
+    dirname = os.path.dirname(abspath)
+    base = os.path.basename(os.path.normpath(out))
+
+    # NOTE: `out` might not exist yet, so using `dirname`(aka `wdir`) to check
+    # if it is a local path.
+    if (
+        os.path.exists(dirname)  # out might not exist yet, so
+        and PathInfo(abspath).isin_or_eq(repo.root_dir)
+        and not contains_symlink_up_to(abspath, repo.root_dir)
+    ):
+        wdir = dirname
+        out = base
+    else:
+        wdir = os.getcwd()
+
+    path = os.path.join(wdir, base + Stage.STAGE_FILE_SUFFIX)
+
+    return (path, wdir, out)
+
+
 def format_link(link):
     return "<{blue}{link}{nc}>".format(
         blue=colorama.Fore.CYAN, link=link, nc=colorama.Fore.RESET

--- a/tests/unit/test_stage.py
+++ b/tests/unit/test_stage.py
@@ -7,7 +7,6 @@ import mock
 import pytest
 
 from dvc.dependency.repo import DependencyREPO
-from dvc.path_info import PathInfo
 from dvc.stage import Stage
 from dvc.stage import StageUpdateError
 
@@ -59,15 +58,6 @@ class TestPathConversion(TestCase):
 
         stage.wdir = os.path.join("..", "..")
         self.assertEqual(stage.dumpd()["wdir"], "../..")
-
-
-@pytest.mark.parametrize("add", [True, False])
-def test_stage_fname(add):
-    out = mock.Mock()
-    out.is_in_repo = False
-    out.path_info = PathInfo("path/to/out.txt")
-    fname = Stage._stage_fname([out], add)
-    assert fname == "out.txt.dvc"
 
 
 def test_stage_update(mocker):


### PR DESCRIPTION
Current logic is extremely complex and messy, hiding a lot of bugs
inside. There are pretty much only 2 scenarios for stage creation:

1) `dvc add/import/etc` when dvcfile is created beside the output file
2) `dvc run` when dvcfile is created at the place of execution

both are transparently affected by `--fname` flag. Since we've removed
`--cwd` complexity already, there is no reason to generalize stage path
resolution for those two scenarios.

This is also useful in preparation for `dvcfile` + `Stage` decoupling.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
