### PR TITLE
(OutputAlreadyTrackedError): Add git suggestions to stop tracking files

### DIFF
--- a/dvc/output/base.py
+++ b/dvc/output/base.py
@@ -31,7 +31,11 @@ class OutputIsNotFileOrDirError(DvcException):
 
 class OutputAlreadyTrackedError(DvcException):
     def __init__(self, path):
-        msg = f"output '{path}' is already tracked by SCM (e.g. Git)"
+        msg = f""" output '{path}' is already tracked by SCM (e.g. Git).
+    You can remove it from git, then add to DVC.
+        To stop tracking from git:
+            git rm -r --cached '{path}'
+            git commit -m "stop tracking {path}" """
         super().__init__(msg)
 
 

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -124,10 +124,16 @@ class TestAddDirectoryWithForwardSlash(TestDvc):
 
 
 def test_add_tracked_file(tmp_dir, scm, dvc):
-    tmp_dir.scm_gen("tracked_file", "...", commit="add tracked file")
+    path = "tracked_file"
+    tmp_dir.scm_gen(path, "...", commit="add tracked file")
+    msg = f""" output '{path}' is already tracked by SCM \\(e.g. Git\\).
+    You can remove it from git, then add to DVC.
+        To stop tracking from git:
+            git rm -r --cached '{path}'
+            git commit -m "stop tracking {path}" """
 
-    with pytest.raises(OutputAlreadyTrackedError):
-        dvc.add("tracked_file")
+    with pytest.raises(OutputAlreadyTrackedError, match=msg):
+        dvc.add(path)
 
 
 class TestAddDirWithExistingCache(TestDvc):


### PR DESCRIPTION
Fixes: #3678

When file has been already tracked under git, OutputAlreadyTrackedError gets raised.
This commits add git command suggestions to help user to stop tracking file from git,
so in future commits they can use DVC for the file.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
