### PR TITLE
logger: add trace, count --verbose/--quiet

### DIFF
--- a/dvc/cli.py
+++ b/dvc/cli.py
@@ -116,14 +116,10 @@ def get_parent_parser():
 
     log_level_group = parent_parser.add_mutually_exclusive_group()
     log_level_group.add_argument(
-        "-q", "--quiet", action="store_true", default=False, help="Be quiet."
+        "-q", "--quiet", action="count", default=0, help="Be quiet."
     )
     log_level_group.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        default=False,
-        help="Be verbose.",
+        "-v", "--verbose", action="count", default=0, help="Be verbose."
     )
 
     return parent_parser

--- a/dvc/logger.py
+++ b/dvc/logger.py
@@ -7,7 +7,7 @@ import colorama
 
 from dvc.progress import Tqdm
 
-DATABASE = 5  # logging level
+TRACE = 5  # logging level
 FOOTER = (
     "\n{yellow}Having any troubles?{nc}"
     " Hit us up at {blue}https://dvc.org/support{nc},"

--- a/dvc/logger.py
+++ b/dvc/logger.py
@@ -7,6 +7,7 @@ import colorama
 
 from dvc.progress import Tqdm
 
+DATABASE = 5  # logging level
 FOOTER = (
     "\n{yellow}Having any troubles?{nc}"
     " Hit us up at {blue}https://dvc.org/support{nc},"
@@ -116,7 +117,11 @@ class LoggerHandler(logging.StreamHandler):
 
 
 def _is_verbose():
-    return logging.getLogger("dvc").getEffectiveLevel() == logging.DEBUG
+    return (
+        logging.NOTSET
+        < logging.getLogger("dvc").getEffectiveLevel()
+        <= logging.DEBUG
+    )
 
 
 def _iter_causes(exc):

--- a/dvc/logger.py
+++ b/dvc/logger.py
@@ -51,14 +51,12 @@ class LoggingException(Exception):
         super().__init__(msg)
 
 
-class ExcludeErrorsFilter(logging.Filter):
-    def filter(self, record):
-        return record.levelno < logging.WARNING
+def excludeFilter(level):
+    class ExcludeLevelFilter(logging.Filter):
+        def filter(self, record):
+            return record.levelno < level
 
-
-class ExcludeInfoFilter(logging.Filter):
-    def filter(self, record):
-        return record.levelno < logging.INFO
+    return ExcludeLevelFilter
 
 
 class ColorFormatter(logging.Formatter):
@@ -189,8 +187,9 @@ def setup(level=logging.INFO):
         {
             "version": 1,
             "filters": {
-                "exclude_errors": {"()": ExcludeErrorsFilter},
-                "exclude_info": {"()": ExcludeInfoFilter},
+                "exclude_errors": {"()": excludeFilter(logging.WARNING)},
+                "exclude_info": {"()": excludeFilter(logging.INFO)},
+                "exclude_debug": {"()": excludeFilter(logging.DEBUG)},
             },
             "formatters": {"color": {"()": ColorFormatter}},
             "handlers": {
@@ -213,7 +212,7 @@ def setup(level=logging.INFO):
                     "level": "TRACE",
                     "formatter": "color",
                     "stream": "ext://sys.stdout",
-                    "filters": ["exclude_info"],
+                    "filters": ["exclude_debug"],
                 },
                 "console_errors": {
                     "class": "dvc.logger.LoggerHandler",

--- a/dvc/main.py
+++ b/dvc/main.py
@@ -8,7 +8,7 @@ from dvc.cli import parse_args
 from dvc.config import ConfigError
 from dvc.exceptions import DvcException, DvcParserError, NotDvcRepoError
 from dvc.external_repo import clean_repos
-from dvc.logger import DATABASE, FOOTER, disable_other_loggers
+from dvc.logger import FOOTER, TRACE, disable_other_loggers
 from dvc.remote.pool import close_pools
 from dvc.utils import format_link
 
@@ -44,7 +44,7 @@ def main(argv=None):
                 -1: logging.ERROR,
                 0: logging.INFO,
                 1: logging.DEBUG,
-                2: DATABASE,
+                2: TRACE,
             }[max(-2, min(args.verbose - args.quiet, 2))]
         )
 

--- a/dvc/main.py
+++ b/dvc/main.py
@@ -8,7 +8,7 @@ from dvc.cli import parse_args
 from dvc.config import ConfigError
 from dvc.exceptions import DvcException, DvcParserError, NotDvcRepoError
 from dvc.external_repo import clean_repos
-from dvc.logger import FOOTER, TRACE, disable_other_loggers
+from dvc.logger import FOOTER, disable_other_loggers
 from dvc.remote.pool import close_pools
 from dvc.utils import format_link
 
@@ -17,7 +17,6 @@ from dvc.utils import format_link
 # [2] https://bugs.python.org/issue29288
 
 "".encode("idna")
-
 
 logger = logging.getLogger("dvc")
 
@@ -44,9 +43,10 @@ def main(argv=None):
                 -1: logging.ERROR,
                 0: logging.INFO,
                 1: logging.DEBUG,
-                2: TRACE,
+                2: logging.TRACE,
             }[max(-2, min(args.verbose - args.quiet, 2))]
         )
+        logger.trace(args)
 
         cmd = args.func(args)
         ret = cmd.run()

--- a/dvc/main.py
+++ b/dvc/main.py
@@ -39,7 +39,7 @@ def main(argv=None):
 
         logger.setLevel(
             {
-                -2: logging.FATAL,
+                -2: logging.CRITICAL,
                 -1: logging.ERROR,
                 0: logging.INFO,
                 1: logging.DEBUG,

--- a/dvc/main.py
+++ b/dvc/main.py
@@ -37,15 +37,16 @@ def main(argv=None):
     try:
         args = parse_args(argv)
 
-        logger.setLevel(
-            {
-                -2: logging.CRITICAL,
-                -1: logging.ERROR,
-                0: logging.INFO,
-                1: logging.DEBUG,
-                2: logging.TRACE,
-            }[max(-2, min(args.verbose - args.quiet, 2))]
-        )
+        verbosity = args.verbose - args.quiet
+        if verbosity:
+            logger.setLevel(
+                {
+                    -2: logging.CRITICAL,
+                    -1: logging.ERROR,
+                    1: logging.DEBUG,
+                    2: logging.TRACE,
+                }[max(-2, min(verbosity, 2))]
+            )
         logger.trace(args)
 
         cmd = args.func(args)

--- a/dvc/main.py
+++ b/dvc/main.py
@@ -8,7 +8,7 @@ from dvc.cli import parse_args
 from dvc.config import ConfigError
 from dvc.exceptions import DvcException, DvcParserError, NotDvcRepoError
 from dvc.external_repo import clean_repos
-from dvc.logger import FOOTER, disable_other_loggers
+from dvc.logger import DATABASE, FOOTER, disable_other_loggers
 from dvc.remote.pool import close_pools
 from dvc.utils import format_link
 
@@ -38,11 +38,15 @@ def main(argv=None):
     try:
         args = parse_args(argv)
 
-        if args.quiet:
-            logger.setLevel(logging.CRITICAL)
-
-        elif args.verbose:
-            logger.setLevel(logging.DEBUG)
+        logger.setLevel(
+            {
+                -2: logging.FATAL,
+                -1: logging.ERROR,
+                0: logging.INFO,
+                1: logging.DEBUG,
+                2: DATABASE,
+            }[max(-2, min(args.verbose - args.quiet, 2))]
+        )
 
         cmd = args.func(args)
         ret = cmd.run()

--- a/dvc/state.py
+++ b/dvc/state.py
@@ -125,7 +125,7 @@ class State:  # pylint: disable=too-many-instance-attributes
         self.dump()
 
     def _execute(self, cmd, parameters=()):
-        logger.debug(cmd)
+        logger.trace(cmd)
         return self.cursor.execute(cmd, parameters)
 
     def _fetchall(self):

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -222,10 +222,11 @@ class TestColorFormatter:
 
 
 def test_handlers():
-    out, deb, err = logger.handlers
+    out, deb, vrb, err = logger.handlers
 
     assert out.level == logging.INFO
     assert deb.level == logging.DEBUG
+    assert vrb.level == logging.TRACE
     assert err.level == logging.WARNING
 
 
@@ -233,6 +234,7 @@ def test_logging_debug_with_datetime(caplog, dt):
     with caplog.at_level(logging.DEBUG, logger="dvc"):
         logger.warning("WARNING")
         logger.debug("DEBUG")
+        logger.trace("TRACE")
         logger.error("ERROR")
 
         for record in caplog.records:


### PR DESCRIPTION
- [x] count `-q`/`-v` CLI flags to determine verbosity
- [x] add `trace`/`TRACE` logging level (more verbose than `debug`)
- [x] move some (e.g. database/state cmd) `debug` logging to `trace`
- [ ] add tests
  - [x] fix/update tests
- fixes #2332
- related (maybe fixes?) #2329

> [...] if you are convinced that you need custom levels, great care should be exercised when doing this, and it is possibly *a very bad idea to define custom levels if you are developing a library* [...] if multiple library authors all define their own custom levels [...]

-- https://docs.python.org/3/howto/logging.html#custom-levels

> We already do `disable_other_loggers()` so muhuhu hahaha.

-- @casperdcl


```bash
# before
dvc (logging-counts)$ dvc status -v | wc -l
34
# after moving state commands to trace (`-vv`)
dvc (logging-counts)$ python -m dvc status -v | wc -l
20
```