### PR TITLE
[WIP] dvc.yaml: rename stages -> run

### DIFF
--- a/dvc/dvcfile.py
+++ b/dvc/dvcfile.py
@@ -197,13 +197,13 @@ class PipelineFile(FileMixin):
         else:
             open(self.path, "w+").close()
 
-        data["stages"] = data.get("stages", {})
+        data["pipeline"] = data.get("pipeline", {})
         stage_data = serialize.to_pipeline_file(stage)
-        if data["stages"].get(stage.name):
-            orig_stage_data = data["stages"][stage.name]
+        if data["pipeline"].get(stage.name):
+            orig_stage_data = data["pipeline"][stage.name]
             apply_diff(stage_data[stage.name], orig_stage_data)
         else:
-            data["stages"].update(stage_data)
+            data["pipeline"].update(stage_data)
 
         dump_stage_file(self.path, data)
         self.repo.scm.track_file(relpath(self.path))
@@ -218,7 +218,7 @@ class PipelineFile(FileMixin):
     def stages(self):
         data, _ = self._load()
         lockfile_data = self._lockfile.load()
-        return StageLoader(self, data.get("stages", {}), lockfile_data)
+        return StageLoader(self, data.get("pipeline", {}), lockfile_data)
 
     def remove(self, force=False):
         if not force:

--- a/dvc/schema.py
+++ b/dvc/schema.py
@@ -5,7 +5,7 @@ from dvc import dependency, output
 from voluptuous import Any, Schema, Optional, Required
 
 
-STAGES = "stages"
+PIPELINE = "pipeline"
 SINGLE_STAGE_SCHEMA = {
     StageParams.PARAM_MD5: output.CHECKSUM_SCHEMA,
     StageParams.PARAM_CMD: Any(str, None),
@@ -38,7 +38,7 @@ SINGLE_PIPELINE_STAGE_SCHEMA = {
         **{Optional(p.value): [str] for p in OutputParams},
     }
 }
-MULTI_STAGE_SCHEMA = {STAGES: SINGLE_PIPELINE_STAGE_SCHEMA}
+MULTI_STAGE_SCHEMA = {PIPELINE: SINGLE_PIPELINE_STAGE_SCHEMA}
 
 COMPILED_SINGLE_STAGE_SCHEMA = Schema(SINGLE_STAGE_SCHEMA)
 COMPILED_MULTI_STAGE_SCHEMA = Schema(MULTI_STAGE_SCHEMA)


### PR DESCRIPTION
`Run` is a more natural terminology for data scientists than `stages` so
it makes sense to rename it so it is more in-sync with it as well as our
commands (e.g. `dvc run`).

* [ ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [ ] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
