### PR TITLE
run: try to save deps before running the command

### DIFF
--- a/dvc/stage/exceptions.py
+++ b/dvc/stage/exceptions.py
@@ -73,15 +73,6 @@ class StageUpdateError(DvcException):
         )
 
 
-class MissingDep(DvcException):
-    def __init__(self, deps):
-        assert len(deps) > 0
-
-        dep = "dependencies" if len(deps) > 1 else "dependency"
-        msg = "missing '{}': {}".format(dep, ", ".join(map(str, deps)))
-        super().__init__(msg)
-
-
 class MissingDataSource(DvcException):
     def __init__(self, missing_files):
         assert len(missing_files) > 0

--- a/tests/func/test_run_single_stage.py
+++ b/tests/func/test_run_single_stage.py
@@ -26,7 +26,6 @@ from dvc.stage.exceptions import (
     StagePathOutsideError,
     StagePathNotFoundError,
     StagePathNotDirectoryError,
-    MissingDep,
 )
 from dvc.system import System
 from dvc.utils import file_md5
@@ -79,7 +78,9 @@ class TestRunEmpty(TestDvc):
 
 class TestRunMissingDep(TestDvc):
     def test(self):
-        with self.assertRaises(MissingDep):
+        from dvc.dependency.base import DependencyDoesNotExistError
+
+        with self.assertRaises(DependencyDoesNotExistError):
             self.dvc.run(
                 cmd="",
                 deps=["non-existing-dep"],


### PR DESCRIPTION
Unlike old `_check_missing_deps`, this also verifies that we are able to
save more complex dependencies such as parameters, where we not only
care about the config file, but also about the parameters in it.

Fixes #3707

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
