### PR TITLE
tests: move mock-ssh-server git dependency

### DIFF
--- a/scripts/ci/install.sh
+++ b/scripts/ci/install.sh
@@ -10,6 +10,8 @@ scriptdir="$(dirname $0)"
 # work or not.
 $scriptdir/retry.sh pip install .[all,tests]
 
+$scriptdir/retry.sh pip install git+https://github.com/iterative/mock-ssh-server.git
+
 git config --global user.email "dvctester@example.com"
 git config --global user.name "DVC Tester"
 

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ tests_requirements = [
     "flake8-docstrings",
     "pydocstyle<4.0",
     "jaraco.windows==3.9.2",
-    "mock-ssh-server@git+https://github.com/iterative/mock-ssh-server.git",
+    "mock-ssh-server",
     "moto==1.3.14.dev464",
     "rangehttpserver==1.2.0",
     "beautifulsoup4==4.4.0",


### PR DESCRIPTION
This one doesn't allow us to release new pre-releases, because pypi
forbids that:

https://travis-ci.com/github/iterative/dvc/jobs/343343967#L2447

Let's install it separately for now, until there is a new official
mock-ssh-server release.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
