### PR TITLE
stage: moving things around, refactor

### DIFF
--- a/dvc/serialize.py
+++ b/dvc/serialize.py
@@ -6,11 +6,12 @@ from typing import TYPE_CHECKING, List
 from funcy import lsplit, rpartial
 
 from dvc.dependency import ParamsDependency
+from dvc.stage.utils import resolve_wdir
 from dvc.utils.collections import apply_diff
 from dvc.utils.stage import parse_stage_for_update
 
 if TYPE_CHECKING:
-    from dvc.stage import PipelineStage, Stage, resolve_wdir
+    from dvc.stage import PipelineStage, Stage
 
 PARAM_PATH = ParamsDependency.PARAM_PATH
 PARAM_PARAMS = ParamsDependency.PARAM_PARAMS

--- a/dvc/serialize.py
+++ b/dvc/serialize.py
@@ -10,7 +10,7 @@ from dvc.utils.collections import apply_diff
 from dvc.utils.stage import parse_stage_for_update
 
 if TYPE_CHECKING:
-    from dvc.stage import PipelineStage, Stage
+    from dvc.stage import PipelineStage, Stage, resolve_wdir
 
 PARAM_PATH = ParamsDependency.PARAM_PATH
 PARAM_PARAMS = ParamsDependency.PARAM_PARAMS
@@ -77,7 +77,7 @@ def to_pipeline_file(stage: "PipelineStage"):
 
     res = [
         (stage.PARAM_CMD, stage.cmd),
-        (stage.PARAM_WDIR, stage.resolve_wdir()),
+        (stage.PARAM_WDIR, resolve_wdir(stage.wdir, stage.path)),
         (stage.PARAM_DEPS, sorted([d.def_path for d in deps])),
         (stage.PARAM_PARAMS, serialized_params),
         *_get_outs(stage),

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -218,6 +218,9 @@ class Stage(params.StageParams):
         if self.always_changed:
             return True
 
+        return self._changed_deps()
+
+    def _changed_deps(self):
         for dep in self.deps:
             status = dep.status()
             if status:
@@ -228,7 +231,6 @@ class Stage(params.StageParams):
                     )
                 )
                 return True
-
         return False
 
     def changed_outs(self):

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -272,13 +272,10 @@ class Stage(params.StageParams):
         for out in self.outs:
             if out.persist and not force:
                 out.unprotect()
-            else:
-                logger.debug(
-                    "Removing output '{out}' of {stage}.".format(
-                        out=out, stage=self
-                    )
-                )
-                out.remove(ignore_remove=ignore_remove)
+                continue
+
+            logger.debug("Removing output '{}' of {}.".format(out, self))
+            out.remove(ignore_remove=ignore_remove)
 
     def unprotect_outs(self):
         for out in self.outs:

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -387,19 +387,20 @@ class Stage(params.StageParams):
         logger.debug("Computed {} md5: '{}'".format(self, m))
         return m
 
+    def save(self):
+        self.save_deps()
+        self.save_outs()
+        self.md5 = self.compute_md5()
+
+        self.repo.stage_cache.save(self)
+
     def save_deps(self):
         for dep in self.deps:
             dep.save()
 
-    def save(self):
-        self.save_deps()
-
+    def save_outs(self):
         for out in self.outs:
             out.save()
-
-        self.md5 = self.compute_md5()
-
-        self.repo.stage_cache.save(self)
 
     @staticmethod
     def _changed_entries(entries):

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -20,7 +20,7 @@ from .utils import (
     compute_md5,
     fill_stage_dependencies,
     fill_stage_outputs,
-    resolve_wdir,
+    get_dump,
     stage_dump_eq,
 )
 
@@ -357,19 +357,7 @@ class Stage(params.StageParams):
         return True
 
     def dumpd(self):
-        return {
-            key: value
-            for key, value in {
-                Stage.PARAM_MD5: self.md5,
-                Stage.PARAM_CMD: self.cmd,
-                Stage.PARAM_WDIR: resolve_wdir(self.wdir, self.path),
-                Stage.PARAM_LOCKED: self.locked,
-                Stage.PARAM_DEPS: [d.dumpd() for d in self.deps],
-                Stage.PARAM_OUTS: [o.dumpd() for o in self.outs],
-                Stage.PARAM_ALWAYS_CHANGED: self.always_changed,
-            }.items()
-            if value
-        }
+        return get_dump(self)
 
     def compute_md5(self):
         m = compute_md5(self)

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -253,20 +253,18 @@ class Stage(params.StageParams):
 
     @rwlocked(read=["deps", "outs"])
     def changed(self):
-        if self._changed():
-            logger.debug("{} changed.".format(self))
-            return True
-
-        logger.debug("{} didn't change.".format(self))
-        return False
-
-    def _changed(self):
-        # Short-circuit order: stage md5 is fast, deps are expected to change
-        return (
+        is_changed = (
+            # Short-circuit order: stage md5 is fast,
+            # deps are expected to change
             self.changed_stage(warn=True)
             or self.changed_deps()
             or self.changed_outs()
         )
+        if is_changed:
+            logger.info("%s changed.", self)
+        else:
+            logger.info("%s didn't change.", self)
+        return is_changed
 
     @rwlocked(write=["outs"])
     def remove_outs(self, ignore_remove=False, force=False):

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -297,7 +297,7 @@ class Stage(params.StageParams):
     @rwlocked(read=["deps"], write=["outs"])
     def reproduce(self, interactive=False, **kwargs):
 
-        if not kwargs.get("force", False) and not self.changed():
+        if not (kwargs.get("force", False) or self.changed()):
             return None
 
         msg = (
@@ -315,7 +315,7 @@ class Stage(params.StageParams):
         return self
 
     def update(self, rev=None):
-        if not self.is_repo_import and not self.is_import:
+        if not (self.is_repo_import or self.is_import):
             raise StageUpdateError(self.relpath)
 
         self.deps[0].update(rev=rev)
@@ -422,7 +422,7 @@ class Stage(params.StageParams):
             msg += "md5" if not (changed_deps or changed_outs) else ""
             msg += " of {} changed. ".format(self)
             msg += "Are you sure you want to commit it?"
-            if not force and not prompt.confirm(msg):
+            if not (force or prompt.confirm(msg)):
                 raise StageCommitError(
                     "unable to commit changed {}. Use `-f|--force` to "
                     "force.".format(self)

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import pathlib
 import string
 
 from funcy import project
@@ -21,6 +20,7 @@ from .utils import (
     compute_md5,
     fill_stage_dependencies,
     fill_stage_outputs,
+    resolve_wdir,
     stage_dump_eq,
 )
 
@@ -361,19 +361,13 @@ class Stage(params.StageParams):
 
         return True
 
-    def resolve_wdir(self):
-        rel_wdir = relpath(self.wdir, os.path.dirname(self.path))
-        return (
-            pathlib.PurePath(rel_wdir).as_posix() if rel_wdir != "." else None
-        )
-
     def dumpd(self):
         return {
             key: value
             for key, value in {
                 Stage.PARAM_MD5: self.md5,
                 Stage.PARAM_CMD: self.cmd,
-                Stage.PARAM_WDIR: self.resolve_wdir(),
+                Stage.PARAM_WDIR: resolve_wdir(self.wdir, self.path),
                 Stage.PARAM_LOCKED: self.locked,
                 Stage.PARAM_DEPS: [d.dumpd() for d in self.deps],
                 Stage.PARAM_OUTS: [o.dumpd() for o in self.outs],

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -529,12 +529,10 @@ class Stage(params.StageParams):
 
 
 class PipelineStage(Stage):
-    def __init__(self, *args, name=None, meta=None, **kwargs):
+    def __init__(self, *args, name=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.name = name
         self.cmd_changed = False
-        # This is how the Stage will discover any discrepancies
-        self.meta = meta or {}
 
     def __eq__(self, other):
         return super().__eq__(other) and self.name == other.name

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -12,11 +12,11 @@ from dvc.utils import relpath
 
 from . import params
 from .decorators import rwlocked
-from .exceptions import MissingDataSource, StageCommitError, StageUpdateError
-from .run import run_stage
+from .exceptions import StageCommitError, StageUpdateError
 from .utils import (
     check_circular_dependency,
     check_duplicated_arguments,
+    check_missing_outputs,
     check_stage_path,
     compute_md5,
     fill_stage_dependencies,
@@ -81,6 +81,8 @@ def create_stage(cls, repo, path, **kwargs):
 
 
 class Stage(params.StageParams):
+    from .run import run_stage, cmd_run
+
     def __init__(
         self,
         repo,
@@ -432,40 +434,43 @@ class Stage(params.StageParams):
         for out in self.outs:
             out.commit()
 
-    def _import_run(self, dry=False, force=False):
+    def _import_sync(self, dry=False, force=False):
+        """Synchronize import's outs to the workspace."""
         logger.info(
             "Importing '{dep}' -> '{out}'".format(
                 dep=self.deps[0], out=self.outs[0]
             )
         )
-        if not dry:
-            if (
-                not force
-                and not self.changed_stage(warn=True)
-                and self.already_cached()
-            ):
-                self.outs[0].checkout()
-            else:
-                self.deps[0].download(self.outs[0])
+        if dry:
+            return
+
+        if (
+            not force
+            and not self.changed_stage(warn=True)
+            and self.already_cached()
+        ):
+            self.outs[0].checkout()
+        else:
+            self.deps[0].download(self.outs[0])
 
     @rwlocked(read=["deps"], write=["outs"])
     def run(self, dry=False, no_commit=False, force=False, run_cache=True):
         if (self.cmd or self.is_import) and not self.locked and not dry:
             self.remove_outs(ignore_remove=False, force=False)
 
-        if self.locked or self.is_data_source:
-            msg = "Verifying {} in {}{}".format(
+        if not self.locked and self.is_import:
+            self._import_sync(dry, force)
+        elif not self.locked and self.cmd:
+            self.run_stage(dry, force, run_cache)
+        else:
+            logger.info(
+                "Verifying %s in %s%s",
                 "outputs" if self.locked else "data sources",
                 "locked " if self.locked else "",
                 self,
             )
-            logger.info(msg)
             if not dry:
-                self.check_missing_outputs()
-        elif self.is_import:
-            self._import_run(dry, force)
-        else:
-            run_stage(self, dry, force, run_cache)
+                check_missing_outputs(self)
 
         if dry:
             return
@@ -473,11 +478,6 @@ class Stage(params.StageParams):
         self.save()
         if not no_commit:
             self.commit()
-
-    def check_missing_outputs(self):
-        paths = [str(out) for out in self.outs if not out.exists]
-        if paths:
-            raise MissingDataSource(paths)
 
     def _filter_outs(self, path_info):
         def _func(o):

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -13,6 +13,7 @@ from . import params
 from .decorators import rwlocked
 from .exceptions import StageCommitError, StageUpdateError
 from .imports import sync_import, update_import
+from .run import run_stage
 from .utils import (
     check_circular_dependency,
     check_duplicated_arguments,
@@ -82,8 +83,6 @@ def create_stage(cls, repo, path, **kwargs):
 
 
 class Stage(params.StageParams):
-    from .run import run_stage, cmd_run
-
     def __init__(
         self,
         repo,
@@ -414,7 +413,7 @@ class Stage(params.StageParams):
         if not self.locked and self.is_import:
             sync_import(self, dry, force)
         elif not self.locked and self.cmd:
-            self.run_stage(dry, force, run_cache)
+            run_stage(self, dry, force, run_cache)
         else:
             args = (
                 ("outputs", "locked ") if self.locked else ("data sources", "")

--- a/dvc/stage/decorators.py
+++ b/dvc/stage/decorators.py
@@ -1,4 +1,6 @@
-from funcy import decorator, wraps
+from functools import wraps
+
+from funcy import decorator
 
 
 @decorator

--- a/dvc/stage/decorators.py
+++ b/dvc/stage/decorators.py
@@ -1,5 +1,3 @@
-from functools import wraps
-
 from funcy import decorator
 
 
@@ -33,19 +31,3 @@ def rwlocked(call, read=None, write=None):
 
     with rwlock(stage.repo.tmp_dir, cmd, _chain(read), _chain(write)):
         return call()
-
-
-def unlocked_repo(f):
-    @wraps(f)
-    def wrapper(stage, *args, **kwargs):
-        stage.repo.state.dump()
-        stage.repo.lock.unlock()
-        stage.repo._reset()
-        try:
-            ret = f(stage, *args, **kwargs)
-        finally:
-            stage.repo.lock.lock()
-            stage.repo.state.load()
-        return ret
-
-    return wrapper

--- a/dvc/stage/exceptions.py
+++ b/dvc/stage/exceptions.py
@@ -2,8 +2,8 @@ from dvc.exceptions import DvcException
 
 
 class StageCmdFailedError(DvcException):
-    def __init__(self, stage, status=None):
-        msg = "failed to run: {}".format(stage.cmd)
+    def __init__(self, cmd, status=None):
+        msg = "failed to run: {}".format(cmd)
         if status is not None:
             msg += ", exited with {}".format(status)
         super().__init__(msg)

--- a/dvc/stage/exceptions.py
+++ b/dvc/stage/exceptions.py
@@ -112,5 +112,5 @@ class DuplicateStageName(DvcException):
 
 
 class InvalidStageName(DvcException):
-    def __init__(self,):
+    def __init__(self):
         super().__init__("Stage name cannot contain punctuation characters.")

--- a/dvc/stage/imports.py
+++ b/dvc/stage/imports.py
@@ -1,0 +1,33 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def update_import(stage, rev=None):
+    stage.deps[0].update(rev=rev)
+    locked = stage.locked
+    stage.locked = False
+    try:
+        stage.reproduce()
+    finally:
+        stage.locked = locked
+
+
+def sync_import(stage, dry=False, force=False):
+    """Synchronize import's outs to the workspace."""
+    logger.info(
+        "Importing '{dep}' -> '{out}'".format(
+            dep=stage.deps[0], out=stage.outs[0]
+        )
+    )
+    if dry:
+        return
+
+    if (
+        not force
+        and not stage.changed_stage(warn=True)
+        and stage.already_cached()
+    ):
+        stage.outs[0].checkout()
+    else:
+        stage.deps[0].download(stage.outs[0])

--- a/dvc/stage/loader.py
+++ b/dvc/stage/loader.py
@@ -15,7 +15,6 @@ from .utils import fill_stage_dependencies, fill_stage_outputs
 
 logger = logging.getLogger(__name__)
 
-
 DEFAULT_PARAMS_FILE = ParamsDependency.DEFAULT_PARAMS_FILE
 
 

--- a/dvc/stage/loader.py
+++ b/dvc/stage/loader.py
@@ -11,6 +11,7 @@ from dvc import dependency, output
 
 from ..dependency import ParamsDependency
 from .exceptions import StageNameUnspecified, StageNotFound
+from .utils import fill_stage_dependencies, fill_stage_outputs
 
 logger = logging.getLogger(__name__)
 
@@ -127,8 +128,8 @@ class StageLoader(Mapping):
         stage = loads_from(PipelineStage, dvcfile.repo, path, wdir, stage_data)
         stage.name = name
         params = stage_data.pop("params", {})
-        stage._fill_stage_dependencies(**stage_data)
-        stage._fill_stage_outputs(**stage_data)
+        fill_stage_dependencies(stage, deps=stage_data.get("deps", []))
+        fill_stage_outputs(stage, **stage_data)
         cls._load_params(stage, params)
         if lock_data:
             stage.cmd_changed = lock_data.get(

--- a/dvc/stage/loader.py
+++ b/dvc/stage/loader.py
@@ -126,10 +126,9 @@ class StageLoader(Mapping):
         )
         stage = loads_from(PipelineStage, dvcfile.repo, path, wdir, stage_data)
         stage.name = name
-        params = stage_data.pop("params", {})
         fill_stage_dependencies(stage, deps=stage_data.get("deps", []))
         fill_stage_outputs(stage, **stage_data)
-        cls._load_params(stage, params)
+        cls._load_params(stage, stage_data.get("params", []))
         if lock_data:
             stage.cmd_changed = lock_data.get(
                 Stage.PARAM_CMD

--- a/dvc/stage/run.py
+++ b/dvc/stage/run.py
@@ -73,7 +73,7 @@ def cmd_run(stage, *args, **kwargs):
 
     retcode = None if not p else p.returncode
     if retcode != 0:
-        raise StageCmdFailedError(cmd, retcode)
+        raise StageCmdFailedError(stage.cmd, retcode)
 
 
 def run_stage(stage, dry=False, force=False, run_cache=False):

--- a/dvc/stage/run.py
+++ b/dvc/stage/run.py
@@ -103,4 +103,4 @@ def run_stage(stage, dry=False, force=False, run_cache=False):
         stage.checkout()
     else:
         logger.info("Running command:\n\t{}".format(stage.cmd))
-        stage.cmd_run(stage.cmd, stage.wdir)
+        cmd_run(stage)

--- a/dvc/stage/run.py
+++ b/dvc/stage/run.py
@@ -1,0 +1,115 @@
+import logging
+import os
+import signal
+import subprocess
+import threading
+from contextlib import contextmanager
+
+from dvc.stage.exceptions import StageCmdFailedError
+from dvc.utils import fix_env
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def unlocked_repo(repo):
+    repo.state.dump()
+    repo.lock.unlock()
+    repo._reset()
+    yield
+    repo.lock.lock()
+    repo.state.load()
+
+
+def warn_if_fish(executable):
+    if (
+        executable is None
+        or os.path.basename(os.path.realpath(executable)) != "fish"
+    ):
+        return
+
+    logger.warning(
+        "DVC detected that you are using fish as your default "
+        "shell. Be aware that it might cause problems by overwriting "
+        "your current environment variables with values defined "
+        "in '.fishrc', which might affect your command. See "
+        "https://github.com/iterative/dvc/issues/1307. "
+    )
+
+
+def _cmd_run(cmd, wdir):
+    kwargs = {"cwd": wdir, "env": fix_env(None), "close_fds": True}
+
+    if os.name == "nt":
+        kwargs["shell"] = True
+        _cmd = cmd
+    else:
+        # NOTE: when you specify `shell=True`, `Popen` [1] will default to
+        # `/bin/sh` on *nix and will add ["/bin/sh", "-c"] to your command.
+        # But we actually want to run the same shell that we are running
+        # from right now, which is usually determined by the `SHELL` env
+        # var. So instead, we compose our command on our own, making sure
+        # to include special flags to prevent shell from reading any
+        # configs and modifying env, which may change the behavior or the
+        # command we are running. See [2] for more info.
+        #
+        # [1] https://github.com/python/cpython/blob/3.7/Lib/subprocess.py
+        #                                                            #L1426
+        # [2] https://github.com/iterative/dvc/issues/2506
+        #                                           #issuecomment-535396799
+        kwargs["shell"] = False
+        executable = os.getenv("SHELL") or "/bin/sh"
+
+        warn_if_fish(executable)
+
+        opts = {"zsh": ["--no-rcs"], "bash": ["--noprofile", "--norc"]}
+        name = os.path.basename(executable).lower()
+        _cmd = [executable] + opts.get(name, []) + ["-c", cmd]
+
+    main_thread = isinstance(threading.current_thread(), threading._MainThread)
+    old_handler = None
+    p = None
+
+    try:
+        p = subprocess.Popen(_cmd, **kwargs)
+        if main_thread:
+            old_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
+        p.communicate()
+    finally:
+        if old_handler:
+            signal.signal(signal.SIGINT, old_handler)
+
+    retcode = None if not p else p.returncode
+    if retcode != 0:
+        raise StageCmdFailedError(cmd, retcode)
+
+
+def run_stage(stage, dry=False, force=False, run_cache=False):
+    if dry:
+        return
+    stage_cache = stage.repo.stage_cache
+    stage_cached = (
+        not force
+        and not stage.is_callback
+        and not stage.always_changed
+        and stage.already_cached()
+    )
+    use_build_cache = False
+    if not stage_cached:
+        stage.save_deps()
+        use_build_cache = (
+            not force and run_cache and stage_cache.is_cached(stage)
+        )
+
+    if use_build_cache:
+        # restore stage from build cache
+        stage.repo.stage_cache.restore(stage)
+        stage_cached = stage.outs_cached()
+
+    if stage_cached:
+        logger.info("Stage is cached, skipping.")
+        stage.checkout()
+    else:
+        logger.info("Running command:\n\t{}".format(stage.cmd))
+        with unlocked_repo(stage.repo):
+            _cmd_run(stage.cmd, stage.wdir)

--- a/dvc/stage/utils.py
+++ b/dvc/stage/utils.py
@@ -135,3 +135,19 @@ def compute_md5(stage):
 def resolve_wdir(wdir, path):
     rel_wdir = relpath(wdir, os.path.dirname(path))
     return pathlib.PurePath(rel_wdir).as_posix() if rel_wdir != "." else None
+
+
+def get_dump(stage):
+    return {
+        key: value
+        for key, value in {
+            stage.PARAM_MD5: stage.md5,
+            stage.PARAM_CMD: stage.cmd,
+            stage.PARAM_WDIR: resolve_wdir(stage.wdir, stage.path),
+            stage.PARAM_LOCKED: stage.locked,
+            stage.PARAM_DEPS: [d.dumpd() for d in stage.deps],
+            stage.PARAM_OUTS: [o.dumpd() for o in stage.outs],
+            stage.PARAM_ALWAYS_CHANGED: stage.always_changed,
+        }.items()
+        if value
+    }

--- a/dvc/stage/utils.py
+++ b/dvc/stage/utils.py
@@ -1,11 +1,12 @@
 import os
+import pathlib
 from itertools import product
 
 from dvc import dependency, output
 from dvc.utils.fs import path_isin
 
 from ..remote import LocalRemote, S3Remote
-from ..utils import dict_md5
+from ..utils import dict_md5, relpath
 from .exceptions import (
     MissingDataSource,
     StagePathNotDirectoryError,
@@ -129,3 +130,8 @@ def compute_md5(stage):
             BaseOutput.PARAM_PERSIST,
         ],
     )
+
+
+def resolve_wdir(wdir, path):
+    rel_wdir = relpath(wdir, os.path.dirname(path))
+    return pathlib.PurePath(rel_wdir).as_posix() if rel_wdir != "." else None

--- a/dvc/stage/utils.py
+++ b/dvc/stage/utils.py
@@ -1,0 +1,74 @@
+import os
+
+from dvc import dependency, output
+from dvc.utils.fs import path_isin
+
+from .exceptions import (
+    StagePathNotDirectoryError,
+    StagePathNotFoundError,
+    StagePathOutsideError,
+)
+from .params import OutputParams
+
+
+def check_stage_path(repo, path, is_wdir=False):
+    assert repo is not None
+
+    error_msg = "{wdir_or_path} '{path}' {{}}".format(
+        wdir_or_path="stage working dir" if is_wdir else "file path",
+        path=path,
+    )
+
+    real_path = os.path.realpath(path)
+    if not os.path.exists(real_path):
+        raise StagePathNotFoundError(error_msg.format("does not exist"))
+
+    if not os.path.isdir(real_path):
+        raise StagePathNotDirectoryError(error_msg.format("is not directory"))
+
+    proj_dir = os.path.realpath(repo.root_dir)
+    if real_path != proj_dir and not path_isin(real_path, proj_dir):
+        raise StagePathOutsideError(error_msg.format("is outside of DVC repo"))
+
+
+def fill_stage_outputs(stage, **kwargs):
+    assert not stage.outs
+
+    stage.outs = []
+    for key in (p.value for p in OutputParams):
+        stage.outs += output.loads_from(
+            stage,
+            kwargs.get(key, []),
+            use_cache="no_cache" not in key,
+            persist="persist" in key,
+            metric="metrics" in key,
+        )
+
+
+def fill_stage_dependencies(stage, deps=None, erepo=None, params=None):
+    assert not stage.deps
+    stage.deps = []
+    stage.deps += dependency.loads_from(stage, deps or [], erepo=erepo)
+    stage.deps += dependency.loads_params(stage, params or [])
+
+
+def check_circular_dependency(stage):
+    from dvc.exceptions import CircularDependencyError
+
+    circular_dependencies = set(d.path_info for d in stage.deps) & set(
+        o.path_info for o in stage.outs
+    )
+
+    if circular_dependencies:
+        raise CircularDependencyError(str(circular_dependencies.pop()))
+
+
+def check_duplicated_arguments(stage):
+    from dvc.exceptions import ArgumentDuplicationError
+    from collections import Counter
+
+    path_counts = Counter(edge.path_info for edge in stage.deps + stage.outs)
+
+    for path, occurrence in path_counts.items():
+        if occurrence > 1:
+            raise ArgumentDuplicationError(str(path))

--- a/dvc/stage/utils.py
+++ b/dvc/stage/utils.py
@@ -60,9 +60,9 @@ def fill_stage_dependencies(stage, deps=None, erepo=None, params=None):
 def check_circular_dependency(stage):
     from dvc.exceptions import CircularDependencyError
 
-    circular_dependencies = set(d.path_info for d in stage.deps) & set(
+    circular_dependencies = {d.path_info for d in stage.deps} & {
         o.path_info for o in stage.outs
-    )
+    }
 
     if circular_dependencies:
         raise CircularDependencyError(str(circular_dependencies.pop()))

--- a/dvc/stage/utils.py
+++ b/dvc/stage/utils.py
@@ -7,6 +7,7 @@ from dvc.utils.fs import path_isin
 from ..remote import LocalRemote, S3Remote
 from ..utils import dict_md5
 from .exceptions import (
+    MissingDataSource,
     StagePathNotDirectoryError,
     StagePathNotFoundError,
     StagePathOutsideError,
@@ -75,6 +76,12 @@ def check_duplicated_arguments(stage):
     for path, occurrence in path_counts.items():
         if occurrence > 1:
             raise ArgumentDuplicationError(str(path))
+
+
+def check_missing_outputs(stage):
+    paths = [str(out) for out in stage.outs if not out.exists]
+    if paths:
+        raise MissingDataSource(paths)
 
 
 def stage_dump_eq(stage_cls, old_d, new_d):

--- a/tests/func/test_repro.py
+++ b/tests/func/test_repro.py
@@ -859,7 +859,9 @@ class TestReproExternalBase(SingleStageRun, TestDvc):
             stage.outs[0], "checkout", wraps=stage.outs[0].checkout
         )
 
-        patch_run = patch.object(stage, "cmd_run", wraps=stage.cmd_run)
+        from dvc.stage.run import cmd_run
+
+        patch_run = patch("dvc.stage.run.cmd_run", wraps=cmd_run)
 
         with self.dvc.lock, self.dvc.state:
             with patch_download as mock_download:

--- a/tests/func/test_repro.py
+++ b/tests/func/test_repro.py
@@ -859,7 +859,7 @@ class TestReproExternalBase(SingleStageRun, TestDvc):
             stage.outs[0], "checkout", wraps=stage.outs[0].checkout
         )
 
-        patch_run = patch.object(stage, "_run", wraps=stage._run)
+        patch_run = patch.object(stage, "cmd_run", wraps=stage.cmd_run)
 
         with self.dvc.lock, self.dvc.state:
             with patch_download as mock_download:

--- a/tests/func/test_run_single_stage.py
+++ b/tests/func/test_run_single_stage.py
@@ -919,7 +919,7 @@ class TestShouldNotCheckoutUponCorruptedLocalHardlinkCache(TestDvc):
         patch_checkout = mock.patch.object(
             stage.outs[0], "checkout", wraps=stage.outs[0].checkout
         )
-        patch_run = mock.patch.object(stage, "_run", wraps=stage._run)
+        patch_run = mock.patch.object(stage, "cmd_run", wraps=stage.cmd_run)
 
         with self.dvc.lock, self.dvc.state:
             with patch_checkout as mock_checkout:

--- a/tests/func/test_run_single_stage.py
+++ b/tests/func/test_run_single_stage.py
@@ -919,7 +919,9 @@ class TestShouldNotCheckoutUponCorruptedLocalHardlinkCache(TestDvc):
         patch_checkout = mock.patch.object(
             stage.outs[0], "checkout", wraps=stage.outs[0].checkout
         )
-        patch_run = mock.patch.object(stage, "cmd_run", wraps=stage.cmd_run)
+        from dvc.stage.run import cmd_run
+
+        patch_run = mock.patch("dvc.stage.run.cmd_run", wraps=cmd_run)
 
         with self.dvc.lock, self.dvc.state:
             with patch_checkout as mock_checkout:

--- a/tests/func/test_stage.py
+++ b/tests/func/test_stage.py
@@ -160,7 +160,7 @@ def test_md5_ignores_comments(tmp_dir, dvc):
         f.write("# End comment\n")
 
     new_stage = SingleStageFile(dvc, stage.path).stage
-    assert not new_stage.stage_changed()
+    assert not new_stage.changed_stage()
 
 
 def test_meta_is_preserved(tmp_dir, dvc):

--- a/tests/unit/test_stage.py
+++ b/tests/unit/test_stage.py
@@ -142,7 +142,7 @@ def test_stage_cache(tmp_dir, dvc, run_copy, mocker):
     assert os.listdir(cache_dir) == [os.path.basename(cache_file)]
     assert os.path.isfile(cache_file)
 
-    run_spy = mocker.spy(stage, "_run")
+    run_spy = mocker.spy(stage, "cmd_run")
     checkout_spy = mocker.spy(stage, "checkout")
     with dvc.lock, dvc.state:
         stage.run()

--- a/tests/unit/test_stage.py
+++ b/tests/unit/test_stage.py
@@ -23,7 +23,7 @@ def test_stage_checksum():
     stage = Stage(None, "path")
 
     with mock.patch.object(stage, "dumpd", return_value=TEST_STAGE_DICT):
-        assert stage._compute_md5() == "e9521a22111493406ea64a88cda63e0b"
+        assert stage.compute_md5() == "e9521a22111493406ea64a88cda63e0b"
 
 
 def test_wdir_default_ignored():
@@ -31,7 +31,7 @@ def test_wdir_default_ignored():
     d = dict(TEST_STAGE_DICT, wdir=".")
 
     with mock.patch.object(stage, "dumpd", return_value=d):
-        assert stage._compute_md5() == "e9521a22111493406ea64a88cda63e0b"
+        assert stage.compute_md5() == "e9521a22111493406ea64a88cda63e0b"
 
 
 def test_wdir_non_default_is_not_ignored():
@@ -39,7 +39,7 @@ def test_wdir_non_default_is_not_ignored():
     d = dict(TEST_STAGE_DICT, wdir="..")
 
     with mock.patch.object(stage, "dumpd", return_value=d):
-        assert stage._compute_md5() == "2ceba15e87f6848aa756502c1e6d24e9"
+        assert stage.compute_md5() == "2ceba15e87f6848aa756502c1e6d24e9"
 
 
 def test_meta_ignored():
@@ -47,7 +47,7 @@ def test_meta_ignored():
     d = dict(TEST_STAGE_DICT, meta={"author": "Suor"})
 
     with mock.patch.object(stage, "dumpd", return_value=d):
-        assert stage._compute_md5() == "e9521a22111493406ea64a88cda63e0b"
+        assert stage.compute_md5() == "e9521a22111493406ea64a88cda63e0b"
 
 
 class TestPathConversion(TestCase):

--- a/tests/unit/test_stage.py
+++ b/tests/unit/test_stage.py
@@ -142,7 +142,7 @@ def test_stage_cache(tmp_dir, dvc, run_copy, mocker):
     assert os.listdir(cache_dir) == [os.path.basename(cache_file)]
     assert os.path.isfile(cache_file)
 
-    run_spy = mocker.spy(stage, "cmd_run")
+    run_spy = mocker.patch("dvc.stage.run.cmd_run")
     checkout_spy = mocker.spy(stage, "checkout")
     with dvc.lock, dvc.state:
         stage.run()


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏


This PR:
* Extracts some functions from `Stage` to `utils.py`.
* Change name of functions: makes name of the most of the functions to not have `_` prefix 
  (at least those that are used outside of the `Stage` class).
* `run` and `import` related functions are on `run.py` and `imports.py` respectively.
* merge some redundant functions (eg: `changed() and _changed()`).

This keeps the bugs and most of the codebases intact, just a small refactor that moves things around.

**TIP:** Look at each commits, that way it might be easy.

Apart from a few methods (eg: `status`, `changed`, etc.), I have splitted the methods from stage on
the basis of "if it modifies outs/deps/cmd". If it does, it stays, otherwise it's extracted to be a helper method.