### PR TITLE
push/pull: properly collect run cache

### DIFF
--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -48,12 +48,7 @@ class DataCloud(object):
         return Remote(self.repo, name=name)
 
     def push(
-        self,
-        cache,
-        jobs=None,
-        remote=None,
-        show_checksums=False,
-        run_cache=False,
+        self, cache, jobs=None, remote=None, show_checksums=False,
     ):
         """Push data items in a cloud-agnostic way.
 
@@ -67,20 +62,12 @@ class DataCloud(object):
         """
         remote = self.get_remote(remote, "push")
 
-        if run_cache:
-            self.repo.stage_cache.push(remote)
-
         return self.repo.cache.local.push(
             cache, jobs=jobs, remote=remote, show_checksums=show_checksums,
         )
 
     def pull(
-        self,
-        cache,
-        jobs=None,
-        remote=None,
-        show_checksums=False,
-        run_cache=False,
+        self, cache, jobs=None, remote=None, show_checksums=False,
     ):
         """Pull data items in a cloud-agnostic way.
 
@@ -93,9 +80,6 @@ class DataCloud(object):
                 information messages.
         """
         remote = self.get_remote(remote, "pull")
-
-        if run_cache:
-            self.repo.stage_cache.pull(remote)
 
         downloaded_items_num = self.repo.cache.local.pull(
             cache, jobs=jobs, remote=remote, show_checksums=show_checksums

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -248,6 +248,7 @@ class Repo(object):
         force=False,
         jobs=None,
         recursive=False,
+        used_run_cache=None,
     ):
         """Get the stages related to the given target and collect
         the `info` of its outputs.
@@ -290,6 +291,12 @@ class Repo(object):
                     filter_info=filter_info,
                 )
                 cache.update(used_cache, suffix=suffix)
+
+        if used_run_cache:
+            used_cache = self.stage_cache.get_used_cache(
+                used_run_cache, remote=remote, force=force, jobs=jobs,
+            )
+            cache.update(used_cache)
 
         return cache
 

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -34,6 +34,9 @@ def _fetch(
         config.NoRemoteError: thrown when downloading only local files and no
             remote is configured
     """
+
+    used_run_cache = self.stage_cache.pull(remote) if run_cache else []
+
     used = self.used_cache(
         targets,
         all_branches=all_branches,
@@ -44,6 +47,7 @@ def _fetch(
         remote=remote,
         jobs=jobs,
         recursive=recursive,
+        used_run_cache=used_run_cache,
     )
 
     downloaded = 0
@@ -51,11 +55,7 @@ def _fetch(
 
     try:
         downloaded += self.cloud.pull(
-            used,
-            jobs,
-            remote=remote,
-            show_checksums=show_checksums,
-            run_cache=run_cache,
+            used, jobs, remote=remote, show_checksums=show_checksums,
         )
     except NoRemoteError:
         if not used.external and used["local"]:

--- a/dvc/repo/push.py
+++ b/dvc/repo/push.py
@@ -14,6 +14,8 @@ def push(
     all_commits=False,
     run_cache=False,
 ):
+    used_run_cache = self.stage_cache.push(remote) if run_cache else []
+
     used = self.used_cache(
         targets,
         all_branches=all_branches,
@@ -24,6 +26,7 @@ def push(
         remote=remote,
         jobs=jobs,
         recursive=recursive,
+        used_run_cache=used_run_cache,
     )
 
-    return self.cloud.push(used, jobs, remote=remote, run_cache=run_cache)
+    return self.cloud.push(used, jobs, remote=remote)


### PR DESCRIPTION
Ideally run cache should be a part of NamedCache and transferred as a regular cache through push/pull, but that requires a refactor, so for now we keep doing that manually to unblock CICD.

Fixes #1234

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
