### PR TITLE
snap: 0.x: prevent user site package conflicts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,9 @@ env:
     - PATH="$PYENV_ROOT/bin:$PATH"
     - PIP_CACHE_DIR="$HOME/.cache/pip"  # unify pip cache location for all platforms
 stages:
-  - name: check
-    if: false
-  - name: test
-    if: false
-  - name: build
-    if: NOT type = pull_request
+  - check
+  - test
+  - build
 # Travis doesn't support testing python on Mac yet, so we need
 # to workaround it by installing it directly with brew.
 #
@@ -109,6 +106,7 @@ jobs:
     - sudo /snap/bin/lxd.migrate -yes
     - sudo /snap/bin/lxd waitready
     - sudo /snap/bin/lxd init --auto
+    - git fetch --tags
     script:
     - ./scripts/build_snap.sh
     after_failure:
@@ -156,9 +154,9 @@ deploy:
       stage: build
   - provider: script
     skip_cleanup: true
-    script: "(echo $SNAP_TOKEN | snapcraft login --with -) && timeout 600 snapcraft push dvc_*.snap --release latest/stable/3878 || echo timed out"
+    script: "(echo $SNAP_TOKEN | snapcraft login --with -) && timeout 600 snapcraft push dvc_*.snap --release $SNAP_CHANNEL || echo timed out"
     on:
       all_branches: true
-      condition: "true"
+      condition: "$(./scripts/ci/deploy_condition.sh dvc_*.snap) && ($TRAVIS_BRANCH = master || -n $TRAVIS_TAG)"
       repo: iterative/dvc
       stage: build

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,12 @@ env:
     - PATH="$PYENV_ROOT/bin:$PATH"
     - PIP_CACHE_DIR="$HOME/.cache/pip"  # unify pip cache location for all platforms
 stages:
-  - check
-  - test
-  - build
+  - name: check
+    if: false
+  - name: test
+    if: false
+  - name: build
+    if: NOT type = pull_request
 # Travis doesn't support testing python on Mac yet, so we need
 # to workaround it by installing it directly with brew.
 #
@@ -153,9 +156,9 @@ deploy:
       stage: build
   - provider: script
     skip_cleanup: true
-    script: "(echo $SNAP_TOKEN | snapcraft login --with -) && timeout 600 snapcraft push dvc_*.snap --release $SNAP_CHANNEL || echo timed out"
+    script: "(echo $SNAP_TOKEN | snapcraft login --with -) && timeout 600 snapcraft push dvc_*.snap --release latest/stable/3878 || echo timed out"
     on:
       all_branches: true
-      condition: "$(./scripts/ci/deploy_condition.sh dvc_*.snap) && ($TRAVIS_BRANCH = master || -n $TRAVIS_TAG)"
+      condition: "true"
       repo: iterative/dvc
       stage: build

--- a/scripts/ci/before_install.sh
+++ b/scripts/ci/before_install.sh
@@ -15,7 +15,7 @@ fi
 
 echo >env.sh
 
-if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Test" ]]; then
+if [[ "$TRAVIS_BUILD_STAGE_NAME" == "test" ]]; then
   if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then
     # NOTE: ssh keys for ssh test to be able to ssh to the localhost
     ssh-keygen -t rsa -N "" -f mykey
@@ -52,7 +52,11 @@ elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
 fi
 
 if [[ -n "$TRAVIS_TAG" ]]; then
-  echo "export SNAP_CHANNEL=stable" >>env.sh
+  if [[ $(echo "$TRAVIS_TAG" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$') ]]; then
+    echo "export SNAP_CHANNEL=stable" >>env.sh
+  else
+    echo "export SNAP_CHANNEL=beta" >>env.sh
+  fi
 else
   echo "export SNAP_CHANNEL=edge" >>env.sh
 fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,7 +29,7 @@ parts:
     - git
     override-pull: |
         snapcraftctl pull
-        snapcraftctl set-version `cd $SNAPCRAFT_PART_SRC && git describe --tags`
+        snapcraftctl set-version $(cd $SNAPCRAFT_PART_SRC && git describe --tags)
         git diff --quiet || error_dirty_build
         echo 'PKG = "snap"' > $SNAPCRAFT_PART_SRC/dvc/utils/build.py
         # install all optional extras
@@ -38,6 +38,8 @@ parts:
         sed -rin 's/.*git.*diff.*--quiet.*//' $SNAPCRAFT_PART_SRC/dvc/version.py
     override-build: |
         snapcraftctl build
+        # prevent user site packages interfering with this snap - reference:
+        # https://github.com/snapcore/snapcraft/blob/19393ef36cd773a28131cec10cc0bfb3bf9c7e77/tools/snapcraft-override-build.sh#L18
         sed -ri 's/^(ENABLE_USER_SITE = )None$/\1False/' $SNAPCRAFT_PART_INSTALL/usr/lib/python*/site.py
         cp $SNAPCRAFT_PART_BUILD/scripts/completion/dvc.bash $SNAPCRAFT_PART_INSTALL/completion.sh
 apps:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,6 +38,7 @@ parts:
         sed -rin 's/.*git.*diff.*--quiet.*//' $SNAPCRAFT_PART_SRC/dvc/version.py
     override-build: |
         snapcraftctl build
+        sed -ri 's/^(ENABLE_USER_SITE = )None$/\1False/' $SNAPCRAFT_PART_INSTALL/usr/lib/python*/site.py
         cp $SNAPCRAFT_PART_BUILD/scripts/completion/dvc.bash $SNAPCRAFT_PART_INSTALL/completion.sh
 apps:
   dvc:


### PR DESCRIPTION
- [x] prevent snap's python looking for user site packages
- [x] revert debug commit
  + allows `snap refresh --channel=stable/3878 dvc`
    * after 30 days (or manual channel closure) will automatically move back to `stable`
- [x] sync current master (`1.x` branch)
- related: #3878 (`1.x` branch)
- fixes #3514
- reference https://github.com/snapcore/snapcraft/blob/19393ef36cd773a28131cec10cc0bfb3bf9c7e77/tools/snapcraft-override-build.sh#L18