### PR TITLE
remote: use string paths over PathInfo for performance reasons

### DIFF
--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -11,8 +11,6 @@ from functools import partial, wraps
 from multiprocessing import cpu_count
 from operator import itemgetter
 
-from funcy import cached_property
-
 from shortuuid import uuid
 
 import dvc.prompt as prompt
@@ -721,12 +719,6 @@ class BaseRemote(object):
     def checksum_to_path_info(self, checksum):
         return self.path_info / checksum[0:2] / checksum[2:]
 
-    checksum_to_path = checksum_to_path_info
-
-    @cached_property
-    def _path_str(self):
-        return str(self.path_info)
-
     def list_cache_paths(self, prefix=None, progress_callback=None):
         raise NotImplementedError
 
@@ -792,7 +784,7 @@ class BaseRemote(object):
     def is_protected(self, path_info):
         return False
 
-    def changed_cache_file(self, checksum):
+    def changed_cache_file(self, checksum, path_info=None):
         """Compare the given checksum with the (corresponding) actual one.
 
         - Use `State` as a cache for computed checksums
@@ -804,7 +796,10 @@ class BaseRemote(object):
 
         - Remove the file from cache if it doesn't match the actual checksum
         """
-        cache_info = self.checksum_to_path(checksum)
+        if path_info:
+            cache_info = path_info
+        else:
+            cache_info = self.checksum_to_path_info(checksum)
         if self.is_protected(cache_info):
             logger.debug(
                 "Assuming '%s' is unchanged since it is read-only", cache_info

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -719,6 +719,10 @@ class BaseRemote(object):
     def checksum_to_path_info(self, checksum):
         return self.path_info / checksum[0:2] / checksum[2:]
 
+    # Return path as a string instead of PathInfo for remotes which support
+    # string paths (see local)
+    checksum_to_path = checksum_to_path_info
+
     def list_cache_paths(self, prefix=None, progress_callback=None):
         raise NotImplementedError
 
@@ -784,7 +788,7 @@ class BaseRemote(object):
     def is_protected(self, path_info):
         return False
 
-    def changed_cache_file(self, checksum, path_info=None):
+    def changed_cache_file(self, checksum):
         """Compare the given checksum with the (corresponding) actual one.
 
         - Use `State` as a cache for computed checksums
@@ -796,10 +800,8 @@ class BaseRemote(object):
 
         - Remove the file from cache if it doesn't match the actual checksum
         """
-        if path_info:
-            cache_info = path_info
-        else:
-            cache_info = self.checksum_to_path_info(checksum)
+        # Prefer string path over PathInfo when possible due to performance
+        cache_info = self.checksum_to_path(checksum)
         if self.is_protected(cache_info):
             logger.debug(
                 "Assuming '%s' is unchanged since it is read-only", cache_info

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -336,11 +336,11 @@ class LocalRemote(BaseRemote):
                     )
                 )
         return self._make_status(
-            named_cache, remote, show_checksums, local_exists, remote_exists
+            named_cache, show_checksums, local_exists, remote_exists
         )
 
     def _make_status(
-        self, named_cache, remote, show_checksums, local_exists, remote_exists
+        self, named_cache, show_checksums, local_exists, remote_exists
     ):
         def make_names(checksum, names):
             return {"name": checksum if show_checksums else " ".join(names)}

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -67,6 +67,9 @@ class LocalRemote(BaseRemote):
     def supported(cls, config):
         return True
 
+    def checksum_to_path(self, checksum):
+        return os.path.join(self.path_info.fspath, checksum[0:2], checksum[2:])
+
     def list_cache_paths(self, prefix=None, progress_callback=None):
         assert self.path_info is not None
         if prefix:
@@ -229,11 +232,6 @@ class LocalRemote(BaseRemote):
         os.rename(fspath_py35(tmp_info), fspath_py35(to_info))
 
     def cache_exists(self, checksums, jobs=None, name=None):
-        base_path = str(self.path_info)
-
-        def checksum_to_path(checksum):
-            return os.path.join(base_path, checksum[0:2], checksum[2:])
-
         return [
             checksum
             for checksum in Tqdm(
@@ -242,9 +240,7 @@ class LocalRemote(BaseRemote):
                 desc="Querying "
                 + ("cache in " + name if name else "local cache"),
             )
-            if not self.changed_cache_file(
-                checksum, path_info=checksum_to_path(checksum)
-            )
+            if not self.changed_cache_file(checksum)
         ]
 
     def _upload(

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -68,9 +68,6 @@ class LocalRemote(BaseRemote):
     def supported(cls, config):
         return True
 
-    def checksum_to_path(self, checksum):
-        return posixpath.join(self._path_str, checksum[0:2], checksum[2:])
-
     def list_cache_paths(self, prefix=None, progress_callback=None):
         assert self.path_info is not None
         if prefix:
@@ -233,6 +230,11 @@ class LocalRemote(BaseRemote):
         os.rename(fspath_py35(tmp_info), fspath_py35(to_info))
 
     def cache_exists(self, checksums, jobs=None, name=None):
+        base_path = str(self.path_info)
+
+        def checksum_to_path(checksum):
+            return posixpath.join(base_path, checksum[0:2], checksum[2:])
+
         return [
             checksum
             for checksum in Tqdm(
@@ -241,7 +243,9 @@ class LocalRemote(BaseRemote):
                 desc="Querying "
                 + ("cache in " + name if name else "local cache"),
             )
-            if not self.changed_cache_file(checksum)
+            if not self.changed_cache_file(
+                checksum, path_info=checksum_to_path(checksum)
+            )
         ]
 
     def _upload(

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -5,7 +5,7 @@ import stat
 from concurrent.futures import as_completed, ThreadPoolExecutor
 from functools import partial
 
-from funcy import concat
+from funcy import cached_property, concat
 
 from shortuuid import uuid
 
@@ -67,8 +67,12 @@ class LocalRemote(BaseRemote):
     def supported(cls, config):
         return True
 
+    @cached_property
+    def cache_path(self):
+        return str(self.cache_dir)
+
     def checksum_to_path(self, checksum):
-        return os.path.join(self.path_info.fspath, checksum[0:2], checksum[2:])
+        return os.path.join(self.cache_path, checksum[0:2], checksum[2:])
 
     def list_cache_paths(self, prefix=None, progress_callback=None):
         assert self.path_info is not None

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -69,7 +69,7 @@ class LocalRemote(BaseRemote):
 
     @cached_property
     def cache_path(self):
-        return str(self.cache_dir)
+        return os.path.abspath(self.cache_dir)
 
     def checksum_to_path(self, checksum):
         return os.path.join(self.cache_path, checksum[0:2], checksum[2:])

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -1,7 +1,6 @@
 import errno
 import logging
 import os
-import posixpath
 import stat
 from concurrent.futures import as_completed, ThreadPoolExecutor
 from functools import partial
@@ -233,7 +232,7 @@ class LocalRemote(BaseRemote):
         base_path = str(self.path_info)
 
         def checksum_to_path(checksum):
-            return posixpath.join(base_path, checksum[0:2], checksum[2:])
+            return os.path.join(base_path, checksum[0:2], checksum[2:])
 
         return [
             checksum

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -88,7 +88,7 @@ class LocalRemote(BaseRemote):
 
     def exists(self, path_info):
         assert is_working_tree(self.repo.tree)
-        assert path_info.scheme == "local"
+        assert isinstance(path_info, str) or path_info.scheme == "local"
         return self.repo.tree.exists(fspath_py35(path_info))
 
     def makedirs(self, path_info):

--- a/dvc/state.py
+++ b/dvc/state.py
@@ -367,7 +367,7 @@ class State(object):  # pylint: disable=too-many-instance-attributes
             path_info (dict): path_info to save checksum for.
             checksum (str): checksum to save.
         """
-        assert path_info.scheme == "local"
+        assert isinstance(path_info, str) or path_info.scheme == "local"
         assert checksum is not None
         assert os.path.exists(fspath_py35(path_info))
 
@@ -398,7 +398,7 @@ class State(object):  # pylint: disable=too-many-instance-attributes
             str or None: checksum for the specified path info or None if it
             doesn't exist in the state database.
         """
-        assert path_info.scheme == "local"
+        assert isinstance(path_info, str) or path_info.scheme == "local"
         path = fspath_py35(path_info)
 
         if not os.path.exists(path):
@@ -425,7 +425,7 @@ class State(object):  # pylint: disable=too-many-instance-attributes
         Args:
             path_info (dict): path info to add to the list of links.
         """
-        assert path_info.scheme == "local"
+        assert isinstance(path_info, str) or path_info.scheme == "local"
 
         if not os.path.exists(fspath_py35(path_info)):
             return


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Should close #3635.

* LocalRemote now uses string paths instead of PathInfo in places where we expect to be dealing with a large number of paths (`status` and `LocalRemote.cache_exists`)
* `_process`/`upload`/`download` pipeline has been left alone for now - in the event that we are pushing or pulling enough files that using PathInfo's becomes noticeably slow, the expectation is already going to be that the operation will be slow, given that we will be uploading/downloading a lot of data.