### PR TITLE
tests: abstract remote setup to fixture

### DIFF
--- a/tests/func/test_api.py
+++ b/tests/func/test_api.py
@@ -36,8 +36,8 @@ def test_get_url(tmp_dir, dvc, remote_url):
 
 
 @pytest.mark.parametrize("remote_url", remote_params, indirect=True)
-def test_get_url_external(erepo_dir, remote_url):
-    _set_remote_url_and_commit(erepo_dir.dvc, remote_url)
+def test_get_url_external(erepo_dir, remote_url, setup_remote):
+    setup_remote(erepo_dir.dvc, url=remote_url)
     with erepo_dir.chdir():
         erepo_dir.dvc_gen("foo", "foo", commit="add foo")
 
@@ -71,8 +71,8 @@ def test_open(remote_url, tmp_dir, dvc):
 
 
 @pytest.mark.parametrize("remote_url", all_remote_params, indirect=True)
-def test_open_external(remote_url, erepo_dir):
-    _set_remote_url_and_commit(erepo_dir.dvc, remote_url)
+def test_open_external(remote_url, erepo_dir, setup_remote):
+    setup_remote(erepo_dir.dvc, url=remote_url)
 
     with erepo_dir.chdir():
         erepo_dir.dvc_gen("version", "master", commit="add version")
@@ -104,13 +104,6 @@ def test_missing(remote_url, tmp_dir, dvc):
 
     with pytest.raises(FileMissingError):
         api.read("foo")
-
-
-def _set_remote_url_and_commit(repo, remote_url):
-    with repo.config.edit() as conf:
-        conf["remote"]["upstream"]["url"] = remote_url
-    repo.scm.add([repo.config.files["repo"]])
-    repo.scm.commit("modify remote")
 
 
 def test_open_scm_controlled(tmp_dir, erepo_dir):

--- a/tests/func/test_gc.py
+++ b/tests/func/test_gc.py
@@ -238,18 +238,18 @@ def test_gc_without_workspace_raises_error(tmp_dir, dvc):
         dvc.gc(force=True, workspace=False)
 
 
-def test_gc_cloud_with_or_without_specifier(tmp_dir, erepo_dir):
+def test_gc_cloud_with_or_without_specifier(tmp_dir, erepo_dir, setup_remote):
     dvc = erepo_dir.dvc
-    with erepo_dir.chdir():
-        from dvc.exceptions import InvalidArgumentError
+    setup_remote(dvc)
+    from dvc.exceptions import InvalidArgumentError
 
-        with pytest.raises(InvalidArgumentError):
-            dvc.gc(force=True, cloud=True)
+    with pytest.raises(InvalidArgumentError):
+        dvc.gc(force=True, cloud=True)
 
-        dvc.gc(cloud=True, all_tags=True)
-        dvc.gc(cloud=True, all_commits=True)
-        dvc.gc(cloud=True, all_branches=True)
-        dvc.gc(cloud=True, all_commits=False, all_branches=True, all_tags=True)
+    dvc.gc(cloud=True, all_tags=True)
+    dvc.gc(cloud=True, all_commits=True)
+    dvc.gc(cloud=True, all_branches=True)
+    dvc.gc(cloud=True, all_commits=False, all_branches=True, all_tags=True)
 
 
 def test_gc_without_workspace_on_tags_branches_commits(tmp_dir, dvc):
@@ -295,13 +295,8 @@ def test_gc_with_possible_args_positive(tmp_dir, dvc):
         assert main(["gc", "-vf", flag]) == 0
 
 
-def test_gc_cloud_positive(tmp_dir, dvc, tmp_path_factory):
-    with dvc.config.edit() as conf:
-        storage = fspath(tmp_path_factory.mktemp("test_remote_base"))
-        conf["remote"]["local_remote"] = {"url": storage}
-        conf["core"]["remote"] = "local_remote"
-
-    dvc.push()
+def test_gc_cloud_positive(tmp_dir, dvc, tmp_path_factory, setup_remote):
+    setup_remote(dvc)
 
     for flag in ["-cw", "-ca", "-cT", "-caT", "-cwT"]:
         assert main(["gc", "-vf", flag]) == 0

--- a/tests/func/test_remote.py
+++ b/tests/func/test_remote.py
@@ -173,10 +173,8 @@ def test_dir_checksum_should_be_key_order_agnostic(tmp_dir, dvc):
     assert checksum1 == checksum2
 
 
-def test_partial_push_n_pull(tmp_dir, dvc, tmp_path_factory):
-    url = fspath(tmp_path_factory.mktemp("upstream"))
-    dvc.config["remote"]["upstream"] = {"url": url}
-    dvc.config["core"]["remote"] = "upstream"
+def test_partial_push_n_pull(tmp_dir, dvc, tmp_path_factory, setup_remote):
+    setup_remote(dvc, name="upstream")
 
     foo = tmp_dir.dvc_gen({"foo": "foo content"})[0].outs[0]
     bar = tmp_dir.dvc_gen({"bar": "bar content"})[0].outs[0]
@@ -212,11 +210,10 @@ def test_partial_push_n_pull(tmp_dir, dvc, tmp_path_factory):
         assert download_error_info.value.amount == 3
 
 
-def test_raise_on_too_many_open_files(tmp_dir, dvc, tmp_path_factory, mocker):
-    storage = fspath(tmp_path_factory.mktemp("test_remote_base"))
-    dvc.config["remote"]["local_remote"] = {"url": storage}
-    dvc.config["core"]["remote"] = "local_remote"
-
+def test_raise_on_too_many_open_files(
+    tmp_dir, dvc, tmp_path_factory, mocker, setup_remote
+):
+    setup_remote(dvc)
     tmp_dir.dvc_gen({"file": "file content"})
 
     mocker.patch.object(
@@ -245,11 +242,8 @@ def test_external_dir_resource_on_no_cache(tmp_dir, dvc, tmp_path_factory):
         dvc.run(deps=[fspath(external_dir)], single_stage=True)
 
 
-def test_push_order(tmp_dir, dvc, tmp_path_factory, mocker):
-    url = fspath(tmp_path_factory.mktemp("upstream"))
-    dvc.config["remote"]["upstream"] = {"url": url}
-    dvc.config["core"]["remote"] = "upstream"
-
+def test_push_order(tmp_dir, dvc, tmp_path_factory, mocker, setup_remote):
+    setup_remote(dvc)
     tmp_dir.dvc_gen({"foo": {"bar": "bar content"}})
     tmp_dir.dvc_gen({"baz": "baz content"})
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
Fixes #2888, related to #3416 

The problem:
In #3416 I could reproduce user problems in script, but it seemed that I am unable to write a test for it. 
The problem turned out to be related to the fact that `erepo_dir` has been setting its default remote to be its cache. Due to that, I have been indirectly using cache "read only mode" optimization, while using remote. Because it is the second time i stumble upon this issue (#2888) I decided to fix it.
This issue introduces "setup_remote" fixture, which is intended to be default way to set up the remote for particular `Repo` instance.