### PR TITLE
setup: relax python-dateutil pip version constraint to include v2.8.2.  #3701

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ class build_py(_build_py):
 
 
 install_requires = [
-    "python-dateutil<=2.8.2,>=2.1",  # Consolidates azure-blob-storage and boto3
     "ply>=3.9",  # See https://github.com/pyinstaller/pyinstaller/issues/1945
     "colorama>=0.3.9",
     "configobj>=5.0.6",

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ class build_py(_build_py):
 
 
 install_requires = [
-    "python-dateutil<2.8.1,>=2.1",  # Consolidates azure-blob-storage and boto3
+    "python-dateutil<=2.8.2,>=2.1",  # Consolidates azure-blob-storage and boto3
     "ply>=3.9",  # See https://github.com/pyinstaller/pyinstaller/issues/1945
     "colorama>=0.3.9",
     "configobj>=5.0.6",


### PR DESCRIPTION
[WIP]. Attempt to relax upper constraints on the version of python-dateutil, to include 2.8.1 and 2.8.2. 

The original constraint was:
    "python-dateutil<2.8.1,>=2.1",  # Consolidates azure-blob-storage and boto3

Requesting to do a CI run, see if new version constraint still works.


Fixes #3701