### PR TITLE
params/metrics: diff: implement tabulated markdown output (--show-md)

### DIFF
--- a/dvc/command/diff.py
+++ b/dvc/command/diff.py
@@ -11,6 +11,21 @@ from dvc.exceptions import DvcException
 logger = logging.getLogger(__name__)
 
 
+def _show_md(diff):
+    from dvc.utils.diff import table
+
+    rows = []
+    for status in ["added", "deleted", "modified"]:
+        entries = diff.get(status, [])
+        if not entries:
+            continue
+        paths = sorted([entry["path"] for entry in entries])
+        for path in paths:
+            rows.append([status, path])
+
+    return table(["Status", "Path"], rows, True)
+
+
 class CmdDiff(CmdBase):
     @staticmethod
     def _format(diff):
@@ -103,6 +118,8 @@ class CmdDiff(CmdBase):
 
             if self.args.show_json:
                 logger.info(json.dumps(diff))
+            elif self.args.show_md:
+                logger.info(_show_md(diff))
             elif diff:
                 logger.info(self._format(diff))
 
@@ -144,6 +161,12 @@ def add_parser(subparsers, parent_parser):
     diff_parser.add_argument(
         "--show-hash",
         help="Display hash value for each entry",
+        action="store_true",
+        default=False,
+    )
+    diff_parser.add_argument(
+        "--show-md",
+        help="Show tabulated output in the Markdown format (GFM).",
         action="store_true",
         default=False,
     )

--- a/dvc/command/metrics.py
+++ b/dvc/command/metrics.py
@@ -87,7 +87,7 @@ class CmdMetricsRemove(CmdBase):
         return 0
 
 
-def _show_diff(diff, markdown):
+def _show_diff(diff, markdown=False):
     from collections import OrderedDict
 
     from dvc.utils.diff import table

--- a/dvc/command/metrics.py
+++ b/dvc/command/metrics.py
@@ -87,7 +87,7 @@ class CmdMetricsRemove(CmdBase):
         return 0
 
 
-def _show_diff(diff):
+def _show_diff(diff, markdown):
     from collections import OrderedDict
 
     from dvc.utils.diff import table
@@ -105,7 +105,7 @@ def _show_diff(diff):
                 ]
             )
 
-    return table(["Path", "Metric", "Value", "Change"], rows)
+    return table(["Path", "Metric", "Value", "Change"], rows, markdown)
 
 
 class CmdMetricsDiff(CmdBase):
@@ -124,7 +124,7 @@ class CmdMetricsDiff(CmdBase):
 
                 logger.info(json.dumps(diff))
             else:
-                table = _show_diff(diff)
+                table = _show_diff(diff, self.args.show_md)
                 if table:
                     logger.info(table)
 
@@ -262,6 +262,12 @@ def add_parser(subparsers, parent_parser):
         action="store_true",
         default=False,
         help="Show output in JSON format.",
+    )
+    metrics_diff_parser.add_argument(
+        "--show-md",
+        action="store_true",
+        default=False,
+        help="Show tabulated output in the Markdown format (GFM).",
     )
     metrics_diff_parser.set_defaults(func=CmdMetricsDiff)
 

--- a/dvc/command/params.py
+++ b/dvc/command/params.py
@@ -8,16 +8,23 @@ from dvc.exceptions import DvcException
 logger = logging.getLogger(__name__)
 
 
-def _show_diff(diff):
+def _show_diff(diff, markdown):
     from dvc.utils.diff import table
 
     rows = []
     for fname, pdiff in diff.items():
         sorted_pdiff = OrderedDict(sorted(pdiff.items()))
         for param, change in sorted_pdiff.items():
-            rows.append([fname, param, change["old"], change["new"]])
+            rows.append(
+                [
+                    fname,
+                    param,
+                    change["old"] or "None",
+                    change["new"] or "None",
+                ]
+            )
 
-    return table(["Path", "Param", "Old", "New"], rows)
+    return table(["Path", "Param", "Old", "New"], rows, markdown)
 
 
 class CmdParamsDiff(CmdBase):
@@ -34,7 +41,7 @@ class CmdParamsDiff(CmdBase):
 
                 logger.info(json.dumps(diff))
             else:
-                table = _show_diff(diff)
+                table = _show_diff(diff, self.args.show_md)
                 if table:
                     logger.info(table)
 
@@ -93,5 +100,11 @@ def add_parser(subparsers, parent_parser):
         action="store_true",
         default=False,
         help="Show output in JSON format.",
+    )
+    params_diff_parser.add_argument(
+        "--show-md",
+        action="store_true",
+        default=False,
+        help="Show tabulated output in the Markdown format (GFM).",
     )
     params_diff_parser.set_defaults(func=CmdParamsDiff)

--- a/dvc/command/params.py
+++ b/dvc/command/params.py
@@ -8,21 +8,14 @@ from dvc.exceptions import DvcException
 logger = logging.getLogger(__name__)
 
 
-def _show_diff(diff, markdown):
+def _show_diff(diff, markdown=False):
     from dvc.utils.diff import table
 
     rows = []
     for fname, pdiff in diff.items():
         sorted_pdiff = OrderedDict(sorted(pdiff.items()))
         for param, change in sorted_pdiff.items():
-            rows.append(
-                [
-                    fname,
-                    param,
-                    change["old"] or "None",
-                    change["new"] or "None",
-                ]
-            )
+            rows.append([fname, param, change["old"], change["new"]])
 
     return table(["Path", "Param", "Old", "New"], rows, markdown)
 

--- a/dvc/utils/diff.py
+++ b/dvc/utils/diff.py
@@ -85,24 +85,18 @@ def diff(old, new, with_unchanged=False):
     return dict(res)
 
 
-def table(header, rows):
-    from texttable import Texttable
+def table(header, rows, markdown=False):
+    from tabulate import tabulate
 
-    if not rows:
+    if not rows and not markdown:
         return ""
 
-    t = Texttable()
-
-    # disable automatic formatting
-    t.set_cols_dtype(["t"] * len(header))
-
-    # remove borders to make it easier for users to copy stuff
-    t.set_chars([""] * len(header))
-    t.set_deco(0)
-
-    t.add_rows([header] + rows)
-
-    return t.draw()
+    return tabulate(
+        rows,
+        header,
+        tablefmt="github" if markdown else "plain",
+        disable_numparse=True,
+    )
 
 
 def format_dict(d):

--- a/dvc/utils/diff.py
+++ b/dvc/utils/diff.py
@@ -96,6 +96,8 @@ def table(header, rows, markdown=False):
         header,
         tablefmt="github" if markdown else "plain",
         disable_numparse=True,
+        # None will be shown as "" by default, overriding
+        missingval="None",
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ install_requires = [
     "pydot>=1.2.4",
     "speedcopy>=2.0.1; python_version < '3.8' and sys_platform == 'win32'",
     "flatten_json>=0.1.6",
-    "texttable>=0.5.2",
+    "tabulate>=0.8.7",
     "pygtrie==2.3.2",
     "dpath>=2.0.1,<3",
 ]

--- a/tests/unit/command/test_params.py
+++ b/tests/unit/command/test_params.py
@@ -1,4 +1,5 @@
 import logging
+import textwrap
 
 from dvc.cli import parse_args
 from dvc.command.params import CmdParamsDiff, _show_diff
@@ -21,25 +22,32 @@ def test_params_diff(dvc, mocker):
 
 
 def test_params_diff_changed():
-    assert _show_diff({"params.yaml": {"a.b.c": {"old": 1, "new": 2}}}) == (
-        "   Path       Param   Old   New\n" "params.yaml   a.b.c   1     2  "
+    assert _show_diff(
+        {"params.yaml": {"a.b.c": {"old": 1, "new": 2}}}
+    ) == textwrap.dedent(
+        """\
+        Path         Param    Old    New
+        params.yaml  a.b.c    1      2"""
     )
 
 
 def test_params_diff_list():
     assert _show_diff(
         {"params.yaml": {"a.b.c": {"old": 1, "new": [2, 3]}}}
-    ) == (
-        "   Path       Param   Old    New  \n"
-        "params.yaml   a.b.c   1     [2, 3]"
+    ) == textwrap.dedent(
+        """\
+        Path         Param    Old    New
+        params.yaml  a.b.c    1      [2, 3]"""
     )
 
 
 def test_params_diff_unchanged():
     assert _show_diff(
         {"params.yaml": {"a.b.d": {"old": "old", "new": "new"}}}
-    ) == (
-        "   Path       Param   Old   New\n" "params.yaml   a.b.d   old   new"
+    ) == textwrap.dedent(
+        """\
+        Path         Param    Old    New
+        params.yaml  a.b.d    old    new"""
     )
 
 
@@ -50,25 +58,30 @@ def test_params_diff_no_changes():
 def test_params_diff_new():
     assert _show_diff(
         {"params.yaml": {"a.b.d": {"old": None, "new": "new"}}}
-    ) == (
-        "   Path       Param   Old    New\n" "params.yaml   a.b.d   None   new"
+    ) == textwrap.dedent(
+        """\
+        Path         Param    Old    New
+        params.yaml  a.b.d    None   new"""
     )
 
 
 def test_params_diff_deleted():
     assert _show_diff(
         {"params.yaml": {"a.b.d": {"old": "old", "new": None}}}
-    ) == (
-        "   Path       Param   Old   New \n" "params.yaml   a.b.d   old   None"
+    ) == textwrap.dedent(
+        """\
+        Path         Param    Old    New
+        params.yaml  a.b.d    old    None"""
     )
 
 
 def test_params_diff_prec():
     assert _show_diff(
         {"params.yaml": {"train.lr": {"old": 0.0042, "new": 0.0043}}}
-    ) == (
-        "   Path        Param      Old      New  \n"
-        "params.yaml   train.lr   0.0042   0.0043"
+    ) == textwrap.dedent(
+        """\
+        Path         Param     Old     New
+        params.yaml  train.lr  0.0042  0.0043"""
     )
 
 
@@ -94,9 +107,38 @@ def test_params_diff_sorted():
                 "a.b.c": {"old": 1, "new": 2},
             }
         }
-    ) == (
-        "   Path       Param   Old   New\n"
-        "params.yaml   a.b.c   1     2  \n"
-        "params.yaml   a.d.e   3     4  \n"
-        "params.yaml   x.b     5     6  "
+    ) == textwrap.dedent(
+        """\
+        Path         Param    Old    New
+        params.yaml  a.b.c    1      2
+        params.yaml  a.d.e    3      4
+        params.yaml  x.b      5      6"""
+    )
+
+
+def test_params_diff_markdown_empty():
+    assert _show_diff({}, markdown=True) == textwrap.dedent(
+        """\
+        | Path   | Param   | Old   | New   |
+        |--------|---------|-------|-------|"""
+    )
+
+
+def test_params_diff_markdown():
+    assert _show_diff(
+        {
+            "params.yaml": {
+                "x.b": {"old": 5, "new": 6},
+                "a.d.e": {"old": None, "new": 4},
+                "a.b.c": {"old": 1, "new": None},
+            }
+        },
+        markdown=True,
+    ) == textwrap.dedent(
+        """\
+        | Path        | Param   | Old   | New   |
+        |-------------|---------|-------|-------|
+        | params.yaml | a.b.c   | 1     | None  |
+        | params.yaml | a.d.e   | None  | 4     |
+        | params.yaml | x.b     | 5     | 6     |"""
     )


### PR DESCRIPTION
Via `--show-md` on `diff`s.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

https://github.com/iterative/dvc.org/pull/1266

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏


- [x] Still unsure about what should be shown in `dvc diff --show-md`.

The `dvc params diff` and similar commands would output header centered. With this change, it will be left-aligned.

Previously:
```sh
$ dvc params diff
   Path           Param        Old     New
params.yaml   lr               None   0.0041
params.yaml   process.bow      None   15000
params.yaml   process.thresh   None   0.98
params.yaml   train.epochs     None   70
params.yaml   train.layers     None   9
```

Now:
```sh
$ dvc params diff
Path         Param           Old    New
params.yaml  lr              None   0.0041
params.yaml  process.bow     None   15000
params.yaml  process.thresh  None   0.98
params.yaml  train.epochs    None   70
params.yaml  train.layers    None   9
```

1. 
```sh
$ dvc params diff --show-md
| Path        | Param          | Old   | New    |
|-------------|----------------|-------|--------|
| params.yaml | lr             | None  | 0.0041 |
| params.yaml | process.bow    | None  | 15000  |
| params.yaml | process.thresh | None  | 0.98   |
| params.yaml | train.epochs   | None  | 70     |
| params.yaml | train.layers   | None  | 9      |
```

^ Same output in markdown parsed by Github:
| Path        | Param          | Old   | New    |
|-------------|----------------|-------|--------|
| params.yaml | lr             | None  | 0.0041 |
| params.yaml | process.bow    | None  | 15000  |
| params.yaml | process.thresh | None  | 0.98   |
| params.yaml | train.epochs   | None  | 70     |
| params.yaml | train.layers   | None  | 9      |

Resolve #3690