### PR TITLE
snap: build fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,8 @@ env:
     - PATH="$PYENV_ROOT/bin:$PATH"
     - PIP_CACHE_DIR="$HOME/.cache/pip"  # unify pip cache location for all platforms
 stages:
-  - name: check
-    if: false
-  - name: test
-    if: false
+  - check
+  - test
   - build
 # Travis doesn't support testing python on Mac yet, so we need
 # to workaround it by installing it directly with brew.

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,9 @@ jobs:
        channel: stable
     env:
     - SNAPCRAFT_IMAGE_INFO: '{"build_url": "$TRAVIS_BUILD_URL"}'
+    - SNAPCRAFT_BUILD_ENVIRONMENT: lxd
     install:
+    - sudo usermod --append --groups lxd $USER
     - sudo /snap/bin/lxd.migrate -yes
     - sudo /snap/bin/lxd waitready
     - sudo /snap/bin/lxd init --auto

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,10 @@ env:
     - PATH="$PYENV_ROOT/bin:$PATH"
     - PIP_CACHE_DIR="$HOME/.cache/pip"  # unify pip cache location for all platforms
 stages:
-  - check
-  - test
+  - name: check
+    if: false
+  - name: test
+    if: false
   - build
 # Travis doesn't support testing python on Mac yet, so we need
 # to workaround it by installing it directly with brew.

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,8 +98,9 @@ jobs:
      - name: lxd
        channel: stable
     env:
-    - SNAPCRAFT_IMAGE_INFO: '{"build_url": "$TRAVIS_BUILD_URL"}'
+    - SNAPCRAFT_IMAGE_INFO: '{"build_url": "$TRAVIS_BUILD_WEB_URL"}'
     - SNAPCRAFT_BUILD_ENVIRONMENT: lxd
+    - SNAPCRAFT_BUILD_INFO: 1  # https://snapcraft.io/blog/introducing-developer-notifications-for-snap-security-updates
     install:
     - sudo usermod --append --groups lxd $USER
     - sudo /snap/bin/lxd.migrate -yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,8 @@ jobs:
      - name: lxd
        channel: stable
     env:
-    - SNAPCRAFT_IMAGE_INFO: '{"build_url": "$TRAVIS_BUILD_WEB_URL"}'
+    - SNAPCRAFT_IMAGE_INFO: |
+        '{"build_url": "$TRAVIS_JOB_WEB_URL"}'
     - SNAPCRAFT_BUILD_ENVIRONMENT: lxd
     - SNAPCRAFT_BUILD_INFO: 1  # https://snapcraft.io/blog/introducing-developer-notifications-for-snap-security-updates
     install:

--- a/scripts/build_snap.sh
+++ b/scripts/build_snap.sh
@@ -7,7 +7,7 @@ if [ ! -d "dvc" ]; then
   exit 1
 fi
 
-sudo snapcraft --use-lxd
+snapcraft --use-lxd
 
 pip uninstall -y dvc
 if which dvc; then

--- a/scripts/build_snap.sh
+++ b/scripts/build_snap.sh
@@ -7,7 +7,7 @@ if [ ! -d "dvc" ]; then
   exit 1
 fi
 
-snapcraft --use-lxd
+sg lxd -c snapcraft
 
 pip uninstall -y dvc
 if which dvc; then

--- a/scripts/ci/before_install.sh
+++ b/scripts/ci/before_install.sh
@@ -53,10 +53,10 @@ fi
 
 if [[ -n "$TRAVIS_TAG" ]]; then
   if [[ $(echo "$TRAVIS_TAG" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$') ]]; then
-    echo "export SNAP_CHANNEL=stable" >>env.sh
+    echo "export SNAP_CHANNEL=stable,v1/stable" >>env.sh
   else
-    echo "export SNAP_CHANNEL=beta" >>env.sh
+    echo "export SNAP_CHANNEL=beta,v1/beta" >>env.sh
   fi
 else
-  echo "export SNAP_CHANNEL=edge" >>env.sh
+  echo "export SNAP_CHANNEL=edge,v1/edge" >>env.sh
 fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,17 +42,6 @@ parts:
         # https://github.com/snapcore/snapcraft/blob/19393ef36cd773a28131cec10cc0bfb3bf9c7e77/tools/snapcraft-override-build.sh#L18
         sed -ri 's/^(ENABLE_USER_SITE = )None$/\1False/' $SNAPCRAFT_PART_INSTALL/usr/lib/python*/site.py
         cp $SNAPCRAFT_PART_BUILD/scripts/completion/dvc.bash $SNAPCRAFT_PART_INSTALL/completion.sh
-  # remove files already available at runtime from the base snap - reference:
-  # https://forum.snapcraft.io/t/reducing-the-size-of-desktop-snaps/17280
-  cleanup:
-    after:
-    - dvc
-    plugin: nil
-    build-snaps:
-    - core18
-    override-prime: |
-      set -eux
-      cd "/snap/core18/current" && find . -type f,l -exec rm -f "$SNAPCRAFT_PRIME/{}" \;
 apps:
   dvc:
     command: bin/dvc

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,6 +42,17 @@ parts:
         # https://github.com/snapcore/snapcraft/blob/19393ef36cd773a28131cec10cc0bfb3bf9c7e77/tools/snapcraft-override-build.sh#L18
         sed -ri 's/^(ENABLE_USER_SITE = )None$/\1False/' $SNAPCRAFT_PART_INSTALL/usr/lib/python*/site.py
         cp $SNAPCRAFT_PART_BUILD/scripts/completion/dvc.bash $SNAPCRAFT_PART_INSTALL/completion.sh
+  # remove files already available at runtime from the base snap - reference:
+  # https://forum.snapcraft.io/t/reducing-the-size-of-desktop-snaps/17280
+  cleanup:
+    after:
+    - dvc
+    plugin: nil
+    build-snaps:
+    - core18
+    override-prime: |
+      set -eux
+      cd "/snap/core18/current" && find . -type f,l -exec rm -f "$SNAPCRAFT_PRIME/{}" \;
 apps:
   dvc:
     command: bin/dvc


### PR DESCRIPTION
- [x] fix #3989 `snapcraft --use-lxd` builds without `sudo`
- [x] enable security notifications https://snapcraft.io/blog/introducing-developer-notifications-for-snap-security-updates
- [x] add `v1` snap channels #3872
- [x] ~~reduce snap size https://forum.snapcraft.io/t/reducing-the-size-of-desktop-snaps/17280~~ doesn't work with `plugin: python` (also barely reduces size in this case - 107MB vs 97MB)