### PR TITLE
metrics diff error message in --no-scm projects

### DIFF
--- a/dvc/repo/brancher.py
+++ b/dvc/repo/brancher.py
@@ -1,7 +1,6 @@
 from funcy import group_by
 
 from dvc.scm.tree import WorkingTree
-from dvc.scm.base import NOSCMError
 
 
 def brancher(  # noqa: E302
@@ -47,7 +46,5 @@ def brancher(  # noqa: E302
             for sha, names in group_by(scm.resolve_rev, revs).items():
                 self.tree = scm.get_tree(sha)
                 yield ", ".join(names)
-    except AttributeError:
-        raise NOSCMError()
     finally:
         self.tree = saved_tree

--- a/dvc/repo/brancher.py
+++ b/dvc/repo/brancher.py
@@ -1,7 +1,7 @@
 from funcy import group_by
 
 from dvc.scm.tree import WorkingTree
-from dvc.exceptions import DvcException
+from dvc.scm.base import NOSCMError
 
 
 def brancher(  # noqa: E302
@@ -48,6 +48,6 @@ def brancher(  # noqa: E302
                 self.tree = scm.get_tree(sha)
                 yield ", ".join(names)
     except AttributeError:
-        raise DvcException("only supported for Git repositories")
+        raise NOSCMError()
     finally:
         self.tree = saved_tree

--- a/dvc/repo/brancher.py
+++ b/dvc/repo/brancher.py
@@ -1,6 +1,7 @@
 from funcy import group_by
 
 from dvc.scm.tree import WorkingTree
+from dvc.exceptions import DvcException
 
 
 def brancher(  # noqa: E302
@@ -46,5 +47,7 @@ def brancher(  # noqa: E302
             for sha, names in group_by(scm.resolve_rev, revs).items():
                 self.tree = scm.get_tree(sha)
                 yield ", ".join(names)
+    except AttributeError:
+        raise DvcException("only supported for Git repositories")
     finally:
         self.tree = saved_tree

--- a/dvc/repo/diff.py
+++ b/dvc/repo/diff.py
@@ -1,9 +1,7 @@
 import os
 
 from dvc.repo import locked
-from dvc.scm.git import Git
 from dvc.scm.tree import is_working_tree
-from dvc.scm.base import NOSCMError
 
 
 @locked
@@ -15,8 +13,6 @@ def diff(self, a_rev="HEAD", b_rev=None):
     the concept of `index`, but it keeps the same interface, thus,
     `dvc diff` would be the same as `dvc diff HEAD`.
     """
-    if type(self.scm) is not Git:
-        raise NOSCMError
 
     def _paths_checksums():
         """

--- a/dvc/repo/diff.py
+++ b/dvc/repo/diff.py
@@ -1,9 +1,9 @@
 import os
 
-from dvc.exceptions import DvcException
 from dvc.repo import locked
 from dvc.scm.git import Git
 from dvc.scm.tree import is_working_tree
+from dvc.scm.base import NOSCMError
 
 
 @locked
@@ -16,7 +16,7 @@ def diff(self, a_rev="HEAD", b_rev=None):
     `dvc diff` would be the same as `dvc diff HEAD`.
     """
     if type(self.scm) is not Git:
-        raise DvcException("only supported for Git repositories")
+        raise NOSCMError
 
     def _paths_checksums():
         """

--- a/dvc/scm/__init__.py
+++ b/dvc/scm/__init__.py
@@ -1,7 +1,6 @@
 """Manages source control systems (e.g. Git)."""
 
-from dvc.scm.base import Base
-from dvc.scm.base import NoSCMError
+from dvc.scm.base import Base, NoSCMError
 from dvc.scm.git import Git
 
 

--- a/dvc/scm/__init__.py
+++ b/dvc/scm/__init__.py
@@ -1,13 +1,15 @@
 """Manages source control systems (e.g. Git)."""
 
 from dvc.scm.base import Base
+from dvc.scm.base import NoSCMError
 from dvc.scm.git import Git
 
 
 # Syntactic sugar to signal that this is an actual implementation for a DVC
 # project under no SCM control.
 class NoSCM(Base):
-    pass
+    def __getattr__(self, name):
+        raise NoSCMError
 
 
 def SCM(

--- a/dvc/scm/base.py
+++ b/dvc/scm/base.py
@@ -24,6 +24,16 @@ class RevError(SCMError):
     pass
 
 
+class NOSCMError(SCMError):
+    def __init__(self):
+        msg = (
+            "only supported for Git repositories. If you had\n already "
+            "initialized a git repo, this may be caused by dvc configuration. "
+            "Use\n `dvc config core.no_scm False` to update it."
+        )
+        super().__init__(msg)
+
+
 class Base(object):
     """Base class for source control management driver implementations."""
 

--- a/dvc/scm/base.py
+++ b/dvc/scm/base.py
@@ -27,9 +27,9 @@ class RevError(SCMError):
 class NOSCMError(SCMError):
     def __init__(self):
         msg = (
-            "only supported for Git repositories. If you had\n already "
-            "initialized a git repo, this may be caused by dvc configuration. "
-            "Use\n `dvc config core.no_scm False` to update it."
+            "Only supported for Git repositories. If you're\n"
+            "seeing this error in a Git repo, try updating the DVC "
+            "configuration with\n`dvc config core.no_scm False`."
         )
         super().__init__(msg)
 

--- a/dvc/scm/base.py
+++ b/dvc/scm/base.py
@@ -155,7 +155,3 @@ class Base(object):
 
     def close(self):
         """ Method to close the files """
-
-    def resolve_rev(self, rev):
-        """Pick out and massage parameters"""
-        raise SCMError("only supported for Git repositories")

--- a/dvc/scm/base.py
+++ b/dvc/scm/base.py
@@ -155,3 +155,7 @@ class Base(object):
 
     def close(self):
         """ Method to close the files """
+
+    def resolve_rev(self, rev):
+        """Pick out and massage parameters"""
+        raise SCMError("only supported for Git repositories")

--- a/dvc/scm/base.py
+++ b/dvc/scm/base.py
@@ -24,12 +24,12 @@ class RevError(SCMError):
     pass
 
 
-class NOSCMError(SCMError):
+class NoSCMError(SCMError):
     def __init__(self):
         msg = (
-            "Only supported for Git repositories. If you're\n"
+            "Only supported for Git repositories. If you're "
             "seeing this error in a Git repo, try updating the DVC "
-            "configuration with\n`dvc config core.no_scm False`."
+            "configuration with `dvc config core.no_scm false`."
         )
         super().__init__(msg)
 

--- a/tests/func/test_diff.py
+++ b/tests/func/test_diff.py
@@ -14,9 +14,11 @@ def digest(text):
 
 
 def test_no_scm(tmp_dir, dvc):
+    from dvc.scm.base import NoSCMError
+
     tmp_dir.dvc_gen("file", "text")
 
-    with pytest.raises(DvcException, match=r"Only supported for Git repos"):
+    with pytest.raises(NoSCMError):
         dvc.diff()
 
 

--- a/tests/func/test_diff.py
+++ b/tests/func/test_diff.py
@@ -16,7 +16,7 @@ def digest(text):
 def test_no_scm(tmp_dir, dvc):
     tmp_dir.dvc_gen("file", "text")
 
-    with pytest.raises(DvcException, match=r"only supported for Git repos"):
+    with pytest.raises(DvcException, match=r"Only supported for Git repos"):
         dvc.diff()
 
 

--- a/tests/func/test_metrics.py
+++ b/tests/func/test_metrics.py
@@ -12,6 +12,7 @@ from dvc.main import main
 from dvc.repo import Repo as DvcRepo
 from dvc.repo.metrics.show import NO_METRICS_FILE_AT_REFERENCE_WARNING
 from dvc.utils import relpath
+from dvc.scm.base import NoSCMError
 from tests.basic_env import TestDvcGit
 
 

--- a/tests/func/test_metrics.py
+++ b/tests/func/test_metrics.py
@@ -1013,5 +1013,5 @@ def test_metrics_without_scm(tmp_dir, dvc):
     tmp_dir.gen({metrics_name: json.dumps(metrics)})
     dvc.add(metrics_name)
     dvc.metrics.add(metrics_name)
-    with pytest.raises(DvcException, match=r"only supported for Git repos"):
+    with pytest.raises(DvcException, match=r"Only supported for Git repos"):
         dvc.metrics.diff()

--- a/tests/func/test_metrics.py
+++ b/tests/func/test_metrics.py
@@ -1013,5 +1013,5 @@ def test_metrics_without_scm(tmp_dir, dvc):
     tmp_dir.gen({metrics_name: json.dumps(metrics)})
     dvc.add(metrics_name)
     dvc.metrics.add(metrics_name)
-    with pytest.raises(DvcException, match=r"Only supported for Git repos"):
+    with pytest.raises(NoSCMError):
         dvc.metrics.diff()

--- a/tests/func/test_metrics.py
+++ b/tests/func/test_metrics.py
@@ -1013,6 +1013,5 @@ def test_metrics_without_scm(tmp_dir, dvc):
     tmp_dir.gen({metrics_name: json.dumps(metrics)})
     dvc.add(metrics_name)
     dvc.metrics.add(metrics_name)
-    with pytest.raises(DvcException) as msg:
+    with pytest.raises(DvcException, match=r"only supported for Git repos"):
         dvc.metrics.diff()
-    assert "only supported for Git repositories" in str(msg.value)

--- a/tests/func/test_metrics.py
+++ b/tests/func/test_metrics.py
@@ -1005,3 +1005,14 @@ def test_metrics_diff_deleted_metric(tmp_dir, scm, dvc):
             "a.b.e": {"old": "3", "new": None},
         }
     }
+
+
+def test_metrics_without_scm(tmp_dir, dvc):
+    metrics = {"acc": 0.97, "recall": 0.95}
+    metrics_name = "metrics.json"
+    tmp_dir.gen({metrics_name: json.dumps(metrics)})
+    dvc.add(metrics_name)
+    dvc.metrics.add(metrics_name)
+    with pytest.raises(DvcException) as msg:
+        dvc.metrics.diff()
+    assert "only supported for Git repositories" in str(msg.value)


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏


I am not sure if there is any other scm tools besides git going to be supported. 
If so, the error message"only supported for Git repositories" is not proper one,
 

fix #3605