### PR TITLE
snap: release non-stable-semver tags to beta

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,8 @@ Snap (Snapcraft/Linux)
    snap install dvc --classic
 
 This corresponds to the latest tagged release.
-Add ``--edge`` for the latest ``master`` version.
+Add ``--beta`` for the latest tagged release candidate,
+or ``--edge`` for the latest ``master`` version.
 
 Choco (Chocolatey/Windows)
 --------------------------

--- a/scripts/ci/before_install.sh
+++ b/scripts/ci/before_install.sh
@@ -52,7 +52,11 @@ elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
 fi
 
 if [[ -n "$TRAVIS_TAG" ]]; then
-  echo "export SNAP_CHANNEL=stable" >>env.sh
+  if [[ $(echo "$TRAVIS_TAG" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$') ]]; then
+    echo "export SNAP_CHANNEL=stable" >>env.sh
+  else
+    echo "export SNAP_CHANNEL=beta" >>env.sh
+  fi
 else
   echo "export SNAP_CHANNEL=edge" >>env.sh
 fi


### PR DESCRIPTION
- [x] push non-stable tags to the snap `channel: beta`
- [x] ensure travis CI has the correct credentials
- [x] document
  - [x] website PR for later https://github.com/iterative/dvc.org/pull/1342
- fixes #3860

Also just rolled back last `stable` to match the new scheme:

```yaml
channels:
  latest/stable:    0.94.0              2020-05-23 (388) 104MB classic
  latest/candidate: ↑
  latest/beta:      1.0.0a4             2020-05-23 (441) 105MB classic
  latest/edge:      1.0.0a4-3-g5ab948f8 2020-05-23 (446) 105MB classic
```