### PR TITLE
lint: isort pre-commit & misc improvements

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,0 @@
-[flake8]
-ignore =
-    E203, # Whitespace before ':'
-    E266, # Too many leading '#' for block comment
-    W503, # Line break occurred before a binary operator
-max-line-length = 79
-select = B,C,E,F,W,T4,B9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,11 @@ repos:
   repo: https://github.com/ambv/black
   rev: 19.10b0
 - hooks:
+  - id: isort
+    language_version: python3
+  repo: https://github.com/timothycrosley/isort
+  rev: 4.3.21
+- hooks:
   - id: flake8
     language_version: python3
   repo: https://gitlab.com/pycqa/flake8

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -9,3 +9,12 @@ restylers:
     - "**/*.py"
     interpreters:
     - python
+  - name: isort
+    image: restyled/restyler-isort:v4.3.21
+    command:
+    - isort
+    arguments: []
+    include:
+    - "**/*.py"
+    interpreters:
+    - python

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ env:
     - PATH="$PYENV_ROOT/bin:$PATH"
     - PIP_CACHE_DIR="$HOME/.cache/pip"  # unify pip cache location for all platforms
 stages:
+  - check
   - test
   - build
-  - check
 # Travis doesn't support testing python on Mac yet, so we need
 # to workaround it by installing it directly with brew.
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ env:
     - PATH="$PYENV_ROOT/bin:$PATH"
     - PIP_CACHE_DIR="$HOME/.cache/pip"  # unify pip cache location for all platforms
 stages:
-  - check
   - test
   - build
+  - check
 # Travis doesn't support testing python on Mac yet, so we need
 # to workaround it by installing it directly with brew.
 #

--- a/dvc/__init__.py
+++ b/dvc/__init__.py
@@ -6,5 +6,4 @@ Make your data science projects reproducible and shareable.
 import dvc.logger
 from dvc.version import __version__  # noqa: F401
 
-
 dvc.logger.setup()

--- a/dvc/analytics.py
+++ b/dvc/analytics.py
@@ -2,12 +2,12 @@ import json
 import logging
 import os
 import platform
-import requests
 import sys
 import tempfile
 import uuid
 
 import distro
+import requests
 
 from dvc import __version__
 from dvc.config import Config, to_bool
@@ -19,7 +19,6 @@ from dvc.scm import SCM, NoSCM
 from dvc.scm.base import SCMError
 from dvc.utils import env2bool, is_binary
 from dvc.utils.fs import makedirs
-
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/api.py
+++ b/dvc/api.py
@@ -1,9 +1,10 @@
 import os
-from contextlib import contextmanager, _GeneratorContextManager as GCM
+from contextlib import _GeneratorContextManager as GCM
+from contextlib import contextmanager
 
-from dvc.repo import Repo
 from dvc.exceptions import DvcException, NotDvcRepoError
 from dvc.external_repo import external_repo
+from dvc.repo import Repo
 
 
 class UrlNotDvcRepoError(DvcException):

--- a/dvc/cli.py
+++ b/dvc/cli.py
@@ -16,16 +16,18 @@ from .command import (
     gc,
     get,
     get_url,
+    git_hook,
     imp,
     imp_url,
     init,
     install,
-    ls,
     lock,
+    ls,
     metrics,
-    params,
     move,
+    params,
     pipeline,
+    plot,
     remote,
     remove,
     repro,
@@ -34,12 +36,9 @@ from .command import (
     unprotect,
     update,
     version,
-    git_hook,
-    plot,
 )
 from .command.base import fix_subparsers
 from .exceptions import DvcParserError
-
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/command/add.py
+++ b/dvc/command/add.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 
-from dvc.command.base import append_doc_link, CmdBase
+from dvc.command.base import CmdBase, append_doc_link
 from dvc.exceptions import DvcException, RecursiveAddingWhileUsingFilename
 
 logger = logging.getLogger(__name__)

--- a/dvc/command/base.py
+++ b/dvc/command/base.py
@@ -1,6 +1,5 @@
 import logging
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/dvc/command/checkout.py
+++ b/dvc/command/checkout.py
@@ -4,8 +4,7 @@ import operator
 
 import colorama
 
-from dvc.command.base import append_doc_link
-from dvc.command.base import CmdBase
+from dvc.command.base import CmdBase, append_doc_link
 from dvc.exceptions import CheckoutError
 from dvc.utils.humanize import get_summary
 

--- a/dvc/command/commit.py
+++ b/dvc/command/commit.py
@@ -1,10 +1,8 @@
 import argparse
 import logging
 
-from dvc.command.base import append_doc_link
-from dvc.command.base import CmdBase
+from dvc.command.base import CmdBase, append_doc_link
 from dvc.exceptions import DvcException
-
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/command/config.py
+++ b/dvc/command/config.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 
-from dvc.command.base import append_doc_link, CmdBaseNoRepo
+from dvc.command.base import CmdBaseNoRepo, append_doc_link
 from dvc.config import Config, ConfigError
 
 logger = logging.getLogger(__name__)

--- a/dvc/command/daemon.py
+++ b/dvc/command/daemon.py
@@ -1,5 +1,4 @@
-from dvc.command.base import CmdBaseNoRepo
-from dvc.command.base import fix_subparsers
+from dvc.command.base import CmdBaseNoRepo, fix_subparsers
 
 
 class CmdDaemonBase(CmdBaseNoRepo):

--- a/dvc/command/data_sync.py
+++ b/dvc/command/data_sync.py
@@ -1,12 +1,10 @@
 import argparse
 import logging
 
-from dvc.command.base import append_doc_link
-from dvc.command.base import CmdBase
+from dvc.command.base import CmdBase, append_doc_link
 from dvc.command.checkout import log_changes
+from dvc.exceptions import CheckoutError, DvcException
 from dvc.utils.humanize import get_summary
-from dvc.exceptions import DvcException, CheckoutError
-
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/command/data_sync.py
+++ b/dvc/command/data_sync.py
@@ -86,24 +86,24 @@ def shared_parent_parser():
     from dvc.cli import get_parent_parser
 
     # Parent parser used in pull/push/status
-    shared_parent_parser = argparse.ArgumentParser(
+    parent_parser = argparse.ArgumentParser(
         add_help=False, parents=[get_parent_parser()]
     )
-    shared_parent_parser.add_argument(
+    parent_parser.add_argument(
         "-j",
         "--jobs",
         type=int,
         help="Number of jobs to run simultaneously.",
         metavar="<number>",
     )
-    shared_parent_parser.add_argument(
+    parent_parser.add_argument(
         "targets",
         nargs="*",
         help="Limit command scope to these DVC-files. "
         "Using -R, directories to search DVC-files in can also be given.",
     )
 
-    return shared_parent_parser
+    return parent_parser
 
 
 def add_parser(subparsers, _parent_parser):

--- a/dvc/command/destroy.py
+++ b/dvc/command/destroy.py
@@ -2,10 +2,8 @@ import argparse
 import logging
 
 import dvc.prompt as prompt
-from dvc.command.base import append_doc_link
-from dvc.command.base import CmdBase
+from dvc.command.base import CmdBase, append_doc_link
 from dvc.exceptions import DvcException
-
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/command/diff.py
+++ b/dvc/command/diff.py
@@ -8,7 +8,6 @@ import colorama
 from dvc.command.base import CmdBase, append_doc_link
 from dvc.exceptions import DvcException
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/dvc/command/gc.py
+++ b/dvc/command/gc.py
@@ -3,9 +3,7 @@ import logging
 import os
 
 import dvc.prompt as prompt
-from dvc.command.base import append_doc_link
-from dvc.command.base import CmdBase
-
+from dvc.command.base import CmdBase, append_doc_link
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/command/get.py
+++ b/dvc/command/get.py
@@ -1,10 +1,9 @@
 import argparse
 import logging
 
-from .base import append_doc_link
-from .base import CmdBaseNoRepo
 from dvc.exceptions import DvcException
 
+from .base import CmdBaseNoRepo, append_doc_link
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/command/get_url.py
+++ b/dvc/command/get_url.py
@@ -1,10 +1,9 @@
 import argparse
 import logging
 
-from .base import append_doc_link
-from .base import CmdBaseNoRepo
 from dvc.exceptions import DvcException
 
+from .base import CmdBaseNoRepo, append_doc_link
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/command/imp.py
+++ b/dvc/command/imp.py
@@ -1,10 +1,8 @@
 import argparse
 import logging
 
-from dvc.command.base import append_doc_link
-from dvc.command.base import CmdBase
+from dvc.command.base import CmdBase, append_doc_link
 from dvc.exceptions import DvcException
-
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/command/imp_url.py
+++ b/dvc/command/imp_url.py
@@ -1,10 +1,8 @@
 import argparse
 import logging
 
-from dvc.command.base import append_doc_link
-from dvc.command.base import CmdBase
+from dvc.command.base import CmdBase, append_doc_link
 from dvc.exceptions import DvcException
-
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/command/init.py
+++ b/dvc/command/init.py
@@ -1,9 +1,7 @@
 import argparse
 import logging
 
-from dvc.command.base import append_doc_link
-from dvc.command.base import CmdBaseNoRepo
-
+from dvc.command.base import CmdBaseNoRepo, append_doc_link
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/command/install.py
+++ b/dvc/command/install.py
@@ -1,9 +1,7 @@
 import argparse
 import logging
 
-from dvc.command.base import append_doc_link
-from dvc.command.base import CmdBase
-
+from dvc.command.base import CmdBase, append_doc_link
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/command/lock.py
+++ b/dvc/command/lock.py
@@ -1,10 +1,8 @@
 import argparse
 import logging
 
-from dvc.command.base import append_doc_link
-from dvc.command.base import CmdBase
+from dvc.command.base import CmdBase, append_doc_link
 from dvc.exceptions import DvcException
-
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/command/ls/__init__.py
+++ b/dvc/command/ls/__init__.py
@@ -2,11 +2,9 @@ import argparse
 import logging
 import sys
 
-from dvc.command.base import append_doc_link
-from dvc.command.base import CmdBaseNoRepo
+from dvc.command.base import CmdBaseNoRepo, append_doc_link
 from dvc.command.ls.ls_colors import LsColors
 from dvc.exceptions import DvcException
-
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/command/metrics.py
+++ b/dvc/command/metrics.py
@@ -1,12 +1,8 @@
 import argparse
 import logging
 
-from dvc.command.base import append_doc_link
-from dvc.command.base import CmdBase
-from dvc.command.base import fix_subparsers
-from dvc.exceptions import BadMetricError
-from dvc.exceptions import DvcException
-
+from dvc.command.base import CmdBase, append_doc_link, fix_subparsers
+from dvc.exceptions import BadMetricError, DvcException
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/command/move.py
+++ b/dvc/command/move.py
@@ -1,10 +1,8 @@
 import argparse
 import logging
 
-from dvc.command.base import append_doc_link
-from dvc.command.base import CmdBase
+from dvc.command.base import CmdBase, append_doc_link
 from dvc.exceptions import DvcException
-
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/command/params.py
+++ b/dvc/command/params.py
@@ -1,13 +1,9 @@
 import argparse
 import logging
-
 from collections import OrderedDict
 
-from dvc.command.base import append_doc_link
-from dvc.command.base import CmdBase
-from dvc.command.base import fix_subparsers
+from dvc.command.base import CmdBase, append_doc_link, fix_subparsers
 from dvc.exceptions import DvcException
-
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/command/pipeline.py
+++ b/dvc/command/pipeline.py
@@ -4,7 +4,6 @@ import logging
 from dvc.command.base import CmdBase, append_doc_link, fix_subparsers
 from dvc.exceptions import DvcException
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/dvc/command/plot.py
+++ b/dvc/command/plot.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 import os
 
-from dvc.command.base import append_doc_link, CmdBase, fix_subparsers
+from dvc.command.base import CmdBase, append_doc_link, fix_subparsers
 from dvc.exceptions import DvcException
 from dvc.repo.plot.data import WORKSPACE_REVISION_NAME
 

--- a/dvc/command/remote.py
+++ b/dvc/command/remote.py
@@ -1,9 +1,9 @@
 import argparse
 import logging
 
-from dvc.config import ConfigError
 from dvc.command.base import append_doc_link, fix_subparsers
 from dvc.command.config import CmdConfig
+from dvc.config import ConfigError
 from dvc.utils import format_link
 
 logger = logging.getLogger(__name__)

--- a/dvc/command/remove.py
+++ b/dvc/command/remove.py
@@ -2,10 +2,8 @@ import argparse
 import logging
 
 import dvc.prompt as prompt
-from dvc.command.base import append_doc_link
-from dvc.command.base import CmdBase
+from dvc.command.base import CmdBase, append_doc_link
 from dvc.exceptions import DvcException
-
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -2,12 +2,10 @@ import argparse
 import logging
 import os
 
-from dvc.command.base import append_doc_link
-from dvc.command.base import CmdBase
+from dvc.command.base import CmdBase, append_doc_link
 from dvc.command.metrics import show_metrics
 from dvc.command.status import CmdDataStatus
 from dvc.exceptions import DvcException
-
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/command/root.py
+++ b/dvc/command/root.py
@@ -1,8 +1,7 @@
 import argparse
 import logging
 
-from dvc.command.base import append_doc_link
-from dvc.command.base import CmdBaseNoRepo
+from dvc.command.base import CmdBaseNoRepo, append_doc_link
 from dvc.utils import relpath
 
 logger = logging.getLogger(__name__)

--- a/dvc/command/run.py
+++ b/dvc/command/run.py
@@ -1,10 +1,8 @@
 import argparse
 import logging
 
-from dvc.command.base import append_doc_link
-from dvc.command.base import CmdBase
+from dvc.command.base import CmdBase, append_doc_link
 from dvc.exceptions import DvcException
-
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/command/status.py
+++ b/dvc/command/status.py
@@ -2,7 +2,6 @@ import logging
 
 from dvc.command.data_sync import CmdDataBase
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/dvc/command/unprotect.py
+++ b/dvc/command/unprotect.py
@@ -1,10 +1,8 @@
 import argparse
 import logging
 
-from dvc.command.base import append_doc_link
-from dvc.command.base import CmdBase
+from dvc.command.base import CmdBase, append_doc_link
 from dvc.exceptions import DvcException
-
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/command/update.py
+++ b/dvc/command/update.py
@@ -1,10 +1,8 @@
 import argparse
 import logging
 
-from dvc.command.base import append_doc_link
-from dvc.command.base import CmdBase
+from dvc.command.base import CmdBase, append_doc_link
 from dvc.exceptions import DvcException
-
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/command/version.py
+++ b/dvc/command/version.py
@@ -2,22 +2,23 @@ import argparse
 import itertools
 import logging
 import os
+import pathlib
 import platform
 import uuid
-import pathlib
+
+from dvc.command.base import CmdBaseNoRepo, append_doc_link
+from dvc.exceptions import DvcException, NotDvcRepoError
+from dvc.scm.base import SCMError
+from dvc.system import System
+from dvc.utils import is_binary, relpath
+from dvc.utils.pkg import PKG
+from dvc.version import __version__
 
 try:
     import psutil
 except ImportError:
     psutil = None
 
-from dvc.utils import is_binary, relpath
-from dvc.command.base import CmdBaseNoRepo, append_doc_link
-from dvc.version import __version__
-from dvc.exceptions import DvcException, NotDvcRepoError
-from dvc.scm.base import SCMError
-from dvc.system import System
-from dvc.utils.pkg import PKG
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/daemon.py
+++ b/dvc/daemon.py
@@ -7,9 +7,7 @@ import sys
 from subprocess import Popen
 
 from dvc.env import DVC_DAEMON
-from dvc.utils import fix_env
-from dvc.utils import is_binary
-
+from dvc.utils import fix_env, is_binary
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/dagascii.py
+++ b/dvc/dagascii.py
@@ -6,12 +6,9 @@ import os
 import pydoc
 import sys
 
-from grandalf.graphs import Edge
-from grandalf.graphs import Graph
-from grandalf.graphs import Vertex
+from grandalf.graphs import Edge, Graph, Vertex
 from grandalf.layouts import SugiyamaLayout
-from grandalf.routing import EdgeViewer
-from grandalf.routing import route_with_lines
+from grandalf.routing import EdgeViewer, route_with_lines
 
 from dvc.env import DVC_PAGER
 from dvc.utils import format_link

--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -5,7 +5,6 @@ import logging
 from dvc.config import NoRemoteError
 from dvc.remote import Remote
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/dvc/dependency/__init__.py
+++ b/dvc/dependency/__init__.py
@@ -1,5 +1,5 @@
-from urllib.parse import urlparse
 from collections import defaultdict
+from urllib.parse import urlparse
 
 import dvc.output as output
 from dvc.dependency.gs import GSDependency
@@ -7,14 +7,14 @@ from dvc.dependency.hdfs import HDFSDependency
 from dvc.dependency.http import HTTPDependency
 from dvc.dependency.https import HTTPSDependency
 from dvc.dependency.local import LocalDependency
+from dvc.dependency.param import ParamsDependency
 from dvc.dependency.s3 import S3Dependency
 from dvc.dependency.ssh import SSHDependency
-from dvc.dependency.param import ParamsDependency
 from dvc.output.base import BaseOutput
 from dvc.remote import Remote
 from dvc.scheme import Schemes
-from .repo import RepoDependency
 
+from .repo import RepoDependency
 
 DEPS = [
     GSDependency,

--- a/dvc/dependency/https.py
+++ b/dvc/dependency/https.py
@@ -1,5 +1,6 @@
-from .http import HTTPDependency
 from dvc.remote.https import HTTPSRemote
+
+from .http import HTTPDependency
 
 
 class HTTPSDependency(HTTPDependency):

--- a/dvc/dependency/param.py
+++ b/dvc/dependency/param.py
@@ -1,8 +1,8 @@
 import os
-import yaml
 from collections import defaultdict
 
 import dpath.util
+import yaml
 from voluptuous import Any
 
 from dvc.compat import fspath_py35

--- a/dvc/dependency/repo.py
+++ b/dvc/dependency/repo.py
@@ -2,9 +2,10 @@ import os
 
 from voluptuous import Required
 
-from .local import LocalDependency
 from dvc.exceptions import OutputNotFoundError
 from dvc.path_info import PathInfo
+
+from .local import LocalDependency
 
 
 class RepoDependency(LocalDependency):

--- a/dvc/dvcfile.py
+++ b/dvc/dvcfile.py
@@ -1,20 +1,20 @@
 import contextlib
-import os
 import logging
-
-import dvc.prompt as prompt
+import os
 
 from voluptuous import MultipleInvalid
+
+import dvc.prompt as prompt
 from dvc import serialize
 from dvc.exceptions import DvcException
-from dvc.stage.loader import SingleStageLoader, StageLoader
 from dvc.stage.exceptions import (
+    StageFileAlreadyExistsError,
     StageFileBadNameError,
     StageFileDoesNotExistError,
-    StageFileIsNotDvcFileError,
     StageFileFormatError,
-    StageFileAlreadyExistsError,
+    StageFileIsNotDvcFileError,
 )
+from dvc.stage.loader import SingleStageLoader, StageLoader
 from dvc.utils import relpath
 from dvc.utils.collections import apply_diff
 from dvc.utils.stage import (

--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -1,7 +1,7 @@
 """Exceptions raised by the dvc."""
 from funcy import first
 
-from dvc.utils import relpath, format_link
+from dvc.utils import format_link, relpath
 
 
 class DvcException(Exception):

--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -1,23 +1,27 @@
 import logging
 import os
 import tempfile
+import threading
 from contextlib import contextmanager
 from distutils.dir_util import copy_tree
-import threading
 
-from funcy import retry, suppress, wrap_with, cached_property
+from funcy import cached_property, retry, suppress, wrap_with
 
-from dvc.path_info import PathInfo
 from dvc.compat import fspath
-from dvc.repo import Repo
 from dvc.config import NoRemoteError, NotDvcRepoError
-from dvc.exceptions import NoRemoteInExternalRepoError, CheckoutError
-from dvc.exceptions import OutputNotFoundError, NoOutputInExternalRepoError
-from dvc.exceptions import FileMissingError, PathMissingError
-from dvc.utils.fs import remove, fs_copy, move
-from dvc.utils import tmp_fname
+from dvc.exceptions import (
+    CheckoutError,
+    FileMissingError,
+    NoOutputInExternalRepoError,
+    NoRemoteInExternalRepoError,
+    OutputNotFoundError,
+    PathMissingError,
+)
+from dvc.path_info import PathInfo
+from dvc.repo import Repo
 from dvc.scm.git import Git
-
+from dvc.utils import tmp_fname
+from dvc.utils.fs import fs_copy, move, remove
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/lock.py
+++ b/dvc/lock.py
@@ -5,12 +5,12 @@ import os
 import time
 from datetime import timedelta
 
-import zc.lockfile
 import flufl.lock
+import zc.lockfile
 
 from dvc.exceptions import DvcException
-from dvc.utils import format_link
 from dvc.progress import Tqdm
+from dvc.utils import format_link
 
 DEFAULT_TIMEOUT = 5
 

--- a/dvc/logger.py
+++ b/dvc/logger.py
@@ -7,7 +7,6 @@ import colorama
 
 from dvc.progress import Tqdm
 
-
 FOOTER = (
     "\n{yellow}Having any troubles?{nc}"
     " Hit us up at {blue}https://dvc.org/support{nc},"

--- a/dvc/main.py
+++ b/dvc/main.py
@@ -6,12 +6,11 @@ import logging
 from dvc import analytics
 from dvc.cli import parse_args
 from dvc.config import ConfigError
-from dvc.exceptions import DvcParserError, DvcException
-from dvc.exceptions import NotDvcRepoError
+from dvc.exceptions import DvcException, DvcParserError, NotDvcRepoError
 from dvc.external_repo import clean_repos
-from dvc.logger import disable_other_loggers, FOOTER
-from dvc.utils import format_link
+from dvc.logger import FOOTER, disable_other_loggers
 from dvc.remote.pool import close_pools
+from dvc.utils import format_link
 
 # Workaround for CPython bug. See [1] and [2] for more info.
 # [1] https://github.com/aws/aws-cli/blob/1.16.277/awscli/clidriver.py#L55

--- a/dvc/output/__init__.py
+++ b/dvc/output/__init__.py
@@ -1,5 +1,6 @@
 from urllib.parse import urlparse
-from voluptuous import Any, Required, Lower, Length, Coerce, And, SetTo
+
+from voluptuous import And, Any, Coerce, Length, Lower, Required, SetTo
 
 from dvc.output.base import BaseOutput
 from dvc.output.gs import GSOutput

--- a/dvc/output/base.py
+++ b/dvc/output/base.py
@@ -1,16 +1,18 @@
 import logging
 import os
-from urllib.parse import urlparse
 from copy import copy
+from urllib.parse import urlparse
 
 from voluptuous import Any
 
 import dvc.prompt as prompt
 from dvc.cache import NamedCache
-from dvc.exceptions import CollectCacheError, RemoteCacheRequiredError
-from dvc.exceptions import DvcException
+from dvc.exceptions import (
+    CollectCacheError,
+    DvcException,
+    RemoteCacheRequiredError,
+)
 from dvc.remote.base import BaseRemote
-
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/output/local.py
+++ b/dvc/output/local.py
@@ -2,14 +2,13 @@ import logging
 import os
 from urllib.parse import urlparse
 
+from dvc.compat import fspath_py35
 from dvc.exceptions import DvcException
 from dvc.istextfile import istextfile
 from dvc.output.base import BaseOutput
 from dvc.remote.local import LocalRemote
 from dvc.utils import relpath
-from dvc.compat import fspath_py35
 from dvc.utils.fs import path_isin
-
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/path_info.py
+++ b/dvc/path_info.py
@@ -1,6 +1,6 @@
 import os
-import posixpath
 import pathlib
+import posixpath
 from urllib.parse import urlparse
 
 from funcy import cached_property

--- a/dvc/remote/__init__.py
+++ b/dvc/remote/__init__.py
@@ -12,7 +12,6 @@ from dvc.remote.oss import OSSRemote
 from dvc.remote.s3 import S3Remote
 from dvc.remote.ssh import SSHRemote
 
-
 REMOTES = [
     AzureRemote,
     GDriveRemote,

--- a/dvc/remote/azure.py
+++ b/dvc/remote/azure.py
@@ -2,9 +2,9 @@ import logging
 import os
 import posixpath
 import re
+import threading
 from datetime import datetime, timedelta
 from urllib.parse import urlparse
-import threading
 
 from funcy import cached_property, wrap_prop
 
@@ -12,7 +12,6 @@ from dvc.path_info import CloudURLInfo
 from dvc.progress import Tqdm
 from dvc.remote.base import BaseRemote
 from dvc.scheme import Schemes
-
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -4,20 +4,20 @@ import itertools
 import json
 import logging
 import tempfile
-from urllib.parse import urlparse
 from concurrent.futures import ThreadPoolExecutor
 from copy import copy
 from functools import partial, wraps
 from multiprocessing import cpu_count
 from operator import itemgetter
+from urllib.parse import urlparse
 
 from shortuuid import uuid
 
 import dvc.prompt as prompt
 from dvc.exceptions import (
     CheckoutError,
-    DvcException,
     ConfirmRemoveError,
+    DvcException,
     DvcIgnoreInCollectedDirError,
     RemoteCacheRequiredError,
 )
@@ -28,7 +28,7 @@ from dvc.remote.index import RemoteIndex, RemoteIndexNoop
 from dvc.remote.slow_link_detection import slow_link_guard
 from dvc.state import StateNoop
 from dvc.utils import tmp_fname
-from dvc.utils.fs import move, makedirs
+from dvc.utils.fs import makedirs, move
 from dvc.utils.http import open_url
 
 logger = logging.getLogger(__name__)

--- a/dvc/remote/gdrive.py
+++ b/dvc/remote/gdrive.py
@@ -1,20 +1,20 @@
-from collections import defaultdict
+import logging
 import os
 import posixpath
-import logging
 import re
 import threading
+from collections import defaultdict
 from urllib.parse import urlparse
 
-from funcy import retry, wrap_with, wrap_prop, cached_property
+from funcy import cached_property, retry, wrap_prop, wrap_with
 from funcy.py3 import cat
 
-from dvc.progress import Tqdm
-from dvc.scheme import Schemes
-from dvc.path_info import CloudURLInfo
-from dvc.remote.base import BaseRemote
 from dvc.exceptions import DvcException
-from dvc.utils import tmp_fname, format_link
+from dvc.path_info import CloudURLInfo
+from dvc.progress import Tqdm
+from dvc.remote.base import BaseRemote
+from dvc.scheme import Schemes
+from dvc.utils import format_link, tmp_fname
 
 logger = logging.getLogger(__name__)
 FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"

--- a/dvc/remote/gs.py
+++ b/dvc/remote/gs.py
@@ -1,10 +1,10 @@
-import logging
-from datetime import timedelta
-from functools import wraps
 import io
+import logging
 import os.path
 import posixpath
 import threading
+from datetime import timedelta
+from functools import wraps
 
 from funcy import cached_property, wrap_prop
 

--- a/dvc/remote/hdfs.py
+++ b/dvc/remote/hdfs.py
@@ -8,10 +8,11 @@ from collections import deque
 from contextlib import closing, contextmanager
 from urllib.parse import urlparse
 
-from .base import BaseRemote, RemoteCmdError
-from .pool import get_connection
 from dvc.scheme import Schemes
 from dvc.utils import fix_env, tmp_fname
+
+from .base import BaseRemote, RemoteCmdError
+from .pool import get_connection
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/remote/http.py
+++ b/dvc/remote/http.py
@@ -4,9 +4,9 @@ import threading
 
 from funcy import cached_property, memoize, wrap_prop, wrap_with
 
-from dvc.path_info import HTTPURLInfo
 import dvc.prompt as prompt
 from dvc.exceptions import DvcException, HTTPError
+from dvc.path_info import HTTPURLInfo
 from dvc.progress import Tqdm
 from dvc.remote.base import BaseRemote
 from dvc.scheme import Schemes

--- a/dvc/remote/https.py
+++ b/dvc/remote/https.py
@@ -1,5 +1,6 @@
-from .http import HTTPRemote
 from dvc.scheme import Schemes
+
+from .http import HTTPRemote
 
 
 class HTTPSRemote(HTTPRemote):

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -2,31 +2,30 @@ import errno
 import logging
 import os
 import stat
-from concurrent.futures import as_completed, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from functools import partial
 
 from funcy import cached_property, concat
-
 from shortuuid import uuid
 
 from dvc.compat import fspath_py35
-from dvc.exceptions import DvcException, DownloadError, UploadError
+from dvc.exceptions import DownloadError, DvcException, UploadError
 from dvc.path_info import PathInfo
 from dvc.progress import Tqdm
 from dvc.remote.base import (
-    index_locked,
-    BaseRemote,
-    STATUS_MAP,
     STATUS_DELETED,
+    STATUS_MAP,
     STATUS_MISSING,
     STATUS_NEW,
+    BaseRemote,
+    index_locked,
 )
 from dvc.remote.index import RemoteIndexNoop
 from dvc.scheme import Schemes
 from dvc.scm.tree import is_working_tree
 from dvc.system import System
 from dvc.utils import file_md5, relpath, tmp_fname
-from dvc.utils.fs import copyfile, move, makedirs, remove, walk_files
+from dvc.utils.fs import copyfile, makedirs, move, remove, walk_files
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/remote/oss.py
+++ b/dvc/remote/oss.py
@@ -10,7 +10,6 @@ from dvc.progress import Tqdm
 from dvc.remote.base import BaseRemote
 from dvc.scheme import Schemes
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/dvc/remote/pool.py
+++ b/dvc/remote/pool.py
@@ -1,6 +1,6 @@
+import threading
 from collections import deque
 from contextlib import contextmanager
-import threading
 
 from funcy import memoize, wrap_with
 

--- a/dvc/remote/s3.py
+++ b/dvc/remote/s3.py
@@ -8,8 +8,7 @@ import threading
 from funcy import cached_property, wrap_prop
 
 from dvc.config import ConfigError
-from dvc.exceptions import DvcException
-from dvc.exceptions import ETagMismatchError
+from dvc.exceptions import DvcException, ETagMismatchError
 from dvc.path_info import CloudURLInfo
 from dvc.progress import Tqdm
 from dvc.remote.base import BaseRemote

--- a/dvc/remote/slow_link_detection.py
+++ b/dvc/remote/slow_link_detection.py
@@ -1,10 +1,9 @@
 import logging
 import sys
 import time
-
 from functools import wraps
-import colorama
 
+import colorama
 
 logger = logging.getLogger(__name__)
 this = sys.modules[__name__]

--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -10,7 +10,7 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import closing, contextmanager
 from urllib.parse import urlparse
 
-from funcy import memoize, wrap_with, silent, first
+from funcy import first, memoize, silent, wrap_with
 
 import dvc.prompt as prompt
 from dvc.progress import Tqdm

--- a/dvc/remote/ssh/connection.py
+++ b/dvc/remote/ssh/connection.py
@@ -7,15 +7,15 @@ from contextlib import suppress
 
 from funcy import cached_property
 
+from dvc.exceptions import DvcException
+from dvc.progress import Tqdm
+from dvc.remote.base import RemoteCmdError
+from dvc.utils import tmp_fname
+
 try:
     import paramiko
 except ImportError:
     paramiko = None
-
-from dvc.utils import tmp_fname
-from dvc.progress import Tqdm
-from dvc.exceptions import DvcException
-from dvc.remote.base import RemoteCmdError
 
 
 logger = logging.getLogger(__name__)

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -3,11 +3,9 @@ import os
 from contextlib import contextmanager
 from functools import wraps
 
-from dvc.ignore import CleanTree
-from dvc.compat import fspath_py35
-
 from funcy import cached_property, cat, first
 
+from dvc.compat import fspath_py35
 from dvc.config import Config
 from dvc.exceptions import (
     FileMissingError,
@@ -15,11 +13,13 @@ from dvc.exceptions import (
     NotDvcRepoError,
     OutputNotFoundError,
 )
+from dvc.ignore import CleanTree
 from dvc.path_info import PathInfo
 from dvc.remote.base import RemoteActionNotImplemented
 from dvc.utils.fs import path_isin
-from .graph import check_acyclic, get_pipeline, get_pipelines
+
 from ..utils import parse_target
+from .graph import check_acyclic, get_pipeline, get_pipelines
 
 
 def locked(f):

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -3,17 +3,18 @@ import os
 
 import colorama
 
-from . import locked
 from dvc.dvcfile import Dvcfile, is_dvc_file
+
 from ..exceptions import (
-    RecursiveAddingWhileUsingFilename,
-    OverlappingOutputPathsError,
     OutputDuplicationError,
+    OverlappingOutputPathsError,
+    RecursiveAddingWhileUsingFilename,
 )
 from ..output.base import OutputDoesNotExistError
 from ..progress import Tqdm
 from ..repo.scm_context import scm_context
 from ..utils import LARGE_DIR_SIZE, resolve_paths
+from . import locked
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/repo/commit.py
+++ b/dvc/repo/commit.py
@@ -1,5 +1,6 @@
-from . import locked
 from dvc.dvcfile import Dvcfile
+
+from . import locked
 
 
 @locked

--- a/dvc/repo/destroy.py
+++ b/dvc/repo/destroy.py
@@ -1,4 +1,5 @@
 from dvc.utils.fs import remove
+
 from . import locked
 
 

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -3,8 +3,8 @@ import logging
 from dvc.cache import NamedCache
 from dvc.config import NoRemoteError
 from dvc.exceptions import DownloadError, OutputNotFoundError
-from dvc.scm.base import CloneError
 from dvc.path_info import PathInfo
+from dvc.scm.base import CloneError
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/repo/gc.py
+++ b/dvc/repo/gc.py
@@ -1,9 +1,9 @@
 import logging
 
-from . import locked
 from dvc.cache import NamedCache
 from dvc.exceptions import InvalidArgumentError
 
+from . import locked
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/repo/get.py
+++ b/dvc/repo/get.py
@@ -4,9 +4,9 @@ import os
 import shortuuid
 
 from dvc.exceptions import DvcException
+from dvc.path_info import PathInfo
 from dvc.utils import resolve_output
 from dvc.utils.fs import remove
-from dvc.path_info import PathInfo
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/repo/imp_url.py
+++ b/dvc/repo/imp_url.py
@@ -1,10 +1,11 @@
 import os
 
-from . import locked as locked_repo
 from dvc.repo.scm_context import scm_context
-from dvc.utils import resolve_output, resolve_paths, relpath
+from dvc.utils import relpath, resolve_output, resolve_paths
 from dvc.utils.fs import path_isin
+
 from ..exceptions import OutputDuplicationError
+from . import locked as locked_repo
 
 
 @locked_repo

--- a/dvc/repo/init.py
+++ b/dvc/repo/init.py
@@ -9,8 +9,7 @@ from dvc.exceptions import InitError, InvalidArgumentError
 from dvc.repo import Repo
 from dvc.scm import SCM
 from dvc.scm.base import SCMError
-from dvc.utils import boxify
-from dvc.utils import relpath
+from dvc.utils import boxify, relpath
 from dvc.utils.fs import remove
 
 logger = logging.getLogger(__name__)

--- a/dvc/repo/ls.py
+++ b/dvc/repo/ls.py
@@ -1,5 +1,5 @@
-from dvc.path_info import PathInfo
 from dvc.exceptions import PathMissingError
+from dvc.path_info import PathInfo
 
 
 @staticmethod

--- a/dvc/repo/metrics/diff.py
+++ b/dvc/repo/metrics/diff.py
@@ -1,5 +1,6 @@
-from dvc.utils.diff import format_dict, diff as _diff
 from dvc.exceptions import NoMetricsError
+from dvc.utils.diff import diff as _diff
+from dvc.utils.diff import format_dict
 
 
 def _get_metrics(repo, *args, rev=None, **kwargs):

--- a/dvc/repo/metrics/show.py
+++ b/dvc/repo/metrics/show.py
@@ -1,13 +1,13 @@
-import yaml
 import logging
 import os
 
-from dvc.path_info import PathInfo
+import yaml
+
 from dvc.compat import fspath_py35
 from dvc.exceptions import NoMetricsError
+from dvc.path_info import PathInfo
 from dvc.repo import locked
 from dvc.repo.tree import RepoTree
-
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/repo/move.py
+++ b/dvc/repo/move.py
@@ -1,8 +1,9 @@
 import os
 
-from . import locked
 from dvc.exceptions import MoveNotDataSourceError
 from dvc.repo.scm_context import scm_context
+
+from . import locked
 
 
 def _expand_target_path(from_path, to_path):

--- a/dvc/repo/params/diff.py
+++ b/dvc/repo/params/diff.py
@@ -1,4 +1,6 @@
-from dvc.utils.diff import format_dict, diff as _diff
+from dvc.utils.diff import diff as _diff
+from dvc.utils.diff import format_dict
+
 from .show import NoParamsError
 
 

--- a/dvc/repo/params/show.py
+++ b/dvc/repo/params/show.py
@@ -1,12 +1,12 @@
-import yaml
 import logging
 
-from dvc.repo import locked
-from dvc.path_info import PathInfo
-from dvc.compat import fspath_py35
-from dvc.exceptions import DvcException
-from dvc.dependency.param import ParamsDependency
+import yaml
 
+from dvc.compat import fspath_py35
+from dvc.dependency.param import ParamsDependency
+from dvc.exceptions import DvcException
+from dvc.path_info import PathInfo
+from dvc.repo import locked
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/repo/plot/__init__.py
+++ b/dvc/repo/plot/__init__.py
@@ -4,9 +4,9 @@ import os
 from funcy import first, last
 
 from dvc.exceptions import DvcException
-from dvc.repo.plot.data import PlotData
-from dvc.repo.plot.template import Template, NoDataForTemplateError
 from dvc.repo import locked
+from dvc.repo.plot.data import PlotData
+from dvc.repo.plot.template import NoDataForTemplateError, Template
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/repo/plot/data.py
+++ b/dvc/repo/plot/data.py
@@ -12,7 +12,6 @@ from yaml import SafeLoader
 
 from dvc.exceptions import DvcException, PathMissingError
 
-
 logger = logging.getLogger(__name__)
 
 WORKSPACE_REVISION_NAME = "workspace"

--- a/dvc/repo/plot/template.py
+++ b/dvc/repo/plot/template.py
@@ -8,7 +8,6 @@ from funcy import cached_property
 from dvc.exceptions import DvcException
 from dvc.utils.fs import makedirs
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/dvc/repo/pull.py
+++ b/dvc/repo/pull.py
@@ -2,7 +2,6 @@ import logging
 
 from dvc.repo import locked
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/dvc/repo/remove.py
+++ b/dvc/repo/remove.py
@@ -1,7 +1,7 @@
 import logging
 
-from . import locked
 from ..utils import parse_target
+from . import locked
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -1,10 +1,10 @@
 import logging
 
-from dvc.exceptions import ReproductionError, InvalidArgumentError
+from dvc.exceptions import InvalidArgumentError, ReproductionError
 from dvc.repo.scm_context import scm_context
+
 from . import locked
 from .graph import get_pipeline, get_pipelines
-
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/repo/run.py
+++ b/dvc/repo/run.py
@@ -1,13 +1,13 @@
 import os
 
-from . import locked
-from .scm_context import scm_context
+from funcy import concat, first
+
 from dvc.exceptions import InvalidArgumentError
 from dvc.stage.exceptions import DuplicateStageName, InvalidStageName
 
-from funcy import first, concat
-
 from ..exceptions import OutputDuplicationError
+from . import locked
+from .scm_context import scm_context
 
 
 def is_valid_name(name: str):

--- a/dvc/repo/status.py
+++ b/dvc/repo/status.py
@@ -4,8 +4,8 @@ from itertools import compress
 from funcy.py3 import cat
 
 from dvc.exceptions import InvalidArgumentError
-from . import locked
 
+from . import locked
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/repo/tree.py
+++ b/dvc/repo/tree.py
@@ -1,9 +1,9 @@
-import os
 import errno
+import os
 
-from dvc.scm.tree import BaseTree, WorkingTree
-from dvc.path_info import PathInfo
 from dvc.exceptions import OutputNotFoundError
+from dvc.path_info import PathInfo
+from dvc.scm.tree import BaseTree, WorkingTree
 
 
 class DvcTree(BaseTree):

--- a/dvc/rwlock.py
+++ b/dvc/rwlock.py
@@ -1,10 +1,9 @@
-import os
 import json
-
+import os
 from collections import defaultdict
 from contextlib import contextmanager
 
-from voluptuous import Schema, Invalid, Required, Optional
+from voluptuous import Invalid, Optional, Required, Schema
 
 from .exceptions import DvcException
 from .lock import LockError

--- a/dvc/schema.py
+++ b/dvc/schema.py
@@ -1,9 +1,8 @@
-from dvc.stage.params import StageParams, OutputParams
-from dvc.output import CHECKSUMS_SCHEMA
+from voluptuous import Any, Optional, Required, Schema
+
 from dvc import dependency, output
-
-from voluptuous import Any, Schema, Optional, Required
-
+from dvc.output import CHECKSUMS_SCHEMA
+from dvc.stage.params import OutputParams, StageParams
 
 STAGES = "stages"
 SINGLE_STAGE_SCHEMA = {

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -2,16 +2,21 @@
 
 import logging
 import os
-import yaml
 import shlex
 
+import yaml
 from funcy import cached_property
 from pathspec.patterns import GitWildMatchPattern
 
 from dvc.exceptions import GitHookAlreadyExistsError
 from dvc.progress import Tqdm
-from dvc.scm.base import Base
-from dvc.scm.base import CloneError, FileNotInRepoError, RevError, SCMError
+from dvc.scm.base import (
+    Base,
+    CloneError,
+    FileNotInRepoError,
+    RevError,
+    SCMError,
+)
 from dvc.scm.git.tree import GitTree
 from dvc.utils import fix_env, is_binary, relpath
 from dvc.utils.fs import path_isin

--- a/dvc/scm/git/tree.py
+++ b/dvc/scm/git/tree.py
@@ -1,11 +1,10 @@
-import io
 import errno
+import io
 import os
 
 from dvc.exceptions import DvcException
 from dvc.scm.tree import BaseTree
 from dvc.utils import relpath
-
 
 # see git-fast-import(1)
 GIT_MODE_DIR = 0o40000

--- a/dvc/serialize.py
+++ b/dvc/serialize.py
@@ -1,14 +1,13 @@
 from collections import OrderedDict
 from functools import partial
 from operator import attrgetter
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
-from funcy import rpartial, lsplit
+from funcy import lsplit, rpartial
 
 from dvc.dependency import ParamsDependency
 from dvc.utils.collections import apply_diff
 from dvc.utils.stage import parse_stage_for_update
-from typing import List
 
 if TYPE_CHECKING:
     from dvc.stage import PipelineStage, Stage

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -1,10 +1,9 @@
-import pathlib
 import logging
 import os
+import pathlib
 import signal
 import subprocess
 import threading
-
 from itertools import chain, product
 
 from funcy import project
@@ -13,21 +12,20 @@ import dvc.dependency as dependency
 import dvc.output as output
 import dvc.prompt as prompt
 from dvc.exceptions import CheckoutError, DvcException
+from dvc.utils import dict_md5, fix_env, relpath
+from dvc.utils.fs import path_isin
+
+from . import params
 from .decorators import rwlocked, unlocked_repo
 from .exceptions import (
-    StageCmdFailedError,
-    StagePathOutsideError,
-    StagePathNotFoundError,
-    StagePathNotDirectoryError,
-    StageCommitError,
-    StageUpdateError,
     MissingDataSource,
+    StageCmdFailedError,
+    StageCommitError,
+    StagePathNotDirectoryError,
+    StagePathNotFoundError,
+    StagePathOutsideError,
+    StageUpdateError,
 )
-from . import params
-from dvc.utils import dict_md5
-from dvc.utils import fix_env
-from dvc.utils import relpath
-from dvc.utils.fs import path_isin
 from .params import OutputParams
 
 logger = logging.getLogger(__name__)

--- a/dvc/stage/cache.py
+++ b/dvc/stage/cache.py
@@ -1,14 +1,14 @@
-import os
-import yaml
 import logging
+import os
 
+import yaml
 from voluptuous import Invalid
 
 from dvc.schema import COMPILED_LOCK_FILE_STAGE_SCHEMA
 from dvc.serialize import to_single_stage_lockfile
 from dvc.stage.loader import StageLoader
+from dvc.utils import dict_sha256, relpath
 from dvc.utils.fs import makedirs
-from dvc.utils import relpath, dict_sha256
 from dvc.utils.stage import dump_stage_file
 
 logger = logging.getLogger(__name__)

--- a/dvc/stage/decorators.py
+++ b/dvc/stage/decorators.py
@@ -1,5 +1,6 @@
-from funcy import decorator
 from functools import wraps
+
+from funcy import decorator
 
 
 @decorator

--- a/dvc/stage/loader.py
+++ b/dvc/stage/loader.py
@@ -1,16 +1,16 @@
 import logging
 import os
+from collections import Mapping, defaultdict
 from contextlib import contextmanager
-
 from copy import deepcopy
-from collections import defaultdict, Mapping
 from itertools import chain
 
 from funcy import first
 
 from dvc import dependency, output
-from .exceptions import StageNameUnspecified, StageNotFound
+
 from ..dependency import ParamsDependency
+from .exceptions import StageNameUnspecified, StageNotFound
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/state.py
+++ b/dvc/state.py
@@ -4,17 +4,12 @@ import logging
 import os
 import re
 import sqlite3
-from urllib.parse import urlunparse, urlencode
+from urllib.parse import urlencode, urlunparse
 
-from dvc.exceptions import DvcException
-from dvc.utils import current_timestamp
-from dvc.utils import relpath
-from dvc.utils import to_chunks
 from dvc.compat import fspath_py35
-from dvc.utils.fs import get_inode
-from dvc.utils.fs import get_mtime_and_size
-from dvc.utils.fs import remove
-
+from dvc.exceptions import DvcException
+from dvc.utils import current_timestamp, relpath, to_chunks
+from dvc.utils.fs import get_inode, get_mtime_and_size, remove
 
 SQLITE_MAX_VARIABLES_NUMBER = 999
 

--- a/dvc/updater.py
+++ b/dvc/updater.py
@@ -7,9 +7,8 @@ import colorama
 from packaging import version
 
 from dvc import __version__
-from dvc.lock import make_lock, LockError
-from dvc.utils import boxify
-from dvc.utils import env2bool
+from dvc.lock import LockError, make_lock
+from dvc.utils import boxify, env2bool
 from dvc.utils.pkg import PKG
 
 logger = logging.getLogger(__name__)

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -1,6 +1,7 @@
 """Helpers for other modules."""
 
 import hashlib
+import io
 import json
 import logging
 import math
@@ -8,7 +9,6 @@ import os
 import re
 import sys
 import time
-import io
 
 import colorama
 import nanotime
@@ -16,7 +16,6 @@ from ruamel.yaml import YAML
 from shortuuid import uuid
 
 from dvc.compat import fspath, fspath_py35
-
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/utils/fs.py
+++ b/dvc/utils/fs.py
@@ -1,9 +1,9 @@
-import sys
 import errno
 import logging
 import os
 import shutil
 import stat
+import sys
 
 import nanotime
 from shortuuid import uuid
@@ -11,10 +11,7 @@ from shortuuid import uuid
 from dvc.exceptions import DvcException
 from dvc.scm.tree import is_working_tree
 from dvc.system import System
-from dvc.utils import dict_md5
-from dvc.utils import fspath
-from dvc.utils import fspath_py35
-
+from dvc.utils import dict_md5, fspath, fspath_py35
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/utils/fs.py
+++ b/dvc/utils/fs.py
@@ -40,14 +40,14 @@ def get_mtime_and_size(path, tree):
         files_mtimes = {}
         for file_path in tree.walk_files(path):
             try:
-                stat = os.stat(file_path)
+                stats = os.stat(file_path)
             except OSError as exc:
                 # NOTE: broken symlink case.
                 if exc.errno != errno.ENOENT:
                     raise
                 continue
-            size += stat.st_size
-            files_mtimes[file_path] = stat.st_mtime
+            size += stats.st_size
+            files_mtimes[file_path] = stats.st_mtime
 
         # We track file changes and moves, which cannot be detected with simply
         # max(mtime(f) for f in non_ignored_files)

--- a/dvc/utils/stage.py
+++ b/dvc/utils/stage.py
@@ -4,12 +4,12 @@ import yaml
 from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
 
+from dvc.exceptions import StageFileCorruptedError
+
 try:
     from yaml import CSafeLoader as SafeLoader
 except ImportError:
     from yaml import SafeLoader
-
-from dvc.exceptions import StageFileCorruptedError
 
 
 def load_stage_file(path):

--- a/dvc/version.py
+++ b/dvc/version.py
@@ -6,7 +6,6 @@
 import os
 import subprocess
 
-
 _BASE_VERSION = "1.0.0a0"
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ max_line_length=79
 select=B,C,E,F,W,T4,B9
 
 [isort]
-line_length=79
 include_trailing_comma=true
+known_first_party=dvc
+line_length=79
 multi_line_output=3

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,8 @@ ignore=
     W503, # Line break occurred before a binary operator
 max_line_length=79
 select=B,C,E,F,W,T4,B9
+
+[isort]
+line_length=79
+include_trailing_comma=true
+multi_line_output=3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,10 @@
 [bdist_wheel]
 universal=1
+
+[flake8]
+ignore=
+    E203, # Whitespace before ':'
+    E266, # Too many leading '#' for block comment
+    W503, # Line break occurred before a binary operator
+max_line_length=79
+select=B,C,E,F,W,T4,B9

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -2,7 +2,6 @@ import os
 import sys
 from subprocess import check_call
 
-
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 os.chdir(REPO_ROOT)
 

--- a/tests/basic_env.py
+++ b/tests/basic_env.py
@@ -14,7 +14,6 @@ from git.exc import GitCommandNotFound
 from dvc.repo import Repo as DvcRepo
 from dvc.utils.fs import remove
 
-
 logger = logging.getLogger("dvc")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,8 @@ import pytest
 
 from dvc.remote.ssh.connection import SSHConnection
 from tests.utils.httpd import PushRequestHandler, StaticFileServer
-from .dir_helpers import *  # noqa
 
+from .dir_helpers import *  # noqa
 
 # Prevent updater and analytics from running their processes
 os.environ["DVC_TEST"] = "true"

--- a/tests/dir_helpers.py
+++ b/tests/dir_helpers.py
@@ -50,10 +50,9 @@ from contextlib import contextmanager
 import pytest
 from funcy import lmap, retry
 
+from dvc.compat import fspath, fspath_py35
 from dvc.logger import disable_other_loggers
 from dvc.utils.fs import makedirs
-from dvc.compat import fspath, fspath_py35
-
 
 __all__ = [
     "make_tmp_dir",

--- a/tests/func/metrics/test_diff.py
+++ b/tests/func/metrics/test_diff.py
@@ -1,4 +1,5 @@
 import json
+
 import yaml
 
 

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -7,15 +7,16 @@ import time
 
 import colorama
 import pytest
-from mock import patch, call
+from mock import call, patch
 
 import dvc as dvc_module
 from dvc.cache import Cache
+from dvc.compat import fspath
 from dvc.dvcfile import DVC_FILE_SUFFIX
 from dvc.exceptions import (
     DvcException,
-    OverlappingOutputPathsError,
     OutputDuplicationError,
+    OverlappingOutputPathsError,
     RecursiveAddingWhileUsingFilename,
     StageFileCorruptedError,
 )
@@ -25,10 +26,7 @@ from dvc.remote import LocalRemote
 from dvc.repo import Repo as DvcRepo
 from dvc.stage import Stage
 from dvc.system import System
-from dvc.utils import file_md5
-from dvc.utils import LARGE_DIR_SIZE
-from dvc.utils import relpath
-from dvc.compat import fspath
+from dvc.utils import LARGE_DIR_SIZE, file_md5, relpath
 from dvc.utils.fs import path_isin
 from dvc.utils.stage import load_stage_file
 from tests.basic_env import TestDvc

--- a/tests/func/test_analytics.py
+++ b/tests/func/test_analytics.py
@@ -1,8 +1,8 @@
 import mock
 
 from dvc.analytics import _scm_in_use
-from dvc.main import main
 from dvc.compat import fspath
+from dvc.main import main
 from dvc.repo import Repo
 
 

--- a/tests/func/test_api.py
+++ b/tests/func/test_api.py
@@ -9,9 +9,7 @@ from dvc.exceptions import FileMissingError
 from dvc.main import main
 from dvc.path_info import URLInfo
 from dvc.utils.fs import remove
-
-from tests.remotes import Azure, GCP, HDFS, Local, OSS, S3, SSH
-
+from tests.remotes import GCP, HDFS, OSS, S3, SSH, Azure, Local
 
 remote_params = [S3, GCP, Azure, OSS, SSH, HDFS]
 all_remote_params = [Local] + remote_params

--- a/tests/func/test_checkout.py
+++ b/tests/func/test_checkout.py
@@ -7,29 +7,29 @@ import shutil
 import pytest
 from mock import patch
 
-from dvc.exceptions import CheckoutError
-from dvc.exceptions import CheckoutErrorSuggestGit
-from dvc.exceptions import ConfirmRemoveError
-from dvc.exceptions import DvcException
+from dvc.dvcfile import DVC_FILE_SUFFIX, Dvcfile
+from dvc.exceptions import (
+    CheckoutError,
+    CheckoutErrorSuggestGit,
+    ConfirmRemoveError,
+    DvcException,
+)
 from dvc.main import main
+from dvc.remote import S3Remote
 from dvc.remote.local import LocalRemote
 from dvc.repo import Repo as DvcRepo
 from dvc.stage import Stage
-from dvc.dvcfile import Dvcfile, DVC_FILE_SUFFIX
 from dvc.stage.exceptions import (
-    StageFileDoesNotExistError,
     StageFileBadNameError,
+    StageFileDoesNotExistError,
 )
 from dvc.system import System
 from dvc.utils import relpath
 from dvc.utils.fs import walk_files
-from dvc.utils.stage import dump_stage_file
-from dvc.utils.stage import load_stage_file
-from dvc.remote import S3Remote
-from tests.remotes import S3
-from tests.basic_env import TestDvc
-from tests.basic_env import TestDvcGit
+from dvc.utils.stage import dump_stage_file, load_stage_file
+from tests.basic_env import TestDvc, TestDvcGit
 from tests.func.test_repro import TestRepro
+from tests.remotes import S3
 
 logger = logging.getLogger("dvc")
 

--- a/tests/func/test_cli.py
+++ b/tests/func/test_cli.py
@@ -5,8 +5,7 @@ from dvc.command.add import CmdAdd
 from dvc.command.base import CmdBase
 from dvc.command.checkout import CmdCheckout
 from dvc.command.config import CmdConfig
-from dvc.command.data_sync import CmdDataPull
-from dvc.command.data_sync import CmdDataPush
+from dvc.command.data_sync import CmdDataPull, CmdDataPush
 from dvc.command.gc import CmdGC
 from dvc.command.init import CmdInit
 from dvc.command.remove import CmdRemove

--- a/tests/func/test_commit.py
+++ b/tests/func/test_commit.py
@@ -1,8 +1,7 @@
 import pytest
 
 from dvc.stage.exceptions import StageCommitError
-from dvc.utils.stage import dump_stage_file
-from dvc.utils.stage import load_stage_file
+from dvc.utils.stage import dump_stage_file, load_stage_file
 
 
 def test_commit_recursive(tmp_dir, dvc):

--- a/tests/func/test_config.py
+++ b/tests/func/test_config.py
@@ -1,8 +1,8 @@
-import pytest
 import configobj
+import pytest
 
-from dvc.main import main
 from dvc.config import Config, ConfigError
+from dvc.main import main
 from tests.basic_env import TestDvc
 
 

--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -7,40 +7,41 @@ from unittest import SkipTest
 
 import pytest
 
-from dvc.compat import fspath, fspath_py35
 from dvc.cache import NamedCache
+from dvc.compat import fspath, fspath_py35
 from dvc.data_cloud import DataCloud
+from dvc.external_repo import clean_repos
 from dvc.main import main
-from dvc.remote import AzureRemote
-from dvc.remote import GDriveRemote
-from dvc.remote import GSRemote
-from dvc.remote import HDFSRemote
-from dvc.remote import HTTPRemote
-from dvc.remote import LocalRemote
-from dvc.remote import OSSRemote
-from dvc.remote import S3Remote
-from dvc.remote import SSHRemote
+from dvc.remote import (
+    AzureRemote,
+    GDriveRemote,
+    GSRemote,
+    HDFSRemote,
+    HTTPRemote,
+    LocalRemote,
+    OSSRemote,
+    S3Remote,
+    SSHRemote,
+)
 from dvc.remote.base import STATUS_DELETED, STATUS_NEW, STATUS_OK
 from dvc.stage.exceptions import StageNotFound
 from dvc.utils import file_md5
 from dvc.utils.fs import remove
 from dvc.utils.stage import dump_stage_file, load_stage_file
-from dvc.external_repo import clean_repos
 from tests.basic_env import TestDvc
-
 from tests.remotes import (
-    Azure,
     GCP,
-    GDrive,
     HDFS,
     HTTP,
-    Local,
-    S3,
-    SSHMocked,
     OSS,
+    S3,
     TEST_CONFIG,
     TEST_GCP_CREDS_FILE,
     TEST_REMOTE,
+    Azure,
+    GDrive,
+    Local,
+    SSHMocked,
 )
 
 

--- a/tests/func/test_dependency.py
+++ b/tests/func/test_dependency.py
@@ -2,11 +2,9 @@ import copy
 
 import pytest
 
-from dvc.dependency import _get
-from dvc.dependency import DEP_MAP
+from dvc.dependency import DEP_MAP, _get
 from dvc.stage import Stage
 from tests.func.test_output import TESTS as OUT_TESTS
-
 
 TESTS = copy.copy(OUT_TESTS)
 TESTS.append(("http://example.com/path/to/file", "http"))

--- a/tests/func/test_diff.py
+++ b/tests/func/test_diff.py
@@ -1,12 +1,12 @@
 import hashlib
 import os
-import pytest
 
+import pytest
 from funcy import first
 
 from dvc.compat import fspath
-from dvc.utils.fs import remove
 from dvc.exceptions import DvcException
+from dvc.utils.fs import remove
 
 
 def digest(text):

--- a/tests/func/test_dvcfile.py
+++ b/tests/func/test_dvcfile.py
@@ -1,11 +1,11 @@
 import pytest
 
-from dvc.dvcfile import Dvcfile, PIPELINE_FILE
-from dvc.stage.loader import StageNotFound
+from dvc.dvcfile import PIPELINE_FILE, Dvcfile
 from dvc.stage.exceptions import (
     StageFileDoesNotExistError,
     StageNameUnspecified,
 )
+from dvc.stage.loader import StageNotFound
 
 
 def test_run_load_one_for_multistage(tmp_dir, dvc):

--- a/tests/func/test_external_repo.py
+++ b/tests/func/test_external_repo.py
@@ -1,11 +1,11 @@
 import os
 
 from mock import patch
-from dvc.compat import fspath
 
+from dvc.compat import fspath
 from dvc.external_repo import external_repo
-from dvc.scm.git import Git
 from dvc.remote import LocalRemote
+from dvc.scm.git import Git
 from dvc.utils import relpath
 from dvc.utils.fs import remove
 

--- a/tests/func/test_fs.py
+++ b/tests/func/test_fs.py
@@ -3,7 +3,7 @@ import stat
 
 import pytest
 
-from dvc.utils.fs import makedirs, copyfile
+from dvc.utils.fs import copyfile, makedirs
 
 
 @pytest.mark.skipif(os.name == "nt", reason="Not supported for Windows.")

--- a/tests/func/test_gc.py
+++ b/tests/func/test_gc.py
@@ -1,6 +1,6 @@
 import logging
-import shutil
 import os
+import shutil
 
 import configobj
 import pytest
@@ -9,8 +9,8 @@ from git import Repo
 from dvc.compat import fspath
 from dvc.exceptions import CollectCacheError
 from dvc.main import main
-from dvc.repo import Repo as DvcRepo
 from dvc.remote.local import LocalRemote
+from dvc.repo import Repo as DvcRepo
 from dvc.utils.fs import remove
 from tests.basic_env import TestDir, TestDvcGit
 

--- a/tests/func/test_get.py
+++ b/tests/func/test_get.py
@@ -4,13 +4,13 @@ import os
 import pytest
 
 from dvc.cache import Cache
-from dvc.main import main
+from dvc.compat import fspath
 from dvc.exceptions import PathMissingError
-from dvc.repo.get import GetDVCFileError
+from dvc.main import main
 from dvc.repo import Repo
+from dvc.repo.get import GetDVCFileError
 from dvc.system import System
 from dvc.utils.fs import makedirs
-from dvc.compat import fspath
 from tests.utils import trees_equal
 
 

--- a/tests/func/test_ignore.py
+++ b/tests/func/test_ignore.py
@@ -1,8 +1,10 @@
 # encoding: utf-8
 import os
 import shutil
+
 import pytest
 
+from dvc.compat import fspath, fspath_py35
 from dvc.exceptions import DvcIgnoreInCollectedDirError
 from dvc.ignore import (
     DvcIgnore,
@@ -10,12 +12,10 @@ from dvc.ignore import (
     DvcIgnorePatterns,
     DvcIgnoreRepo,
 )
+from dvc.remote import LocalRemote
 from dvc.scm.tree import WorkingTree
 from dvc.utils import relpath
-from dvc.compat import fspath_py35, fspath
 from dvc.utils.fs import get_mtime_and_size
-from dvc.remote import LocalRemote
-
 from tests.dir_helpers import TmpDir
 from tests.utils import to_posixpath
 

--- a/tests/func/test_import.py
+++ b/tests/func/test_import.py
@@ -1,17 +1,17 @@
 import filecmp
 import os
-from dvc.compat import fspath
 
 import pytest
 from mock import patch
 
+import dvc.data_cloud as cloud
 from dvc.cache import Cache
-from dvc.exceptions import DownloadError, PathMissingError
+from dvc.compat import fspath
 from dvc.config import NoRemoteError
 from dvc.dvcfile import Dvcfile
+from dvc.exceptions import DownloadError, PathMissingError
 from dvc.system import System
 from dvc.utils.fs import makedirs, remove
-import dvc.data_cloud as cloud
 from tests.utils import trees_equal
 
 

--- a/tests/func/test_import_url.py
+++ b/tests/func/test_import_url.py
@@ -3,10 +3,10 @@ from uuid import uuid4
 
 import pytest
 
-from dvc.stage import Stage
-from dvc.main import main
-from dvc.utils.fs import makedirs
 from dvc.compat import fspath
+from dvc.main import main
+from dvc.stage import Stage
+from dvc.utils.fs import makedirs
 from tests.basic_env import TestDvc
 
 

--- a/tests/func/test_init.py
+++ b/tests/func/test_init.py
@@ -6,8 +6,7 @@ from dvc.config import Config
 from dvc.exceptions import InitError
 from dvc.main import main
 from dvc.repo import Repo as DvcRepo
-from tests.basic_env import TestDir
-from tests.basic_env import TestGit
+from tests.basic_env import TestDir, TestGit
 
 
 class TestInit(TestGit):

--- a/tests/func/test_lock.py
+++ b/tests/func/test_lock.py
@@ -1,7 +1,6 @@
 import os
 
-from dvc.lock import Lock
-from dvc.lock import LockError
+from dvc.lock import Lock, LockError
 from dvc.main import main
 from tests.basic_env import TestDvc
 

--- a/tests/func/test_lockfile.py
+++ b/tests/func/test_lockfile.py
@@ -4,13 +4,12 @@ from textwrap import dedent
 
 import pytest
 import yaml
+
 from dvc.dvcfile import PIPELINE_LOCK
 from dvc.serialize import get_params_deps
 from dvc.utils.fs import remove
 from dvc.utils.stage import parse_stage_for_update
-
 from tests.func.test_run_multistage import supported_params
-
 
 FS_STRUCTURE = {
     "foo": "bar\nfoobar",

--- a/tests/func/test_ls.py
+++ b/tests/func/test_ls.py
@@ -1,11 +1,12 @@
 import os
 import shutil
+
 import pytest
 
 from dvc.compat import fspath
 from dvc.exceptions import PathMissingError
-from dvc.scm.base import CloneError
 from dvc.repo import Repo
+from dvc.scm.base import CloneError
 
 FS_STRUCTURE = {
     "README.md": "content",

--- a/tests/func/test_move.py
+++ b/tests/func/test_move.py
@@ -1,12 +1,10 @@
 import os
 
 from dvc.dvcfile import DVC_FILE_SUFFIX
-from dvc.exceptions import DvcException
-from dvc.exceptions import MoveNotDataSourceError
+from dvc.exceptions import DvcException, MoveNotDataSourceError
 from dvc.main import main
 from dvc.utils.stage import load_stage_file
-from tests.basic_env import TestDvc
-from tests.basic_env import TestDvcGit
+from tests.basic_env import TestDvc, TestDvcGit
 from tests.func.test_repro import TestRepro
 from tests.utils import cd
 

--- a/tests/func/test_output.py
+++ b/tests/func/test_output.py
@@ -1,9 +1,7 @@
 import pytest
 
-from dvc.output import _get
-from dvc.output import OUTS_MAP
+from dvc.output import OUTS_MAP, _get
 from dvc.stage import Stage
-
 
 TESTS = [
     ("s3://bucket/path", "s3"),

--- a/tests/func/test_pipeline.py
+++ b/tests/func/test_pipeline.py
@@ -1,10 +1,9 @@
 import logging
 
+from dvc.command.pipeline import CmdPipelineList, CmdPipelineShow
 from dvc.main import main
-from dvc.command.pipeline import CmdPipelineShow, CmdPipelineList
 from tests.basic_env import TestDvc
-from tests.func.test_repro import TestRepro
-from tests.func.test_repro import TestReproChangedDeepData
+from tests.func.test_repro import TestRepro, TestReproChangedDeepData
 
 
 class TestPipelineShowSingle(TestDvc):

--- a/tests/func/test_plot.py
+++ b/tests/func/test_plot.py
@@ -6,20 +6,20 @@ from collections import OrderedDict
 
 import pytest
 import yaml
-from bs4 import BeautifulSoup
 from funcy import first
 
+from bs4 import BeautifulSoup
 from dvc.compat import fspath
+from dvc.repo.plot import NoDataOrTemplateProvided
 from dvc.repo.plot.data import (
     NoMetricInHistoryError,
-    PlotMetricTypeError,
     PlotData,
+    PlotMetricTypeError,
 )
 from dvc.repo.plot.template import (
-    TemplateNotFoundError,
     NoDataForTemplateError,
+    TemplateNotFoundError,
 )
-from dvc.repo.plot import NoDataOrTemplateProvided
 
 
 def _remove_whitespace(value):

--- a/tests/func/test_remote.py
+++ b/tests/func/test_remote.py
@@ -5,13 +5,13 @@ import configobj
 import pytest
 from mock import patch
 
+from dvc.compat import fspath
 from dvc.config import Config
 from dvc.exceptions import DownloadError, UploadError
 from dvc.main import main
 from dvc.path_info import PathInfo
 from dvc.remote import LocalRemote
 from dvc.remote.base import BaseRemote, RemoteCacheRequiredError
-from dvc.compat import fspath
 from dvc.utils.fs import remove
 from tests.basic_env import TestDvc
 from tests.remotes import Local

--- a/tests/func/test_repo.py
+++ b/tests/func/test_repo.py
@@ -1,9 +1,9 @@
 import os
 
 from dvc.cache import Cache
+from dvc.compat import fspath
 from dvc.repo import Repo
 from dvc.system import System
-from dvc.compat import fspath
 
 
 def test_destroy(tmp_dir, dvc, run_copy):

--- a/tests/func/test_repro.py
+++ b/tests/func/test_repro.py
@@ -6,10 +6,9 @@ import re
 import shutil
 import uuid
 from pathlib import Path
-from subprocess import PIPE
-from subprocess import Popen
-from urllib.parse import urljoin
+from subprocess import PIPE, Popen
 from unittest import SkipTest
+from urllib.parse import urljoin
 
 import boto3
 import paramiko
@@ -19,35 +18,35 @@ from google.cloud import storage as gc
 from mock import patch
 
 from dvc.compat import fspath
-from dvc.exceptions import CyclicGraphError
-from dvc.exceptions import ReproductionError
-from dvc.exceptions import StagePathAsOutputError
+from dvc.dvcfile import Dvcfile
+from dvc.exceptions import (
+    CyclicGraphError,
+    ReproductionError,
+    StagePathAsOutputError,
+)
 from dvc.main import main
 from dvc.output.base import BaseOutput
 from dvc.path_info import URLInfo
 from dvc.remote.local import LocalRemote
 from dvc.repo import Repo as DvcRepo
 from dvc.stage import Stage
-from dvc.dvcfile import Dvcfile
 from dvc.stage.exceptions import StageFileDoesNotExistError
 from dvc.system import System
-from dvc.utils import file_md5
-from dvc.utils import relpath
-from dvc.utils.stage import dump_stage_file
-from dvc.utils.stage import load_stage_file
+from dvc.utils import file_md5, relpath
 from dvc.utils.fs import remove
+from dvc.utils.stage import dump_stage_file, load_stage_file
 from tests.basic_env import TestDvc
 from tests.remotes import (
     GCP,
     HDFS,
-    Local,
     S3,
     SSH,
-    SSHMocked,
     TEST_AWS_REPO_BUCKET,
     TEST_GCP_REPO_BUCKET,
+    Local,
+    SSHMocked,
 )
-from tests.utils.httpd import StaticFileServer, ContentMD5Handler
+from tests.utils.httpd import ContentMD5Handler, StaticFileServer
 
 
 class SingleStageRun:

--- a/tests/func/test_repro_multistage.py
+++ b/tests/func/test_repro_multistage.py
@@ -8,13 +8,10 @@ from funcy import lsplit
 
 from dvc.dvcfile import PIPELINE_FILE, PIPELINE_LOCK
 from dvc.exceptions import CyclicGraphError
+from dvc.main import main
 from dvc.stage import PipelineStage
 from dvc.utils.stage import dump_stage_file, parse_stage
-
 from tests.func import test_repro
-
-from dvc.main import main
-
 
 COPY_SCRIPT_FORMAT = dedent(
     """\

--- a/tests/func/test_run_multistage.py
+++ b/tests/func/test_run_multistage.py
@@ -1,9 +1,9 @@
-import pytest
 import os
 
+import pytest
 import yaml
 
-from dvc.stage.exceptions import InvalidStageName, DuplicateStageName
+from dvc.stage.exceptions import DuplicateStageName, InvalidStageName
 
 
 def test_run_with_name(tmp_dir, dvc, run_copy):

--- a/tests/func/test_run_single_stage.py
+++ b/tests/func/test_run_single_stage.py
@@ -8,13 +8,15 @@ import mock
 import pytest
 
 from dvc.dependency.base import DependencyIsStageFileError
-from dvc.exceptions import ArgumentDuplicationError
-from dvc.exceptions import CircularDependencyError
-from dvc.exceptions import CyclicGraphError
-from dvc.exceptions import OutputDuplicationError
-from dvc.exceptions import OverlappingOutputPathsError
-from dvc.exceptions import StagePathAsOutputError
 from dvc.dvcfile import DVC_FILE_SUFFIX
+from dvc.exceptions import (
+    ArgumentDuplicationError,
+    CircularDependencyError,
+    CyclicGraphError,
+    OutputDuplicationError,
+    OverlappingOutputPathsError,
+    StagePathAsOutputError,
+)
 from dvc.main import main
 from dvc.output import BaseOutput
 from dvc.output.base import OutputIsStageFileError
@@ -23,9 +25,9 @@ from dvc.stage import Stage
 from dvc.stage.exceptions import (
     StageFileAlreadyExistsError,
     StageFileBadNameError,
-    StagePathOutsideError,
-    StagePathNotFoundError,
     StagePathNotDirectoryError,
+    StagePathNotFoundError,
+    StagePathOutsideError,
 )
 from dvc.system import System
 from dvc.utils import file_md5

--- a/tests/func/test_s3.py
+++ b/tests/func/test_s3.py
@@ -1,13 +1,12 @@
 from functools import wraps
 
 import boto3
-import moto.s3.models as s3model
 import pytest
-from moto import mock_s3
 
+import moto.s3.models as s3model
 from dvc.remote.s3 import S3Remote
+from moto import mock_s3
 from tests.remotes import S3
-
 
 # from https://github.com/spulec/moto/blob/v1.3.5/tests/test_s3/test_s3.py#L40
 REDUCED_PART_SIZE = 256

--- a/tests/func/test_scm.py
+++ b/tests/func/test_scm.py
@@ -3,14 +3,11 @@ import os
 import pytest
 from git import Repo
 
-from dvc.scm import Git
-from dvc.scm import NoSCM
-from dvc.scm import SCM
+from dvc.compat import fspath
+from dvc.scm import SCM, Git, NoSCM
 from dvc.scm.base import SCMError
 from dvc.system import System
-from dvc.compat import fspath
-from tests.basic_env import TestGit
-from tests.basic_env import TestGitSubmodule
+from tests.basic_env import TestGit, TestGitSubmodule
 from tests.utils import get_gitignore_content
 
 

--- a/tests/func/test_stage.py
+++ b/tests/func/test_stage.py
@@ -1,16 +1,16 @@
 import os
 import tempfile
+
 import pytest
 
+from dvc.dvcfile import SingleStageFile
 from dvc.main import main
 from dvc.output.local import LocalOutput
 from dvc.remote.local import LocalRemote
 from dvc.repo import Repo
 from dvc.stage import Stage
-from dvc.dvcfile import SingleStageFile
 from dvc.stage.exceptions import StageFileFormatError
-from dvc.utils.stage import dump_stage_file
-from dvc.utils.stage import load_stage_file
+from dvc.utils.stage import dump_stage_file, load_stage_file
 from tests.basic_env import TestDvc
 
 

--- a/tests/func/test_state.py
+++ b/tests/func/test_state.py
@@ -1,5 +1,6 @@
-import mock
 import os
+
+import mock
 
 from dvc.path_info import PathInfo
 from dvc.state import State

--- a/tests/func/test_status.py
+++ b/tests/func/test_status.py
@@ -2,8 +2,8 @@ import os
 
 from mock import patch
 
-from dvc.main import main
 from dvc.compat import fspath
+from dvc.main import main
 from tests.basic_env import TestDvc
 
 

--- a/tests/func/test_tree.py
+++ b/tests/func/test_tree.py
@@ -6,9 +6,7 @@ from dvc.ignore import CleanTree
 from dvc.scm import SCM
 from dvc.scm.git import GitTree
 from dvc.scm.tree import WorkingTree
-from tests.basic_env import TestDir
-from tests.basic_env import TestGit
-from tests.basic_env import TestGitSubmodule
+from tests.basic_env import TestDir, TestGit, TestGitSubmodule
 
 
 class TestWorkingTree(TestDir):

--- a/tests/func/test_update.py
+++ b/tests/func/test_update.py
@@ -1,8 +1,9 @@
-import pytest
 import os
 
-from dvc.dvcfile import Dvcfile
+import pytest
+
 from dvc.compat import fspath, fspath_py35
+from dvc.dvcfile import Dvcfile
 
 
 @pytest.mark.parametrize("cached", [True, False])

--- a/tests/remotes.py
+++ b/tests/remotes.py
@@ -1,19 +1,16 @@
+import getpass
 import os
 import platform
 import uuid
-import getpass
-
 from contextlib import contextmanager
-from subprocess import CalledProcessError, check_output, Popen
+from subprocess import CalledProcessError, Popen, check_output
 
-from dvc.utils import env2bool
 from dvc.remote import GDriveRemote
 from dvc.remote.gs import GSRemote
 from dvc.remote.s3 import S3Remote
-from tests.basic_env import TestDvc
-
+from dvc.utils import env2bool
 from moto.s3 import mock_s3
-
+from tests.basic_env import TestDvc
 
 TEST_REMOTE = "upstream"
 TEST_CONFIG = {

--- a/tests/unit/command/test_diff.py
+++ b/tests/unit/command/test_diff.py
@@ -1,6 +1,6 @@
 import collections
-import os
 import logging
+import os
 
 from dvc.cli import parse_args
 

--- a/tests/unit/command/test_metrics.py
+++ b/tests/unit/command/test_metrics.py
@@ -1,5 +1,5 @@
 from dvc.cli import parse_args
-from dvc.command.metrics import CmdMetricsDiff, _show_diff, CmdMetricsShow
+from dvc.command.metrics import CmdMetricsDiff, CmdMetricsShow, _show_diff
 
 
 def test_metrics_diff(dvc, mocker):

--- a/tests/unit/command/test_plot.py
+++ b/tests/unit/command/test_plot.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dvc.cli import parse_args
-from dvc.command.plot import CmdPlotShow, CmdPlotDiff
+from dvc.command.plot import CmdPlotDiff, CmdPlotShow
 
 
 def test_metrics_diff(mocker):

--- a/tests/unit/command/test_update.py
+++ b/tests/unit/command/test_update.py
@@ -1,4 +1,5 @@
 import pytest
+
 from dvc.cli import parse_args
 from dvc.command.update import CmdUpdate
 

--- a/tests/unit/dependency/test_params.py
+++ b/tests/unit/dependency/test_params.py
@@ -1,11 +1,9 @@
+import pytest
 import yaml
 
-import pytest
-
-from dvc.dependency import ParamsDependency, loads_params, loadd_from
+from dvc.dependency import ParamsDependency, loadd_from, loads_params
 from dvc.dependency.param import BadParamFileError, MissingParamsError
 from dvc.stage import Stage
-
 
 PARAMS = {
     "foo": 1,

--- a/tests/unit/output/test_local.py
+++ b/tests/unit/output/test_local.py
@@ -1,6 +1,7 @@
 import os
 
 from mock import patch
+
 from dvc.output import LocalOutput
 from dvc.remote.local import LocalRemote
 from dvc.stage import Stage

--- a/tests/unit/output/test_output.py
+++ b/tests/unit/output/test_output.py
@@ -2,8 +2,7 @@ import logging
 
 import pytest
 from funcy import first
-
-from voluptuous import Schema, MultipleInvalid
+from voluptuous import MultipleInvalid, Schema
 
 from dvc.cache import NamedCache
 from dvc.output import CHECKSUM_SCHEMA, BaseOutput

--- a/tests/unit/remote/ssh/test_connection.py
+++ b/tests/unit/remote/ssh/test_connection.py
@@ -9,7 +9,6 @@ import pytest
 from dvc.command.version import CmdVersion
 from dvc.system import System
 
-
 here = os.path.abspath(os.path.dirname(__file__))
 
 

--- a/tests/unit/remote/ssh/test_ssh.py
+++ b/tests/unit/remote/ssh/test_ssh.py
@@ -3,8 +3,7 @@ import os
 import sys
 
 import pytest
-from mock import mock_open
-from mock import patch
+from mock import mock_open, patch
 
 from dvc.remote.ssh import SSHRemote
 from dvc.system import System

--- a/tests/unit/remote/test_azure.py
+++ b/tests/unit/remote/test_azure.py
@@ -1,6 +1,5 @@
 from dvc.remote.azure import AzureRemote
 
-
 container_name = "container-name"
 connection_string = (
     "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;"

--- a/tests/unit/remote/test_base.py
+++ b/tests/unit/remote/test_base.py
@@ -1,11 +1,10 @@
 import math
+
 import mock
 import pytest
 
 from dvc.path_info import PathInfo
-from dvc.remote.base import BaseRemote
-from dvc.remote.base import RemoteCmdError
-from dvc.remote.base import RemoteMissingDepsError
+from dvc.remote.base import BaseRemote, RemoteCmdError, RemoteMissingDepsError
 
 
 class _CallableOrNone(object):

--- a/tests/unit/remote/test_gdrive.py
+++ b/tests/unit/remote/test_gdrive.py
@@ -1,7 +1,8 @@
-import pytest
 import os
 
-from dvc.remote.gdrive import GDriveRemote, GDriveAuthError
+import pytest
+
+from dvc.remote.gdrive import GDriveAuthError, GDriveRemote
 
 USER_CREDS_TOKEN_REFRESH_ERROR = '{"access_token": "", "client_id": "", "client_secret": "", "refresh_token": "", "token_expiry": "", "token_uri": "https://oauth2.googleapis.com/token", "user_agent": null, "revoke_uri": "https://oauth2.googleapis.com/revoke", "id_token": null, "id_token_jwt": null, "token_response": {"access_token": "", "expires_in": 3600, "scope": "https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/drive", "token_type": "Bearer"}, "scopes": ["https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/drive.appdata"], "token_info_uri": "https://oauth2.googleapis.com/tokeninfo", "invalid": true, "_class": "OAuth2Credentials", "_module": "oauth2client.client"}'  # noqa: E501
 

--- a/tests/unit/remote/test_gs.py
+++ b/tests/unit/remote/test_gs.py
@@ -2,9 +2,7 @@ import mock
 import pytest
 import requests
 
-from dvc.remote.gs import dynamic_chunk_size
-from dvc.remote.gs import GSRemote
-
+from dvc.remote.gs import GSRemote, dynamic_chunk_size
 
 BUCKET = "bucket"
 PREFIX = "prefix"

--- a/tests/unit/remote/test_local.py
+++ b/tests/unit/remote/test_local.py
@@ -1,5 +1,5 @@
-import os
 import errno
+import os
 
 import pytest
 

--- a/tests/unit/remote/test_oss.py
+++ b/tests/unit/remote/test_oss.py
@@ -1,6 +1,5 @@
 from dvc.remote.oss import OSSRemote
 
-
 bucket_name = "bucket-name"
 endpoint = "endpoint"
 key_id = "Fq2UVErCz4I6tq"

--- a/tests/unit/remote/test_remote.py
+++ b/tests/unit/remote/test_remote.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dvc.remote import Remote, S3Remote, GSRemote
+from dvc.remote import GSRemote, Remote, S3Remote
 
 
 def test_remote_with_checksum_jobs(dvc):

--- a/tests/unit/remote/test_remote_dir.py
+++ b/tests/unit/remote/test_remote_dir.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
-import pytest
 import os
+
+import pytest
+
+from dvc.path_info import PathInfo
 from dvc.remote.s3 import S3Remote
 from dvc.utils.fs import walk_files
-from dvc.path_info import PathInfo
 from tests.remotes import GCP, S3Mocked
 
 remotes = [GCP, S3Mocked]

--- a/tests/unit/remote/test_s3.py
+++ b/tests/unit/remote/test_s3.py
@@ -3,7 +3,6 @@ import pytest
 from dvc.config import ConfigError
 from dvc.remote.s3 import S3Remote
 
-
 bucket_name = "bucket-name"
 prefix = "some/prefix"
 url = "s3://{}/{}".format(bucket_name, prefix)

--- a/tests/unit/repo/test_repo.py
+++ b/tests/unit/repo/test_repo.py
@@ -1,7 +1,7 @@
 import os
 
-from funcy import raiser
 import pytest
+from funcy import raiser
 
 from dvc.repo import locked
 

--- a/tests/unit/repo/test_tree.py
+++ b/tests/unit/repo/test_tree.py
@@ -1,8 +1,8 @@
 import os
 import shutil
 
-from dvc.repo.tree import DvcTree
 from dvc.compat import fspath_py35
+from dvc.repo.tree import DvcTree
 
 
 def test_exists(tmp_dir, dvc):

--- a/tests/unit/scm/test_git.py
+++ b/tests/unit/scm/test_git.py
@@ -1,7 +1,6 @@
 import os
 
 from dvc.compat import fspath
-
 from tests.basic_env import TestDvcGit
 
 

--- a/tests/unit/test_analytics.py
+++ b/tests/unit/test_analytics.py
@@ -1,9 +1,9 @@
-import pytest
-import mock
-import platform
 import json
+import platform
 
-from voluptuous import Schema, Any
+import mock
+import pytest
+from voluptuous import Any, Schema
 
 from dvc import analytics
 from dvc.cli import parse_args

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 
 from dvc.config import Config

--- a/tests/unit/test_ignore.py
+++ b/tests/unit/test_ignore.py
@@ -1,12 +1,9 @@
 import os
 
 import pytest
-from mock import MagicMock
-from mock import mock_open
-from mock import patch
+from mock import MagicMock, mock_open, patch
 
-from dvc.ignore import DvcIgnoreDirs
-from dvc.ignore import DvcIgnorePatterns
+from dvc.ignore import DvcIgnoreDirs, DvcIgnorePatterns
 
 
 def mock_dvcignore(dvcignore_path, patterns):

--- a/tests/unit/test_lockfile.py
+++ b/tests/unit/test_lockfile.py
@@ -1,7 +1,8 @@
-from dvc.stage import PipelineStage
-from dvc.dvcfile import Lockfile, LockfileCorruptedError
-import yaml
 import pytest
+import yaml
+
+from dvc.dvcfile import Lockfile, LockfileCorruptedError
+from dvc.stage import PipelineStage
 
 
 def test_stage_dump_no_outs_deps(tmp_dir, dvc):

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1,15 +1,13 @@
 import logging
+import time
 import traceback
+from datetime import datetime
 
 import colorama
-
-import dvc.logger
-import time
-from datetime import datetime
 import pytest
 
+import dvc.logger
 from dvc.exceptions import DvcException
-
 
 logger = logging.getLogger("dvc")
 formatter = dvc.logger.ColorFormatter()

--- a/tests/unit/test_path_info.py
+++ b/tests/unit/test_path_info.py
@@ -3,11 +3,7 @@ import pathlib
 
 import pytest
 
-from dvc.path_info import CloudURLInfo
-from dvc.path_info import HTTPURLInfo
-from dvc.path_info import PathInfo
-from dvc.path_info import URLInfo
-
+from dvc.path_info import CloudURLInfo, HTTPURLInfo, PathInfo, URLInfo
 
 TEST_DEPTH = len(pathlib.Path(__file__).parents) + 1
 

--- a/tests/unit/test_plot.py
+++ b/tests/unit/test_plot.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 
 import pytest
 
-from dvc.repo.plot.data import _apply_path, _lists, _find_data
+from dvc.repo.plot.data import _apply_path, _find_data, _lists
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_rwlock.py
+++ b/tests/unit/test_rwlock.py
@@ -2,15 +2,15 @@ import os
 
 import pytest
 
-from dvc.rwlock import (
-    rwlock,
-    _edit_rwlock,
-    RWLockFileFormatError,
-    RWLockFileCorruptedError,
-)
-from dvc.lock import LockError
 from dvc.compat import fspath
+from dvc.lock import LockError
 from dvc.path_info import PathInfo
+from dvc.rwlock import (
+    RWLockFileCorruptedError,
+    RWLockFileFormatError,
+    _edit_rwlock,
+    rwlock,
+)
 
 
 def test_rwlock(tmp_path):

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -1,4 +1,5 @@
 import pytest
+
 from dvc.state import _build_sqlite_uri
 
 

--- a/tests/unit/test_updater.py
+++ b/tests/unit/test_updater.py
@@ -1,5 +1,6 @@
 import json
 import os
+
 import mock
 import pytest
 

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -12,15 +12,18 @@ from dvc.path_info import PathInfo
 from dvc.scm.tree import WorkingTree
 from dvc.system import System
 from dvc.utils import relpath
-from dvc.utils.fs import BasePathNotInCheckedPathException
-from dvc.utils.fs import copyfile
-from dvc.utils.fs import contains_symlink_up_to
-from dvc.utils.fs import get_inode
-from dvc.utils.fs import get_mtime_and_size
-from dvc.utils.fs import move
-from dvc.utils.fs import path_isin, remove
-from dvc.utils.fs import makedirs
-from dvc.utils.fs import walk_files
+from dvc.utils.fs import (
+    BasePathNotInCheckedPathException,
+    contains_symlink_up_to,
+    copyfile,
+    get_inode,
+    get_mtime_and_size,
+    makedirs,
+    move,
+    path_isin,
+    remove,
+    walk_files,
+)
 from tests.basic_env import TestDir
 
 

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -1,18 +1,18 @@
-import re
 import os
+import re
 
 import pytest
 
 from dvc.path_info import PathInfo
 from dvc.utils import (
-    file_md5,
     dict_sha256,
-    resolve_output,
+    file_md5,
     fix_env,
-    relpath,
-    to_chunks,
-    tmp_fname,
     parse_target,
+    relpath,
+    resolve_output,
+    tmp_fname,
+    to_chunks,
 )
 
 

--- a/tests/utils/httpd.py
+++ b/tests/utils/httpd.py
@@ -3,6 +3,7 @@ import os
 import threading
 from http import HTTPStatus
 from http.server import HTTPServer, SimpleHTTPRequestHandler
+
 from RangeHTTPServer import RangeRequestHandler
 
 


### PR DESCRIPTION
- [x] consistently order `import`s
- [x] add `pre-commit` hook
- [x] fix minor deepsource issues
- [x] move `.flake8` root clutter to `setup.cfg`
- [x] add `isort` to `restyled`
- [x] ~~fix or~~ ignore CI & restyled failing for `isort` (maybe only an issue for this first PR adding config?)
- [x] ~~maybe~~ open issue for DVC pre-commit failing for more files than hyperthreads? -> #3751
- closes #3750