### PR TITLE
remote.ssh: suppress paramiko logging

### DIFF
--- a/dvc/remote/ssh/connection.py
+++ b/dvc/remote/ssh/connection.py
@@ -9,6 +9,8 @@ from funcy import cached_property
 
 try:
     import paramiko
+
+    logging.getLogger("paramiko.transport").disabled = True
 except ImportError:
     paramiko = None
 

--- a/dvc/remote/ssh/connection.py
+++ b/dvc/remote/ssh/connection.py
@@ -9,8 +9,6 @@ from funcy import cached_property
 
 try:
     import paramiko
-
-    logging.getLogger("paramiko.transport").disabled = True
 except ImportError:
     paramiko = None
 
@@ -43,6 +41,14 @@ class SSHConnection:
         self.timeout = kwargs.get("timeout", 1800)
 
         self._ssh = paramiko.SSHClient()
+
+        # Explicitly disable paramiko logger. Due to how paramiko dynamically
+        # loads loggers, it is not disabled by DVC disable_other_loggers().
+        # See https://github.com/iterative/dvc/issues/3482
+        self._ssh.set_log_channel("dvc.paramiko")
+        logging.getLogger("dvc.paramiko").disabled = True
+        logging.getLogger("dvc.paramiko.sftp").disabled = True
+
         self._ssh.load_system_host_keys()
         self._ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will close #3482.

paramiko is loaded lazily, so the paramiko logger is not suppressed in `dvc/logger.py::disable_other_loggers()`. This leads to paramiko emitting expected error messages when we hit the max SFTP channel limit, even though it is not an error condition for DVC. The logger should just be suppressed when we load paramiko, since any actual SSH/SFTP errors will be caught and logged as DvcExceptions.