### PR TITLE
(bugfix) get/import: fix broken progress bar

### DIFF
--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -626,8 +626,12 @@ class LocalCache(LocalRemote, CacheMixin):
             func = pbar.wrap_fn(func)
             with ThreadPoolExecutor(max_workers=jobs) as executor:
                 if download:
-                    fails = sum(executor.map(func, *dir_plans))
-                    fails += sum(executor.map(func, *file_plans))
+                    from_infos, to_infos, names, _ = (
+                        d + f for d, f in zip(dir_plans, file_plans)
+                    )
+                    fails = sum(
+                        executor.map(func, from_infos, to_infos, names)
+                    )
                 else:
                     # for uploads, push files first, and any .dir files last
 


### PR DESCRIPTION
#3672 (6d8499ea) extended `LocalRemote::_get_plans` to return
`checksums`. As all of the args from `_get_plans` was passed
down to `download()`, it recognized extra arg of checksum as
`no_progress_bar` due to which it became True and stopped showing
progress bar at all.

Fix #3874

#### Screenshots

[![asciicast](https://asciinema.org/a/1jLaOc0X1EpyNTJnc6yqnRwt4.svg)](https://asciinema.org/a/1jLaOc0X1EpyNTJnc6yqnRwt4)

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
