### PR TITLE
[WIP] remote: use explicit tree parameter for cache operations

### DIFF
--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -126,8 +126,9 @@ class BaseExternalRepo:
                 raise PathMissingError(path, self.url)
             save_info = self.local_cache.save(
                 path,
+                self.repo_tree,
                 None,
-                tree=self.repo_tree,
+                save_link=False,
                 download_callback=download_update,
             )
             save_infos.append(save_info)

--- a/dvc/output/base.py
+++ b/dvc/output/base.py
@@ -267,7 +267,7 @@ class BaseOutput:
 
     def commit(self):
         if self.use_cache:
-            self.cache.save(self.path_info, self.info)
+            self.cache.save(self.path_info, self.cache.tree, self.info)
 
     def dumpd(self):
         ret = copy(self.info)

--- a/dvc/remote/azure.py
+++ b/dvc/remote/azure.py
@@ -108,6 +108,9 @@ class AzureRemoteTree(BaseRemoteTree):
         logger.debug(f"Removing {path_info}")
         self.blob_service.delete_blob(path_info.bucket, path_info.path)
 
+    def get_file_checksum(self, path_info):
+        return self.get_etag(path_info)
+
     def _upload(
         self, from_file, to_info, name=None, no_progress_bar=False, **_kwargs
     ):
@@ -138,6 +141,3 @@ class AzureRemote(BaseRemote):
     COPY_POLL_SECONDS = 5
     LIST_OBJECT_PAGE_SIZE = 5000
     TREE_CLS = AzureRemoteTree
-
-    def get_file_checksum(self, path_info):
-        return self.tree.get_etag(path_info)

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -165,6 +165,9 @@ class BaseRemoteTree:
     def reflink(self, from_info, to_info):
         raise RemoteActionNotImplemented("reflink", self.scheme)
 
+    def get_file_checksum(self, path_info):
+        raise NotImplementedError
+
     @staticmethod
     def _handle_transfer_exception(from_info, to_info, exception, operation):
         if isinstance(exception, OSError) and exception.errno == errno.EMFILE:

--- a/dvc/remote/gdrive.py
+++ b/dvc/remote/gdrive.py
@@ -545,6 +545,9 @@ class GDriveRemoteTree(BaseRemoteTree):
         item_id = self._get_item_id(path_info)
         self.gdrive_delete_file(item_id)
 
+    def get_file_checksum(self, path_info):
+        raise NotImplementedError
+
     def _upload(self, from_file, to_info, name=None, no_progress_bar=False):
         dirname = to_info.parent
         assert dirname
@@ -567,6 +570,3 @@ class GDriveRemote(BaseRemote):
     TRAVERSE_WEIGHT_MULTIPLIER = 1
     TRAVERSE_PREFIX_LEN = 2
     TREE_CLS = GDriveRemoteTree
-
-    def get_file_checksum(self, path_info):
-        raise NotImplementedError

--- a/dvc/remote/gs.py
+++ b/dvc/remote/gs.py
@@ -157,6 +157,20 @@ class GSRemoteTree(BaseRemoteTree):
         to_bucket = self.gs.bucket(to_info.bucket)
         from_bucket.copy_blob(blob, to_bucket, new_name=to_info.path)
 
+    def get_file_checksum(self, path_info):
+        import base64
+        import codecs
+
+        bucket = path_info.bucket
+        path = path_info.path
+        blob = self.gs.bucket(bucket).get_blob(path)
+        if not blob:
+            return None
+
+        b64_md5 = blob.md5_hash
+        md5 = base64.b64decode(b64_md5)
+        return codecs.getencoder("hex")(md5)[0].decode("utf-8")
+
     def _upload(self, from_file, to_info, name=None, no_progress_bar=False):
         bucket = self.gs.bucket(to_info.bucket)
         _upload_to_bucket(
@@ -186,17 +200,3 @@ class GSRemote(BaseRemote):
     REQUIRES = {"google-cloud-storage": "google.cloud.storage"}
     PARAM_CHECKSUM = "md5"
     TREE_CLS = GSRemoteTree
-
-    def get_file_checksum(self, path_info):
-        import base64
-        import codecs
-
-        bucket = path_info.bucket
-        path = path_info.path
-        blob = self.tree.gs.bucket(bucket).get_blob(path)
-        if not blob:
-            return None
-
-        b64_md5 = blob.md5_hash
-        md5 = base64.b64decode(b64_md5)
-        return codecs.getencoder("hex")(md5)[0].decode("utf-8")

--- a/dvc/remote/hdfs.py
+++ b/dvc/remote/hdfs.py
@@ -122,28 +122,6 @@ class HDFSRemoteTree(BaseRemoteTree):
                     self.remove(tmp_info)
                     raise
 
-    def _upload(self, from_file, to_info, **_kwargs):
-        with self.hdfs(to_info) as hdfs:
-            hdfs.mkdir(posixpath.dirname(to_info.path))
-            tmp_file = tmp_fname(to_info.path)
-            with open(from_file, "rb") as fobj:
-                hdfs.upload(tmp_file, fobj)
-            hdfs.rename(tmp_file, to_info.path)
-
-    def _download(self, from_info, to_file, **_kwargs):
-        with self.hdfs(from_info) as hdfs:
-            with open(to_file, "wb+") as fobj:
-                hdfs.download(from_info.path, fobj)
-
-
-class HDFSRemote(BaseRemote):
-    scheme = Schemes.HDFS
-    REGEX = r"^hdfs://((?P<user>.*)@)?.*$"
-    PARAM_CHECKSUM = "checksum"
-    REQUIRES = {"pyarrow": "pyarrow"}
-    TRAVERSE_PREFIX_LEN = 2
-    TREE_CLS = HDFSRemoteTree
-
     def hadoop_fs(self, cmd, user=None):
         cmd = "hadoop fs -" + cmd
         if user:
@@ -182,3 +160,25 @@ class HDFSRemote(BaseRemote):
             f"checksum {path_info.path}", user=path_info.user
         )
         return self._group(regex, stdout, "checksum")
+
+    def _upload(self, from_file, to_info, **_kwargs):
+        with self.hdfs(to_info) as hdfs:
+            hdfs.mkdir(posixpath.dirname(to_info.path))
+            tmp_file = tmp_fname(to_info.path)
+            with open(from_file, "rb") as fobj:
+                hdfs.upload(tmp_file, fobj)
+            hdfs.rename(tmp_file, to_info.path)
+
+    def _download(self, from_info, to_file, **_kwargs):
+        with self.hdfs(from_info) as hdfs:
+            with open(to_file, "wb+") as fobj:
+                hdfs.download(from_info.path, fobj)
+
+
+class HDFSRemote(BaseRemote):
+    scheme = Schemes.HDFS
+    REGEX = r"^hdfs://((?P<user>.*)@)?.*$"
+    PARAM_CHECKSUM = "checksum"
+    REQUIRES = {"pyarrow": "pyarrow"}
+    TRAVERSE_PREFIX_LEN = 2
+    TREE_CLS = HDFSRemoteTree

--- a/dvc/remote/http.py
+++ b/dvc/remote/http.py
@@ -121,6 +121,25 @@ class HTTPRemoteTree(BaseRemoteTree):
     def exists(self, path_info):
         return bool(self.request("HEAD", path_info.url))
 
+    def get_file_checksum(self, path_info):
+        url = path_info.url
+        headers = self.request("HEAD", url).headers
+        etag = headers.get("ETag") or headers.get("Content-MD5")
+
+        if not etag:
+            raise DvcException(
+                "could not find an ETag or "
+                "Content-MD5 header for '{url}'".format(url=url)
+            )
+
+        if etag.startswith("W/"):
+            raise DvcException(
+                "Weak ETags are not supported."
+                " (Etag: '{etag}', URL: '{url}')".format(etag=etag, url=url)
+            )
+
+        return etag
+
     def _download(self, from_info, to_file, name=None, no_progress_bar=False):
         response = self.request("GET", from_info.url, stream=True)
         if response.status_code != 200:
@@ -173,25 +192,6 @@ class HTTPRemote(BaseRemote):
     PARAM_CHECKSUM = "etag"
     CAN_TRAVERSE = False
     TREE_CLS = HTTPRemoteTree
-
-    def get_file_checksum(self, path_info):
-        url = path_info.url
-        headers = self.tree.request("HEAD", url).headers
-        etag = headers.get("ETag") or headers.get("Content-MD5")
-
-        if not etag:
-            raise DvcException(
-                "could not find an ETag or "
-                "Content-MD5 header for '{url}'".format(url=url)
-            )
-
-        if etag.startswith("W/"):
-            raise DvcException(
-                "Weak ETags are not supported."
-                " (Etag: '{etag}', URL: '{url}')".format(etag=etag, url=url)
-            )
-
-        return etag
 
     def list_cache_paths(self, prefix=None, progress_callback=None):
         raise NotImplementedError

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -209,6 +209,9 @@ class LocalRemoteTree(BaseRemoteTree):
         os.chmod(tmp_info, self.file_mode)
         os.rename(tmp_info, to_info)
 
+    def get_file_checksum(self, path_info):
+        return file_md5(path_info)[0]
+
     @staticmethod
     def getsize(path_info):
         return os.path.getsize(path_info)
@@ -317,9 +320,6 @@ class LocalRemote(BaseRemote):
             return
 
         super()._verify_link(path_info, link_type)
-
-    def get_file_checksum(self, path_info):
-        return file_md5(path_info)[0]
 
     def cache_exists(self, checksums, jobs=None, name=None):
         return [

--- a/dvc/remote/s3.py
+++ b/dvc/remote/s3.py
@@ -305,6 +305,9 @@ class S3RemoteTree(BaseRemoteTree):
         if etag != cached_etag:
             raise ETagMismatchError(etag, cached_etag)
 
+    def get_file_checksum(self, path_info):
+        return self.get_etag(self.s3, path_info.bucket, path_info.path)
+
     def _upload(self, from_file, to_info, name=None, no_progress_bar=False):
         total = os.path.getsize(from_file)
         with Tqdm(
@@ -338,8 +341,3 @@ class S3Remote(BaseRemote):
     REQUIRES = {"boto3": "boto3"}
     PARAM_CHECKSUM = "etag"
     TREE_CLS = S3RemoteTree
-
-    def get_file_checksum(self, path_info):
-        return self.tree.get_etag(
-            self.tree.s3, path_info.bucket, path_info.path
-        )

--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -225,6 +225,13 @@ class SSHRemoteTree(BaseRemoteTree):
         with self.ssh(from_info) as ssh:
             ssh.reflink(from_info.path, to_info.path)
 
+    def get_file_checksum(self, path_info):
+        if path_info.scheme != self.scheme:
+            raise NotImplementedError
+
+        with self.ssh(path_info) as ssh:
+            return ssh.md5(path_info.path)
+
     def getsize(self, path_info):
         with self.ssh(path_info) as ssh:
             return ssh.getsize(path_info.path)
@@ -264,13 +271,6 @@ class SSHRemote(BaseRemote):
     TREE_CLS = SSHRemoteTree
 
     DEFAULT_CACHE_TYPES = ["copy"]
-
-    def get_file_checksum(self, path_info):
-        if path_info.scheme != self.scheme:
-            raise NotImplementedError
-
-        with self.tree.ssh(path_info) as ssh:
-            return ssh.md5(path_info.path)
 
     def list_cache_paths(self, prefix=None, progress_callback=None):
         if prefix:

--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -24,6 +24,7 @@ from dvc.remote import (
     SSHRemote,
 )
 from dvc.remote.base import STATUS_DELETED, STATUS_NEW, STATUS_OK
+from dvc.remote.local import LocalRemoteTree
 from dvc.stage.exceptions import StageNotFound
 from dvc.utils import file_md5
 from dvc.utils.fs import remove
@@ -614,7 +615,7 @@ class TestRecursiveSyncOperations(Local, TestDataCloudBase):
 
 def test_checksum_recalculation(mocker, dvc, tmp_dir):
     tmp_dir.gen({"foo": "foo"})
-    test_get_file_checksum = mocker.spy(LocalRemote, "get_file_checksum")
+    test_get_file_checksum = mocker.spy(LocalRemoteTree, "get_file_checksum")
     url = Local.get_url()
     ret = main(["remote", "add", "-d", TEST_REMOTE, url])
     assert ret == 0
@@ -693,7 +694,7 @@ def test_verify_checksums(
     remove("dir")
     remove(dvc.cache.local.cache_dir)
 
-    checksum_spy = mocker.spy(dvc.cache.local, "get_file_checksum")
+    checksum_spy = mocker.spy(dvc.cache.local.tree, "get_file_checksum")
 
     dvc.pull()
     assert checksum_spy.call_count == 0

--- a/tests/func/test_tree.py
+++ b/tests/func/test_tree.py
@@ -218,7 +218,7 @@ def test_repotree_cache_save(tmp_dir, dvc, scm, erepo_dir, setup_remote):
     with erepo_dir.dvc.state:
         cache = dvc.cache.local
         with cache.state:
-            cache.save(PathInfo(erepo_dir / "dir"), None, tree=tree)
+            cache.save(PathInfo(erepo_dir / "dir"), tree, None)
     for checksum in expected:
         assert os.path.exists(cache.checksum_to_path_info(checksum))
 

--- a/tests/unit/remote/test_azure.py
+++ b/tests/unit/remote/test_azure.py
@@ -42,7 +42,7 @@ def test_get_file_checksum(tmp_dir):
     to_info = remote.tree.PATH_CLS(Azure.get_url())
     remote.tree.upload(PathInfo("foo"), to_info)
     assert remote.tree.exists(to_info)
-    checksum = remote.get_file_checksum(to_info)
+    checksum = remote.tree.get_file_checksum(to_info)
     assert checksum
     assert isinstance(checksum, str)
     assert checksum.strip("'").strip('"') == checksum


### PR DESCRIPTION
* [ ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [ ] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

* `remote.save()` now takes an explicit `tree` parameter
    * When `tree` is `remote.tree`, save is done via `move()` + `link()`
    * For all other trees, save is done by copying object from `tree` into `remote.tree`