### PR TITLE
dvc.yaml: make persist/cache bool flags in outs/metrics

### DIFF
--- a/dvc/schema.py
+++ b/dvc/schema.py
@@ -2,7 +2,8 @@ from voluptuous import Any, Optional, Required, Schema
 
 from dvc import dependency, output
 from dvc.output import CHECKSUMS_SCHEMA
-from dvc.stage.params import OutputParams, StageParams
+from dvc.output.base import BaseOutput
+from dvc.stage.params import StageParams
 
 STAGES = "stages"
 SINGLE_STAGE_SCHEMA = {
@@ -34,7 +35,24 @@ SINGLE_PIPELINE_STAGE_SCHEMA = {
         Optional(StageParams.PARAM_LOCKED): bool,
         Optional(StageParams.PARAM_META): object,
         Optional(StageParams.PARAM_ALWAYS_CHANGED): bool,
-        **{Optional(p.value): [str] for p in OutputParams},
+        Optional(StageParams.PARAM_OUTS): [
+            Any(
+                str,
+                {
+                    str: {
+                        Optional(BaseOutput.PARAM_CACHE): bool,
+                        Optional(BaseOutput.PARAM_PERSIST): bool,
+                    }
+                },
+            )
+        ],
+        Optional(StageParams.PARAM_OUTS_NO_CACHE): [str],
+        Optional(StageParams.PARAM_METRICS): [
+            Any(str, {str: {Optional(BaseOutput.PARAM_CACHE): bool}})
+        ],
+        Optional(StageParams.PARAM_METRICS_NO_CACHE): [str],
+        Optional(StageParams.PARAM_OUTS_PERSIST): [str],
+        Optional(StageParams.PARAM_OUTS_PERSIST_NO_CACHE): [str],
     }
 }
 MULTI_STAGE_SCHEMA = {STAGES: SINGLE_PIPELINE_STAGE_SCHEMA}

--- a/dvc/serialize.py
+++ b/dvc/serialize.py
@@ -24,14 +24,17 @@ sort_by_path = partial(sorted, key=attrgetter("def_path"))
 def _get_outs(stage: "PipelineStage"):
     outs_bucket = {}
     for o in sort_by_path(stage.outs):
-        bucket_key = ["metrics"] if o.metric else ["outs"]
+        key = "metrics" if o.metric else "outs"
 
-        if not o.metric and o.persist:
-            bucket_key += ["persist"]
+        extra = {}
+        if o.persist:
+            extra["persist"] = True
         if not o.use_cache:
-            bucket_key += ["no_cache"]
-        key = "_".join(bucket_key)
-        outs_bucket[key] = outs_bucket.get(key, []) + [o.def_path]
+            extra["cache"] = False
+
+        value = {o.def_path: extra} if extra else o.def_path
+
+        outs_bucket[key] = outs_bucket.get(key, []) + [value]
     return [(key, outs_bucket[key]) for key in sorted(outs_bucket.keys())]
 
 

--- a/dvc/stage/params.py
+++ b/dvc/stage/params.py
@@ -1,6 +1,3 @@
-from enum import Enum
-
-
 class StageParams:
     PARAM_MD5 = "md5"
     PARAM_CMD = "cmd"
@@ -12,11 +9,9 @@ class StageParams:
     PARAM_ALWAYS_CHANGED = "always_changed"
     PARAM_PARAMS = "params"
 
-
-class OutputParams(Enum):
-    PERSIST = "outs_persist"
-    PERSIST_NO_CACHE = "outs_persist_no_cache"
-    METRICS_NO_CACHE = "metrics_no_cache"
-    METRICS = "metrics"
-    NO_CACHE = "outs_no_cache"
-    OUTS = "outs"
+    PARAM_OUTS_PERSIST = "outs_persist"
+    PARAM_OUTS_PERSIST_NO_CACHE = "outs_persist_no_cache"
+    PARAM_METRICS_NO_CACHE = "metrics_no_cache"
+    PARAM_METRICS = "metrics"
+    PARAM_OUTS_NO_CACHE = "outs_no_cache"
+    PARAM_OUTS = "outs"

--- a/tests/func/test_run_multistage.py
+++ b/tests/func/test_run_multistage.py
@@ -151,7 +151,7 @@ def test_run_dump_on_multistage(tmp_dir, dvc):
             "copy-foo-foo2": {
                 "cmd": "cp foo foo2",
                 "deps": ["foo"],
-                "outs_persist": ["foo2"],
+                "outs": [{"foo2": {"persist": True}}],
                 "always_changed": True,
                 "wdir": "dir",
             },


### PR DESCRIPTION
More explicit CLI-like options `metrics/persist_no_cache` are still supported,
but we use flags when generating dvc.yaml.

Part of #3409, prerequisite for `plot`.

* [ ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [ ] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
