### PR TITLE
bugfix: `get` dump folder contents in respective output folder

### DIFF
--- a/dvc/repo/tree.py
+++ b/dvc/repo/tree.py
@@ -404,10 +404,8 @@ class RepoTree(BaseTree):
 
         for root, _, files in self.walk(top):
             root = PathInfo(root)
-            dest_dir = root.relative_to(top)
-            makedirs(dest_dir, exist_ok=True)
+            makedirs(dest, exist_ok=True)
             for fname in files:
                 src = root / fname
-                dest = dest_dir / fname
                 with self.open(src, mode="rb") as fobj:
-                    copy_fobj_to_file(fobj, dest)
+                    copy_fobj_to_file(fobj, dest / fname)

--- a/tests/func/test_get.py
+++ b/tests/func/test_get.py
@@ -33,7 +33,9 @@ def test_get_repo_dir(tmp_dir, erepo_dir):
     trees_equal(erepo_dir / "dir", "dir_imported")
 
 
-def test_get_git_file(tmp_dir, erepo_dir):
+@pytest.mark.parametrize("repo_type", ["git_dir", "erepo_dir"])
+def test_get_git_file(request, tmp_dir, repo_type):
+    erepo_dir = request.getfixturevalue(repo_type)
     src = "some_file"
     dst = "some_file_imported"
 
@@ -45,7 +47,9 @@ def test_get_git_file(tmp_dir, erepo_dir):
     assert (tmp_dir / dst).read_text() == "hello"
 
 
-def test_get_git_dir(tmp_dir, erepo_dir):
+@pytest.mark.parametrize("repo_type", ["git_dir", "erepo_dir"])
+def test_get_git_dir(request, tmp_dir, repo_type):
+    erepo_dir = request.getfixturevalue(repo_type)
     src = "some_directory"
     dst = "some_directory_imported"
 


### PR DESCRIPTION
The relative path for external git directory was computed relative to
the root of the repo itself, which created a relative path which is
current working directory. So, all of the contents of the erepo to download
was dumped in the pwd rather than inside of it's own directory.

Fix #4033

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
