### PR TITLE
remote: use separate working tree instance for local cache

### DIFF
--- a/dvc/ignore.py
+++ b/dvc/ignore.py
@@ -186,8 +186,7 @@ class CleanTree(BaseTree):
         if path.parent == self.tree_root or Repo.DVC_DIR in path.parts:
             return True
 
-        # if path is outside of tree, assume this is a local remote/local cache
-        # link/move operation where we do not need to filter ignores
+        # paths outside of the CleanTree root should be ignored
         path = relpath(path, self.tree_root)
         if path.startswith("..") or (
             os.name == "nt"
@@ -195,7 +194,7 @@ class CleanTree(BaseTree):
                 [os.path.abspath(path), self.tree_root]
             )
         ):
-            return True
+            return False
 
         # check if parent directories are in our ignores, starting from
         # tree_root

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -111,14 +111,14 @@ class Repo:
             friendly=True,
         )
 
+        self.cache = Cache(self)
+        self.cloud = DataCloud(self)
+
         if not scm:
             # NOTE: storing state and link_state in the repository itself to
             # avoid any possible state corruption in 'shared cache dir'
             # scenario.
-            self.state = State(self)
-
-        self.cache = Cache(self)
-        self.cloud = DataCloud(self)
+            self.state = State(self.cache.local)
 
         self.stage_cache = StageCache(self)
 

--- a/dvc/state.py
+++ b/dvc/state.py
@@ -364,7 +364,7 @@ class State:  # pylint: disable=too-many-instance-attributes
         """
         assert isinstance(path_info, str) or path_info.scheme == "local"
         assert checksum is not None
-        assert self.tree.exists(path_info)
+        assert os.path.exists(path_info)
 
         actual_mtime, actual_size = get_mtime_and_size(path_info, self.tree)
         actual_inode = get_inode(path_info)
@@ -394,7 +394,10 @@ class State:  # pylint: disable=too-many-instance-attributes
         assert isinstance(path_info, str) or path_info.scheme == "local"
         path = os.fspath(path_info)
 
-        if not self.tree.exists(path):
+        # NOTE: use os.path.exists instead of WorkingTree.exists
+        # WorkingTree.exists uses lexists() and will return True for broken
+        # symlinks that we cannot stat() in get_mtime_and_size
+        if not os.path.exists(path):
             return None
 
         actual_mtime, actual_size = get_mtime_and_size(path, self.tree)

--- a/tests/func/test_ignore.py
+++ b/tests/func/test_ignore.py
@@ -10,7 +10,6 @@ from dvc.ignore import (
     DvcIgnorePatterns,
     DvcIgnoreRepo,
 )
-from dvc.remote import LocalRemote
 from dvc.repo import Repo
 from dvc.scm.tree import WorkingTree
 from dvc.utils import relpath
@@ -139,8 +138,7 @@ def test_match_nested(tmp_dir, dvc):
         }
     )
 
-    remote = LocalRemote(dvc, {})
-    result = {os.fspath(f) for f in remote.tree.walk_files(".")}
+    result = {os.fspath(os.path.normpath(f)) for f in dvc.tree.walk_files(".")}
     assert result == {".dvcignore", "foo"}
 
 
@@ -149,8 +147,7 @@ def test_ignore_external(tmp_dir, scm, dvc, tmp_path_factory):
     ext_dir = TmpDir(os.fspath(tmp_path_factory.mktemp("external_dir")))
     ext_dir.gen({"y.backup": "y", "tmp": "ext tmp"})
 
-    remote = LocalRemote(dvc, {})
-    result = {relpath(f, ext_dir) for f in remote.tree.walk_files(ext_dir)}
+    result = {relpath(f, ext_dir) for f in dvc.tree.walk_files(ext_dir)}
     assert result == {"y.backup", "tmp"}
 
 

--- a/tests/func/test_state.py
+++ b/tests/func/test_state.py
@@ -13,7 +13,7 @@ def test_state(tmp_dir, dvc):
     path_info = PathInfo(path)
     md5 = file_md5(path)[0]
 
-    state = State(dvc)
+    state = State(dvc.cache.local)
 
     with state:
         state.save(path_info, md5)
@@ -57,7 +57,7 @@ def mock_get_inode(inode):
 def test_get_state_record_for_inode(get_inode_mock, tmp_dir, dvc):
     tmp_dir.gen("foo", "foo content")
 
-    state = State(dvc)
+    state = State(dvc.cache.local)
     inode = state.MAX_INT + 2
     assert inode != state._to_sqlite(inode)
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Related to #3882

* Local cache/remote always uses its own working tree
    * local cache no longer affected by whether `repo.tree` is working or git tree
* State is tied to the local cache working tree rather than `repo.tree`
* CleanTree now ignores paths outside of the DVC tree/repo root
    * previously it was used interchangeably with working tree, and was expected to return true for paths outside of the DVC repo root in cases where local cache directory was moved or on a different logical drive
    * local cache working tree should now be used for handling all cache paths, not the DVC repo cleantree instance