### PR TITLE
Implement removing of the stage

### DIFF
--- a/dvc/command/remove.py
+++ b/dvc/command/remove.py
@@ -1,7 +1,6 @@
 import argparse
 import logging
 
-import dvc.prompt as prompt
 from dvc.command.base import CmdBase, append_doc_link
 from dvc.exceptions import DvcException
 
@@ -9,30 +8,10 @@ logger = logging.getLogger(__name__)
 
 
 class CmdRemove(CmdBase):
-    def _is_dvc_only(self, target):
-        if not self.args.purge:
-            return True
-
-        if self.args.force:
-            return False
-
-        msg = "Are you sure you want to remove '{}' with its outputs?".format(
-            target
-        )
-
-        if prompt.confirm(msg):
-            return False
-
-        raise DvcException(
-            "Cannot purge without a confirmation from the user."
-            " Use `-f` to force."
-        )
-
     def run(self):
         for target in self.args.targets:
             try:
-                dvc_only = self._is_dvc_only(target)
-                self.repo.remove(target, dvc_only=dvc_only)
+                self.repo.remove(target, outs=self.args.outs)
             except DvcException:
                 logger.exception(f"failed to remove '{target}'")
                 return 1
@@ -40,7 +19,7 @@ class CmdRemove(CmdBase):
 
 
 def add_parser(subparsers, parent_parser):
-    REMOVE_HELP = "Remove DVC-tracked files or directories."
+    REMOVE_HELP = "Remove stage entry and unprotect outputs"
     remove_parser = subparsers.add_parser(
         "remove",
         parents=[parent_parser],
@@ -48,27 +27,11 @@ def add_parser(subparsers, parent_parser):
         help=REMOVE_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    remove_parser_group = remove_parser.add_mutually_exclusive_group()
-    remove_parser_group.add_argument(
-        "-o",
+    remove_parser.add_argument(
         "--outs",
         action="store_true",
-        default=True,
-        help="Only remove DVC-file outputs. (Default)",
-    )
-    remove_parser_group.add_argument(
-        "-p",
-        "--purge",
-        action="store_true",
         default=False,
-        help="Remove DVC-file and all its outputs.",
-    )
-    remove_parser.add_argument(
-        "-f",
-        "--force",
-        action="store_true",
-        default=False,
-        help="Force purge.",
+        help="Remove outputs as well.",
     )
     remove_parser.add_argument(
         "targets", nargs="+", help="DVC-files to remove."

--- a/dvc/command/run.py
+++ b/dvc/command/run.py
@@ -45,7 +45,7 @@ class CmdRun(CmdBase):
                 fname=self.args.file,
                 wdir=self.args.wdir,
                 no_exec=self.args.no_exec,
-                overwrite=self.args.overwrite_dvcfile,
+                overwrite=self.args.overwrite,
                 run_cache=not self.args.no_run_cache,
                 no_commit=self.args.no_commit,
                 outs_persist=self.args.outs_persist,
@@ -177,10 +177,10 @@ def add_parser(subparsers, parent_parser):
         help="Only create stage file without actually running it.",
     )
     run_parser.add_argument(
-        "--overwrite-dvcfile",
+        "--overwrite",
         action="store_true",
         default=False,
-        help="Overwrite existing DVC-file without asking for confirmation.",
+        help="Overwrite existing stage",
     )
     run_parser.add_argument(
         "--no-run-cache",

--- a/dvc/repo/remove.py
+++ b/dvc/repo/remove.py
@@ -7,15 +7,11 @@ logger = logging.getLogger(__name__)
 
 
 @locked
-def remove(self, target, dvc_only=False):
-    from ..dvcfile import Dvcfile, is_valid_filename
-
+def remove(self, target, outs=False):
     path, name = parse_target(target)
     stages = self.get_stages(path, name)
-    for stage in stages:
-        stage.remove_outs(force=True)
 
-    if path and is_valid_filename(path) and not dvc_only:
-        Dvcfile(self, path).remove()
+    for stage in stages:
+        stage.remove(remove_outs=outs, force=outs)
 
     return stages

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -280,12 +280,13 @@ class Stage(params.StageParams):
             out.unprotect()
 
     @rwlocked(write=["outs"])
-    def remove(self, force=False, remove_outs=True):
+    def remove(self, force=False, remove_outs=True, purge=True):
         if remove_outs:
             self.remove_outs(ignore_remove=True, force=force)
         else:
             self.unprotect_outs()
-        self.dvcfile.remove()
+        if purge:
+            self.dvcfile.remove_stage(self)
 
     @rwlocked(read=["deps"], write=["outs"])
     def reproduce(self, interactive=False, **kwargs):

--- a/tests/func/test_gc.py
+++ b/tests/func/test_gc.py
@@ -68,7 +68,7 @@ class TestGCBranchesTags(TestDvcGit):
         self.dvc.scm.tag("v1.0")
 
         self.dvc.scm.checkout("test", create_new=True)
-        self.dvc.remove(stages[0].relpath, dvc_only=True)
+        self.dvc.remove(stages[0].relpath)
         with open(fname, "w+") as fobj:
             fobj.write("test")
         stages = self.dvc.add(fname)
@@ -77,7 +77,7 @@ class TestGCBranchesTags(TestDvcGit):
         self.dvc.scm.commit("test")
 
         self.dvc.scm.checkout("master")
-        self.dvc.remove(stages[0].relpath, dvc_only=True)
+        self.dvc.remove(stages[0].relpath)
         with open(fname, "w+") as fobj:
             fobj.write("trash")
         stages = self.dvc.add(fname)
@@ -85,7 +85,7 @@ class TestGCBranchesTags(TestDvcGit):
         self.dvc.scm.add([".gitignore", stages[0].relpath])
         self.dvc.scm.commit("trash")
 
-        self.dvc.remove(stages[0].relpath, dvc_only=True)
+        self.dvc.remove(stages[0].relpath)
         with open(fname, "w+") as fobj:
             fobj.write("master")
         stages = self.dvc.add(fname)

--- a/tests/func/test_remove.py
+++ b/tests/func/test_remove.py
@@ -1,129 +1,64 @@
 import os
 
-from mock import patch
+import pytest
 
 from dvc.exceptions import DvcException
 from dvc.main import main
-from dvc.stage import Stage
 from dvc.stage.exceptions import StageFileDoesNotExistError
 from dvc.system import System
 from dvc.utils.fs import remove
-from tests.basic_env import TestDvc
 
 
-class TestRemove(TestDvc):
-    def test(self):
-        stages = self.dvc.add(self.FOO)
-        self.assertEqual(len(stages), 1)
-        stage = stages[0]
-        self.assertTrue(stage is not None)
-        (stage_removed,) = self.dvc.remove(stage.path, dvc_only=True)
+@pytest.mark.parametrize("remove_outs", [True, False])
+def test_remove(tmp_dir, dvc, run_copy, remove_outs):
+    (stage1,) = tmp_dir.dvc_gen("foo", "foo")
+    stage2 = run_copy("foo", "bar", single_stage=True)
+    stage3 = run_copy("bar", "foobar", name="copy-bar-foobar")
 
-        self.assertIsInstance(stage_removed, Stage)
-        self.assertEqual(stage.path, stage_removed.path)
-        self.assertFalse(os.path.isfile(self.FOO))
-
-        (stage_removed,) = self.dvc.remove(stage.path)
-        self.assertIsInstance(stage_removed, Stage)
-        self.assertEqual(stage.path, stage_removed.path)
-        self.assertFalse(os.path.isfile(self.FOO))
-        self.assertFalse(os.path.exists(stage.path))
+    for stage in [stage1, stage2, stage3]:
+        dvc.remove(stage.addressing, outs=remove_outs)
+        out_exists = (out.exists for out in stage.outs)
+        assert stage not in dvc._collect_stages()
+        if remove_outs:
+            assert not any(out_exists)
+        else:
+            assert all(out_exists)
 
 
-class TestRemoveNonExistentFile(TestDvc):
-    def test(self):
-        with self.assertRaises(StageFileDoesNotExistError):
-            self.dvc.remove("non_existent_dvc_file")
+def test_remove_non_existent_file(tmp_dir, dvc):
+    with pytest.raises(StageFileDoesNotExistError):
+        dvc.remove("non_existent_dvc_file.dvc")
+    with pytest.raises(StageFileDoesNotExistError):
+        dvc.remove("non_existent_stage_name")
 
 
-class TestRemoveBrokenSymlink(TestDvc):
-    def test(self):
-        ret = main(["config", "cache.type", "symlink"])
-        self.assertEqual(ret, 0)
-
-        ret = main(["add", self.FOO])
-        self.assertEqual(ret, 0)
-
-        remove(self.dvc.cache.local.cache_dir)
-
-        self.assertTrue(System.is_symlink(self.FOO))
-
-        ret = main(["remove", self.FOO + ".dvc"])
-        self.assertEqual(ret, 0)
-
-        self.assertFalse(os.path.lexists(self.FOO))
-
-
-class TestRemoveDirectory(TestDvc):
-    def test(self):
-        stages = self.dvc.add(self.DATA_DIR)
-        self.assertEqual(len(stages), 1)
-        stage_add = stages[0]
-        self.assertTrue(stage_add is not None)
-        (stage_removed,) = self.dvc.remove(stage_add.path)
-        self.assertEqual(stage_add.path, stage_removed.path)
-        self.assertFalse(os.path.exists(self.DATA_DIR))
-        self.assertFalse(os.path.exists(stage_removed.path))
-
-
-class TestCmdRemove(TestDvc):
-    def test(self):
-        stages = self.dvc.add(self.FOO)
-        self.assertEqual(len(stages), 1)
-        stage = stages[0]
-        self.assertTrue(stage is not None)
-        ret = main(["remove", stage.path])
-        self.assertEqual(ret, 0)
-
-        ret = main(["remove", "non-existing-dvc-file"])
-        self.assertNotEqual(ret, 0)
-
-
-class TestRemovePurge(TestDvc):
-    def test(self):
-        dvcfile = self.dvc.add(self.FOO)[0].path
-        ret = main(["remove", "--purge", "--force", dvcfile])
-
-        self.assertEqual(ret, 0)
-        self.assertFalse(os.path.exists(self.FOO))
-        self.assertFalse(os.path.exists(dvcfile))
-
-    @patch("dvc.prompt.confirm", return_value=False)
-    def test_force(self, mock_prompt):
-        dvcfile = self.dvc.add(self.FOO)[0].path
-        ret = main(["remove", "--purge", dvcfile])
-
-        mock_prompt.assert_called()
-        self.assertEqual(ret, 1)
-        self.assertRaises(DvcException)
-
-
-def test_remove_pipeline_outs(tmp_dir, dvc, run_copy):
-    from dvc.dvcfile import PIPELINE_FILE
-
+def test_remove_broken_symlink(tmp_dir, dvc):
     tmp_dir.gen("foo", "foo")
-    stage = run_copy("foo", "bar", name="copy-foo-bar")
+    dvc.cache.local.cache_types = ["symlink"]
 
-    assert main(["remove", stage.path]) == 0
-    assert not (tmp_dir / "bar").exists()
-    assert (tmp_dir / PIPELINE_FILE).exists()
+    (stage,) = dvc.add("foo")
+    remove(dvc.cache.local.cache_dir)
+    assert System.is_symlink("foo")
 
-    stage = run_copy("foo", "foobar", name="copy-foo-foobar")
+    with pytest.raises(DvcException):
+        dvc.remove(stage.addressing)
+    assert os.path.lexists("foo")
+    assert (tmp_dir / stage.relpath).exists()
 
+    dvc.remove(stage.addressing, outs=True)
+    assert not os.path.lexists("foo")
+    assert not (tmp_dir / stage.relpath).exists()
+
+
+def test_cmd_remove(tmp_dir, dvc):
+    assert main(["remove", "non-existing-dvc-file"]) == 1
+
+    (stage,) = tmp_dir.dvc_gen("foo", "foo")
     assert main(["remove", stage.addressing]) == 0
-    assert not (tmp_dir / "foobar").exists()
+    assert not (tmp_dir / stage.relpath).exists()
     assert (tmp_dir / "foo").exists()
 
-    stage = run_copy("foo", "baz", name="copy-foo-baz")
-    assert main(["remove", "--purge", "-f", stage.addressing]) == 0
-    assert not (tmp_dir / "baz").exists()
-    assert (tmp_dir / "foo").exists()
-    assert (tmp_dir / PIPELINE_FILE).exists()
-
-    dvc.reproduce(PIPELINE_FILE)
-    assert main(["remove", PIPELINE_FILE]) == 0
-    for file in ["bar", "foobar", "baz"]:
-        assert not (tmp_dir / file).exists()
-
-    assert (tmp_dir / "foo").exists()
-    assert (tmp_dir / PIPELINE_FILE).exists()
+    (stage,) = tmp_dir.dvc_gen("foo", "foo")
+    assert main(["remove", stage.addressing, "--outs"]) == 0
+    assert not (tmp_dir / stage.relpath).exists()
+    assert not (tmp_dir / "foo").exists()

--- a/tests/func/test_run_multistage.py
+++ b/tests/func/test_run_multistage.py
@@ -218,7 +218,8 @@ def test_run_already_exists(tmp_dir, dvc, run_copy):
     tmp_dir.dvc_gen("foo", "foo")
     run_copy("foo", "bar", name="copy")
     with pytest.raises(DuplicateStageName):
-        run_copy("bar", "foobar", name="copy")
+        run_copy("bar", "foobar", name="copy", overwrite=False)
+    run_copy("bar", "foobar", name="copy", overwrite=True)
 
 
 supported_params = {

--- a/tests/unit/command/test_run.py
+++ b/tests/unit/command/test_run.py
@@ -27,7 +27,7 @@ def test_run(mocker, dvc):
             "--wdir",
             "wdir",
             "--no-exec",
-            "--overwrite-dvcfile",
+            "--overwrite",
             "--no-run-cache",
             "--no-commit",
             "--outs-persist",


### PR DESCRIPTION
This PR adds support for removing stage entry for pipeline files and allows overwriting stage entry during `run`.

Backward Incompatible changes:
1. Changes `--overwrite-dvcfile` flag to `--overwrite` so that it makes sense for both kind of files.
2. Removes `--outs` flag from `dvc remove`.
3. `run` will always raise an exception if there already exists a stage, previously it'd prompt to overwrite.


* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).
PR will come shortly.

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Closes https://github.com/iterative/dvc/issues/3317