### PR TITLE
dvc: introduce DvcTree

### DIFF
--- a/dvc/ignore.py
+++ b/dvc/ignore.py
@@ -130,6 +130,9 @@ class CleanTree(BaseTree):
     def isfile(self, path):
         return self.tree.isfile(path)
 
+    def isexec(self, path):
+        return self.tree.isexec(path)
+
     def walk(self, top, topdown=True):
         for root, dirs, files in self.tree.walk(top, topdown):
             dirs[:], files[:] = self.dvcignore(root, dirs, files)

--- a/dvc/repo/tree.py
+++ b/dvc/repo/tree.py
@@ -1,0 +1,116 @@
+import errno
+
+from dvc.scm.tree import BaseTree
+from dvc.path_info import PathInfo
+from dvc.exceptions import OutputNotFoundError
+
+
+class DvcTree(BaseTree):
+    def __init__(self, repo):
+        self.repo = repo
+
+    def _find_outs(self, path, *args, **kwargs):
+        outs = self.repo.find_outs_by_path(path, *args, **kwargs)
+
+        def _is_cached(out):
+            return out.use_cache
+
+        outs = list(filter(_is_cached, outs))
+        if not outs:
+            raise OutputNotFoundError(path, self.repo)
+
+        return outs
+
+    def open(self, path, mode="r", encoding="utf-8"):
+        try:
+            outs = self._find_outs(path, strict=False)
+        except OutputNotFoundError as exc:
+            raise FileNotFoundError from exc
+
+        if len(outs) != 1 or outs[0].isdir():
+            raise IOError(errno.EISDIR)
+
+        out = outs[0]
+        if not out.changed_cache():
+            return open(out.cache_path.fspath, mode=mode, encoding=encoding)
+
+        raise FileNotFoundError
+
+    def exists(self, path):
+        try:
+            self._find_outs(path, strict=False, recursive=True)
+            return True
+        except OutputNotFoundError:
+            return False
+
+    def isdir(self, path):
+        if not self.exists(path):
+            return False
+
+        outs = self._find_outs(path, strict=False, recursive=True)
+
+        if len(outs) != 1 or outs[0].path_info.fspath != path:
+            return True
+
+        return outs[0].isdir()
+
+    def isfile(self, path):
+        if not self.exists(path):
+            return False
+
+        return not self.isdir(path)
+
+    def _walk(self, root, trie, topdown=True):
+        dirs = set()
+        files = []
+
+        root_len = len(root.parts)
+        for key, out in trie.iteritems(prefix=root.parts):
+            if key == root.parts:
+                continue
+
+            name = key[root_len]
+            if len(key) > root_len + 1 or out.isdir():
+                dirs.add(name)
+                continue
+
+            files.append(name)
+
+        if topdown:
+            yield root.fspath, list(dirs), files
+
+            for dname in dirs:
+                yield from self._walk(root / dname, trie)
+        else:
+            assert False
+
+    def walk(self, top, topdown=True):
+        from pygtrie import Trie
+
+        assert topdown
+
+        if not self.exists(top):
+            raise FileNotFoundError
+
+        if not self.isdir(top):
+            raise NotADirectoryError
+
+        root = PathInfo(top)
+        outs = self._find_outs(top, recursive=True, strict=False)
+
+        trie = Trie()
+
+        for out in outs:
+            trie[out.path_info.parts] = out
+
+        yield from self._walk(root, trie, topdown=topdown)
+
+    def isdvc(self, path):
+        try:
+            return len(self._find_outs(path)) == 1
+        except OutputNotFoundError:
+            pass
+        return False
+
+    def isexec(self, path):
+        return False

--- a/dvc/scm/tree.py
+++ b/dvc/scm/tree.py
@@ -1,4 +1,5 @@
 import os
+import stat
 
 from dvc.compat import fspath
 
@@ -74,6 +75,10 @@ class WorkingTree(BaseTree):
             top, topdown=topdown, onerror=onerror
         ):
             yield os.path.normpath(root), dirs, files
+
+    def isexec(self, path):
+        mode = os.stat(path).st_mode
+        return mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
 def is_working_tree(tree):


### PR DESCRIPTION
This is useful as it is in `dvc ls` implementation, but this is also a
prerequisite for `RepoTree` that will combine git(workspace) files and
dvc files into one tree, allowing things like `dvc metrics` and       
`external_repo` to have a universal interface to access whatever      
file/dir they want without cumbersome git/dvc path detection.         

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
