### PR TITLE
external_repo: use RepoTree for fetch/import/get

### DIFF
--- a/dvc/dependency/repo.py
+++ b/dvc/dependency/repo.py
@@ -50,13 +50,24 @@ class RepoDependency(LocalDependency):
         return external_repo(d["url"], rev=rev)
 
     def _get_checksum(self, locked=True):
+        from dvc.repo.tree import RepoTree
+
         with self._make_repo(locked=locked) as repo:
             try:
                 return repo.find_out_by_relpath(self.def_path).info["md5"]
             except OutputNotFoundError:
                 path = PathInfo(os.path.join(repo.root_dir, self.def_path))
+
+                # we want stream but not fetch, so DVC out directories are
+                # walked, but dir contents is not fetched
+                tree = RepoTree(repo, stream=True)
+
                 # We are polluting our repo cache with some dir listing here
-                return self.repo.cache.local.get_checksum(path)
+                if tree.isdir(path):
+                    return self.repo.cache.local.get_dir_checksum(
+                        path, tree=tree
+                    )
+                return tree.get_file_checksum(path)
 
     def status(self):
         current_checksum = self._get_checksum(locked=True)

--- a/dvc/dependency/repo.py
+++ b/dvc/dependency/repo.py
@@ -78,10 +78,10 @@ class RepoDependency(LocalDependency):
             if self.def_repo.get(self.PARAM_REV_LOCK) is None:
                 self.def_repo[self.PARAM_REV_LOCK] = repo.scm.get_rev()
 
-            if hasattr(repo, "cache"):
-                repo.cache.local.cache_dir = self.repo.cache.local.cache_dir
-
-            repo.pull_to(self.def_path, to.path_info)
+            cache = self.repo.cache.local
+            with repo.use_cache(cache):
+                _, _, cache_infos = repo.fetch_external([self.def_path])
+            cache.checkout(to.path_info, cache_infos[0])
 
     def update(self, rev=None):
         if rev:

--- a/dvc/dependency/repo.py
+++ b/dvc/dependency/repo.py
@@ -76,7 +76,7 @@ class RepoDependency(LocalDependency):
     def download(self, to):
         with self._make_repo() as repo:
             if self.def_repo.get(self.PARAM_REV_LOCK) is None:
-                self.def_repo[self.PARAM_REV_LOCK] = repo.scm.get_rev()
+                self.def_repo[self.PARAM_REV_LOCK] = repo.get_rev()
 
             cache = self.repo.cache.local
             with repo.use_cache(cache):
@@ -88,4 +88,4 @@ class RepoDependency(LocalDependency):
             self.def_repo[self.PARAM_REV] = rev
 
         with self._make_repo(locked=False) as repo:
-            self.def_repo[self.PARAM_REV_LOCK] = repo.scm.get_rev()
+            self.def_repo[self.PARAM_REV_LOCK] = repo.get_rev()

--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -20,6 +20,7 @@ from dvc.path_info import PathInfo
 from dvc.repo import Repo
 from dvc.repo.tree import RepoTree
 from dvc.scm.git import Git
+from dvc.scm.tree import is_working_tree
 from dvc.utils.fs import remove
 
 logger = logging.getLogger(__name__)
@@ -95,6 +96,13 @@ class BaseExternalRepo:
     @cached_property
     def repo_tree(self):
         return RepoTree(self, fetch=True)
+
+    def get_rev(self):
+        if is_working_tree(self.tree):
+            return self.scm.get_rev()
+        if hasattr(self.tree, "tree"):
+            return self.tree.tree.rev
+        return self.tree.rev
 
     def fetch_external(self, paths: Iterable, **kwargs):
         """Fetch specified external repo paths into cache.

--- a/dvc/istextfile.py
+++ b/dvc/istextfile.py
@@ -7,13 +7,17 @@
 TEXT_CHARS = bytes(range(32, 127)) + b"\n\r\t\f\b"
 
 
-def istextfile(fname, blocksize=512):
+def istextfile(fname, blocksize=512, tree=None):
     """ Uses heuristics to guess whether the given file is text or binary,
         by reading a single block of bytes from the file.
         If more than 30% of the chars in the block are non-text, or there
         are NUL ('\x00') bytes in the block, assume this is a binary file.
     """
-    with open(fname, "rb") as fobj:
+    if tree:
+        open_func = tree.open
+    else:
+        open_func = open
+    with open_func(fname, "rb") as fobj:
         block = fobj.read(blocksize)
 
     if not block:

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -227,7 +227,7 @@ class BaseRemote:
             file_infos.add(fname)
 
         if tree:
-            checksums = {fi: tree.get_checksum(fi) for fi in file_infos}
+            checksums = {fi: tree.get_file_checksum(fi) for fi in file_infos}
             if save_tree:
                 for fi, checksum in checksums.items():
                     self._save_file(fi, checksum, tree=tree, **kwargs)
@@ -259,11 +259,14 @@ class BaseRemote:
         # Sorting the list by path to ensure reproducibility
         return sorted(result, key=itemgetter(self.PARAM_RELPATH))
 
-    def get_dir_checksum(self, path_info):
+    def get_dir_checksum(self, path_info, tree=None):
         if not self.cache:
             raise RemoteCacheRequiredError(path_info)
 
-        dir_info = self._collect_dir(path_info)
+        dir_info = self._collect_dir(path_info, tree=None)
+        if tree:
+            # don't save state entry for path_info if it is a tree path
+            path_info = None
         return self._save_dir_info(dir_info, path_info)
 
     def _save_dir_info(self, dir_info, path_info=None):

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -481,7 +481,12 @@ class BaseRemote:
         if tree:
             if self.changed_cache(checksum):
                 with tree.open(path_info, mode="rb") as fobj:
-                    self.copy_fobj(fobj, cache_info)
+                    # if tree has fetch enabled, DVC out will be fetched on
+                    # open and we do not need to read/copy any data
+                    if not (
+                        tree.isdvc(path_info, strict=False) and tree.fetch
+                    ):
+                        self.copy_fobj(fobj, cache_info)
                 callback = kwargs.get("download_callback")
                 if callback:
                     callback(1)

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -492,6 +492,7 @@ class BaseRemote:
         if not tree or is_working_tree(tree):
             self.state.save(path_info, checksum)
         self.state.save(cache_info, checksum)
+        return {self.PARAM_CHECKSUM: checksum}
 
     def _cache_is_copy(self, path_info):
         """Checks whether cache uses copies."""
@@ -537,6 +538,7 @@ class BaseRemote:
         self.state.save(cache_info, checksum)
         if not tree or is_working_tree(tree):
             self.state.save(path_info, checksum)
+        return {self.PARAM_CHECKSUM: checksum}
 
     def _save_tree(self, path_info, tree, **kwargs):
         # save tree directory to cache, collect dir cache during walk and
@@ -598,7 +600,7 @@ class BaseRemote:
                 checksum = tree.get_file_checksum(path_info)
         else:
             checksum = checksum_info[self.PARAM_CHECKSUM]
-        self._save(path_info, checksum, save_link, tree, **kwargs)
+        return self._save(path_info, checksum, save_link, tree, **kwargs)
 
     def _save(self, path_info, checksum, save_link=True, tree=None, **kwargs):
         if tree:
@@ -614,9 +616,10 @@ class BaseRemote:
             isdir = self.isdir
 
         if isdir(path_info):
-            self._save_dir(path_info, checksum, save_link, tree, **kwargs)
-            return
-        self._save_file(path_info, checksum, save_link, tree, **kwargs)
+            return self._save_dir(
+                path_info, checksum, save_link, tree, **kwargs
+            )
+        return self._save_file(path_info, checksum, save_link, tree, **kwargs)
 
     def _handle_transfer_exception(
         self, from_info, to_info, exception, operation

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -175,9 +175,11 @@ class LocalRemote(BaseRemote):
         return os.path.getsize(path_info)
 
     def walk_files(self, path_info):
-        assert is_working_tree(self.repo.tree)
-
-        for fname in self.repo.tree.walk_files(path_info):
+        if self.work_tree:
+            tree = self.work_tree
+        else:
+            tree = self.repo.tree
+        for fname in tree.walk_files(path_info):
             yield PathInfo(fname)
 
     def get_file_checksum(self, path_info):

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -58,7 +58,7 @@ class Repo:
     from dvc.repo.update import update
 
     def __init__(self, root_dir=None, scm=None, rev=None):
-        from dvc.state import State
+        from dvc.state import State, StateNoop
         from dvc.lock import make_lock
         from dvc.scm import SCM
         from dvc.cache import Cache
@@ -76,6 +76,7 @@ class Repo:
             self.root_dir = self.find_root(root_dir, tree)
             self.scm = scm
             self.tree = tree
+            self.state = StateNoop()
         else:
             root_dir = self.find_root(root_dir)
             self.root_dir = os.path.abspath(os.path.realpath(root_dir))
@@ -100,9 +101,11 @@ class Repo:
             friendly=True,
         )
 
-        # NOTE: storing state and link_state in the repository itself to avoid
-        # any possible state corruption in 'shared cache dir' scenario.
-        self.state = State(self)
+        if not scm:
+            # NOTE: storing state and link_state in the repository itself to
+            # avoid any possible state corruption in 'shared cache dir'
+            # scenario.
+            self.state = State(self)
 
         self.cache = Cache(self)
         self.cloud = DataCloud(self)

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -1,9 +1,7 @@
 import logging
 
-from dvc.cache import NamedCache
 from dvc.config import NoRemoteError
-from dvc.exceptions import DownloadError, OutputNotFoundError
-from dvc.path_info import PathInfo
+from dvc.exceptions import DownloadError
 from dvc.scm.base import CloneError
 
 logger = logging.getLogger(__name__)
@@ -78,35 +76,15 @@ def _fetch(
 
 
 def _fetch_external(self, repo_url, repo_rev, files, jobs):
-    from dvc.external_repo import external_repo, ExternalRepo
+    from dvc.external_repo import external_repo
 
     failed, downloaded = 0, 0
     try:
         with external_repo(repo_url, repo_rev) as repo:
-            is_dvc_repo = isinstance(repo, ExternalRepo)
-            # gather git-only tracked files if dvc repo
-            git_files = [] if is_dvc_repo else files
-            if is_dvc_repo:
-                repo.cache.local.cache_dir = self.cache.local.cache_dir
-                with repo.state:
-                    cache = NamedCache()
-                    for name in files:
-                        try:
-                            out = repo.find_out_by_relpath(name)
-                        except OutputNotFoundError:
-                            # try to add to cache if they are git-tracked files
-                            git_files.append(name)
-                        else:
-                            cache.update(out.get_used_cache())
-
-                        try:
-                            downloaded += repo.cloud.pull(cache, jobs=jobs)
-                        except DownloadError as exc:
-                            failed += exc.amount
-
-            d, f = _git_to_cache(self.cache.local, repo.root_dir, git_files)
-            downloaded += d
-            failed += f
+            with repo.use_cache(self.cache.local):
+                d, f = repo.fetch_external(files, jobs=jobs)
+                downloaded += d
+                failed += f
     except CloneError:
         failed += 1
         logger.exception(
@@ -114,27 +92,3 @@ def _fetch_external(self, repo_url, repo_rev, files, jobs):
         )
 
     return downloaded, failed
-
-
-def _git_to_cache(cache, repo_root, files):
-    """Save files from a git repo directly to the cache."""
-    failed = set()
-    num_downloads = 0
-    repo_root = PathInfo(repo_root)
-    for file in files:
-        info = cache.save_info(repo_root / file)
-        if info.get(cache.PARAM_CHECKSUM) is None:
-            failed.add(file)
-            continue
-
-        if cache.changed_cache(info[cache.PARAM_CHECKSUM]):
-            logger.debug("fetched '%s' from '%s' repo", file, repo_root)
-            num_downloads += 1
-            cache.save(repo_root / file, info, save_link=False)
-
-    if failed:
-        logger.exception(
-            "failed to fetch data for {}".format(", ".join(failed))
-        )
-
-    return num_downloads, len(failed)

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -82,7 +82,7 @@ def _fetch_external(self, repo_url, repo_rev, files, jobs):
     try:
         with external_repo(repo_url, repo_rev) as repo:
             with repo.use_cache(self.cache.local):
-                d, f = repo.fetch_external(files, jobs=jobs)
+                d, f, _ = repo.fetch_external(files, jobs=jobs)
                 downloaded += d
                 failed += f
     except CloneError:

--- a/dvc/repo/get.py
+++ b/dvc/repo/get.py
@@ -4,7 +4,6 @@ import os
 import shortuuid
 
 from dvc.exceptions import DvcException
-from dvc.path_info import PathInfo
 from dvc.utils import resolve_output
 from dvc.utils.fs import remove
 
@@ -51,7 +50,6 @@ def get(url, path, out=None, rev=None):
                 # Also, we can't use theoretical "move" link type here, because
                 # the same cache file might be used a few times in a directory.
                 repo.cache.local.cache_types = ["reflink", "hardlink", "copy"]
-
-            repo.pull_to(path, PathInfo(out))
+            repo.get_external(path, out)
     finally:
         remove(tmp_dir)

--- a/dvc/repo/tree.py
+++ b/dvc/repo/tree.py
@@ -235,6 +235,18 @@ class RepoTree(BaseTree):
             # git-only erepo's do not need dvctree
             self.dvctree = None
 
+    @property
+    def fetch(self):
+        if self.dvctree:
+            return self.dvctree.fetch
+        return False
+
+    @property
+    def stream(self):
+        if self.dvctree:
+            return self.dvctree.stream
+        return False
+
     def open(self, path, mode="r", encoding="utf-8", **kwargs):
         if "b" in mode:
             encoding = None

--- a/dvc/repo/tree.py
+++ b/dvc/repo/tree.py
@@ -105,10 +105,25 @@ class DvcTree(BaseTree):
 
         path_info = PathInfo(os.path.abspath(path))
         outs = self._find_outs(path, strict=False, recursive=True)
-        if len(outs) != 1 or outs[0].path_info != path_info:
+        if len(outs) != 1:
             return True
 
-        return outs[0].is_dir_checksum
+        out = outs[0]
+        if not out.is_dir_checksum:
+            if out.path_info != path_info:
+                return True
+            return False
+
+        if out.path_info == path_info:
+            return True
+
+        # for dir checksum, we need to check if this is a file inside the
+        # directory
+        try:
+            self._get_granular_checksum(path, out)
+            return False
+        except FileNotFoundError:
+            return True
 
     def isfile(self, path):
         if not self.exists(path):

--- a/dvc/repo/tree.py
+++ b/dvc/repo/tree.py
@@ -48,7 +48,10 @@ class DvcTree(BaseTree):
             raise FileNotFoundError
         dir_cache = out.get_dir_cache(remote=remote)
         for entry in dir_cache:
-            if path == out.path_info / entry[out.remote.PARAM_RELPATH]:
+            entry_relpath = entry[out.remote.PARAM_RELPATH]
+            if os.name == "nt":
+                entry_relpath = entry_relpath.replace("/", os.sep)
+            if path == out.path_info / entry_relpath:
                 return entry[out.remote.PARAM_CHECKSUM]
         raise FileNotFoundError
 
@@ -188,6 +191,8 @@ class DvcTree(BaseTree):
 
                 for entry in dir_cache:
                     entry_relpath = entry[out.remote.PARAM_RELPATH]
+                    if os.name == "nt":
+                        entry_relpath = entry_relpath.replace("/", os.sep)
                     path_info = out.path_info / entry_relpath
                     trie[path_info.parts] = None
 

--- a/dvc/repo/tree.py
+++ b/dvc/repo/tree.py
@@ -141,7 +141,7 @@ class DvcTree(BaseTree):
         else:
             assert False
 
-    def walk(self, top, topdown=True, **kwargs):
+    def walk(self, top, topdown=True, download_callback=None, **kwargs):
         from pygtrie import Trie
 
         assert topdown
@@ -168,7 +168,9 @@ class DvcTree(BaseTree):
                 if self.fetch:
                     if out.changed_cache(filter_info=top):
                         used_cache = out.get_used_cache(filter_info=top)
-                        self.repo.cloud.pull(used_cache, **kwargs)
+                        downloaded = self.repo.cloud.pull(used_cache, **kwargs)
+                        if download_callback:
+                            download_callback(downloaded)
 
                 for entry in dir_cache:
                     entry_relpath = entry[out.remote.PARAM_RELPATH]

--- a/dvc/repo/tree.py
+++ b/dvc/repo/tree.py
@@ -80,10 +80,8 @@ class DvcTree(BaseTree):
                     )
                 except RemoteActionNotImplemented:
                     pass
-                cache_info = out.get_used_cache(
-                    filter_info=path, remote=remote
-                )
-                self.repo.cloud.pull(cache_info, remote=remote)
+            cache_info = out.get_used_cache(filter_info=path, remote=remote)
+            self.repo.cloud.pull(cache_info, remote=remote)
 
         if out.is_dir_checksum:
             checksum = self._get_granular_checksum(path, out)

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -52,18 +52,14 @@ def file_md5(fname, tree=None):
         exists_func = tree.exists
         stat_func = tree.stat
         open_func = tree.open
-        # assume we don't need to run dos2unix when comparing git blobs
-        binary = True
     else:
         exists_func = os.path.exists
         stat_func = os.stat
         open_func = open
-        binary = False
 
     if exists_func(fname):
         hash_md5 = hashlib.md5()
-        if not binary:
-            binary = not istextfile(fname)
+        binary = not istextfile(fname, tree=tree)
         size = stat_func(fname).st_size
         no_progress_bar = True
         if size >= LARGE_FILE_SIZE:

--- a/tests/func/test_external_repo.py
+++ b/tests/func/test_external_repo.py
@@ -3,6 +3,7 @@ import os
 from mock import patch
 
 from dvc.external_repo import external_repo
+from dvc.path_info import PathInfo
 from dvc.remote import LocalRemote
 from dvc.scm.git import Git
 from dvc.utils import relpath
@@ -92,7 +93,7 @@ def test_pull_subdir_file(tmp_dir, erepo_dir):
         _, _, save_infos = repo.fetch_external(
             [os.path.join("subdir", "file")]
         )
-        repo.cache.local.checkout(dest, save_infos[0])
+        repo.cache.local.checkout(PathInfo(dest), save_infos[0])
 
     assert dest.is_file()
     assert dest.read_text() == "contents"

--- a/tests/func/test_external_repo.py
+++ b/tests/func/test_external_repo.py
@@ -89,7 +89,10 @@ def test_pull_subdir_file(tmp_dir, erepo_dir):
 
     dest = tmp_dir / "file"
     with external_repo(os.fspath(erepo_dir)) as repo:
-        repo.pull_to(os.path.join("subdir", "file"), dest)
+        _, _, save_infos = repo.fetch_external(
+            [os.path.join("subdir", "file")]
+        )
+        repo.cache.local.checkout(dest, save_infos[0])
 
     assert dest.is_file()
     assert dest.read_text() == "contents"

--- a/tests/func/test_get.py
+++ b/tests/func/test_get.py
@@ -157,17 +157,13 @@ def test_get_to_dir(tmp_dir, erepo_dir, dname):
     assert (tmp_dir / dname / "file").read_text() == "contents"
 
 
-def test_get_from_non_dvc_master(tmp_dir, git_dir, caplog):
+def test_get_from_non_dvc_master(tmp_dir, git_dir):
     with git_dir.chdir(), git_dir.branch("branch", new=True):
         git_dir.init(dvc=True)
         git_dir.dvc_gen("some_file", "some text", commit="create some file")
 
-    caplog.clear()
+    Repo.get(os.fspath(git_dir), "some_file", out="some_dst", rev="branch")
 
-    with caplog.at_level(logging.INFO, logger="dvc"):
-        Repo.get(os.fspath(git_dir), "some_file", out="some_dst", rev="branch")
-
-    assert caplog.text == ""
     assert (tmp_dir / "some_dst").read_text() == "some text"
 
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Related to #3811.
Will fix #3611.

Changes:
* erepo: use GitTree instead of `git checkout` for cloned repos (unless dvcx `for_write=True`)
* erepo: use `RepoTree`/`cache.save()` for fetching external DVC+ git files
* erepo: remove `pull_to`
    * RepoDependency: use `erepo.fetch_external() -> cache.checkout` with host repo cache
    * get: use `erepo.fetch_external() -> cache.checkout()` with erepo tmpdir cache
* `ls`: use RepoTree