### PR TITLE
Make comparisons in is_cached independent of order

### DIFF
--- a/dvc/serialize.py
+++ b/dvc/serialize.py
@@ -23,7 +23,7 @@ sort_by_path = partial(sorted, key=attrgetter("def_path"))
 
 def _get_outs(stage: "PipelineStage"):
     outs_bucket = {}
-    for o in stage.outs:
+    for o in sort_by_path(stage.outs):
         bucket_key = ["metrics"] if o.metric else ["outs"]
 
         if not o.metric and o.persist:
@@ -32,7 +32,7 @@ def _get_outs(stage: "PipelineStage"):
             bucket_key += ["no_cache"]
         key = "_".join(bucket_key)
         outs_bucket[key] = outs_bucket.get(key, []) + [o.def_path]
-    return [(key, outs_bucket[key]) for key in outs_bucket.keys()]
+    return [(key, outs_bucket[key]) for key in sorted(outs_bucket.keys())]
 
 
 def get_params_deps(stage: "PipelineStage"):
@@ -79,7 +79,7 @@ def to_pipeline_file(stage: "PipelineStage"):
     res = [
         (stage.PARAM_CMD, stage.cmd),
         (stage.PARAM_WDIR, stage.resolve_wdir()),
-        (stage.PARAM_DEPS, [d.def_path for d in deps]),
+        (stage.PARAM_DEPS, sorted([d.def_path for d in deps])),
         (stage.PARAM_PARAMS, serialized_params),
         *_get_outs(stage),
         (stage.PARAM_LOCKED, stage.locked),

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -5,7 +5,7 @@ import signal
 import subprocess
 import threading
 
-from itertools import chain
+from itertools import chain, product
 
 from funcy import project
 
@@ -386,6 +386,15 @@ class Stage(params.StageParams):
         for out in outs:
             out.pop(LocalRemote.PARAM_CHECKSUM, None)
             out.pop(S3Remote.PARAM_CHECKSUM, None)
+
+        # outs and deps are lists of dicts. To check equality, we need to make
+        # them independent of the order, so, we convert them to dicts.
+        combination = product(
+            [old_d, new_d], [self.PARAM_DEPS, self.PARAM_OUTS]
+        )
+        for coll, key in combination:
+            if coll.get(key):
+                coll[key] = {item["path"]: item for item in coll[key]}
 
         if old_d != new_d:
             return False


### PR DESCRIPTION
On is_cached, we used to compare two dicts: one of current stage in memory
created by `run` and one that's already written to the file.
As `outs` and `dicts` are lists (which is generate by `dumpd`), the
comparison was dependent on the order of outs and deps.

So, the `run` before and now, can be in different order and would fail the comparisons.

Also, given that we can compare without order, we can make pipeline files sorted by outs and deps.

Plus, in the post-pipeline-file world, we don't even need `is_cached`. We could just throw
`DuplicateStage` or `OutputDuplicationError`. It's convenient of course, to be able to `dvc run`
same command many times but, I'm not sure if it's worth the hassle of having `is_cached` for just that.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
