### PR TITLE
Fix loading of params from run cache

### DIFF
--- a/dvc/stage/cache.py
+++ b/dvc/stage/cache.py
@@ -80,27 +80,12 @@ class StageCache:
     def _create_stage(self, cache, wdir=None):
         from dvc.stage import create_stage, PipelineStage
 
-        params = []
-        for param in cache.get("params", []):
-            if isinstance(param, str):
-                params.append(param)
-                continue
-
-            assert isinstance(param, dict)
-            assert len(param) == 1
-            path = list(param.keys())[0]
-            params_list = param[path]
-            assert isinstance(params_list, list)
-            params.append(f"{path}:" + ",".join(params_list))
-
         stage = create_stage(
             PipelineStage,
             repo=self.repo,
             path="dvc.yaml",
             cmd=cache["cmd"],
             wdir=wdir,
-            params=params,
-            deps=[dep["path"] for dep in cache.get("deps", [])],
             outs=[out["path"] for out in cache["outs"]],
             external=True,
         )

--- a/tests/unit/stage/test_cache.py
+++ b/tests/unit/stage/test_cache.py
@@ -1,7 +1,7 @@
 import os
 
 
-def test_stage_cache(tmp_dir, dvc, run_copy, mocker):
+def test_stage_cache(tmp_dir, dvc, mocker):
     tmp_dir.gen("dep", "dep")
     tmp_dir.gen(
         "script.py",
@@ -53,7 +53,7 @@ def test_stage_cache(tmp_dir, dvc, run_copy, mocker):
     assert (tmp_dir / "out_no_cache").read_text() == "out_no_cache"
 
 
-def test_stage_cache_params(tmp_dir, dvc, run_copy, mocker):
+def test_stage_cache_params(tmp_dir, dvc, mocker):
     tmp_dir.gen("params.yaml", "foo: 1\nbar: 2")
     tmp_dir.gen("myparams.yaml", "baz: 3\nqux: 4")
     tmp_dir.gen(
@@ -106,7 +106,7 @@ def test_stage_cache_params(tmp_dir, dvc, run_copy, mocker):
     assert (tmp_dir / "out_no_cache").read_text() == "out_no_cache"
 
 
-def test_stage_cache_wdir(tmp_dir, dvc, run_copy, mocker):
+def test_stage_cache_wdir(tmp_dir, dvc, mocker):
     tmp_dir.gen("dep", "dep")
     tmp_dir.gen(
         "script.py",


### PR DESCRIPTION
This is more or less a dead code. The params and deps loaded from the stage cache are not used anywhere. I changed the interface when refactoring but missed on changing it here, but as it is an "unused" stuff, it didnot affect run-cache at all. Anyway, I have fixed it, and even though it's an internal API, I have added a test so that we can catch this soon. 

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
