### PR TITLE
snap: make future major version upgrades easier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,6 @@ jobs:
     - sudo /snap/bin/lxd.migrate -yes
     - sudo /snap/bin/lxd waitready
     - sudo /snap/bin/lxd init --auto
-    - git fetch --tags
     script:
     - ./scripts/build_snap.sh
     after_failure:
@@ -158,6 +157,14 @@ deploy:
     script: "(echo $SNAP_TOKEN | snapcraft login --with -) && timeout 600 snapcraft push dvc_*.snap --release $SNAP_CHANNEL || echo timed out"
     on:
       all_branches: true
-      condition: "$(./scripts/ci/deploy_condition.sh dvc_*.snap) && ($TRAVIS_BRANCH = master || -n $TRAVIS_TAG)"
+      condition: "$(./scripts/ci/deploy_condition.sh dvc_*.snap) && ($TRAVIS_BRANCH = master || -n $TRAVIS_TAG) && -n $SNAP_CHANNEL"
+      repo: iterative/dvc
+      stage: build
+  - provider: script
+    skip_cleanup: true
+    script: "(echo $SNAP_TOKEN | snapcraft login --with -) && timeout 600 snapcraft push dvc_*.snap --release $SNAP_CHANNEL_MAJOR || echo timed out"
+    on:
+      all_branches: true
+      condition: "$(./scripts/ci/deploy_condition.sh dvc_*.snap) && ($TRAVIS_BRANCH = master || -n $TRAVIS_TAG) && -n $SNAP_CHANNEL_MAJOR"
       repo: iterative/dvc
       stage: build


### PR DESCRIPTION
- [x] make future major version upgrades as easy as uncommenting one line
- related: #3999 (and #4037)

# Proposed wiki changes for discussion

- [ ] update https://github.com/iterative/dvc/wiki/Release-checklist to add:

## Major version transitions

1. request a new channel version-prefix (aka track) at https://forum.snapcraft.io/t/track-request-for-dvc/17735 (e.g. `v2`)
    + otherwise attempting to `snapcraft release --channel=v2` will fail
1. create a new legacy-dev git branch (e.g. `1.x-dev`)
1. (optional) give a warning message: cherry-pick 6f0a05adb45526a7334f438b964e7dd4b9b64798. Wait ~30 days before continuing to the next step
    + the idea is to warn & give 2 options: opt-in now, or opt-out permanently. Both options will suppress the warning. Ignoring the warning will result in an auto-upgrade in 30 days
1. uncomment the `echo "unset SNAP_CHANNEL" >>env.sh` line in `scripts/ci/before_install.sh`