### PR TITLE
dvc.yaml: remove outs_no_cache, etc. keys, merge inside metrics/outs

### DIFF
--- a/dvc/output/__init__.py
+++ b/dvc/output/__init__.py
@@ -110,16 +110,9 @@ def loadd_from(stage, d_list):
 
 
 def loads_from(stage, s_list, use_cache=True, metric=False, persist=False):
-    ret = []
-    for s in s_list:
-        ret.append(
-            _get(
-                stage,
-                s,
-                info={},
-                cache=use_cache,
-                metric=metric,
-                persist=persist,
-            )
+    return [
+        _get(
+            stage, s, info={}, cache=use_cache, metric=metric, persist=persist,
         )
-    return ret
+        for s in s_list
+    ]

--- a/dvc/schema.py
+++ b/dvc/schema.py
@@ -1,8 +1,8 @@
 from voluptuous import Any, Optional, Required, Schema
 
 from dvc import dependency, output
-from dvc.output import CHECKSUMS_SCHEMA
-from dvc.stage.params import OutputParams, StageParams
+from dvc.output import CHECKSUMS_SCHEMA, BaseOutput
+from dvc.stage.params import StageParams
 
 STAGES = "stages"
 SINGLE_STAGE_SCHEMA = {
@@ -25,16 +25,29 @@ LOCK_FILE_STAGE_SCHEMA = {
 }
 LOCKFILE_SCHEMA = {str: LOCK_FILE_STAGE_SCHEMA}
 
+OUT_PSTAGE_DETAILED_SCHEMA = {
+    str: {
+        BaseOutput.PARAM_CACHE: bool,
+        BaseOutput.PARAM_PERSIST: bool,
+        BaseOutput.PARAM_METRIC: bool,
+    }
+}
+PARAM_PSTAGE_NON_DEFAULT_SCHEMA = {str: [str]}
+
 SINGLE_PIPELINE_STAGE_SCHEMA = {
     str: {
         StageParams.PARAM_CMD: str,
         Optional(StageParams.PARAM_WDIR): str,
         Optional(StageParams.PARAM_DEPS): [str],
-        Optional(StageParams.PARAM_PARAMS): [Any(str, {str: [str]})],
+        Optional(StageParams.PARAM_PARAMS): [
+            Any(str, PARAM_PSTAGE_NON_DEFAULT_SCHEMA)
+        ],
         Optional(StageParams.PARAM_LOCKED): bool,
         Optional(StageParams.PARAM_META): object,
         Optional(StageParams.PARAM_ALWAYS_CHANGED): bool,
-        **{Optional(p.value): [str] for p in OutputParams},
+        Optional(StageParams.PARAM_OUTS): [
+            Any(str, OUT_PSTAGE_DETAILED_SCHEMA)
+        ],
     }
 }
 MULTI_STAGE_SCHEMA = {STAGES: SINGLE_PIPELINE_STAGE_SCHEMA}

--- a/dvc/stage/loader.py
+++ b/dvc/stage/loader.py
@@ -11,7 +11,6 @@ from dvc import dependency, output
 
 from ..dependency import ParamsDependency
 from .exceptions import StageNameUnspecified, StageNotFound
-from .utils import fill_stage_dependencies, fill_stage_outputs
 
 logger = logging.getLogger(__name__)
 
@@ -112,10 +111,34 @@ class StageLoader(Mapping):
                 path = first(key)
                 res[path].extend(key[path])
 
-        stage.deps += dependency.loadd_from(
-            stage,
-            [{"path": key, "params": params} for key, params in res.items()],
+        stage.deps.extend(
+            dependency.loadd_from(
+                stage,
+                [
+                    {"path": key, "params": params}
+                    for key, params in res.items()
+                ],
+            )
         )
+
+    @classmethod
+    def _load_outs(cls, stage, data):
+        d = []
+        for key in data:
+            extra_kwargs = {}
+            if isinstance(key, str):
+                path = key
+            elif isinstance(key, dict):
+                path = first(key)
+                extra_kwargs = key[path]
+            else:
+                continue
+            d.append({"path": path, **extra_kwargs})
+        stage.outs.extend(output.loadd_from(stage, d))
+
+    @classmethod
+    def _load_deps(cls, stage, data):
+        stage.deps.extend(dependency.loads_from(stage, data))
 
     @classmethod
     def load_stage(cls, dvcfile, name, stage_data, lock_data):
@@ -126,9 +149,12 @@ class StageLoader(Mapping):
         )
         stage = loads_from(PipelineStage, dvcfile.repo, path, wdir, stage_data)
         stage.name = name
-        fill_stage_dependencies(stage, deps=stage_data.get("deps", []))
-        fill_stage_outputs(stage, **stage_data)
+        stage.deps, stage.outs = [], []
+
+        cls._load_outs(stage, stage_data.get("outs", []))
+        cls._load_deps(stage, stage_data.get("deps", []))
         cls._load_params(stage, stage_data.get("params", []))
+
         if lock_data:
             stage.cmd_changed = lock_data.get(
                 Stage.PARAM_CMD

--- a/tests/func/test_lockfile.py
+++ b/tests/func/test_lockfile.py
@@ -1,8 +1,6 @@
 from collections import OrderedDict
 from operator import itemgetter
-from textwrap import dedent
 
-import pytest
 import yaml
 
 from dvc.dvcfile import PIPELINE_LOCK
@@ -18,32 +16,6 @@ FS_STRUCTURE = {
     "params.yaml": yaml.dump(supported_params),
     "params2.yaml": yaml.dump(supported_params),
 }
-
-
-@pytest.fixture
-def run_head(tmp_dir, dvc):
-    """Output first line of each file to different file with '-1' appended."""
-    tmp_dir.gen(
-        "head.py",
-        dedent(
-            """
-        import sys
-        for file in sys.argv[1:]:
-            with open(file) as f, open(file +"-1","w+") as w:
-                w.write(f.readline())
-        """
-        ),
-    )
-
-    def run(*args, **run_kwargs):
-        return dvc.run(
-            cmd="python head.py {}".format(" ".join(args)),
-            outs=[dep + "-1" for dep in args],
-            deps=args,
-            **run_kwargs
-        )
-
-    return run
 
 
 def read_lock_file(file=PIPELINE_LOCK):


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

* ~~Fix schema~~ (technical debt, will be handled separately)
* ~~Refactor constant string literals~~ (technical debt will be handled separately)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

The dvc.yaml had following kinds of keys for ech stages:
```yaml
  evaluate:
    cmd: python src/evaluate.py model.pkl data/features auc.metric
    deps:
    - data/features
    - model.pkl
    - src/evaluate.py
    metrics_no_cache:
    - auc.metric
```

This will be changed to:
```yaml
  evaluate:
    cmd: python src/evaluate.py model.pkl data/features auc.metric
    deps:
    - data/features
    - model.pkl
    - src/evaluate.py
    metrics:
    - auc.metric:
        cache: false
```

Similarly, `persist_outs` will have `persist: true` and `persist_no_cache` will have `cache: false and persist: true`. And, this will only happen if they are not the defaults (i.e cache is false or persist is true). Otherwise, they will be just a list of strings.
