### PR TITLE
progress: add postfix info to avoid overwriting desc

### DIFF
--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -68,7 +68,6 @@ class Tqdm(tqdm):
             kwargs.setdefault("unit_scale", total > 999 if total else True)
         if file is None:
             file = sys.stderr
-        self.desc_persist = desc
         # auto-disable based on `logger.level`
         if not disable:
             disable = logger.getEffectiveLevel() > level
@@ -102,11 +101,11 @@ class Tqdm(tqdm):
             self.bar_format = bar_format
         self.refresh()
 
-    def update_desc(self, desc, n=1):
+    def update_msg(self, msg, n=1):
         """
-        Calls `set_description_str(desc)` and `update(n)`
+        Calls `set_postfix_str(msg)` and `update(n)`
         """
-        self.set_description_str(desc, refresh=False)
+        self.set_postfix_str(msg, refresh=False)
         self.update(n)
 
     def update_to(self, current, total=None):
@@ -130,8 +129,6 @@ class Tqdm(tqdm):
         return wrapped
 
     def close(self):
-        if self.desc_persist is not None:
-            self.set_description_str(self.desc_persist, refresh=False)
         # unknown/zero ETA
         self.bar_format = self.bar_format.replace("<{remaining}", "")
         # remove completed bar

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -19,18 +19,17 @@ class Tqdm(tqdm):
 
     BAR_FMT_DEFAULT = (
         "{percentage:3.0f}% {desc}|{bar}|"
-        "{n_fmt}/{total_fmt}"
-        " [{elapsed}<{remaining}, {rate_fmt:>11}{postfix}]"
+        "{postfix[info]}{n_fmt}/{total_fmt}"
+        " [{elapsed}<{remaining}, {rate_fmt:>11}]"
     )
     # nested bars should have fixed bar widths to align nicely
     BAR_FMT_DEFAULT_NESTED = (
         "{percentage:3.0f}%|{bar:10}|{desc:{ncols_desc}.{ncols_desc}}"
-        "{n_fmt}/{total_fmt}"
-        " [{elapsed}<{remaining}, {rate_fmt:>11}{postfix}]"
+        "{postfix[info]}{n_fmt}/{total_fmt}"
+        " [{elapsed}<{remaining}, {rate_fmt:>11}]"
     )
     BAR_FMT_NOTOTAL = (
-        "{desc:{ncols_desc}.{ncols_desc}}{n_fmt}"
-        " [{elapsed}, {rate_fmt:>11}{postfix}]"
+        "{desc}{bar:b}|{postfix[info]}{n_fmt} [{elapsed}, {rate_fmt:>11}]"
     )
     BYTES_DEFAULTS = dict(
         unit="B", unit_scale=True, unit_divisor=1024, miniters=1
@@ -47,6 +46,7 @@ class Tqdm(tqdm):
         bytes=False,  # pylint: disable=W0622
         file=None,
         total=None,
+        postfix=None,
         **kwargs
     ):
         """
@@ -88,6 +88,7 @@ class Tqdm(tqdm):
             total=total,
             **kwargs
         )
+        self.postfix = postfix or {"info": ""}
         if bar_format is None:
             if self.__len__():
                 self.bar_format = (
@@ -103,9 +104,9 @@ class Tqdm(tqdm):
 
     def update_msg(self, msg, n=1):
         """
-        Calls `set_postfix_str(msg)` and `update(n)`
+        Sets `msg` as a postfix and calls `update(n)`.
         """
-        self.set_postfix_str(msg, refresh=False)
+        self.postfix["info"] = " %s |" % msg
         self.update(n)
 
     def update_to(self, current, total=None):
@@ -129,10 +130,11 @@ class Tqdm(tqdm):
         return wrapped
 
     def close(self):
-        # unknown/zero ETA
-        self.bar_format = self.bar_format.replace("<{remaining}", "")
-        # remove completed bar
-        self.bar_format = self.bar_format.replace("|{bar:10}|", " ")
+        self.postfix["info"] = ""
+        # remove ETA (either unknown or zero); remove completed bar
+        self.bar_format = self.bar_format.replace("<{remaining}", "").replace(
+            "|{bar:10}|", " "
+        )
         super().close()
 
     @property
@@ -140,12 +142,15 @@ class Tqdm(tqdm):
         """inject `ncols_desc` to fill the display width (`ncols`)"""
         d = super().format_dict
         ncols = d["ncols"] or 80
-        ncols_desc = ncols - len(self.format_meter(ncols_desc=1, **d)) + 1
-        ncols_desc = max(ncols_desc, 0)
-        if ncols_desc:
-            d["ncols_desc"] = ncols_desc
+        # assumes `bar_format` has max one of ("ncols_desc" & "ncols_info")
+        ncols_left = (
+            ncols - len(self.format_meter(ncols_desc=1, ncols_info=1, **d)) + 1
+        )
+        ncols_left = max(ncols_left, 0)
+        if ncols_left:
+            d["ncols_desc"] = d["ncols_info"] = ncols_left
         else:
             # work-around for zero-width description
-            d["ncols_desc"] = 1
+            d["ncols_desc"] = d["ncols_info"] = 1
             d["prefix"] = ""
         return d

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -1081,7 +1081,7 @@ class BaseRemote(object):
 
             def exists_with_progress(path_info):
                 ret = self.exists(path_info)
-                pbar.update_desc(str(path_info))
+                pbar.update_msg(str(path_info))
                 return ret
 
             with ThreadPoolExecutor(max_workers=jobs or self.JOBS) as executor:

--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -330,7 +330,7 @@ class SSHRemote(BaseRemote):
         ) as pbar:
 
             def exists_with_progress(chunks):
-                return self.batch_exists(chunks, callback=pbar.update_desc)
+                return self.batch_exists(chunks, callback=pbar.update_msg)
 
             with ThreadPoolExecutor(max_workers=jobs or self.JOBS) as executor:
                 path_infos = [self.checksum_to_path_info(x) for x in checksums]

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -144,6 +144,6 @@ def _create_stages(repo, targets, fname, pbar=None):
 
         stages.append(stage)
         if pbar is not None:
-            pbar.update_desc(out)
+            pbar.update_msg(out)
 
     return stages

--- a/dvc/repo/checkout.py
+++ b/dvc/repo/checkout.py
@@ -80,7 +80,7 @@ def _checkout(
         for stage, filter_info in pairs:
             result = stage.checkout(
                 force=force,
-                progress_callback=pbar.update_desc,
+                progress_callback=pbar.update_msg,
                 relink=relink,
                 filter_info=filter_info,
             )

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -25,7 +25,7 @@ class TqdmGit(Tqdm):
         if op_code:
             self.set_description_str(op_code, refresh=False)
         if message:
-            self.set_postfix_str(message, refresh=False)
+            self.postfix["info"] = " %s |" % message
         self.update_to(cur_count, max_count)
 
     @staticmethod

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -23,9 +23,9 @@ class TqdmGit(Tqdm):
     def update_git(self, op_code, cur_count, max_count=None, message=""):
         op_code = self.code2desc(op_code)
         if op_code:
-            self.set_description_str(op_code, refresh=False)
+            message = (op_code + " | " + message) if message else op_code
         if message:
-            self.postfix["info"] = " %s |" % message
+            self.postfix["info"] = " {} | ".format(message)
         self.update_to(cur_count, max_count)
 
     @staticmethod


### PR DESCRIPTION
- [x] persist `desc` so as not to confuse users about the operation
- [x] put info message updates into the postfix
- [x] fix everything that breaks because of this change
- [x] discuss git progress
  + was (top recording): `Cloning:    [elapsed<remaining]` => `Receiving:    | MBps [elapsed<remaining]` => `Receiving:    [elapsed]`
  + could be (lower recording): `Cloning:    [elapsed<remaining]` => `Cloning:    | Receiving | MBps [elapsed<remaining]` => `Cloning:    [elapsed]`
- fixes #3681

[![much asciinema such rec](https://asciinema.org/a/xLuYWs5szrSLw01uafAzFRLyI.svg)](https://asciinema.org/a/xLuYWs5szrSLw01uafAzFRLyI?speed=3)

[![much asciinema such rec](https://asciinema.org/a/znhzNFbYgvH0lE8w2h93Buvhl.svg)](https://asciinema.org/a/znhzNFbYgvH0lE8w2h93Buvhl?speed=3)