### PR TITLE
run: use multistage dvcfiles by default

### DIFF
--- a/dvc/command/run.py
+++ b/dvc/command/run.py
@@ -50,6 +50,7 @@ class CmdRun(CmdBase):
                 outs_persist_no_cache=self.args.outs_persist_no_cache,
                 always_changed=self.args.always_changed,
                 name=self.args.name,
+                single_stage=self.args.single_stage,
             )
         except DvcException:
             logger.exception("")
@@ -96,7 +97,9 @@ def add_parser(subparsers, parent_parser):
         help="Declare dependencies for reproducible cmd.",
         metavar="<path>",
     )
-    run_parser.add_argument("-n", "--name", help=argparse.SUPPRESS)
+    run_parser.add_argument(
+        "-n", "--name", help="Stage name.",
+    )
     run_parser.add_argument(
         "-o",
         "--outs",
@@ -197,6 +200,12 @@ def add_parser(subparsers, parent_parser):
         action="store_true",
         default=False,
         help="Always consider this DVC-file as changed.",
+    )
+    run_parser.add_argument(
+        "--single-stage",
+        action="store_true",
+        default=False,
+        help=argparse.SUPPRESS,
     )
     run_parser.add_argument(
         "command", nargs=argparse.REMAINDER, help="Command to execute."

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -264,7 +264,7 @@ def test_should_update_state_entry_for_file_after_add(mocker, dvc, tmp_dir):
     assert ret == 0
     assert file_md5_counter.mock.call_count == 1
 
-    ret = main(["run", "-d", "foo", "echo foo"])
+    ret = main(["run", "--single-stage", "-d", "foo", "echo foo"])
     assert ret == 0
     assert file_md5_counter.mock.call_count == 1
 
@@ -297,7 +297,9 @@ def test_should_update_state_entry_for_directory_after_add(
     assert file_md5_counter.mock.call_count == 3
 
     ls = "dir" if os.name == "nt" else "ls"
-    ret = main(["run", "-d", "data", "{} {}".format(ls, "data")])
+    ret = main(
+        ["run", "--single-stage", "-d", "data", "{} {}".format(ls, "data")]
+    )
     assert ret == 0
     assert file_md5_counter.mock.call_count == 3
 

--- a/tests/func/test_api.py
+++ b/tests/func/test_api.py
@@ -129,6 +129,7 @@ def test_open_not_cached(dvc):
         metric_file, metric_content
     )
     dvc.run(
+        single_stage=True,
         metrics_no_cache=[metric_file],
         cmd=('python -c "{}"'.format(metric_code)),
     )

--- a/tests/func/test_checkout.py
+++ b/tests/func/test_checkout.py
@@ -256,6 +256,7 @@ class TestGitIgnoreBasic(CheckoutBase):
         self.commit_data_file(fname1)
         self.commit_data_file(fname2)
         self.dvc.run(
+            single_stage=True,
             cmd="python {} {} {}".format(self.CODE, self.FOO, fname3),
             deps=[self.CODE, self.FOO],
             outs_no_cache=[fname3],
@@ -341,7 +342,10 @@ class TestCheckoutNotCachedFile(TestDvc):
 
         self.dvc.add(self.FOO)
         stage = self.dvc.run(
-            cmd=cmd, deps=[self.FOO, self.CODE], outs_no_cache=["out"]
+            cmd=cmd,
+            deps=[self.FOO, self.CODE],
+            outs_no_cache=["out"],
+            single_stage=True,
         )
         self.assertTrue(stage is not None)
 
@@ -480,7 +484,9 @@ class TestCheckoutMovedCacheDirWithSymlinks(TestDvc):
 
 def test_checkout_no_checksum(tmp_dir, dvc):
     tmp_dir.gen("file", "file content")
-    stage = dvc.run(outs=["file"], no_exec=True, cmd="somecmd")
+    stage = dvc.run(
+        outs=["file"], no_exec=True, cmd="somecmd", single_stage=True
+    )
 
     with pytest.raises(CheckoutError):
         dvc.checkout([stage.path], force=True)
@@ -706,7 +712,11 @@ def test_checkout_with_relink_existing(tmp_dir, dvc, link):
 def test_checkout_with_deps(tmp_dir, dvc):
     tmp_dir.dvc_gen({"foo": "foo"})
     dvc.run(
-        fname="copy_file.dvc", cmd="echo foo > bar", outs=["bar"], deps=["foo"]
+        fname="copy_file.dvc",
+        cmd="echo foo > bar",
+        outs=["bar"],
+        deps=["foo"],
+        single_stage=True,
     )
 
     (tmp_dir / "bar").unlink()

--- a/tests/func/test_commit.py
+++ b/tests/func/test_commit.py
@@ -38,7 +38,7 @@ def test_commit_force(tmp_dir, dvc):
     assert dvc.status([stage.path]) == {}
 
 
-@pytest.mark.parametrize("run_kw", [{}, {"name": "copy"}])
+@pytest.mark.parametrize("run_kw", [{"single_stage": True}, {"name": "copy"}])
 def test_commit_with_deps(tmp_dir, dvc, run_copy, run_kw):
     tmp_dir.gen("foo", "foo")
     (foo_stage,) = dvc.add("foo", no_commit=True)

--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -520,7 +520,9 @@ class TestWarnOnOutdatedStage(TestDvc):
         url = Local.get_url()
         self.main(["remote", "add", "-d", TEST_REMOTE, url])
 
-        stage = self.dvc.run(outs=["bar"], cmd="echo bar > bar")
+        stage = self.dvc.run(
+            outs=["bar"], cmd="echo bar > bar", single_stage=True
+        )
         self.main(["push"])
 
         stage_file_path = stage.relpath
@@ -630,7 +632,7 @@ def test_checksum_recalculation(mocker, dvc, tmp_dir):
     assert ret == 0
     ret = main(["push"])
     assert ret == 0
-    ret = main(["run", "-d", "foo", "echo foo"])
+    ret = main(["run", "--single-stage", "-d", "foo", "echo foo"])
     assert ret == 0
     assert test_get_file_checksum.mock.call_count == 1
 
@@ -783,7 +785,7 @@ def recurse_list_dir(d):
 
 def test_dvc_pull_pipeline_stages(tmp_dir, dvc, local_remote, run_copy):
     (stage0,) = tmp_dir.dvc_gen("foo", "foo")
-    stage1 = run_copy("foo", "bar")
+    stage1 = run_copy("foo", "bar", single_stage=True)
     stage2 = run_copy("bar", "foobar", name="copy-bar-foobar")
     outs = ["foo", "bar", "foobar"]
 
@@ -813,7 +815,7 @@ def test_dvc_pull_pipeline_stages(tmp_dir, dvc, local_remote, run_copy):
 
 def test_pipeline_file_target_ops(tmp_dir, dvc, local_remote, run_copy):
     tmp_dir.dvc_gen("foo", "foo")
-    run_copy("foo", "bar")
+    run_copy("foo", "bar", single_stage=True)
 
     tmp_dir.dvc_gen("lorem", "lorem")
     run_copy("lorem", "lorem2", name="copy-lorem-lorem2")

--- a/tests/func/test_dvcfile.py
+++ b/tests/func/test_dvcfile.py
@@ -50,7 +50,11 @@ def test_run_load_one_for_multistage_non_existing_stage_name(tmp_dir, dvc):
 def test_run_load_one_on_single_stage(tmp_dir, dvc):
     tmp_dir.gen("foo", "foo")
     stage = dvc.run(
-        cmd="cp foo foo2", deps=["foo"], metrics=["foo2"], always_changed=True,
+        cmd="cp foo foo2",
+        deps=["foo"],
+        metrics=["foo2"],
+        always_changed=True,
+        single_stage=True,
     )
     assert Dvcfile(dvc, stage.path).stages.get("random-name")
     assert Dvcfile(dvc, stage.path).stage
@@ -97,7 +101,11 @@ def test_load_all_multistage(tmp_dir, dvc):
 def test_load_all_singlestage(tmp_dir, dvc):
     tmp_dir.gen("foo", "foo")
     stage1 = dvc.run(
-        cmd="cp foo foo2", deps=["foo"], metrics=["foo2"], always_changed=True,
+        cmd="cp foo foo2",
+        deps=["foo"],
+        metrics=["foo2"],
+        always_changed=True,
+        single_stage=True,
     )
     stages = Dvcfile(dvc, "foo2.dvc").stages.values()
     assert len(stages) == 1
@@ -107,7 +115,11 @@ def test_load_all_singlestage(tmp_dir, dvc):
 def test_load_singlestage(tmp_dir, dvc):
     tmp_dir.gen("foo", "foo")
     stage1 = dvc.run(
-        cmd="cp foo foo2", deps=["foo"], metrics=["foo2"], always_changed=True,
+        cmd="cp foo foo2",
+        deps=["foo"],
+        metrics=["foo2"],
+        always_changed=True,
+        single_stage=True,
     )
     assert Dvcfile(dvc, "foo2.dvc").stage == stage1
 
@@ -144,7 +156,11 @@ def test_stage_collection(tmp_dir, dvc):
         always_changed=True,
     )
     stage3 = dvc.run(
-        cmd="cp bar bar2", deps=["bar"], metrics=["bar2"], always_changed=True,
+        cmd="cp bar bar2",
+        deps=["bar"],
+        metrics=["bar2"],
+        always_changed=True,
+        single_stage=True,
     )
     assert {s for s in dvc.stages} == {stage1, stage3, stage2}
 
@@ -174,7 +190,7 @@ def test_stage_filter(tmp_dir, dvc, run_copy):
 
 def test_stage_filter_in_singlestage_file(tmp_dir, dvc, run_copy):
     tmp_dir.gen("foo", "foo")
-    stage = run_copy("foo", "bar")
+    stage = run_copy("foo", "bar", single_stage=True)
     dvcfile = Dvcfile(dvc, stage.path)
     assert set(dvcfile.stages.filter(None).values()) == {stage}
     assert dvcfile.stages.filter(None).get(None) == stage

--- a/tests/func/test_repro_multistage.py
+++ b/tests/func/test_repro_multistage.py
@@ -223,16 +223,33 @@ def test_downstream(tmp_dir, dvc):
     #
     assert main(["run", "-n", "A-gen", "-o", "A", "echo A>A"]) == 0
     assert main(["run", "-n", "B-gen", "-d", "A", "-o", "B", "echo B>B"]) == 0
-    assert main(["run", "-d", "A", "-o", "C", "echo C>C"]) == 0
+    assert (
+        main(["run", "--single-stage", "-d", "A", "-o", "C", "echo C>C"]) == 0
+    )
     assert (
         main(
             ["run", "-n", "D-gen", "-d", "B", "-d", "C", "-o", "D", "echo D>D"]
         )
         == 0
     )
-    assert main(["run", "-o", "G", "echo G>G"]) == 0
+    assert main(["run", "--single-stage", "-o", "G", "echo G>G"]) == 0
     assert main(["run", "-n", "F-gen", "-d", "G", "-o", "F", "echo F>F"]) == 0
-    assert main(["run", "-d", "D", "-d", "F", "-o", "E", "echo E>E"]) == 0
+    assert (
+        main(
+            [
+                "run",
+                "--single-stage",
+                "-d",
+                "D",
+                "-d",
+                "F",
+                "-o",
+                "E",
+                "echo E>E",
+            ]
+        )
+        == 0
+    )
 
     # We want the evaluation to move from B to E
     #

--- a/tests/func/test_run_multistage.py
+++ b/tests/func/test_run_multistage.py
@@ -23,9 +23,9 @@ def test_run_with_multistage_and_single_stage(tmp_dir, dvc, run_copy):
     from dvc.stage import PipelineStage, Stage
 
     tmp_dir.dvc_gen("foo", "foo")
-    stage1 = run_copy("foo", "foo1")
+    stage1 = run_copy("foo", "foo1", single_stage=True)
     stage2 = run_copy("foo1", "foo2", name="copy-foo1-foo2")
-    stage3 = run_copy("foo2", "foo3")
+    stage3 = run_copy("foo2", "foo3", single_stage=True)
 
     assert isinstance(stage2, PipelineStage)
     assert isinstance(stage1, Stage)
@@ -40,7 +40,7 @@ def test_run_multi_stage_repeat(tmp_dir, dvc, run_copy):
     tmp_dir.dvc_gen("foo", "foo")
     run_copy("foo", "foo1", name="copy-foo-foo1")
     run_copy("foo1", "foo2", name="copy-foo1-foo2")
-    run_copy("foo2", "foo3")
+    run_copy("foo2", "foo3", single_stage=True)
 
     stages = list(Dvcfile(dvc, PIPELINE_FILE).stages.values())
     assert len(stages) == 2


### PR DESCRIPTION
Adding hidden `--single-stage` to simplify the test migration.

* [ ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [ ] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
