### PR TITLE
snap: restrict site-package checks

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,6 +38,7 @@ parts:
         sed -rin 's/.*git.*diff.*--quiet.*//' $SNAPCRAFT_PART_SRC/dvc/version.py
     override-build: |
         snapcraftctl build
+        sed -ri 's/^(ENABLE_USER_SITE = )None$/\1False/' $SNAPCRAFT_PART_INSTALL/usr/lib/python*/site.py
         cp $SNAPCRAFT_PART_BUILD/scripts/completion/dvc.bash $SNAPCRAFT_PART_INSTALL/completion.sh
 apps:
   dvc:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,6 +38,8 @@ parts:
         sed -rin 's/.*git.*diff.*--quiet.*//' $SNAPCRAFT_PART_SRC/dvc/version.py
     override-build: |
         snapcraftctl build
+        # prevent user site packages interfering with this snap - reference:
+        # https://github.com/snapcore/snapcraft/blob/19393ef36cd773a28131cec10cc0bfb3bf9c7e77/tools/snapcraft-override-build.sh#L18
         sed -ri 's/^(ENABLE_USER_SITE = )None$/\1False/' $SNAPCRAFT_PART_INSTALL/usr/lib/python*/site.py
         cp $SNAPCRAFT_PART_BUILD/scripts/completion/dvc.bash $SNAPCRAFT_PART_INSTALL/completion.sh
 apps:


### PR DESCRIPTION
- [x] prevent snap's python looking for user site packages
- [ ] check if this really fixes #3514
- related: #3879 (`0.x` branch)
- fixes #3514
- reference https://github.com/snapcore/snapcraft/blob/19393ef36cd773a28131cec10cc0bfb3bf9c7e77/tools/snapcraft-override-build.sh#L18