### PR TITLE
dvc: move temporary files to .dvc/tmp

### DIFF
--- a/dvc/command/base.py
+++ b/dvc/command/base.py
@@ -36,7 +36,7 @@ class CmdBase(object):
         self.config = self.repo.config
         self.args = args
         hardlink_lock = self.config["core"].get("hardlink_lock", False)
-        updater = Updater(self.repo.dvc_dir, hardlink_lock=hardlink_lock)
+        updater = Updater(self.repo.tmp_dir, hardlink_lock=hardlink_lock)
         updater.check()
 
     @property

--- a/dvc/command/daemon.py
+++ b/dvc/command/daemon.py
@@ -15,9 +15,10 @@ class CmdDaemonUpdater(CmdDaemonBase):
 
         root_dir = Repo.find_root()
         dvc_dir = os.path.join(root_dir, Repo.DVC_DIR)
+        tmp_dir = os.path.join(dvc_dir, "tmp")
         config = Config(dvc_dir, validate=False)
         hardlink_lock = config.get("core", {}).get("hardlink_lock", False)
-        updater = Updater(dvc_dir, hardlink_lock=hardlink_lock)
+        updater = Updater(tmp_dir, hardlink_lock=hardlink_lock)
         updater.fetch(detach=False)
 
         return 0

--- a/dvc/lock.py
+++ b/dvc/lock.py
@@ -17,7 +17,7 @@ DEFAULT_TIMEOUT = 5
 FAILED_TO_LOCK_MESSAGE = (
     "cannot perform the command because another DVC process seems to be "
     "running on this project. If that is not the case, manually remove "
-    "`.dvc/lock` and try again."
+    "`.dvc/tmp/lock` and try again."
 )
 
 

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -93,8 +93,8 @@ class Repo(object):
 
         hardlink_lock = self.config["core"].get("hardlink_lock", False)
         self.lock = make_lock(
-            os.path.join(self.dvc_dir, "lock"),
-            tmp_dir=os.path.join(self.dvc_dir, "tmp"),
+            os.path.join(self.tmp_dir, "lock"),
+            tmp_dir=self.tmp_dir,
             hardlink_lock=hardlink_lock,
             friendly=True,
         )
@@ -164,15 +164,7 @@ class Repo(object):
         return self.cache.local.unprotect(PathInfo(target))
 
     def _ignore(self):
-        from dvc.updater import Updater
-
-        updater = Updater(self.dvc_dir)
-
-        flist = (
-            [self.config.files["local"], updater.updater_file]
-            + [self.lock.lockfile, updater.lock.lockfile, self.tmp_dir]
-            + self.state.files
-        )
+        flist = [self.config.files["local"], self.tmp_dir]
 
         if path_isin(self.cache.local.cache_dir, self.root_dir):
             flist += [self.cache.local.cache_dir]

--- a/dvc/state.py
+++ b/dvc/state.py
@@ -96,7 +96,6 @@ class State(object):  # pylint: disable=too-many-instance-attributes
 
     def __init__(self, repo):
         self.repo = repo
-        self.dvc_dir = repo.dvc_dir
         self.root_dir = repo.root_dir
 
         state_config = repo.config.get("state", {})
@@ -105,11 +104,11 @@ class State(object):  # pylint: disable=too-many-instance-attributes
             "row_cleanup_quota", self.STATE_ROW_CLEANUP_QUOTA
         )
 
-        if not self.dvc_dir:
+        if not repo.tmp_dir:
             self.state_file = None
             return
 
-        self.state_file = os.path.join(self.dvc_dir, self.STATE_FILE)
+        self.state_file = os.path.join(repo.tmp_dir, self.STATE_FILE)
 
         # https://www.sqlite.org/tempfiles.html
         self.temp_files = [

--- a/dvc/updater.py
+++ b/dvc/updater.py
@@ -21,12 +21,11 @@ class Updater(object):  # pragma: no cover
     TIMEOUT = 24 * 60 * 60  # every day
     TIMEOUT_GET = 10
 
-    def __init__(self, dvc_dir, friendly=False, hardlink_lock=False):
-        self.dvc_dir = dvc_dir
-        self.updater_file = os.path.join(dvc_dir, self.UPDATER_FILE)
+    def __init__(self, tmp_dir, friendly=False, hardlink_lock=False):
+        self.updater_file = os.path.join(tmp_dir, self.UPDATER_FILE)
         self.lock = make_lock(
             self.updater_file + ".lock",
-            tmp_dir=os.path.join(dvc_dir, "tmp"),
+            tmp_dir=tmp_dir,
             friendly=friendly,
             hardlink_lock=hardlink_lock,
         )

--- a/tests/func/test_diff.py
+++ b/tests/func/test_diff.py
@@ -39,7 +39,7 @@ def test_no_cache_entry(tmp_dir, scm, dvc):
     tmp_dir.dvc_gen("file", "second")
 
     remove(fspath(tmp_dir / ".dvc" / "cache"))
-    (tmp_dir / ".dvc" / "state").unlink()
+    (tmp_dir / ".dvc" / "tmp" / "state").unlink()
 
     dir_checksum = "5fb6b29836c388e093ca0715c872fe2a.dir"
 

--- a/tests/func/test_lock.py
+++ b/tests/func/test_lock.py
@@ -8,7 +8,7 @@ from tests.basic_env import TestDvc
 
 class TestLock(TestDvc):
     def test_with(self):
-        lockfile = os.path.join(self.dvc.dvc_dir, "lock")
+        lockfile = os.path.join(self.dvc.dvc_dir, "tmp", "lock")
         lock = Lock(lockfile)
         with lock:
             with self.assertRaises(LockError):
@@ -17,7 +17,7 @@ class TestLock(TestDvc):
                     self.assertTrue(False)
 
     def test_cli(self):
-        lockfile = os.path.join(self.dvc.dvc_dir, "lock")
+        lockfile = os.path.join(self.dvc.dvc_dir, "tmp", "lock")
         lock = Lock(lockfile)
         with lock:
             ret = main(["add", self.FOO])


### PR DESCRIPTION
Moving
```
state
updater
updater.lock
lock
```
from `.dvc/` to `.dvc/tmp/`.

Fixes #3666

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

https://github.com/iterative/dvc.org/pull/1215

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
