### PR TITLE
serialize: use checksums that are already saved

### DIFF
--- a/dvc/serialize.py
+++ b/dvc/serialize.py
@@ -89,11 +89,10 @@ def to_lockfile(stage: "PipelineStage") -> dict:
     res = {"cmd": stage.cmd}
     params, deps = get_params_deps(stage)
     deps = [
-        {"path": dep.def_path, dep.checksum_type: dep.get_checksum()}
-        for dep in deps
+        {"path": dep.def_path, dep.checksum_type: dep.checksum} for dep in deps
     ]
     outs = [
-        {"path": out.def_path, out.checksum_type: out.get_checksum()}
+        {"path": out.def_path, out.checksum_type: out.checksum}
         for out in stage.outs
     ]
     if deps:


### PR DESCRIPTION
`get_checksum()` recomputes the checksum which might not match the
pre-recorded one. `checksum` is the one that was `save()`ed during run
and it is the one that should be used in the lockfile.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
