### PR TITLE
Added S3 SSEKMSKeyId config option

### DIFF
--- a/dvc/config.py
+++ b/dvc/config.py
@@ -151,6 +151,7 @@ SCHEMA = {
                     Optional("listobjects", default=False): Bool,
                     Optional("use_ssl", default=True): Bool,
                     "sse": str,
+                    "sse_kms_key_id": str,
                     "acl": str,
                     "grant_read": str,
                     "grant_read_acp": str,

--- a/dvc/remote/s3.py
+++ b/dvc/remote/s3.py
@@ -46,6 +46,10 @@ class S3Remote(BaseRemote):
         if self.sse:
             self.extra_args["ServerSideEncryption"] = self.sse
 
+        self.sse_kms_key_id = config.get("sse_kms_key_id")
+        if self.sse_kms_key_id:
+            self.extra_args["SSEKMSKeyId"] = self.sse_kms_key_id
+
         self.acl = config.get("acl")
         if self.acl:
             self.extra_args["ACL"] = self.acl

--- a/tests/unit/remote/test_s3.py
+++ b/tests/unit/remote/test_s3.py
@@ -53,3 +53,8 @@ def test_grants_mutually_exclusive_acl_error(dvc, grants):
 
         with pytest.raises(ConfigError):
             S3Remote(dvc, config)
+
+
+def test_sse_kms_key_id(dvc):
+    remote = S3Remote(dvc, {"url": url, "sse_kms_key_id": "key"})
+    assert remote.extra_args["SSEKMSKeyId"] == "key"


### PR DESCRIPTION
* [X ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [(will do) ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [X ] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
---
I added an `sse_kms_key_id` parameter to the S3 config section.

Ultimately, it may make sense to iterate through the S3 ALLOWED_UPLOAD_ARGS and add any that exist to extra_args, but you'd need to enable ALLOW_EXTRA in the S3 voluptuous schema. With the way the schema is set up, you'd end up allowing extra arguments in the entire configuration schema, which I'm not sure is what we want.

Here's an example of the S3 init sequence if you did ALLOW_EXTRA in the S3 schema - and you could git rid of the sse, acl, and _append_aws_grants_to_extra_args() code.
```
        self.extra_args = {}
        for key in self.ALLOWED_UPLOAD_ARGS:
            value = config.get(key)
            if value:
                self.extra_args[key] = value
```