### PR TITLE
plots: fix error when there are no plots in repo

### DIFF
--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -178,6 +178,14 @@ class NoMetricsError(DvcException):
         )
 
 
+class NoPlotsError(DvcException):
+    def __init__(self):
+        super().__init__(
+            "no plots in this repository. Use `--plots/--plots-no-cache` "
+            "options for `dvc run` to mark stage outputs as plots."
+        )
+
+
 class YAMLFileCorruptedError(DvcException):
     def __init__(self, path):
         path = relpath(path)

--- a/dvc/repo/plots/show.py
+++ b/dvc/repo/plots/show.py
@@ -4,7 +4,7 @@ import os
 
 from funcy import first, last, project
 
-from dvc.exceptions import DvcException
+from dvc.exceptions import DvcException, NoPlotsError
 from dvc.repo import locked
 from dvc.schema import PLOT_PROPS
 
@@ -108,6 +108,9 @@ def _show(repo, datafile=None, revs=None, props=None):
     if revs is None:
         revs = ["workspace"]
 
+    if props is None:
+        props = {}
+
     if not datafile and not props.get("template"):
         raise NoDataOrTemplateProvided()
 
@@ -201,7 +204,11 @@ def show(repo, targets=None, revs=None, props=None) -> dict:
         if targets:
             raise NoMetricInHistoryError(", ".join(targets))
 
-        datafile, plot = _show(repo, datafile=None, revs=revs, props=props)
+        try:
+            datafile, plot = _show(repo, datafile=None, revs=revs, props=props)
+        except NoDataOrTemplateProvided:
+            raise NoPlotsError()
+
         return {datafile: plot}
 
     return {

--- a/tests/func/plots/test_plots.py
+++ b/tests/func/plots/test_plots.py
@@ -14,7 +14,6 @@ from dvc.repo.plots.data import (
     PlotData,
     PlotMetricTypeError,
 )
-from dvc.repo.plots.show import NoDataOrTemplateProvided
 from dvc.repo.plots.template import (
     NoDataForTemplateError,
     NoFieldInDataError,
@@ -457,8 +456,10 @@ def test_plot_override_specified_data_source(
     assert plot_content["encoding"]["y"]["field"] == "b"
 
 
-def test_should_raise_on_no_template_and_datafile(tmp_dir, dvc):
-    with pytest.raises(NoDataOrTemplateProvided):
+def test_no_plots(tmp_dir, dvc):
+    from dvc.exceptions import NoPlotsError
+
+    with pytest.raises(NoPlotsError):
         dvc.plots.show()
 
 


### PR DESCRIPTION
Consistent with `dvc metrics show/diff` behaviour.

Fixes #3925

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
