### PR TITLE
gdrive: download: stream & add progress

### DIFF
--- a/dvc/remote/gdrive.py
+++ b/dvc/remote/gdrive.py
@@ -396,14 +396,34 @@ class GDriveRemote(BaseRemote):
         param = {"id": item_id}
         # it does not create a file on the remote
         gdrive_file = self._drive.CreateFile(param)
-        bar_format = (
-            "Downloading {desc:{ncols_desc}.{ncols_desc}}... "
-            + Tqdm.format_sizeof(int(gdrive_file["fileSize"]), "B", 1024)
-        )
-        with Tqdm(
-            bar_format=bar_format, desc=progress_desc, disable=no_progress_bar
-        ):
-            gdrive_file.GetContentFile(to_file)  # TODO: actually use pbar
+
+        import httplib2
+
+        OrigClass = httplib2.HTTPConnectionWithTimeout.response_class
+
+        class Custom(OrigClass):
+            def _readall_chunked(self):
+                assert self.chunked != "UNKNOWN"
+                value = []
+                with Tqdm(
+                    total=int(gdrive_file["fileSize"]),
+                    desc=progress_desc,
+                    disable=no_progress_bar,
+                    bytes=True,
+                ) as pbar:
+                    while True:
+                        chunk_left = self._get_chunk_left()
+                        if chunk_left is None:
+                            break
+                        chunk = self._safe_read(chunk_left)
+                        value.append(chunk)
+                        pbar.update(len(chunk))
+                        self.chunk_left = 0
+                return b"".join(value)
+
+        httplib2.HTTPConnectionWithTimeout.response_class = Custom
+        gdrive_file.GetContentFile(to_file)
+        httplib2.HTTPConnectionWithTimeout.response_class = OrigClass
 
     @_gdrive_retry
     def _gdrive_delete_file(self, item_id):

--- a/dvc/remote/gdrive.py
+++ b/dvc/remote/gdrive.py
@@ -387,7 +387,11 @@ class GDriveRemote(BaseRemote):
         gdrive_file = self._drive.CreateFile(param)
 
         with Tqdm(
-            desc=progress_desc, disable=no_progress_bar, bytes=True,
+            desc=progress_desc,
+            disable=no_progress_bar,
+            bytes=True,
+            # explicit `bar_format` as `total` will be set by `update_to`
+            bar_format=Tqdm.BAR_FMT_DEFAULT,
         ) as pbar:
             gdrive_file.GetContentFile(to_file, callback=pbar.update_to)
 

--- a/dvc/remote/gdrive.py
+++ b/dvc/remote/gdrive.py
@@ -403,7 +403,7 @@ class GDriveRemote(BaseRemote):
         with Tqdm(
             bar_format=bar_format, desc=progress_desc, disable=no_progress_bar
         ):
-            gdrive_file.GetContentFile(to_file)
+            gdrive_file.GetContentFile(to_file)  # TODO: actually use pbar
 
     @_gdrive_retry
     def _gdrive_delete_file(self, item_id):

--- a/dvc/remote/gdrive.py
+++ b/dvc/remote/gdrive.py
@@ -387,10 +387,7 @@ class GDriveRemote(BaseRemote):
         gdrive_file = self._drive.CreateFile(param)
 
         with Tqdm(
-            total=int(gdrive_file["fileSize"]),
-            desc=progress_desc,
-            disable=no_progress_bar,
-            bytes=True,
+            desc=progress_desc, disable=no_progress_bar, bytes=True,
         ) as pbar:
             gdrive_file.GetContentFile(to_file, callback=pbar.update_to)
 

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ install_requires = [
 # Extra dependencies for remote integrations
 
 gs = ["google-cloud-storage==1.19.0"]
-gdrive = ["pydrive2>=1.4.10"]
+gdrive = ["pydrive2>=1.4.11"]
 s3 = ["boto3>=1.9.201"]
 azure = ["azure-storage-blob==2.1.0"]
 oss = ["oss2==2.6.1"]


### PR DESCRIPTION
- [x] ~~patch underlying `httplib2` for gdrive progress~~
- [x] ~~Also consider using something other than `httplib2`/`pydrive2` (e.g. use `http.client` directly or `requests` which both support iteration) to~~ avoid loading the whole file into RAM
  - [x] depends on https://github.com/iterative/PyDrive2/pull/30 (`pydrive>=1.4.11`)
    - > Let there be no more in-memory downloads. Let the files stream until the hard drives overfloweth. Let RAM be ignored, and let us answer the call to progress.
    - [x] use new `ApiRequestError.GetField()`
    - [x] use new `GetContentFile(callback=Tqdm.update_to)`
  - [x] depends on https://github.com/conda-forge/pydrive2-feedstock/pull/10
- [x] test
- part of #2865
  + related #3408