### PR TITLE
run: maintain order when -f/--force overwrite stage

### DIFF
--- a/dvc/repo/run.py
+++ b/dvc/repo/run.py
@@ -1,4 +1,5 @@
 import os
+from contextlib import suppress
 
 from funcy import concat, first, lfilter
 
@@ -109,12 +110,12 @@ def run(self, fname=None, no_exec=False, single_stage=False, **kwargs):
         return None
 
     dvcfile = Dvcfile(self, stage.path)
-    if kwargs.get("force", True):
-        dvcfile.remove_stage(stage)
-    else:
-        _check_stage_exists(dvcfile, stage)
-
     try:
+        if kwargs.get("force", True):
+            with suppress(ValueError):
+                self.stages.remove(stage)
+        else:
+            _check_stage_exists(dvcfile, stage)
         self.check_modified_graph([stage])
     except OutputDuplicationError as exc:
         raise OutputDuplicationError(exc.output, set(exc.stages) - {stage})


### PR DESCRIPTION
This commit preserves comments, meta and order inside a dvc.yaml
when `-f/--force` is used. But, it does not maintain comments/meta
for .dvc files.

Related: #4014

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
