### PR TITLE
git: is_tracked: use ls_files instead of walking the index

### DIFF
--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -271,11 +271,7 @@ class Git(Base):
         return [os.path.join(self.repo.working_dir, fname) for fname in files]
 
     def is_tracked(self, path):
-        # it is equivalent to `bool(self.repo.git.ls_files(path))` by
-        # functionality, but ls_files fails on unicode filenames
-        path = relpath(path, self.root_dir)
-        # There are 4 stages, see BaseIndexEntry.stage
-        return any((path, i) in self.repo.index.entries for i in (0, 1, 2, 3))
+        return bool(self.repo.git.ls_files(path))
 
     def is_dirty(self):
         return self.repo.is_dirty()

--- a/tests/unit/scm/test_git.py
+++ b/tests/unit/scm/test_git.py
@@ -37,3 +37,37 @@ def test_walk_with_submodules(tmp_dir, scm, git_dir):
     # currently we don't walk through submodules
     assert not dirs
     assert set(files) == {".gitmodules", "submodule"}
+
+
+def test_is_tracked(tmp_dir, scm):
+    tmp_dir.scm_gen(
+        {
+            "tracked": "tracked",
+            "dir": {"data": "data", "subdir": {"subdata": "subdata"}},
+        },
+        commit="add dirs and files",
+    )
+    tmp_dir.gen({"untracked": "untracked", "dir": {"untracked": "untracked"}})
+
+    # sanity check
+    assert (tmp_dir / "untracked").exists()
+    assert (tmp_dir / "tracked").exists()
+    assert (tmp_dir / "dir" / "untracked").exists()
+    assert (tmp_dir / "dir" / "data").exists()
+    assert (tmp_dir / "dir" / "subdir" / "subdata").exists()
+
+    assert not scm.is_tracked("untracked")
+    assert not scm.is_tracked(os.path.join("dir", "untracked"))
+
+    assert scm.is_tracked("tracked")
+    assert scm.is_tracked("dir")
+    assert scm.is_tracked(os.path.join("dir", "data"))
+    assert scm.is_tracked(os.path.join("dir", "subdir"))
+    assert scm.is_tracked(os.path.join("dir", "subdir", "subdata"))
+
+
+def test_is_tracked_unicode(tmp_dir, scm):
+    tmp_dir.scm_gen("ṭṝḁḉḵḗḋ", "tracked", commit="add unicode")
+    tmp_dir.gen("ṳṋṭṝḁḉḵḗḋ", "untracked")
+    assert scm.is_tracked("ṭṝḁḉḵḗḋ")
+    assert not scm.is_tracked("ṳṋṭṝḁḉḵḗḋ")


### PR DESCRIPTION
Current implementation doesn't work with directories, which results in
hard-to-debug bugs like #3561. The bug that made us walk through index
manually is now fixed in gitpython, so we can simply use `ls_files` from
now on. Added some tests to prevent this from happening in the future.

Fixes #3561

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
