### PR TITLE
plot: add doctype at the beggining of html embedding

### DIFF
--- a/dvc/repo/plot/__init__.py
+++ b/dvc/repo/plot/__init__.py
@@ -10,7 +10,8 @@ from dvc.repo.plot.template import NoDataForTemplateError, Template
 
 logger = logging.getLogger(__name__)
 
-PAGE_HTML = """<html>
+PAGE_HTML = """<!DOCTYPE html>
+<html>
 <head>
     <title>DVC Plot</title>
     <script src="https://cdn.jsdelivr.net/npm/vega@5.10.0"></script>


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Credits to @fabiosantoscode for noticing! 