### PR TITLE
dvc: rename "working tree" to "workspace"

### DIFF
--- a/dvc/command/gc.py
+++ b/dvc/command/gc.py
@@ -21,7 +21,7 @@ class CmdGC(CmdBase):
 
         msg = "This will remove all cache except items used in "
 
-        msg += "the working tree"
+        msg += "the workspace"
         if self.args.all_commits:
             msg += " and all git commits"
         elif self.args.all_branches and self.args.all_tags:
@@ -77,7 +77,7 @@ def add_parser(subparsers, parent_parser):
         "--workspace",
         action="store_true",
         default=False,
-        help="Keep data files used in the current workspace (working tree).",
+        help="Keep data files used in the current workspace.",
     )
     gc_parser.add_argument(
         "-a",

--- a/dvc/repo/brancher.py
+++ b/dvc/repo/brancher.py
@@ -18,7 +18,7 @@ def brancher(  # noqa: E302
         str: the display name for the currently selected tree, it could be:
             - a git revision identifier
             - empty string it there is no branches to iterate over
-            - "Working Tree" if there are uncommitted changes in the SCM repo
+            - "workspace" if there are uncommitted changes in the SCM repo
     """
     if not any([revs, all_branches, all_tags, all_commits]):
         yield ""
@@ -30,10 +30,10 @@ def brancher(  # noqa: E302
     scm = self.scm
 
     self.tree = WorkingTree(self.root_dir)
-    yield "working tree"
+    yield "workspace"
 
-    if revs and "working tree" in revs:
-        revs.remove("working tree")
+    if revs and "workspace" in revs:
+        revs.remove("workspace")
 
     if all_commits:
         revs = scm.list_all_commits()

--- a/dvc/repo/diff.py
+++ b/dvc/repo/diff.py
@@ -7,7 +7,7 @@ from dvc.scm.tree import is_working_tree
 @locked
 def diff(self, a_rev="HEAD", b_rev=None):
     """
-    By default, it compares the working tree with the last commit's tree.
+    By default, it compares the workspace with the last commit's tree.
 
     This implementation differs from `git diff` since DVC doesn't have
     the concept of `index`, but it keeps the same interface, thus,

--- a/dvc/repo/metrics/show.py
+++ b/dvc/repo/metrics/show.py
@@ -104,13 +104,13 @@ def show(
     if not res:
         raise NoMetricsError()
 
-    # Hide working tree metrics if they are the same as in the active branch
+    # Hide workspace metrics if they are the same as in the active branch
     try:
         active_branch = repo.scm.active_branch()
     except TypeError:
         pass  # Detached head
     else:
-        if res.get("working tree") == res.get(active_branch):
-            res.pop("working tree", None)
+        if res.get("workspace") == res.get(active_branch):
+            res.pop("workspace", None)
 
     return res

--- a/dvc/repo/params/show.py
+++ b/dvc/repo/params/show.py
@@ -58,13 +58,13 @@ def show(repo, revs=None):
     if not res:
         raise NoParamsError("no parameter configs files in this repository")
 
-    # Hide working tree params if they are the same as in the active branch
+    # Hide workspace params if they are the same as in the active branch
     try:
         active_branch = repo.scm.active_branch()
     except TypeError:
         pass  # Detached head
     else:
-        if res.get("working tree") == res.get(active_branch):
-            res.pop("working tree", None)
+        if res.get("workspace") == res.get(active_branch):
+            res.pop("workspace", None)
 
     return res

--- a/dvc/repo/plots/data.py
+++ b/dvc/repo/plots/data.py
@@ -258,7 +258,7 @@ def _load_from_revisions(repo, datafile, revisions):
     exceptions = []
 
     for rev in repo.brancher(revs=revisions):
-        if rev == "working tree" and rev not in revisions:
+        if rev == "workspace" and rev not in revisions:
             continue
 
         try:

--- a/dvc/repo/plots/diff.py
+++ b/dvc/repo/plots/diff.py
@@ -3,7 +3,7 @@ def _revisions(revs, is_dirty):
     if len(revisions) <= 1:
         if len(revisions) == 0 and is_dirty:
             revisions.append("HEAD")
-        revisions.append("working tree")
+        revisions.append("workspace")
     return revisions
 
 

--- a/dvc/repo/plots/show.py
+++ b/dvc/repo/plots/show.py
@@ -106,7 +106,7 @@ def _infer_y_field(rev_data_points, x_field):
 
 def _show(repo, datafile=None, revs=None, props=None):
     if revs is None:
-        revs = ["working tree"]
+        revs = ["workspace"]
 
     if not datafile and not props.get("template"):
         raise NoDataOrTemplateProvided()

--- a/scripts/completion/dvc.zsh
+++ b/scripts/completion/dvc.zsh
@@ -132,7 +132,7 @@ _dvc_get=(
 )
 
 _dvc_gc=(
-  {-w,--workspace}"[Keep data files used in the current workspace (working tree).]"
+  {-w,--workspace}"[Keep data files used in the current workspace.]"
   {-a,--all-branches}"[Keep data files for the tips of all Git branches.]"
   "--all-commits[Keep data files for all Git commits.]"
   {-T,--all-tags}"[Keep data files for all Git tags.]"

--- a/tests/func/metrics/test_show.py
+++ b/tests/func/metrics/test_show.py
@@ -56,7 +56,7 @@ def test_show_branch(tmp_dir, scm, dvc, run_copy_metrics):
         tmp_dir.scm_gen("metrics.yaml", "foo: 2", commit="branch")
 
     assert dvc.metrics.show(revs=["branch"]) == {
-        "working tree": {"metrics.yaml": {"foo": 1}},
+        "workspace": {"metrics.yaml": {"foo": 1}},
         "branch": {"metrics.yaml": {"foo": 2}},
     }
 
@@ -90,6 +90,6 @@ def test_show_subrepo_with_preexisting_tags(tmp_dir, scm):
 
     expected_path = os.path.join("subdir", "metrics.yaml")
     assert dvc.metrics.show(all_tags=True) == {
-        "working tree": {expected_path: {"foo": 1}},
+        "workspace": {expected_path: {"foo": 1}},
         "v1": {expected_path: {"foo": 1}},
     }

--- a/tests/func/params/test_show.py
+++ b/tests/func/params/test_show.py
@@ -49,7 +49,7 @@ def test_show_branch(tmp_dir, scm, dvc):
         tmp_dir.scm_gen("params.yaml", "foo: baz", commit="branch")
 
     assert dvc.params.show(revs=["branch"]) == {
-        "working tree": {"params.yaml": {"foo": "bar"}},
+        "workspace": {"params.yaml": {"foo": "bar"}},
         "branch": {"params.yaml": {"foo": "baz"}},
     }
 

--- a/tests/func/plots/test_diff.py
+++ b/tests/func/plots/test_diff.py
@@ -32,8 +32,8 @@ def test_diff_dirty(tmp_dir, scm, dvc, run_copy_metrics):
 
     plot_content = json.loads(plot_string)
     assert plot_content["data"]["values"] == [
-        {"y": 5, PlotData.INDEX_FIELD: 0, "rev": "working tree"},
-        {"y": 6, PlotData.INDEX_FIELD: 1, "rev": "working tree"},
+        {"y": 5, PlotData.INDEX_FIELD: 0, "rev": "workspace"},
+        {"y": 6, PlotData.INDEX_FIELD: 1, "rev": "workspace"},
         {"y": 3, PlotData.INDEX_FIELD: 0, "rev": "HEAD"},
         {"y": 5, PlotData.INDEX_FIELD: 1, "rev": "HEAD"},
     ]

--- a/tests/func/plots/test_plots.py
+++ b/tests/func/plots/test_plots.py
@@ -60,8 +60,8 @@ def test_plot_csv_one_column(tmp_dir, scm, dvc, run_copy_metrics):
     plot_content = json.loads(plot_string)
     assert plot_content["title"] == "mytitle"
     assert plot_content["data"]["values"] == [
-        {"0": "2", PlotData.INDEX_FIELD: 0, "rev": "working tree"},
-        {"0": "3", PlotData.INDEX_FIELD: 1, "rev": "working tree"},
+        {"0": "2", PlotData.INDEX_FIELD: 0, "rev": "workspace"},
+        {"0": "3", PlotData.INDEX_FIELD: 1, "rev": "workspace"},
     ]
     assert plot_content["encoding"]["x"]["field"] == PlotData.INDEX_FIELD
     assert plot_content["encoding"]["y"]["field"] == "0"
@@ -86,14 +86,14 @@ def test_plot_csv_multiple_columns(tmp_dir, scm, dvc, run_copy_metrics):
         {
             "val": "2",
             PlotData.INDEX_FIELD: 0,
-            "rev": "working tree",
+            "rev": "workspace",
             "first_val": "100",
             "second_val": "100",
         },
         {
             "val": "3",
             PlotData.INDEX_FIELD: 1,
-            "rev": "working tree",
+            "rev": "workspace",
             "first_val": "200",
             "second_val": "300",
         },
@@ -119,13 +119,13 @@ def test_plot_csv_choose_axes(tmp_dir, scm, dvc, run_copy_metrics):
     assert plot_content["data"]["values"] == [
         {
             "val": "2",
-            "rev": "working tree",
+            "rev": "workspace",
             "first_val": "100",
             "second_val": "100",
         },
         {
             "val": "3",
-            "rev": "working tree",
+            "rev": "workspace",
             "first_val": "200",
             "second_val": "300",
         },
@@ -148,8 +148,8 @@ def test_plot_json_single_val(tmp_dir, scm, dvc, run_copy_metrics):
 
     plot_json = json.loads(plot_string)
     assert plot_json["data"]["values"] == [
-        {"val": 2, PlotData.INDEX_FIELD: 0, "rev": "working tree"},
-        {"val": 3, PlotData.INDEX_FIELD: 1, "rev": "working tree"},
+        {"val": 2, PlotData.INDEX_FIELD: 0, "rev": "workspace"},
+        {"val": 3, PlotData.INDEX_FIELD: 1, "rev": "workspace"},
     ]
     assert plot_json["encoding"]["x"]["field"] == PlotData.INDEX_FIELD
     assert plot_json["encoding"]["y"]["field"] == "val"
@@ -176,13 +176,13 @@ def test_plot_json_multiple_val(tmp_dir, scm, dvc, run_copy_metrics):
             "val": 2,
             PlotData.INDEX_FIELD: 0,
             "first_val": 100,
-            "rev": "working tree",
+            "rev": "workspace",
         },
         {
             "val": 3,
             PlotData.INDEX_FIELD: 1,
             "first_val": 200,
-            "rev": "working tree",
+            "rev": "workspace",
         },
     ]
     assert plot_content["encoding"]["x"]["field"] == PlotData.INDEX_FIELD
@@ -207,8 +207,8 @@ def test_plot_confusion(tmp_dir, dvc, run_copy_metrics):
 
     plot_content = json.loads(plot_string)
     assert plot_content["data"]["values"] == [
-        {"predicted": "B", "actual": "A", "rev": "working tree"},
-        {"predicted": "A", "actual": "A", "rev": "working tree"},
+        {"predicted": "B", "actual": "A", "rev": "workspace"},
+        {"predicted": "A", "actual": "A", "rev": "workspace"},
     ]
     assert plot_content["encoding"]["x"]["field"] == "predicted"
     assert plot_content["encoding"]["y"]["field"] == "actual"
@@ -380,8 +380,8 @@ def test_custom_template(tmp_dir, scm, dvc, custom_template, run_copy_metrics):
 
     plot_content = json.loads(plot_string)
     assert plot_content["data"]["values"] == [
-        {"a": 1, "b": 2, "rev": "working tree"},
-        {"a": 2, "b": 3, "rev": "working tree"},
+        {"a": 1, "b": 2, "rev": "workspace"},
+        {"a": 2, "b": 3, "rev": "workspace"},
     ]
     assert plot_content["encoding"]["x"]["field"] == "a"
     assert plot_content["encoding"]["y"]["field"] == "b"
@@ -413,8 +413,8 @@ def test_custom_template_with_specified_data(
 
     plot_content = json.loads(plot_string)
     assert plot_content["data"]["values"] == [
-        {"a": 1, "b": 2, "rev": "working tree"},
-        {"a": 2, "b": 3, "rev": "working tree"},
+        {"a": 1, "b": 2, "rev": "workspace"},
+        {"a": 2, "b": 3, "rev": "workspace"},
     ]
     assert plot_content["encoding"]["x"]["field"] == "a"
     assert plot_content["encoding"]["y"]["field"] == "b"
@@ -450,8 +450,8 @@ def test_plot_override_specified_data_source(
 
     plot_content = json.loads(plot_string)
     assert plot_content["data"]["values"] == [
-        {"a": 1, "b": 2, "rev": "working tree"},
-        {"a": 2, "b": 3, "rev": "working tree"},
+        {"a": 1, "b": 2, "rev": "workspace"},
+        {"a": 2, "b": 3, "rev": "workspace"},
     ]
     assert plot_content["encoding"]["x"]["field"] == "a"
     assert plot_content["encoding"]["y"]["field"] == "b"
@@ -518,8 +518,8 @@ def test_plot_choose_columns(
 
     plot_content = json.loads(plot_string)
     assert plot_content["data"]["values"] == [
-        {"b": 2, "c": 3, "rev": "working tree"},
-        {"b": 3, "c": 4, "rev": "working tree"},
+        {"b": 2, "c": 3, "rev": "workspace"},
+        {"b": 3, "c": 4, "rev": "workspace"},
     ]
     assert plot_content["encoding"]["x"]["field"] == "b"
     assert plot_content["encoding"]["y"]["field"] == "c"
@@ -540,8 +540,8 @@ def test_plot_default_choose_column(tmp_dir, scm, dvc, run_copy_metrics):
 
     plot_content = json.loads(plot_string)
     assert plot_content["data"]["values"] == [
-        {PlotData.INDEX_FIELD: 0, "b": 2, "rev": "working tree"},
-        {PlotData.INDEX_FIELD: 1, "b": 3, "rev": "working tree"},
+        {PlotData.INDEX_FIELD: 0, "b": 2, "rev": "workspace"},
+        {PlotData.INDEX_FIELD: 1, "b": 3, "rev": "workspace"},
     ]
     assert plot_content["encoding"]["x"]["field"] == PlotData.INDEX_FIELD
     assert plot_content["encoding"]["y"]["field"] == "b"
@@ -560,8 +560,8 @@ def test_plot_yaml(tmp_dir, scm, dvc, run_copy_metrics):
 
     plot_content = json.loads(plot_string)
     assert plot_content["data"]["values"] == [
-        {"val": 2, PlotData.INDEX_FIELD: 0, "rev": "working tree"},
-        {"val": 3, PlotData.INDEX_FIELD: 1, "rev": "working tree"},
+        {"val": 2, PlotData.INDEX_FIELD: 0, "rev": "workspace"},
+        {"val": 3, PlotData.INDEX_FIELD: 1, "rev": "workspace"},
     ]
 
 

--- a/tests/unit/repo/plots/test_diff.py
+++ b/tests/unit/repo/plots/test_diff.py
@@ -6,10 +6,10 @@ from dvc.repo.plots.diff import _revisions
 @pytest.mark.parametrize(
     "arg_revisions,is_dirty,expected_revisions",
     [
-        ([], False, ["working tree"]),
-        ([], True, ["HEAD", "working tree"]),
-        (["v1", "v2", "working tree"], False, ["v1", "v2", "working tree"]),
-        (["v1", "v2", "working tree"], True, ["v1", "v2", "working tree"]),
+        ([], False, ["workspace"]),
+        ([], True, ["HEAD", "workspace"]),
+        (["v1", "v2", "workspace"], False, ["v1", "v2", "workspace"]),
+        (["v1", "v2", "workspace"], True, ["v1", "v2", "workspace"]),
     ],
 )
 def test_revisions(mocker, arg_revisions, is_dirty, expected_revisions):

--- a/tests/unit/repo/test_repo_tree.py
+++ b/tests/unit/repo/test_repo_tree.py
@@ -38,7 +38,7 @@ def test_open_in_history(tmp_dir, scm, dvc):
     dvc.scm.commit("foofoo")
 
     for rev in dvc.brancher(revs=["HEAD~1"]):
-        if rev == "working tree":
+        if rev == "workspace":
             continue
 
         tree = RepoTree(dvc)

--- a/tests/unit/repo/test_tree.py
+++ b/tests/unit/repo/test_tree.py
@@ -38,7 +38,7 @@ def test_open_in_history(tmp_dir, scm, dvc):
     dvc.scm.commit("foofoo")
 
     for rev in dvc.brancher(revs=["HEAD~1"]):
-        if rev == "working tree":
+        if rev == "workspace":
             continue
 
         tree = DvcTree(dvc)


### PR DESCRIPTION
Fixes #3892

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

There are only two occurrences of `working tree` in docs:
```
./content/docs/tutorials/pipelines.md:working tree:                                                                     
./content/docs/tutorials/deep/sharing-data.md:references in the <abbr>workspace</abbr> (in the _working tree_ of the Git
```
neither of those need to be changed right now.

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
