### PR TITLE
cache: rename `.dvc/cache/run` to `.dvc/cache/runs`

### DIFF
--- a/dvc/stage/cache.py
+++ b/dvc/stage/cache.py
@@ -37,7 +37,7 @@ def _get_stage_hash(stage):
 
 class StageCache:
     def __init__(self, cache_dir):
-        self.cache_dir = os.path.join(cache_dir, "run")
+        self.cache_dir = os.path.join(cache_dir, "runs")
 
     def _get_cache_dir(self, key):
         return os.path.join(self.cache_dir, key[:2], key)

--- a/tests/func/test_repro.py
+++ b/tests/func/test_repro.py
@@ -1295,7 +1295,7 @@ class TestReproNoCommit(TestRepro):
             ["repro", self._get_stage_target(self.stage), "--no-commit"]
         )
         self.assertEqual(ret, 0)
-        self.assertEqual(os.listdir(self.dvc.cache.local.cache_dir), ["run"])
+        self.assertEqual(os.listdir(self.dvc.cache.local.cache_dir), ["runs"])
 
 
 class TestReproAlreadyCached(TestRepro):


### PR DESCRIPTION
To be consistent with how git does it (e.g. objects/branches/refs) as well as with
future cache structure where we plan on adding `dirs`/`files`/`objects`
subdirs in the future.

* [ ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [ ] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
