### PR TITLE
repo: Support streaming and pulling files on `RepoTree/DvcTree.open()`

### DIFF
--- a/dvc/output/base.py
+++ b/dvc/output/base.py
@@ -339,7 +339,7 @@ class BaseOutput:
         if self.exists:
             self.remote.unprotect(self.path_info)
 
-    def _collect_used_dir_cache(
+    def collect_used_dir_cache(
         self, remote=None, force=False, jobs=None, filter_info=None
     ):
         """Get a list of `info`s related to the given directory.
@@ -449,7 +449,7 @@ class BaseOutput:
             return ret
 
         ret.add_child_cache(
-            self.checksum, self._collect_used_dir_cache(**kwargs),
+            self.checksum, self.collect_used_dir_cache(**kwargs),
         )
 
         return ret

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -119,10 +119,6 @@ class Repo:
         # tree.
         self._reset()
 
-    @cached_property
-    def repo_tree(self):
-        return RepoTree(self, stream=True)
-
     def __repr__(self):
         return f"{self.__class__.__name__}: '{self.root_dir}'"
 
@@ -486,10 +482,12 @@ class Repo:
 
     @contextmanager
     def open_by_relpath(self, path, remote=None, mode="r", encoding=None):
+        tree = RepoTree(self, stream=True)
+
         """Opens a specified resource as a file descriptor"""
         path = os.path.join(self.root_dir, path)
         try:
-            with self.repo_tree.open(
+            with tree.open(
                 os.path.join(self.root_dir, path),
                 mode=mode,
                 encoding=encoding,

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -482,9 +482,9 @@ class Repo:
 
     @contextmanager
     def open_by_relpath(self, path, remote=None, mode="r", encoding=None):
-        tree = RepoTree(self, stream=True)
-
         """Opens a specified resource as a file descriptor"""
+
+        tree = RepoTree(self, stream=True)
         path = os.path.join(self.root_dir, path)
         try:
             with tree.open(

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -5,15 +5,12 @@ from functools import wraps
 from funcy import cached_property, cat, first
 
 from dvc.config import Config
-from dvc.exceptions import (
-    FileMissingError,
-    IsADirectoryError,
-    NotDvcRepoError,
-    OutputNotFoundError,
-)
+from dvc.exceptions import FileMissingError
+from dvc.exceptions import IsADirectoryError as DvcIsADirectoryError
+from dvc.exceptions import NotDvcRepoError, OutputNotFoundError
 from dvc.ignore import CleanTree
 from dvc.path_info import PathInfo
-from dvc.remote.base import RemoteActionNotImplemented
+from dvc.repo.tree import RepoTree
 from dvc.utils.fs import path_isin
 
 from ..utils import parse_target
@@ -121,6 +118,10 @@ class Repo:
         # Our graph cache is no longer valid, as it was based on the previous
         # tree.
         self._reset()
+
+    @cached_property
+    def repo_tree(self):
+        return RepoTree(self, stream=True)
 
     def __repr__(self):
         return f"{self.__class__.__name__}: '{self.root_dir}'"
@@ -486,48 +487,19 @@ class Repo:
     @contextmanager
     def open_by_relpath(self, path, remote=None, mode="r", encoding=None):
         """Opens a specified resource as a file descriptor"""
-        cause = None
+        path = os.path.join(self.root_dir, path)
         try:
-            out = self.find_out_by_relpath(path)
-        except OutputNotFoundError as exc:
-            out = None
-            cause = exc
-
-        if out and out.use_cache:
-            try:
-                with self._open_cached(out, remote, mode, encoding) as fd:
-                    yield fd
-                return
-            except FileNotFoundError as exc:
-                raise FileMissingError(path) from exc
-
-        abs_path = os.path.join(self.root_dir, path)
-        if os.path.exists(abs_path):
-            with open(abs_path, mode=mode, encoding=encoding) as fd:
-                yield fd
-            return
-
-        raise FileMissingError(path) from cause
-
-    def _open_cached(self, out, remote=None, mode="r", encoding=None):
-        if out.isdir():
-            raise IsADirectoryError("Can't open a dir")
-
-        cache_file = self.cache.local.checksum_to_path_info(out.checksum)
-
-        if os.path.exists(cache_file):
-            return open(cache_file, mode=mode, encoding=encoding)
-
-        try:
-            remote_obj = self.cloud.get_remote(remote)
-            remote_info = remote_obj.checksum_to_path_info(out.checksum)
-            return remote_obj.open(remote_info, mode=mode, encoding=encoding)
-        except RemoteActionNotImplemented:
-            with self.state:
-                cache_info = out.get_used_cache(remote=remote)
-                self.cloud.pull(cache_info, remote=remote)
-
-            return open(cache_file, mode=mode, encoding=encoding)
+            with self.repo_tree.open(
+                os.path.join(self.root_dir, path),
+                mode=mode,
+                encoding=encoding,
+                remote=remote,
+            ) as fobj:
+                yield fobj
+        except FileNotFoundError as exc:
+            raise FileMissingError(path) from exc
+        except IsADirectoryError as exc:
+            raise DvcIsADirectoryError from exc
 
     def close(self):
         self.scm.close()

--- a/dvc/repo/tree.py
+++ b/dvc/repo/tree.py
@@ -192,7 +192,8 @@ class RepoTree(BaseTree):
                     path, mode=mode, encoding=encoding, **kwargs
                 )
             except FileNotFoundError:
-                pass
+                if self.isdvc(path):
+                    raise
         return self.repo.tree.open(path, mode=mode, encoding=encoding)
 
     def exists(self, path):

--- a/dvc/repo/tree.py
+++ b/dvc/repo/tree.py
@@ -214,6 +214,8 @@ class RepoTree(BaseTree):
         )
 
     def isexec(self, path):
+        if self.dvctree and self.dvctree.exists(path):
+            return self.dvctree.isexec(path)
         return self.repo.tree.isexec(path)
 
     def _walk_one(self, walk):

--- a/tests/unit/repo/test_repo_tree.py
+++ b/tests/unit/repo/test_repo_tree.py
@@ -1,0 +1,119 @@
+import os
+import shutil
+
+from dvc.repo.tree import RepoTree
+
+
+def test_exists(tmp_dir, dvc):
+    tmp_dir.gen("foo", "foo")
+    dvc.add("foo")
+    (tmp_dir / "foo").unlink()
+
+    tree = RepoTree(dvc)
+    assert tree.exists("foo")
+
+
+def test_open(tmp_dir, dvc):
+    tmp_dir.gen("foo", "foo")
+    dvc.add("foo")
+    (tmp_dir / "foo").unlink()
+
+    tree = RepoTree(dvc)
+    with tree.open("foo", "r") as fobj:
+        assert fobj.read() == "foo"
+
+
+def test_open_in_history(tmp_dir, scm, dvc):
+    tmp_dir.gen("foo", "foo")
+    dvc.add("foo")
+    dvc.scm.add(["foo.dvc", ".gitignore"])
+    dvc.scm.commit("foo")
+
+    tmp_dir.gen("foo", "foofoo")
+    dvc.add("foo")
+    dvc.scm.add(["foo.dvc", ".gitignore"])
+    dvc.scm.commit("foofoo")
+
+    for rev in dvc.brancher(revs=["HEAD~1"]):
+        if rev == "working tree":
+            continue
+
+        tree = RepoTree(dvc)
+        with tree.open("foo", "r") as fobj:
+            assert fobj.read() == "foo"
+
+
+def test_isdir_isfile(tmp_dir, dvc):
+    tmp_dir.gen({"datafile": "data", "datadir": {"foo": "foo", "bar": "bar"}})
+
+    tree = RepoTree(dvc)
+    assert tree.isdir("datadir")
+    assert not tree.isfile("datadir")
+    assert not tree.isdvc("datadir")
+    assert not tree.isdir("datafile")
+    assert tree.isfile("datafile")
+    assert not tree.isdvc("datafile")
+
+    dvc.add(["datadir", "datafile"])
+    shutil.rmtree(tmp_dir / "datadir")
+    (tmp_dir / "datafile").unlink()
+
+    assert tree.isdir("datadir")
+    assert not tree.isfile("datadir")
+    assert tree.isdvc("datadir")
+    assert not tree.isdir("datafile")
+    assert tree.isfile("datafile")
+    assert tree.isdvc("datafile")
+
+
+def test_isdir_mixed(tmp_dir, dvc):
+    tmp_dir.gen({"dir": {"foo": "foo", "bar": "bar"}})
+
+    dvc.add(str(tmp_dir / "dir" / "foo"))
+
+    tree = RepoTree(dvc)
+    assert tree.isdir("dir")
+    assert not tree.isfile("dir")
+
+
+def test_walk(tmp_dir, dvc):
+    tmp_dir.gen(
+        {
+            "dir": {
+                "subdir1": {"foo1": "foo1", "bar1": "bar1"},
+                "subdir2": {"foo2": "foo2"},
+            }
+        }
+    )
+    dvc.add(str(tmp_dir / "dir"), recursive=True)
+    tmp_dir.gen({"dir": {"foo": "foo", "bar": "bar"}})
+    tree = RepoTree(dvc)
+
+    expected = [
+        os.path.join("dir", "subdir1"),
+        os.path.join("dir", "subdir2"),
+        os.path.join("dir", "subdir1", "foo1"),
+        os.path.join("dir", "subdir1", "foo1.dvc"),
+        os.path.join("dir", "subdir1", "bar1"),
+        os.path.join("dir", "subdir1", "bar1.dvc"),
+        os.path.join("dir", "subdir2", "foo2"),
+        os.path.join("dir", "subdir2", "foo2.dvc"),
+        os.path.join("dir", "foo"),
+        os.path.join("dir", "bar"),
+    ]
+
+    actual = []
+    for root, dirs, files in tree.walk("dir"):
+        for entry in dirs + files:
+            actual.append(os.path.join(root, entry))
+
+    assert set(actual) == set(expected)
+    assert len(actual) == len(expected)
+
+
+def test_isdvc(tmp_dir, dvc):
+    tmp_dir.gen({"foo": "foo", "bar": "bar"})
+    dvc.add("foo")
+    tree = RepoTree(dvc)
+    assert tree.isdvc("foo")
+    assert not tree.isdvc("bar")


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

* `RepoTree` now supports all `BaseTree` methods
* Adds support for fetching or streaming DVC outs directly from remote on `RepoTree`/`DvcTree.open()`.
    * If an out is already in local cache, it will always be opened from cache.
    * For outs which are not in local cache, if `DvcTree` was initialized with `fetch=True` or `stream=True`, the out will be fetched or streamed, otherwise an error will be raised
* `Repo.open_by_relpath()` now uses `RepoTree.open()`
* `RepoTree`/`DvcTree.walk()` now support walking dir contents for dir outs
    * If tree was initialized with `fetch=True` or `stream=True`, tree will pull dir cache for dir outs on `walk` when needed
    * Otherwise, dir contents will not be walked (same as existing behavior)

Related to #3811.