### PR TITLE
dvc: implement params support for pipeline file

### DIFF
--- a/dvc/schema.py
+++ b/dvc/schema.py
@@ -21,7 +21,7 @@ DATA_SCHEMA = {**CHECKSUMS_SCHEMA, Required("path"): str}
 LOCK_FILE_STAGE_SCHEMA = {
     Required(StageParams.PARAM_CMD): str,
     StageParams.PARAM_DEPS: [DATA_SCHEMA],
-    StageParams.PARAM_PARAMS: [{str: object}],
+    StageParams.PARAM_PARAMS: {str: {str: object}},
     StageParams.PARAM_OUTS: [DATA_SCHEMA],
 }
 LOCKFILE_SCHEMA = {str: LOCK_FILE_STAGE_SCHEMA}

--- a/dvc/schema.py
+++ b/dvc/schema.py
@@ -21,6 +21,7 @@ DATA_SCHEMA = {**CHECKSUMS_SCHEMA, Required("path"): str}
 LOCK_FILE_STAGE_SCHEMA = {
     Required(StageParams.PARAM_CMD): str,
     StageParams.PARAM_DEPS: [DATA_SCHEMA],
+    StageParams.PARAM_PARAMS: [{str: object}],
     StageParams.PARAM_OUTS: [DATA_SCHEMA],
 }
 LOCKFILE_SCHEMA = {str: LOCK_FILE_STAGE_SCHEMA}
@@ -30,6 +31,7 @@ SINGLE_PIPELINE_STAGE_SCHEMA = {
         StageParams.PARAM_CMD: str,
         Optional(StageParams.PARAM_WDIR): str,
         Optional(StageParams.PARAM_DEPS): [str],
+        Optional(StageParams.PARAM_PARAMS): [Any(str, {str: [str]})],
         Optional(StageParams.PARAM_LOCKED): bool,
         Optional(StageParams.PARAM_META): object,
         Optional(StageParams.PARAM_ALWAYS_CHANGED): bool,

--- a/dvc/serialize.py
+++ b/dvc/serialize.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from funcy import rpartial, lsplit_by
+from funcy import rpartial, lsplit
 
 from dvc.dependency import ParamsDependency
 from dvc.utils.collections import apply_diff
@@ -30,7 +30,7 @@ def _get_outs(stage: "PipelineStage"):
 
 
 def get_params_deps(stage: "PipelineStage"):
-    return lsplit_by(rpartial(isinstance, ParamsDependency), stage.deps)
+    return lsplit(rpartial(isinstance, ParamsDependency), stage.deps)
 
 
 def _serialize_params(params: List[ParamsDependency]):

--- a/dvc/stage/params.py
+++ b/dvc/stage/params.py
@@ -10,6 +10,7 @@ class StageParams:
     PARAM_LOCKED = "locked"
     PARAM_META = "meta"
     PARAM_ALWAYS_CHANGED = "always_changed"
+    PARAM_PARAMS = "params"
 
 
 class OutputParams(Enum):

--- a/tests/func/test_repro_multistage.py
+++ b/tests/func/test_repro_multistage.py
@@ -1,7 +1,9 @@
 import os
+from copy import deepcopy
 from textwrap import dedent
 
 import pytest
+import yaml
 
 from dvc.dvcfile import PIPELINE_FILE, PIPELINE_LOCK
 from dvc.exceptions import CyclicGraphError
@@ -485,3 +487,61 @@ def test_cyclic_graph_error(tmp_dir, dvc, run_copy):
     dump_stage_file(PIPELINE_FILE, data)
     with pytest.raises(CyclicGraphError):
         dvc.reproduce(":copy-baz-foo")
+
+
+def test_repro_multiple_params(tmp_dir, dvc):
+    from tests.func.test_run_multistage import supported_params
+
+    from dvc.serialize import get_params_deps
+
+    with (tmp_dir / "params2.yaml").open("w+") as f:
+        yaml.dump(supported_params, f)
+
+    with (tmp_dir / "params.yaml").open("w+") as f:
+        yaml.dump(supported_params, f)
+
+    (tmp_dir / "foo").write_text("foo")
+    stage = dvc.run(
+        name="read_params",
+        deps=["foo"],
+        outs=["bar"],
+        params=[
+            "params2.yaml:lists,floats,name",
+            "answer,floats,nested.nested1",
+        ],
+        cmd="cat params2.yaml params.yaml > bar",
+    )
+
+    params, deps = get_params_deps(stage)
+    assert len(params) == 2
+    assert len(deps) == 1
+    assert len(stage.outs) == 1
+
+    lockfile = stage.dvcfile._lockfile
+    assert lockfile.load()["read_params"]["params"] == {
+        "params2.yaml": {
+            "lists": [42, 42.0, "42"],
+            "floats": 42.0,
+            "name": "Answer",
+        },
+        "params.yaml": {
+            "answer": 42,
+            "floats": 42.0,
+            "nested.nested1": {"nested2": "42", "nested2-2": 41.99999},
+        },
+    }
+    data, _ = stage.dvcfile._load()
+    assert data["stages"]["read_params"]["params"] == [
+        {"params2.yaml": ["lists", "floats", "name"]},
+        "answer",
+        "floats",
+        "nested.nested1",
+    ]
+
+    assert not dvc.reproduce(stage.addressing)
+    with (tmp_dir / "params.yaml").open("w+") as f:
+        params = deepcopy(supported_params)
+        params["answer"] = 43
+        yaml.dump(params, f)
+
+    assert dvc.reproduce(stage.addressing) == [stage]


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Continuing from #3676 
Part of #1871 

This PR implements params support for pipeline file.

The pipeline file will have following format:
```yaml
    params:
   -  process.thresh
    - process.bow
    - params2.yaml:  # notice the format for custom params file
      - lr
      - train.epochs
```