### PR TITLE
repro: use dvc.yaml by default

### DIFF
--- a/dvc/command/base.py
+++ b/dvc/command/base.py
@@ -41,12 +41,12 @@ class CmdBase(object):
 
     @property
     def default_targets(self):
-        """Default targets for `dvc repro` and `dvc pipeline`."""
-        from dvc.dvcfile import DVC_FILE
+        """Default targets for `dvc repro`."""
+        from dvc.dvcfile import PIPELINE_FILE
 
-        msg = "assuming default target '{}'.".format(DVC_FILE)
+        msg = "assuming default target '{}'.".format(PIPELINE_FILE)
         logger.warning(msg)
-        return [DVC_FILE]
+        return [PIPELINE_FILE]
 
     # Abstract methods that have to be implemented by any inheritance class
     def run(self):

--- a/dvc/command/pipeline.py
+++ b/dvc/command/pipeline.py
@@ -119,8 +119,10 @@ class CmdPipelineShow(CmdBase):
         logger.info(dot_file.getvalue())
 
     def run(self):
+        from dvc.dvcfile import DVC_FILE
+
         if not self.args.targets:
-            self.args.targets = self.default_targets
+            self.args.targets = [DVC_FILE]
 
         for target in self.args.targets:
             try:

--- a/tests/func/test_repro.py
+++ b/tests/func/test_repro.py
@@ -28,7 +28,7 @@ from dvc.path_info import URLInfo
 from dvc.remote.local import LocalRemote
 from dvc.repo import Repo as DvcRepo
 from dvc.stage import Stage
-from dvc.dvcfile import Dvcfile
+from dvc.dvcfile import Dvcfile, DVC_FILE
 from dvc.stage.exceptions import StageFileDoesNotExistError
 from dvc.system import System
 from dvc.utils import file_md5
@@ -407,11 +407,11 @@ class TestReproDryNoExec(TestDvc):
             self.assertEqual(ret, 0)
 
         ret = main(
-            ["run", "--no-exec", "--single-stage", "-f", "Dvcfile"] + deps
+            ["run", "--no-exec", "--single-stage", "-f", DVC_FILE] + deps
         )
         self.assertEqual(ret, 0)
 
-        ret = main(["repro", "--dry"])
+        ret = main(["repro", "--dry", DVC_FILE])
         self.assertEqual(ret, 0)
 
 
@@ -820,7 +820,7 @@ class TestCmdReproChdir(TestDvc):
 
         os.unlink(bar)
 
-        ret = main(["repro", "-c", dname])
+        ret = main(["repro", "-c", dname, DVC_FILE])
         self.assertEqual(ret, 0)
         self.assertTrue(os.path.isfile(foo))
         self.assertTrue(os.path.isfile(bar))
@@ -1458,7 +1458,7 @@ def repro_dir(tmp_dir, dvc, run_copy):
     assert dir_file_copy.read_text() == "dir file content"
     stages["dir_file_copy"] = stage
 
-    last_stage = tmp_dir / "dir" / "Dvcfile"
+    last_stage = tmp_dir / "dir" / DVC_FILE
     stage = dvc.run(
         fname=fspath(last_stage),
         deps=[fspath(origin_copy_2), fspath(dir_file_copy)],

--- a/tests/unit/command/test_repro.py
+++ b/tests/unit/command/test_repro.py
@@ -1,5 +1,6 @@
 from dvc.cli import parse_args
 from dvc.command.repro import CmdRepro
+from dvc.dvcfile import PIPELINE_FILE
 
 default_arguments = {
     "all_pipelines": False,
@@ -19,7 +20,7 @@ def test_default_arguments(dvc, mocker):
     cmd = CmdRepro(parse_args(["repro"]))
     mocker.patch.object(cmd.repo, "reproduce")
     cmd.run()
-    cmd.repo.reproduce.assert_called_with("Dvcfile", **default_arguments)
+    cmd.repo.reproduce.assert_called_with(PIPELINE_FILE, **default_arguments)
 
 
 def test_downstream(dvc, mocker):
@@ -28,4 +29,4 @@ def test_downstream(dvc, mocker):
     cmd.run()
     arguments = default_arguments.copy()
     arguments.update({"downstream": True})
-    cmd.repo.reproduce.assert_called_with("Dvcfile", **arguments)
+    cmd.repo.reproduce.assert_called_with(PIPELINE_FILE, **arguments)


### PR DESCRIPTION
Note: This does not change default for `pipeline` as
it cannot show multiple DAGs at the same time. If we
are able to show multiple DAGs, we can just default to
`dvc.yaml`.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

https://github.com/iterative/dvc.org/issues/1173

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
