### PR TITLE
flake8: fix ambiguous var names

### DIFF
--- a/dvc/dagascii.py
+++ b/dvc/dagascii.py
@@ -95,7 +95,7 @@ class AsciiCanvas(object):
         self.cols = cols
         self.lines = lines
 
-        self.canvas = [[" "] * cols for l in range(lines)]
+        self.canvas = [[" "] * cols for line in range(lines)]
 
     def draw(self):
         """Draws ASCII canvas on the screen."""

--- a/tests/func/test_repro.py
+++ b/tests/func/test_repro.py
@@ -1555,7 +1555,7 @@ def test_dvc_formatting_retained(tmp_dir, dvc, run_copy):
     # Add comments and custom formatting to DVC-file
     lines = list(map(_format_dvc_line, stage_path.read_text().splitlines()))
     lines.insert(0, "# Starting comment")
-    stage_text = "".join(l + "\n" for l in lines)
+    stage_text = "".join(line + "\n" for line in lines)
     stage_path.write_text(stage_text)
 
     # Rewrite data source and repro


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Fixes errors from latest flake8 master (`pycodestyle >= 2.6.0a1, < 2.7.0`)

```
[INFO] This may take a few minutes...
black....................................................................Passed
flake8...................................................................Failed
- hook id: flake8
- exit code: 1
tests/func/test_repro.py:1558:39: E741 ambiguous variable name 'l'
dvc/dagascii.py:98:41: E741 ambiguous variable name 'l'
beautysh.................................................................Passed
DVC pre-commit...........................................................Passed
- hook id: dvc-pre-commit
- duration: 16.59s
```