### PR TITLE
remote: support saving RepoTree objects directly to cache

### DIFF
--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -194,12 +194,11 @@ class BaseRemote:
     def cache(self):
         return getattr(self.repo.cache, self.scheme)
 
-    def get_file_checksum(self, path_info, **kwargs):
+    def get_file_checksum(self, path_info):
         raise NotImplementedError
 
     def _calculate_checksums(self, file_infos):
         file_infos = list(file_infos)
-
         with Tqdm(
             total=len(file_infos),
             unit="md5",
@@ -327,7 +326,7 @@ class BaseRemote:
     def is_dir_checksum(cls, checksum):
         return checksum.endswith(cls.CHECKSUM_DIR_SUFFIX)
 
-    def get_checksum(self, path_info, tree=None):
+    def get_checksum(self, path_info):
         assert isinstance(path_info, str) or path_info.scheme == self.scheme
 
         if not self.exists(path_info):

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -197,20 +197,15 @@ class BaseRemote:
     def get_file_checksum(self, path_info, **kwargs):
         raise NotImplementedError
 
-    def _calculate_checksums(self, file_infos, tree=None):
+    def _calculate_checksums(self, file_infos):
         file_infos = list(file_infos)
-
-        if tree:
-            checksum_func = tree.get_file_checksum
-        else:
-            checksum_func = self.get_file_checksum
 
         with Tqdm(
             total=len(file_infos),
             unit="md5",
             desc="Computing file/dir hashes (only done once)",
         ) as pbar:
-            worker = pbar.wrap_fn(checksum_func)
+            worker = pbar.wrap_fn(self.get_file_checksum)
             with ThreadPoolExecutor(
                 max_workers=self.checksum_jobs
             ) as executor:
@@ -218,15 +213,10 @@ class BaseRemote:
                 checksums = dict(zip(file_infos, tasks))
         return checksums
 
-    def _collect_dir(self, path_info, tree=None):
+    def _collect_dir(self, path_info):
         file_infos = set()
 
-        if tree:
-            walk_files = tree.walk_files
-        else:
-            walk_files = self.walk_files
-
-        for fname in walk_files(path_info):
+        for fname in self.walk_files(path_info):
             if DvcIgnore.DVCIGNORE_FILE == fname.name:
                 raise DvcIgnoreInCollectedDirError(fname.parent)
 
@@ -237,7 +227,7 @@ class BaseRemote:
             fi for fi, checksum in checksums.items() if checksum is None
         }
 
-        new_checksums = self._calculate_checksums(not_in_state, tree=tree)
+        new_checksums = self._calculate_checksums(not_in_state)
 
         checksums.update(new_checksums)
 
@@ -260,18 +250,21 @@ class BaseRemote:
         # Sorting the list by path to ensure reproducibility
         return sorted(result, key=itemgetter(self.PARAM_RELPATH))
 
-    def get_dir_checksum(self, path_info, tree=None):
+    def get_dir_checksum(self, path_info):
         if not self.cache:
             raise RemoteCacheRequiredError(path_info)
 
-        dir_info = self._collect_dir(path_info, tree=tree)
+        dir_info = self._collect_dir(path_info)
+        return self._save_dir_info(dir_info, path_info)
+
+    def _save_dir_info(self, dir_info, path_info=None):
         checksum, tmp_info = self._get_dir_info_checksum(dir_info)
         new_info = self.cache.checksum_to_path_info(checksum)
         if self.cache.changed_cache_file(checksum):
             self.cache.makedirs(new_info.parent)
             self.cache.move(tmp_info, new_info, mode=self.CACHE_MODE)
 
-        if not tree or is_working_tree(tree):
+        if path_info:
             self.state.save(path_info, checksum)
         self.state.save(new_info, checksum)
 
@@ -337,13 +330,7 @@ class BaseRemote:
     def get_checksum(self, path_info, tree=None):
         assert isinstance(path_info, str) or path_info.scheme == self.scheme
 
-        if tree:
-            exists = tree.exists
-            isdir = tree.isdir
-        else:
-            exists = self.exists
-            isdir = self.isdir
-        if not exists(path_info):
+        if not self.exists(path_info):
             return None
 
         checksum = self.state.get(path_info)
@@ -361,20 +348,18 @@ class BaseRemote:
         if checksum:
             return checksum
 
-        if isdir(path_info):
-            checksum = self.get_dir_checksum(path_info, tree=tree)
-        elif tree:
-            checksum = tree.get_file_checksum(path_info)
+        if self.isdir(path_info):
+            checksum = self.get_dir_checksum(path_info)
         else:
             checksum = self.get_file_checksum(path_info)
 
-        if checksum and (not tree or is_working_tree(tree)):
+        if checksum:
             self.state.save(path_info, checksum)
 
         return checksum
 
-    def save_info(self, path_info, tree=None):
-        return {self.PARAM_CHECKSUM: self.get_checksum(path_info, tree=tree)}
+    def save_info(self, path_info):
+        return {self.PARAM_CHECKSUM: self.get_checksum(path_info)}
 
     def changed(self, path_info, checksum_info):
         """Checks if data has changed.

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -24,7 +24,14 @@ from dvc.scheme import Schemes
 from dvc.scm.tree import is_working_tree
 from dvc.system import System
 from dvc.utils import file_md5, relpath, tmp_fname
-from dvc.utils.fs import copyfile, makedirs, move, remove, walk_files
+from dvc.utils.fs import (
+    copy_fobj_to_file,
+    copyfile,
+    makedirs,
+    move,
+    remove,
+    walk_files,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -181,6 +188,17 @@ class LocalRemote(BaseRemote):
         tmp_info = to_info.parent / tmp_fname(to_info.name)
         try:
             System.copy(from_info, tmp_info)
+            os.chmod(tmp_info, self._file_mode)
+            os.rename(tmp_info, to_info)
+        except Exception:
+            self.remove(tmp_info)
+            raise
+
+    def copy_fobj(self, fobj, to_info):
+        self.makedirs(to_info.parent)
+        tmp_info = to_info.parent / tmp_fname(to_info.name)
+        try:
+            copy_fobj_to_file(fobj, tmp_info)
             os.chmod(tmp_info, self._file_mode)
             os.rename(tmp_info, to_info)
         except Exception:

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -498,7 +498,7 @@ class Repo:
         except FileNotFoundError as exc:
             raise FileMissingError(path) from exc
         except IsADirectoryError as exc:
-            raise DvcIsADirectoryError from exc
+            raise DvcIsADirectoryError(f"'{path}' is a directory") from exc
 
     def close(self):
         self.scm.close()

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -488,13 +488,14 @@ class Repo:
         tree = RepoTree(self, stream=True)
         path = os.path.join(self.root_dir, path)
         try:
-            with tree.open(
-                os.path.join(self.root_dir, path),
-                mode=mode,
-                encoding=encoding,
-                remote=remote,
-            ) as fobj:
-                yield fobj
+            with self.state:
+                with tree.open(
+                    os.path.join(self.root_dir, path),
+                    mode=mode,
+                    encoding=encoding,
+                    remote=remote,
+                ) as fobj:
+                    yield fobj
         except FileNotFoundError as exc:
             raise FileMissingError(path) from exc
         except IsADirectoryError as exc:

--- a/dvc/repo/tree.py
+++ b/dvc/repo/tree.py
@@ -149,11 +149,12 @@ class DvcTree(BaseTree):
             if out.is_dir_checksum and (self.fetch or self.stream):
                 # will pull dir cache if needed
                 with self.repo.state:
-                    cache = out.collect_used_dir_cache()
-                for _, names in cache.scheme_names(out.scheme):
-                    for name in names:
-                        path_info = out.path_info.parent / name
-                        trie[path_info.parts] = None
+                    cache = out.get_dir_cache()
+
+                for entry in cache:
+                    entry_relpath = entry[out.remote.PARAM_RELPATH]
+                    path_info = out.path_info / entry_relpath
+                    trie[path_info.parts] = None
 
         yield from self._walk(root, trie, topdown=topdown)
 

--- a/dvc/repo/tree.py
+++ b/dvc/repo/tree.py
@@ -6,6 +6,7 @@ from dvc.exceptions import OutputNotFoundError
 from dvc.path_info import PathInfo
 from dvc.remote.base import RemoteActionNotImplemented
 from dvc.scm.tree import BaseTree, WorkingTree
+from dvc.utils import file_md5
 
 logger = logging.getLogger(__name__)
 
@@ -295,3 +296,8 @@ class RepoTree(BaseTree):
         dvc_walk = self.dvctree.walk(top, topdown=topdown, **kwargs)
         repo_walk = self.repo.tree.walk(top, topdown=topdown)
         yield from self._walk(dvc_walk, repo_walk, dvcfiles=dvcfiles)
+
+    def get_file_checksum(self, path_info):
+        if not self.exists(path_info):
+            raise FileNotFoundError
+        return file_md5(path_info, self)[0]

--- a/dvc/repo/tree.py
+++ b/dvc/repo/tree.py
@@ -301,7 +301,17 @@ class RepoTree(BaseTree):
                 yield from self._walk_one(repo_walk)
 
     def walk(self, top, topdown=True, dvcfiles=False, **kwargs):
-        """Walk and merge both DVC and repo trees."""
+        """Walk and merge both DVC and repo trees.
+
+        Args:
+            top: path to walk from
+            topdown: if True, tree will be walked from top down.
+            dvcfiles: if True, dvcfiles will be included in the files list
+                for walked directories.
+
+        Any kwargs will be passed into methods used for fetching and/or
+        streaming DVC outs from remotes.
+        """
         assert topdown
 
         if not self.exists(top):

--- a/dvc/repo/tree.py
+++ b/dvc/repo/tree.py
@@ -63,30 +63,27 @@ class DvcTree(BaseTree):
             raise IsADirectoryError
 
         out = outs[0]
-        with self.repo.state:
-            if out.changed_cache(filter_info=path):
-                if not self.fetch and not self.stream:
-                    raise FileNotFoundError
+        if out.changed_cache(filter_info=path):
+            if not self.fetch and not self.stream:
+                raise FileNotFoundError
 
-                remote_obj = self.repo.cloud.get_remote(remote)
-                if self.stream:
-                    if out.is_dir_checksum:
-                        checksum = self._get_granular_checksum(path, out)
-                    else:
-                        checksum = out.checksum
-                    try:
-                        remote_info = remote_obj.checksum_to_path_info(
-                            checksum
-                        )
-                        return remote_obj.open(
-                            remote_info, mode=mode, encoding=encoding
-                        )
-                    except RemoteActionNotImplemented:
-                        pass
-                    cache_info = out.get_used_cache(
-                        filter_info=path, remote=remote
+            remote_obj = self.repo.cloud.get_remote(remote)
+            if self.stream:
+                if out.is_dir_checksum:
+                    checksum = self._get_granular_checksum(path, out)
+                else:
+                    checksum = out.checksum
+                try:
+                    remote_info = remote_obj.checksum_to_path_info(checksum)
+                    return remote_obj.open(
+                        remote_info, mode=mode, encoding=encoding
                     )
-                    self.repo.cloud.pull(cache_info, remote=remote)
+                except RemoteActionNotImplemented:
+                    pass
+                cache_info = out.get_used_cache(
+                    filter_info=path, remote=remote
+                )
+                self.repo.cloud.pull(cache_info, remote=remote)
 
         if out.is_dir_checksum:
             checksum = self._get_granular_checksum(path, out)

--- a/dvc/repo/tree.py
+++ b/dvc/repo/tree.py
@@ -159,9 +159,9 @@ class DvcTree(BaseTree):
 
         yield from self._walk(root, trie, topdown=topdown)
 
-    def isdvc(self, path):
+    def isdvc(self, path, **kwargs):
         try:
-            return len(self._find_outs(path)) == 1
+            return len(self._find_outs(path, **kwargs)) == 1
         except OutputNotFoundError:
             pass
         return False
@@ -208,8 +208,8 @@ class RepoTree(BaseTree):
             self.dvctree and self.dvctree.isdir(path)
         )
 
-    def isdvc(self, path):
-        return self.dvctree is not None and self.dvctree.isdvc(path)
+    def isdvc(self, path, **kwargs):
+        return self.dvctree is not None and self.dvctree.isdvc(path, **kwargs)
 
     def isfile(self, path):
         return self.repo.tree.isfile(path) or (

--- a/dvc/repo/tree.py
+++ b/dvc/repo/tree.py
@@ -161,13 +161,14 @@ class DvcTree(BaseTree):
             trie[out.path_info.parts] = out
 
             if out.is_dir_checksum and (self.fetch or self.stream):
-                with self.repo.state:
-                    # pull dir contents if needed
-                    if self.fetch:
-                        used_cache = out.get_used_cache()
+                # pull dir cache if needed
+                dir_cache = out.get_dir_cache(**kwargs)
+
+                # pull dir contents if needed
+                if self.fetch:
+                    if out.changed_cache(filter_info=top):
+                        used_cache = out.get_used_cache(filter_info=top)
                         self.repo.cloud.pull(used_cache, **kwargs)
-                    # pull dir cache if needed
-                    dir_cache = out.get_dir_cache(**kwargs)
 
                 for entry in dir_cache:
                     entry_relpath = entry[out.remote.PARAM_RELPATH]

--- a/tests/func/test_api.py
+++ b/tests/func/test_api.py
@@ -94,6 +94,19 @@ def test_open_external(remote_url, erepo_dir, setup_remote):
 
 
 @pytest.mark.parametrize("remote_url", all_remote_params, indirect=True)
+def test_open_granular(remote_url, tmp_dir, dvc):
+    run_dvc("remote", "add", "-d", "upstream", remote_url)
+    tmp_dir.dvc_gen({"dir": {"foo": "foo-text"}})
+    run_dvc("push")
+
+    # Remove cache to force download
+    remove(dvc.cache.local.cache_dir)
+
+    with api.open("dir/foo") as fd:
+        assert fd.read() == "foo-text"
+
+
+@pytest.mark.parametrize("remote_url", all_remote_params, indirect=True)
 def test_missing(remote_url, tmp_dir, dvc):
     tmp_dir.dvc_gen("foo", "foo")
     run_dvc("remote", "add", "-d", "upstream", remote_url)

--- a/tests/func/test_tree.py
+++ b/tests/func/test_tree.py
@@ -185,8 +185,9 @@ def test_repotree_walk_fetch(tmp_dir, dvc, scm, setup_remote):
     remove(dvc.cache.local.cache_dir)
 
     tree = RepoTree(dvc, fetch=True)
-    for _, _, _ in tree.walk("dir"):
-        pass
+    with dvc.state:
+        for _, _, _ in tree.walk("dir"):
+            pass
 
     assert os.path.exists(out.cache_path)
     for entry in out.dir_cache:
@@ -213,8 +214,9 @@ def test_repotree_cache_save(tmp_dir, dvc, scm, erepo_dir, setup_remote):
         for path in ("dir/bar", "dir/subdir/foo")
     ]
 
-    cache = dvc.cache.local
-    with cache.state:
-        cache.save(PathInfo(erepo_dir / "dir"), None, tree=tree)
+    with erepo_dir.dvc.state:
+        cache = dvc.cache.local
+        with cache.state:
+            cache.save(PathInfo(erepo_dir / "dir"), None, tree=tree)
     for checksum in expected:
         assert os.path.exists(cache.checksum_to_path_info(checksum))

--- a/tests/unit/repo/test_repo_tree.py
+++ b/tests/unit/repo/test_repo_tree.py
@@ -125,8 +125,12 @@ def test_walk(tmp_dir, dvc, dvcfiles, extra_expected):
 
 
 def test_isdvc(tmp_dir, dvc):
-    tmp_dir.gen({"foo": "foo", "bar": "bar"})
+    tmp_dir.gen({"foo": "foo", "bar": "bar", "dir": {"baz": "baz"}})
     dvc.add("foo")
+    dvc.add("dir")
     tree = RepoTree(dvc)
     assert tree.isdvc("foo")
     assert not tree.isdvc("bar")
+    assert tree.isdvc("dir")
+    assert not tree.isdvc("dir/baz")
+    assert tree.isdvc("dir/baz", recursive=True, strict=False)

--- a/tests/unit/repo/test_repo_tree.py
+++ b/tests/unit/repo/test_repo_tree.py
@@ -3,6 +3,7 @@ import shutil
 
 import pytest
 
+from dvc.path_info import PathInfo
 from dvc.repo.tree import RepoTree
 
 
@@ -85,9 +86,9 @@ def test_isdir_mixed(tmp_dir, dvc):
         (
             True,
             [
-                "dir/subdir1/foo1.dvc",
-                "dir/subdir1/bar1.dvc",
-                "dir/subdir2/foo2.dvc",
+                PathInfo("dir") / "subdir1" / "foo1.dvc",
+                PathInfo("dir") / "subdir1" / "bar1.dvc",
+                PathInfo("dir") / "subdir2" / "foo2.dvc",
             ],
         ),
     ],
@@ -106,13 +107,13 @@ def test_walk(tmp_dir, dvc, dvcfiles, extra_expected):
     tree = RepoTree(dvc)
 
     expected = [
-        "dir/subdir1",
-        "dir/subdir2",
-        "dir/subdir1/foo1",
-        "dir/subdir1/bar1",
-        "dir/subdir2/foo2",
-        "dir/foo",
-        "dir/bar",
+        PathInfo("dir") / "subdir1",
+        PathInfo("dir") / "subdir2",
+        PathInfo("dir") / "subdir1" / "foo1",
+        PathInfo("dir") / "subdir1" / "bar1",
+        PathInfo("dir") / "subdir2" / "foo2",
+        PathInfo("dir") / "foo",
+        PathInfo("dir") / "bar",
     ]
 
     actual = []
@@ -120,8 +121,9 @@ def test_walk(tmp_dir, dvc, dvcfiles, extra_expected):
         for entry in dirs + files:
             actual.append(os.path.join(root, entry))
 
-    assert set(actual) == set(expected + extra_expected)
-    assert len(actual) == len(expected + extra_expected)
+    expected = [str(path) for path in expected + extra_expected]
+    assert set(actual) == set(expected)
+    assert len(actual) == len(expected)
 
 
 def test_isdvc(tmp_dir, dvc):

--- a/tests/unit/repo/test_tree.py
+++ b/tests/unit/repo/test_tree.py
@@ -143,10 +143,11 @@ def test_walk_dir(tmp_dir, dvc, fetch, expected):
 
     expected = [str(tmp_dir / path) for path in expected]
 
-    actual = []
-    for root, dirs, files in tree.walk("dir"):
-        for entry in dirs + files:
-            actual.append(os.path.join(root, entry))
+    with dvc.state:
+        actual = []
+        for root, dirs, files in tree.walk("dir"):
+            for entry in dirs + files:
+                actual.append(os.path.join(root, entry))
 
     assert set(actual) == set(expected)
     assert len(actual) == len(expected)

--- a/tests/unit/repo/test_tree.py
+++ b/tests/unit/repo/test_tree.py
@@ -3,6 +3,7 @@ import shutil
 
 import pytest
 
+from dvc.path_info import PathInfo
 from dvc.repo.tree import DvcTree
 
 
@@ -115,13 +116,13 @@ def test_walk(tmp_dir, dvc):
         (
             True,
             [
-                "dir/subdir1",
-                "dir/subdir2",
-                "dir/subdir1/foo1",
-                "dir/subdir1/bar1",
-                "dir/subdir2/foo2",
-                "dir/foo",
-                "dir/bar",
+                PathInfo("dir") / "subdir1",
+                PathInfo("dir") / "subdir2",
+                PathInfo("dir") / "subdir1" / "foo1",
+                PathInfo("dir") / "subdir1" / "bar1",
+                PathInfo("dir") / "subdir2" / "foo2",
+                PathInfo("dir") / "foo",
+                PathInfo("dir") / "bar",
             ],
         ),
     ],


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Related to #3811.

added support for:

* Granular support for `RepoTree`/`DvcTree.open()` (Will close #3541)
    * Files inside DVC directory outs can be opened by any function using `RepoTree.open()` (`Repo.open_by_relpath()`, `api.open()`)
    * If file is not cached, it will only be opened if tree was initialized with `fetch=True` or `stream=True`
* RepoTree paths can be saved directly to remote (i.e. local cache)

ex:
```py
tree = RepoTree(..., fetch=True)  # stream or fetch must be set to save DVC outs properly

cache = repo.cache.local
cache.save(path_in_tree, None, tree=tree)
```

For saving tree paths, rather than requiring the call to `cache.save_info(...)` to get a destination checksum, for tree paths the checksum will be calculated during `save()`. The reason for this is that for directories, it makes more sense to collect dir cache information as we walk the tree (and save files from the tree), rather than walking the tree once to collect dir cache information, and then walking it a second time to save files.