### PR TITLE
remote: don't use PathInfo.from_posix

### DIFF
--- a/dvc/path_info.py
+++ b/dvc/path_info.py
@@ -33,10 +33,6 @@ class PathInfo(pathlib.PurePath, _BasePath):
             cls = WindowsPathInfo if os.name == "nt" else PosixPathInfo
         return cls._from_parts(args)
 
-    @classmethod
-    def from_posix(cls, s):
-        return cls(PosixPathInfo(s))
-
     def as_posix(self):
         f = self._flavour
         # Unlike original implementation [1] that uses `str()` we actually need

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -21,7 +21,7 @@ from dvc.exceptions import (
     RemoteCacheRequiredError,
 )
 from dvc.ignore import DvcIgnore
-from dvc.path_info import PathInfo, URLInfo
+from dvc.path_info import PathInfo, URLInfo, WindowsPathInfo
 from dvc.progress import Tqdm
 from dvc.remote.slow_link_detection import slow_link_guard
 from dvc.state import StateNoop
@@ -285,10 +285,13 @@ class RemoteBASE(object):
             )
             return []
 
-        for info in d:
-            # NOTE: here is a BUG, see comment to .as_posix() below
-            relative_path = PathInfo.from_posix(info[self.PARAM_RELPATH])
-            info[self.PARAM_RELPATH] = relative_path.fspath
+        if self.path_cls == WindowsPathInfo:
+            # only need to convert it for Windows
+            for info in d:
+                # NOTE: here is a BUG, see comment to .as_posix() below
+                info[self.PARAM_RELPATH] = info[self.PARAM_RELPATH].replace(
+                    "/", self.path_cls.sep
+                )
 
         return d
 


### PR DESCRIPTION
Using it to load dirs takes around 50 sec compared to 0.4 with simple
`replace()`. Path objects are great, but not when you need lots of them.

Related to #3635

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
