### PR TITLE
dvc: add: set top level md5 to None

### DIFF
--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -356,7 +356,11 @@ class Stage(params.StageParams):
         return get_dump(self)
 
     def compute_md5(self):
-        m = compute_md5(self)
+        # `dvc add`ed files don't need stage md5
+        if self.is_data_source and not (self.is_import or self.is_repo_import):
+            m = None
+        else:
+            m = compute_md5(self)
         logger.debug(f"Computed {self} md5: '{m}'")
         return m
 

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -44,10 +44,9 @@ def test_add(tmp_dir, dvc):
     assert len(stage.deps) == 0
     assert stage.cmd is None
     assert stage.outs[0].info["md5"] == md5
-    assert stage.md5 == "411854a9fc55b3cebda28704e41b23b3"
+    assert stage.md5 is None
 
     assert load_stage_file("foo.dvc") == {
-        "md5": "411854a9fc55b3cebda28704e41b23b3",
         "outs": [{"md5": "acbd18db4cc2f85cedef654fccc4a4d8", "path": "foo"}],
     }
 

--- a/tests/func/test_commit.py
+++ b/tests/func/test_commit.py
@@ -70,6 +70,7 @@ def test_commit_changed_md5(tmp_dir, dvc):
         dvc.commit(stage.path)
 
     dvc.commit(stage.path, force=True)
+    assert "md5" not in load_stage_file(stage.path)
 
 
 def test_commit_no_exec(tmp_dir, dvc):

--- a/tests/unit/stage/test_stage.py
+++ b/tests/unit/stage/test_stage.py
@@ -20,14 +20,14 @@ TEST_STAGE_DICT = {
 
 
 def test_stage_checksum():
-    stage = Stage(None, "path")
+    stage = Stage(None, "path", cmd="mycmd")
 
     with mock.patch.object(stage, "dumpd", return_value=TEST_STAGE_DICT):
         assert stage.compute_md5() == "e9521a22111493406ea64a88cda63e0b"
 
 
 def test_wdir_default_ignored():
-    stage = Stage(None, "path")
+    stage = Stage(None, "path", cmd="mycmd")
     d = dict(TEST_STAGE_DICT, wdir=".")
 
     with mock.patch.object(stage, "dumpd", return_value=d):
@@ -35,7 +35,7 @@ def test_wdir_default_ignored():
 
 
 def test_wdir_non_default_is_not_ignored():
-    stage = Stage(None, "path")
+    stage = Stage(None, "path", cmd="mycmd")
     d = dict(TEST_STAGE_DICT, wdir="..")
 
     with mock.patch.object(stage, "dumpd", return_value=d):
@@ -43,7 +43,7 @@ def test_wdir_non_default_is_not_ignored():
 
 
 def test_meta_ignored():
-    stage = Stage(None, "path")
+    stage = Stage(None, "path", cmd="mycmd")
     d = dict(TEST_STAGE_DICT, meta={"author": "Suor"})
 
     with mock.patch.object(stage, "dumpd", return_value=d):


### PR DESCRIPTION
This way it won't be included into produced dvcfiles (we don't need it
for `dvc add`).

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
