### PR TITLE
remote: continue remote/cache/tree refactoring

### DIFF
--- a/dvc/cache.py
+++ b/dvc/cache.py
@@ -28,13 +28,15 @@ def _make_remote_property(name):
     """
 
     def getter(self):
-        from dvc.remote import Cache as CloudCache
+        from dvc.remote import get_cloud_tree
+        from dvc.remote.base import CloudCache
 
         remote = self.config.get(name)
         if not remote:
             return None
 
-        return CloudCache(self.repo, name=remote)
+        tree = get_cloud_tree(self.repo, name=remote)
+        return CloudCache(tree)
 
     getter.__name__ = name
     return cached_property(getter)
@@ -50,7 +52,8 @@ class Cache:
     CACHE_DIR = "cache"
 
     def __init__(self, repo):
-        from dvc.remote import Cache as CloudCache
+        from dvc.remote import get_cloud_tree
+        from dvc.remote.local import LocalCache
 
         self.repo = repo
         self.config = config = repo.config["cache"]
@@ -62,7 +65,8 @@ class Cache:
         else:
             settings = {**config, "url": config["dir"]}
 
-        self.local = CloudCache(repo, **settings)
+        tree = get_cloud_tree(repo, **settings)
+        self.local = LocalCache(tree)
 
     s3 = _make_remote_property("s3")
     gs = _make_remote_property("gs")

--- a/dvc/command/version.py
+++ b/dvc/command/version.py
@@ -122,12 +122,12 @@ class CmdVersion(CmdBaseNoRepo):
 
     @staticmethod
     def get_supported_remotes():
-        from dvc.remote import REMOTES
+        from dvc.remote import TREES
 
         supported_remotes = []
-        for remote in REMOTES:
-            if not remote.get_missing_deps():
-                supported_remotes.append(remote.scheme)
+        for tree_cls in TREES:
+            if not tree_cls.get_missing_deps():
+                supported_remotes.append(tree_cls.scheme)
 
         return ", ".join(supported_remotes)
 

--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -3,7 +3,7 @@
 import logging
 
 from dvc.config import NoRemoteError
-from dvc.remote import Remote
+from dvc.remote import get_remote
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +45,7 @@ class DataCloud:
         raise NoRemoteError(error_msg)
 
     def _init_remote(self, name):
-        return Remote(self.repo, name=name)
+        return get_remote(self.repo, name=name)
 
     def push(
         self, cache, jobs=None, remote=None, show_checksums=False,

--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -85,7 +85,7 @@ class DataCloud:
             cache, jobs=jobs, remote=remote, show_checksums=show_checksums
         )
 
-        if not remote.verify:
+        if not remote.tree.verify:
             self._save_pulled_checksums(cache)
 
         return downloaded_items_num

--- a/dvc/dependency/__init__.py
+++ b/dvc/dependency/__init__.py
@@ -12,7 +12,7 @@ from dvc.dependency.param import ParamsDependency
 from dvc.dependency.s3 import S3Dependency
 from dvc.dependency.ssh import SSHDependency
 from dvc.output.base import BaseOutput
-from dvc.remote import Remote
+from dvc.remote import get_remote
 from dvc.scheme import Schemes
 
 from .repo import RepoDependency
@@ -54,7 +54,7 @@ SCHEMA.update(ParamsDependency.PARAM_SCHEMA)
 def _get(stage, p, info):
     parsed = urlparse(p) if p else None
     if parsed and parsed.scheme == "remote":
-        remote = Remote(stage.repo, name=parsed.netloc)
+        remote = get_remote(stage.repo, name=parsed.netloc)
         return DEP_MAP[remote.scheme](stage, p, info, remote=remote)
 
     if info and info.get(RepoDependency.PARAM_REPO):

--- a/dvc/dependency/azure.py
+++ b/dvc/dependency/azure.py
@@ -1,7 +1,7 @@
 from dvc.dependency.base import BaseDependency
 from dvc.output.base import BaseOutput
-from dvc.remote.azure import AzureRemote
+from dvc.remote.azure import AzureRemoteTree
 
 
 class AzureDependency(BaseDependency, BaseOutput):
-    REMOTE = AzureRemote
+    TREE_CLS = AzureRemoteTree

--- a/dvc/dependency/http.py
+++ b/dvc/dependency/http.py
@@ -1,7 +1,7 @@
 from dvc.dependency.base import BaseDependency
 from dvc.output.base import BaseOutput
-from dvc.remote.http import HTTPRemote
+from dvc.remote.http import HTTPRemoteTree
 
 
 class HTTPDependency(BaseDependency, BaseOutput):
-    REMOTE = HTTPRemote
+    TREE_CLS = HTTPRemoteTree

--- a/dvc/dependency/https.py
+++ b/dvc/dependency/https.py
@@ -1,7 +1,7 @@
-from dvc.remote.https import HTTPSRemote
+from dvc.remote.https import HTTPSRemoteTree
 
 from .http import HTTPDependency
 
 
 class HTTPSDependency(HTTPDependency):
-    REMOTE = HTTPSRemote
+    TREE_CLS = HTTPSRemoteTree

--- a/dvc/output/__init__.py
+++ b/dvc/output/__init__.py
@@ -10,10 +10,10 @@ from dvc.output.hdfs import HDFSOutput
 from dvc.output.local import LocalOutput
 from dvc.output.s3 import S3Output
 from dvc.output.ssh import SSHOutput
-from dvc.remote import Remote
-from dvc.remote.hdfs import HDFSRemote
-from dvc.remote.local import LocalRemote
-from dvc.remote.s3 import S3Remote
+from dvc.remote import get_remote
+from dvc.remote.hdfs import HDFSRemoteTree
+from dvc.remote.local import LocalRemoteTree
+from dvc.remote.s3 import S3RemoteTree
 from dvc.scheme import Schemes
 
 OUTS = [
@@ -47,9 +47,9 @@ CHECKSUM_SCHEMA = Any(
 # so when a few types of outputs share the same name, we only need
 # specify it once.
 CHECKSUMS_SCHEMA = {
-    LocalRemote.PARAM_CHECKSUM: CHECKSUM_SCHEMA,
-    S3Remote.PARAM_CHECKSUM: CHECKSUM_SCHEMA,
-    HDFSRemote.PARAM_CHECKSUM: CHECKSUM_SCHEMA,
+    LocalRemoteTree.PARAM_CHECKSUM: CHECKSUM_SCHEMA,
+    S3RemoteTree.PARAM_CHECKSUM: CHECKSUM_SCHEMA,
+    HDFSRemoteTree.PARAM_CHECKSUM: CHECKSUM_SCHEMA,
 }
 
 SCHEMA = CHECKSUMS_SCHEMA.copy()
@@ -66,7 +66,7 @@ def _get(
     parsed = urlparse(p)
 
     if parsed.scheme == "remote":
-        remote = Remote(stage.repo, name=parsed.netloc)
+        remote = get_remote(stage.repo, name=parsed.netloc)
         return OUTS_MAP[remote.scheme](
             stage,
             p,

--- a/dvc/output/gs.py
+++ b/dvc/output/gs.py
@@ -1,6 +1,6 @@
 from dvc.output.s3 import S3Output
-from dvc.remote.gs import GSRemote
+from dvc.remote.gs import GSRemoteTree
 
 
 class GSOutput(S3Output):
-    REMOTE = GSRemote
+    TREE_CLS = GSRemoteTree

--- a/dvc/output/hdfs.py
+++ b/dvc/output/hdfs.py
@@ -3,4 +3,4 @@ from dvc.remote.hdfs import HDFSRemoteTree
 
 
 class HDFSOutput(BaseOutput):
-    REMOTE = HDFSRemoteTree
+    TREE_CLS = HDFSRemoteTree

--- a/dvc/output/hdfs.py
+++ b/dvc/output/hdfs.py
@@ -1,6 +1,6 @@
 from dvc.output.base import BaseOutput
-from dvc.remote.hdfs import HDFSRemote
+from dvc.remote.hdfs import HDFSRemoteTree
 
 
 class HDFSOutput(BaseOutput):
-    REMOTE = HDFSRemote
+    REMOTE = HDFSRemoteTree

--- a/dvc/output/local.py
+++ b/dvc/output/local.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 from dvc.exceptions import DvcException
 from dvc.istextfile import istextfile
 from dvc.output.base import BaseOutput
-from dvc.remote.local import LocalRemote
+from dvc.remote.local import LocalRemote, LocalRemoteTree
 from dvc.utils import relpath
 from dvc.utils.fs import path_isin
 
@@ -13,7 +13,8 @@ logger = logging.getLogger(__name__)
 
 
 class LocalOutput(BaseOutput):
-    REMOTE = LocalRemote
+    REMOTE_CLS = LocalRemote
+    TREE_CLS = LocalRemoteTree
     sep = os.sep
 
     def __init__(self, stage, path, *args, **kwargs):
@@ -33,12 +34,12 @@ class LocalOutput(BaseOutput):
             #
             # FIXME: if we have Windows path containing / or posix one with \
             # then we have #2059 bug and can't really handle that.
-            p = self.REMOTE.TREE_CLS.PATH_CLS(path)
+            p = self.TREE_CLS.PATH_CLS(path)
             if not p.is_absolute():
                 p = self.stage.wdir / p
 
         abs_p = os.path.abspath(os.path.normpath(p))
-        return self.REMOTE.TREE_CLS.PATH_CLS(abs_p)
+        return self.TREE_CLS.PATH_CLS(abs_p)
 
     def __str__(self):
         if not self.is_in_repo:

--- a/dvc/output/s3.py
+++ b/dvc/output/s3.py
@@ -1,6 +1,6 @@
 from dvc.output.base import BaseOutput
-from dvc.remote.s3 import S3Remote
+from dvc.remote.s3 import S3RemoteTree
 
 
 class S3Output(BaseOutput):
-    REMOTE = S3Remote
+    TREE_CLS = S3RemoteTree

--- a/dvc/output/ssh.py
+++ b/dvc/output/ssh.py
@@ -1,6 +1,7 @@
 from dvc.output.base import BaseOutput
-from dvc.remote.ssh import SSHRemote
+from dvc.remote.ssh import SSHRemote, SSHRemoteTree
 
 
 class SSHOutput(BaseOutput):
-    REMOTE = SSHRemote
+    REMOTE_CLS = SSHRemote
+    TREE_CLS = SSHRemoteTree

--- a/dvc/remote/__init__.py
+++ b/dvc/remote/__init__.py
@@ -1,45 +1,36 @@
 import posixpath
 from urllib.parse import urlparse
 
-from dvc.remote.azure import AzureCache, AzureRemote
-from dvc.remote.gdrive import GDriveRemote
-from dvc.remote.gs import GSCache, GSRemote
-from dvc.remote.hdfs import HDFSCache, HDFSRemote
-from dvc.remote.http import HTTPRemote
-from dvc.remote.https import HTTPSRemote
-from dvc.remote.local import LocalCache, LocalRemote
-from dvc.remote.oss import OSSRemote
-from dvc.remote.s3 import S3Cache, S3Remote
-from dvc.remote.ssh import SSHCache, SSHRemote
+from dvc.remote.azure import AzureRemoteTree
+from dvc.remote.gdrive import GDriveRemoteTree
+from dvc.remote.gs import GSRemoteTree
+from dvc.remote.hdfs import HDFSRemoteTree
+from dvc.remote.http import HTTPRemoteTree
+from dvc.remote.https import HTTPSRemoteTree
+from dvc.remote.local import LocalRemoteTree
+from dvc.remote.oss import OSSRemoteTree
+from dvc.remote.s3 import S3RemoteTree
+from dvc.remote.ssh import SSHRemoteTree
 
-CACHES = [
-    AzureCache,
-    GSCache,
-    HDFSCache,
-    S3Cache,
-    SSHCache,
-    # LocalCache is the default
-]
-
-REMOTES = [
-    AzureRemote,
-    GDriveRemote,
-    GSRemote,
-    HDFSRemote,
-    HTTPRemote,
-    HTTPSRemote,
-    S3Remote,
-    SSHRemote,
-    OSSRemote,
-    # NOTE: LocalRemote is the default
+TREES = [
+    AzureRemoteTree,
+    GDriveRemoteTree,
+    GSRemoteTree,
+    HDFSRemoteTree,
+    HTTPRemoteTree,
+    HTTPSRemoteTree,
+    S3RemoteTree,
+    SSHRemoteTree,
+    OSSRemoteTree,
+    # NOTE: LocalRemoteTree is the default
 ]
 
 
-def _get(remote_conf, remotes, default):
-    for remote in remotes:
-        if remote.supported(remote_conf):
-            return remote
-    return default
+def get_cloud_tree(remote_conf, remotes):
+    for tree_cls in TREES:
+        if tree_cls.supported(remote_conf):
+            return tree_cls
+    return LocalRemoteTree
 
 
 def _get_conf(repo, **kwargs):
@@ -49,16 +40,6 @@ def _get_conf(repo, **kwargs):
     else:
         remote_conf = kwargs
     return _resolve_remote_refs(repo.config, remote_conf)
-
-
-def Remote(repo, **kwargs):
-    remote_conf = _get_conf(repo, **kwargs)
-    return _get(remote_conf, REMOTES, LocalRemote)(repo, remote_conf)
-
-
-def Cache(repo, **kwargs):
-    remote_conf = _get_conf(repo, **kwargs)
-    return _get(remote_conf, CACHES, LocalCache)(repo, remote_conf)
 
 
 def _resolve_remote_refs(config, remote_conf):

--- a/dvc/remote/azure.py
+++ b/dvc/remote/azure.py
@@ -7,17 +7,22 @@ from funcy import cached_property, wrap_prop
 
 from dvc.path_info import CloudURLInfo
 from dvc.progress import Tqdm
-from dvc.remote.base import BaseRemote, BaseRemoteTree, CacheMixin
+from dvc.remote.base import BaseRemoteTree
 from dvc.scheme import Schemes
 
 logger = logging.getLogger(__name__)
 
 
 class AzureRemoteTree(BaseRemoteTree):
+    scheme = Schemes.AZURE
     PATH_CLS = CloudURLInfo
+    REQUIRES = {"azure-storage-blob": "azure.storage.blob"}
+    PARAM_CHECKSUM = "etag"
+    COPY_POLL_SECONDS = 5
+    LIST_OBJECT_PAGE_SIZE = 5000
 
-    def __init__(self, remote, config):
-        super().__init__(remote, config)
+    def __init__(self, repo, config):
+        super().__init__(repo, config)
 
         url = config.get("url", "azure://")
         self.path_info = self.PATH_CLS(url)
@@ -132,16 +137,3 @@ class AzureRemoteTree(BaseRemoteTree):
                 to_file,
                 progress_callback=pbar.update_to,
             )
-
-
-class AzureRemote(BaseRemote):
-    scheme = Schemes.AZURE
-    REQUIRES = {"azure-storage-blob": "azure.storage.blob"}
-    TREE_CLS = AzureRemoteTree
-    PARAM_CHECKSUM = "etag"
-    COPY_POLL_SECONDS = 5
-    LIST_OBJECT_PAGE_SIZE = 5000
-
-
-class AzureCache(AzureRemote, CacheMixin):
-    pass

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -98,6 +98,7 @@ class BaseRemoteTree:
     TRAVERSE_THRESHOLD_SIZE = 500000
     CAN_TRAVERSE = True
 
+    CACHE_MODE = None
     SHARED_MODE_MAP = {None: (None, None), "group": (None, None)}
     CHECKSUM_DIR_SUFFIX = ".dir"
 
@@ -380,7 +381,9 @@ class BaseRemoteTree:
         new_info = self.cache.checksum_to_path_info(checksum)
         if self.cache.changed_cache_file(checksum):
             self.cache.tree.makedirs(new_info.parent)
-            self.cache.tree.move(tmp_info, new_info, mode=self.CACHE_MODE)
+            self.cache.tree.move(
+                tmp_info, new_info, mode=self.cache.CACHE_MODE
+            )
 
         if self.exists(path_info):
             self.state.save(path_info, checksum)
@@ -891,7 +894,7 @@ class CloudCache:
     """Cloud cache class."""
 
     DEFAULT_CACHE_TYPES = ["copy"]
-    CACHE_MODE = None
+    CACHE_MODE = BaseRemoteTree.CACHE_MODE
 
     def __init__(self, tree):
         self.tree = tree

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -904,6 +904,10 @@ class CloudCache:
         self._dir_info = {}
 
     @property
+    def path_info(self):
+        return self.tree.path_info
+
+    @property
     def cache(self):
         return getattr(self.repo.cache, self.scheme)
 
@@ -999,7 +1003,7 @@ class CloudCache:
             logger.debug("'%s' doesn't exist.", path_info)
             return True
 
-        checksum = checksum_info.get(self.PARAM_CHECKSUM)
+        checksum = checksum_info.get(self.tree.PARAM_CHECKSUM)
         if checksum is None:
             logger.debug("hash value for '%s' is missing.", path_info)
             return True
@@ -1159,7 +1163,7 @@ class CloudCache:
             )
 
         if not checksum_info:
-            checksum_info = self.save_info(path_info, tree=tree, **kwargs)
+            checksum_info = self.tree.save_info(path_info, tree=tree, **kwargs)
         checksum = checksum_info[self.tree.PARAM_CHECKSUM]
         return self._save(path_info, tree, checksum, save_link, **kwargs)
 

--- a/dvc/remote/gdrive.py
+++ b/dvc/remote/gdrive.py
@@ -14,7 +14,7 @@ from funcy.py3 import cat
 from dvc.exceptions import DvcException, FileMissingError
 from dvc.path_info import CloudURLInfo
 from dvc.progress import Tqdm
-from dvc.remote.base import BaseRemote, BaseRemoteTree
+from dvc.remote.base import BaseRemoteTree
 from dvc.scheme import Schemes
 from dvc.utils import format_link, tmp_fname
 from dvc.utils.stream import IterStream
@@ -85,7 +85,13 @@ class GDriveURLInfo(CloudURLInfo):
 
 
 class GDriveRemoteTree(BaseRemoteTree):
+    scheme = Schemes.GDRIVE
     PATH_CLS = GDriveURLInfo
+    REQUIRES = {"pydrive2": "pydrive2"}
+    DEFAULT_VERIFY = True
+    # Always prefer traverse for GDrive since API usage quotas are a concern.
+    TRAVERSE_WEIGHT_MULTIPLIER = 1
+    TRAVERSE_PREFIX_LEN = 2
 
     GDRIVE_CREDENTIALS_DATA = "GDRIVE_CREDENTIALS_DATA"
     DEFAULT_USER_CREDENTIALS_FILE = "gdrive-user-credentials.json"
@@ -93,8 +99,8 @@ class GDriveRemoteTree(BaseRemoteTree):
     DEFAULT_GDRIVE_CLIENT_ID = "710796635688-iivsgbgsb6uv1fap6635dhvuei09o66c.apps.googleusercontent.com"  # noqa: E501
     DEFAULT_GDRIVE_CLIENT_SECRET = "a1Fz59uTpVNeG_VGuSKDLJXv"
 
-    def __init__(self, remote, config):
-        super().__init__(remote, config)
+    def __init__(self, repo, config):
+        super().__init__(repo, config)
 
         self.path_info = self.PATH_CLS(config["url"])
 
@@ -122,13 +128,12 @@ class GDriveRemoteTree(BaseRemoteTree):
         self._client_secret = config.get("gdrive_client_secret")
         self._validate_config()
         self._gdrive_user_credentials_path = (
-            tmp_fname(os.path.join(self.remote.repo.tmp_dir, ""))
+            tmp_fname(os.path.join(self.repo.tmp_dir, ""))
             if os.getenv(GDriveRemoteTree.GDRIVE_CREDENTIALS_DATA)
             else config.get(
                 "gdrive_user_credentials_file",
                 os.path.join(
-                    self.remote.repo.tmp_dir,
-                    self.DEFAULT_USER_CREDENTIALS_FILE,
+                    self.repo.tmp_dir, self.DEFAULT_USER_CREDENTIALS_FILE,
                 ),
             )
         )
@@ -574,13 +579,3 @@ class GDriveRemoteTree(BaseRemoteTree):
     def _download(self, from_info, to_file, name=None, no_progress_bar=False):
         item_id = self._get_item_id(from_info)
         self._gdrive_download_file(item_id, to_file, name, no_progress_bar)
-
-
-class GDriveRemote(BaseRemote):
-    scheme = Schemes.GDRIVE
-    REQUIRES = {"pydrive2": "pydrive2"}
-    TREE_CLS = GDriveRemoteTree
-    DEFAULT_VERIFY = True
-    # Always prefer traverse for GDrive since API usage quotas are a concern.
-    TRAVERSE_WEIGHT_MULTIPLIER = 1
-    TRAVERSE_PREFIX_LEN = 2

--- a/dvc/remote/gs.py
+++ b/dvc/remote/gs.py
@@ -9,7 +9,7 @@ from funcy import cached_property, wrap_prop
 from dvc.exceptions import DvcException
 from dvc.path_info import CloudURLInfo
 from dvc.progress import Tqdm
-from dvc.remote.base import BaseRemote, BaseRemoteTree, CacheMixin
+from dvc.remote.base import BaseRemoteTree
 from dvc.scheme import Schemes
 
 logger = logging.getLogger(__name__)
@@ -65,10 +65,13 @@ def _upload_to_bucket(
 
 
 class GSRemoteTree(BaseRemoteTree):
+    scheme = Schemes.GS
     PATH_CLS = CloudURLInfo
+    REQUIRES = {"google-cloud-storage": "google.cloud.storage"}
+    PARAM_CHECKSUM = "md5"
 
-    def __init__(self, remote, config):
-        super().__init__(remote, config)
+    def __init__(self, repo, config):
+        super().__init__(repo, config)
 
         url = config.get("url", "gs:///")
         self.path_info = self.PATH_CLS(url)
@@ -193,14 +196,3 @@ class GSRemoteTree(BaseRemoteTree):
                 disable=no_progress_bar,
             ) as wrapped:
                 blob.download_to_file(wrapped)
-
-
-class GSRemote(BaseRemote):
-    scheme = Schemes.GS
-    REQUIRES = {"google-cloud-storage": "google.cloud.storage"}
-    TREE_CLS = GSRemoteTree
-    PARAM_CHECKSUM = "md5"
-
-
-class GSCache(GSRemote, CacheMixin):
-    pass

--- a/dvc/remote/hdfs.py
+++ b/dvc/remote/hdfs.py
@@ -11,15 +11,21 @@ from urllib.parse import urlparse
 from dvc.scheme import Schemes
 from dvc.utils import fix_env, tmp_fname
 
-from .base import BaseRemote, BaseRemoteTree, CacheMixin, RemoteCmdError
+from .base import BaseRemoteTree, RemoteCmdError
 from .pool import get_connection
 
 logger = logging.getLogger(__name__)
 
 
 class HDFSRemoteTree(BaseRemoteTree):
-    def __init__(self, remote, config):
-        super().__init__(remote, config)
+    scheme = Schemes.HDFS
+    REQUIRES = {"pyarrow": "pyarrow"}
+    REGEX = r"^hdfs://((?P<user>.*)@)?.*$"
+    PARAM_CHECKSUM = "checksum"
+    TRAVERSE_PREFIX_LEN = 2
+
+    def __init__(self, repo, config):
+        super().__init__(repo, config)
 
         self.path_info = None
         url = config.get("url")
@@ -173,16 +179,3 @@ class HDFSRemoteTree(BaseRemoteTree):
         with self.hdfs(from_info) as hdfs:
             with open(to_file, "wb+") as fobj:
                 hdfs.download(from_info.path, fobj)
-
-
-class HDFSRemote(BaseRemote):
-    scheme = Schemes.HDFS
-    REGEX = r"^hdfs://((?P<user>.*)@)?.*$"
-    PARAM_CHECKSUM = "checksum"
-    REQUIRES = {"pyarrow": "pyarrow"}
-    TREE_CLS = HDFSRemoteTree
-    TRAVERSE_PREFIX_LEN = 2
-
-
-class HDFSCache(HDFSRemote, CacheMixin):
-    pass

--- a/dvc/remote/http.py
+++ b/dvc/remote/http.py
@@ -8,7 +8,7 @@ import dvc.prompt as prompt
 from dvc.exceptions import DvcException, HTTPError
 from dvc.path_info import HTTPURLInfo
 from dvc.progress import Tqdm
-from dvc.remote.base import BaseRemote, BaseRemoteTree
+from dvc.remote.base import BaseRemoteTree
 from dvc.scheme import Schemes
 
 logger = logging.getLogger(__name__)
@@ -24,15 +24,18 @@ def ask_password(host, user):
 
 
 class HTTPRemoteTree(BaseRemoteTree):
+    scheme = Schemes.HTTP
     PATH_CLS = HTTPURLInfo
+    PARAM_CHECKSUM = "etag"
+    CAN_TRAVERSE = False
 
     SESSION_RETRIES = 5
     SESSION_BACKOFF_FACTOR = 0.1
     REQUEST_TIMEOUT = 10
     CHUNK_SIZE = 2 ** 16
 
-    def __init__(self, remote, config):
-        super().__init__(remote, config)
+    def __init__(self, repo, config):
+        super().__init__(repo, config)
 
         url = config.get("url")
         if url:
@@ -185,16 +188,3 @@ class HTTPRemoteTree(BaseRemoteTree):
     def _content_length(response):
         res = response.headers.get("Content-Length")
         return int(res) if res else None
-
-
-class HTTPRemote(BaseRemote):
-    scheme = Schemes.HTTP
-    PARAM_CHECKSUM = "etag"
-    CAN_TRAVERSE = False
-    TREE_CLS = HTTPRemoteTree
-
-    def list_paths(self, prefix=None, progress_callback=None):
-        raise NotImplementedError
-
-    def gc(self):
-        raise NotImplementedError

--- a/dvc/remote/https.py
+++ b/dvc/remote/https.py
@@ -1,7 +1,7 @@
 from dvc.scheme import Schemes
 
-from .http import HTTPRemote
+from .http import HTTPRemoteTree
 
 
-class HTTPSRemote(HTTPRemote):
+class HTTPSRemoteTree(HTTPRemoteTree):
     scheme = Schemes.HTTPS

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -43,7 +43,6 @@ class LocalRemoteTree(BaseRemoteTree):
     PATH_CLS = PathInfo
     PARAM_CHECKSUM = "md5"
     PARAM_PATH = "path"
-    DEFAULT_CACHE_TYPES = ["reflink", "copy"]
     TRAVERSE_PREFIX_LEN = 2
     UNPACKED_DIR_SUFFIX = ".unpacked"
 
@@ -345,6 +344,9 @@ class LocalRemote(Remote):
 
 
 class LocalCache(CloudCache):
+    DEFAULT_CACHE_TYPES = ["reflink", "copy"]
+    CACHE_MODE = LocalRemoteTree.CACHE_MODE
+
     def __init__(self, tree):
         super().__init__(tree)
         self.cache_dir = tree.config.get("url")

--- a/dvc/remote/local.py
+++ b/dvc/remote/local.py
@@ -318,12 +318,6 @@ def _log_exceptions(func, operation):
 
 
 class LocalRemote(Remote):
-    def get(self, md5):
-        if not md5:
-            return None
-
-        return self.checksum_to_path_info(md5).url
-
     def list_paths(self, prefix=None, progress_callback=None):
         assert self.path_info is not None
         if prefix:

--- a/dvc/remote/oss.py
+++ b/dvc/remote/oss.py
@@ -6,14 +6,37 @@ from funcy import cached_property, wrap_prop
 
 from dvc.path_info import CloudURLInfo
 from dvc.progress import Tqdm
-from dvc.remote.base import BaseRemote, BaseRemoteTree
+from dvc.remote.base import BaseRemoteTree
 from dvc.scheme import Schemes
 
 logger = logging.getLogger(__name__)
 
 
 class OSSRemoteTree(BaseRemoteTree):
+    """
+    oss2 document:
+    https://www.alibabacloud.com/help/doc-detail/32026.htm
+
+
+    Examples
+    ----------
+    $ dvc remote add myremote oss://my-bucket/path
+    Set key id, key secret and endpoint using modify command
+    $ dvc remote modify myremote oss_key_id my-key-id
+    $ dvc remote modify myremote oss_key_secret my-key-secret
+    $ dvc remote modify myremote oss_endpoint endpoint
+    or environment variables
+    $ export OSS_ACCESS_KEY_ID="my-key-id"
+    $ export OSS_ACCESS_KEY_SECRET="my-key-secret"
+    $ export OSS_ENDPOINT="endpoint"
+    """
+
+    scheme = Schemes.OSS
     PATH_CLS = CloudURLInfo
+    REQUIRES = {"oss2": "oss2"}
+    PARAM_CHECKSUM = "etag"
+    COPY_POLL_SECONDS = 5
+    LIST_OBJECT_PAGE_SIZE = 100
 
     def __init__(self, repo, config):
         super().__init__(repo, config)
@@ -105,30 +128,3 @@ class OSSRemoteTree(BaseRemoteTree):
             self.oss_service.get_object_to_file(
                 from_info.path, to_file, progress_callback=pbar.update_to
             )
-
-
-class OSSRemote(BaseRemote):
-    """
-    oss2 document:
-    https://www.alibabacloud.com/help/doc-detail/32026.htm
-
-
-    Examples
-    ----------
-    $ dvc remote add myremote oss://my-bucket/path
-    Set key id, key secret and endpoint using modify command
-    $ dvc remote modify myremote oss_key_id my-key-id
-    $ dvc remote modify myremote oss_key_secret my-key-secret
-    $ dvc remote modify myremote oss_endpoint endpoint
-    or environment variables
-    $ export OSS_ACCESS_KEY_ID="my-key-id"
-    $ export OSS_ACCESS_KEY_SECRET="my-key-secret"
-    $ export OSS_ENDPOINT="endpoint"
-    """
-
-    scheme = Schemes.OSS
-    REQUIRES = {"oss2": "oss2"}
-    PARAM_CHECKSUM = "etag"
-    COPY_POLL_SECONDS = 5
-    LIST_OBJECT_PAGE_SIZE = 100
-    TREE_CLS = OSSRemoteTree

--- a/dvc/remote/s3.py
+++ b/dvc/remote/s3.py
@@ -8,14 +8,17 @@ from dvc.config import ConfigError
 from dvc.exceptions import DvcException, ETagMismatchError
 from dvc.path_info import CloudURLInfo
 from dvc.progress import Tqdm
-from dvc.remote.base import BaseRemote, BaseRemoteTree, CacheMixin
+from dvc.remote.base import BaseRemoteTree
 from dvc.scheme import Schemes
 
 logger = logging.getLogger(__name__)
 
 
 class S3RemoteTree(BaseRemoteTree):
+    scheme = Schemes.S3
     PATH_CLS = CloudURLInfo
+    REQUIRES = {"boto3": "boto3"}
+    PARAM_CHECKSUM = "etag"
 
     def __init__(self, repo, config):
         super().__init__(repo, config)
@@ -334,14 +337,3 @@ class S3RemoteTree(BaseRemoteTree):
             self.s3.download_file(
                 from_info.bucket, from_info.path, to_file, Callback=pbar.update
             )
-
-
-class S3Remote(BaseRemote):
-    scheme = Schemes.S3
-    REQUIRES = {"boto3": "boto3"}
-    PARAM_CHECKSUM = "etag"
-    TREE_CLS = S3RemoteTree
-
-
-class S3Cache(S3Remote, CacheMixin):
-    pass

--- a/dvc/remote/ssh/__init__.py
+++ b/dvc/remote/ssh/__init__.py
@@ -268,8 +268,6 @@ class SSHRemoteTree(BaseRemoteTree):
                 no_progress_bar=no_progress_bar,
             )
 
-
-class SSHRemote(Remote):
     def list_paths(self, prefix=None, progress_callback=None):
         if prefix:
             root = posixpath.join(self.path_info.path, prefix[:2])
@@ -286,6 +284,8 @@ class SSHRemote(Remote):
             else:
                 yield from ssh.walk_files(root)
 
+
+class SSHRemote(Remote):
     def batch_exists(self, path_infos, callback):
         def _exists(chunk_and_channel):
             chunk, channel = chunk_and_channel

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -187,7 +187,7 @@ class Repo:
         return Repo(root_dir)
 
     def unprotect(self, target):
-        return self.cache.local.unprotect(PathInfo(target))
+        return self.cache.local.tree.unprotect(PathInfo(target))
 
     def _ignore(self):
         flist = [self.config.files["local"], self.tmp_dir]

--- a/dvc/repo/gc.py
+++ b/dvc/repo/gc.py
@@ -8,8 +8,10 @@ from . import locked
 logger = logging.getLogger(__name__)
 
 
-def _do_gc(typ, func, clist, jobs=None):
-    removed = func(clist, jobs=jobs)
+def _do_gc(typ, remote, clist, jobs=None):
+    from dvc.remote.base import Remote
+
+    removed = Remote.gc(clist, remote, jobs=jobs)
     if not removed:
         logger.info(f"No unused '{typ}' cache to remove.")
 
@@ -74,22 +76,23 @@ def gc(
                 )
             )
 
-    _do_gc("local", self.cache.local.gc, used, jobs)
+    # treat caches as remotes for garbage collection
+    _do_gc("local", self.cache.local, used, jobs)
 
     if self.cache.s3:
-        _do_gc("s3", self.cache.s3.gc, used, jobs)
+        _do_gc("s3", self.cache.s3, used, jobs)
 
     if self.cache.gs:
-        _do_gc("gs", self.cache.gs.gc, used, jobs)
+        _do_gc("gs", self.cache.gs, used, jobs)
 
     if self.cache.ssh:
-        _do_gc("ssh", self.cache.ssh.gc, used, jobs)
+        _do_gc("ssh", self.cache.ssh, used, jobs)
 
     if self.cache.hdfs:
-        _do_gc("hdfs", self.cache.hdfs.gc, used, jobs)
+        _do_gc("hdfs", self.cache.hdfs, used, jobs)
 
     if self.cache.azure:
-        _do_gc("azure", self.cache.azure.gc, used, jobs)
+        _do_gc("azure", self.cache.azure, used, jobs)
 
     if cloud:
-        _do_gc("remote", self.cloud.get_remote(remote, "gc -c").gc, used, jobs)
+        _do_gc("remote", self.cloud.get_remote(remote, "gc -c"), used, jobs)

--- a/dvc/repo/tree.py
+++ b/dvc/repo/tree.py
@@ -48,11 +48,11 @@ class DvcTree(BaseTree):
             raise FileNotFoundError
         dir_cache = out.get_dir_cache(remote=remote)
         for entry in dir_cache:
-            entry_relpath = entry[out.remote.PARAM_RELPATH]
+            entry_relpath = entry[out.remote.tree.PARAM_RELPATH]
             if os.name == "nt":
                 entry_relpath = entry_relpath.replace("/", os.sep)
             if path == out.path_info / entry_relpath:
-                return entry[out.remote.PARAM_CHECKSUM]
+                return entry[out.remote.tree.PARAM_CHECKSUM]
         raise FileNotFoundError
 
     def open(self, path, mode="r", encoding="utf-8", remote=None):

--- a/dvc/repo/tree.py
+++ b/dvc/repo/tree.py
@@ -194,7 +194,7 @@ class DvcTree(BaseTree):
                             download_callback(downloaded)
 
                 for entry in dir_cache:
-                    entry_relpath = entry[out.remote.PARAM_RELPATH]
+                    entry_relpath = entry[out.remote.tree.PARAM_RELPATH]
                     if os.name == "nt":
                         entry_relpath = entry_relpath.replace("/", os.sep)
                     path_info = out.path_info / entry_relpath

--- a/dvc/stage/utils.py
+++ b/dvc/stage/utils.py
@@ -8,7 +8,8 @@ from dvc import dependency, output
 from dvc.utils.fs import path_isin
 
 from ..dependency import ParamsDependency
-from ..remote import LocalRemote, S3Remote
+from ..remote.local import LocalRemoteTree
+from ..remote.s3 import S3RemoteTree
 from ..utils import dict_md5, format_link, relpath
 from .exceptions import (
     MissingDataSource,
@@ -132,8 +133,8 @@ def stage_dump_eq(stage_cls, old_d, new_d):
     new_d.pop(stage_cls.PARAM_MD5, None)
     outs = old_d.get(stage_cls.PARAM_OUTS, [])
     for out in outs:
-        out.pop(LocalRemote.PARAM_CHECKSUM, None)
-        out.pop(S3Remote.PARAM_CHECKSUM, None)
+        out.pop(LocalRemoteTree.PARAM_CHECKSUM, None)
+        out.pop(S3RemoteTree.PARAM_CHECKSUM, None)
 
     # outs and deps are lists of dicts. To check equality, we need to make
     # them independent of the order, so, we convert them to dicts.

--- a/tests/func/remote/test_index.py
+++ b/tests/func/remote/test_index.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 from dvc.exceptions import DownloadError, UploadError
-from dvc.remote.base import BaseRemote
+from dvc.remote.base import Remote
 from dvc.remote.index import RemoteIndex
 from dvc.remote.local import LocalRemote, LocalRemoteTree
 from dvc.utils.fs import remove
@@ -16,9 +16,9 @@ def remote(tmp_dir, dvc, tmp_path_factory, mocker):
     dvc.config["core"]["remote"] = "upstream"
 
     # patch checksums_exist since the LocalRemote normally overrides
-    # BaseRemote.checksums_exist.
+    # BaseRemoteTree.checksums_exist.
     def checksums_exist(self, *args, **kwargs):
-        return BaseRemote.checksums_exist(self, *args, **kwargs)
+        return Remote.checksums_exist(self, *args, **kwargs)
 
     mocker.patch.object(LocalRemote, "checksums_exist", checksums_exist)
 

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -21,7 +21,7 @@ from dvc.exceptions import (
 )
 from dvc.main import main
 from dvc.output.base import OutputAlreadyTrackedError, OutputIsStageFileError
-from dvc.remote.local import LocalRemote, LocalRemoteTree
+from dvc.remote.local import LocalRemoteTree
 from dvc.repo import Repo as DvcRepo
 from dvc.stage import Stage
 from dvc.system import System
@@ -583,7 +583,7 @@ def test_readding_dir_should_not_unprotect_all(tmp_dir, dvc, mocker):
     dvc.add("dir")
     tmp_dir.gen("dir/new_file", "new_file_content")
 
-    unprotect_spy = mocker.spy(LocalRemote, "unprotect")
+    unprotect_spy = mocker.spy(LocalRemoteTree, "unprotect")
     dvc.add("dir")
 
     assert not unprotect_spy.mock.called

--- a/tests/func/test_cache.py
+++ b/tests/func/test_cache.py
@@ -30,14 +30,14 @@ class TestCache(TestDvc):
         self.create(self.cache2, "2")
 
     def test_all(self):
-        md5_list = list(Cache(self.dvc).local.all())
+        md5_list = list(Cache(self.dvc).local.tree.all())
         self.assertEqual(len(md5_list), 2)
         self.assertIn(self.cache1_md5, md5_list)
         self.assertIn(self.cache2_md5, md5_list)
 
     def test_get(self):
-        cache = Cache(self.dvc).local.get(self.cache1_md5)
-        self.assertEqual(cache, self.cache1)
+        cache = Cache(self.dvc).local.checksum_to_path_info(self.cache1_md5)
+        self.assertEqual(os.fspath(cache), self.cache1)
 
 
 class TestCacheLoadBadDirCache(TestDvc):
@@ -47,13 +47,13 @@ class TestCacheLoadBadDirCache(TestDvc):
 
     def test(self):
         checksum = "123.dir"
-        fname = self.dvc.cache.local.get(checksum)
+        fname = os.fspath(self.dvc.cache.local.checksum_to_path_info(checksum))
         self.create(fname, "<clearly>not,json")
         with pytest.raises(DirCacheError):
             self.dvc.cache.local.load_dir_cache(checksum)
 
         checksum = "234.dir"
-        fname = self.dvc.cache.local.get(checksum)
+        fname = os.fspath(self.dvc.cache.local.checksum_to_path_info(checksum))
         self.create(fname, '{"a": "b"}')
         self._do_test(self.dvc.cache.local.load_dir_cache(checksum))
 

--- a/tests/func/test_gc.py
+++ b/tests/func/test_gc.py
@@ -8,7 +8,7 @@ from git import Repo
 
 from dvc.exceptions import CollectCacheError
 from dvc.main import main
-from dvc.remote.local import LocalRemote, LocalRemoteTree
+from dvc.remote.local import LocalRemoteTree
 from dvc.repo import Repo as DvcRepo
 from dvc.utils.fs import remove
 from tests.basic_env import TestDir, TestDvcGit
@@ -21,7 +21,8 @@ class TestGC(TestDvcGit):
         self.dvc.add(self.FOO)
         self.dvc.add(self.DATA_DIR)
         self.good_cache = [
-            self.dvc.cache.local.get(md5) for md5 in self.dvc.cache.local.all()
+            self.dvc.cache.local.checksum_to_path_info(md5)
+            for md5 in self.dvc.cache.local.tree.all()
         ]
 
         self.bad_cache = []
@@ -216,7 +217,7 @@ def test_gc_no_unpacked_dir(tmp_dir, dvc):
 
     os.remove("dir.dvc")
     unpackeddir = (
-        dir_stages[0].outs[0].cache_path + LocalRemote.UNPACKED_DIR_SUFFIX
+        dir_stages[0].outs[0].cache_path + LocalRemoteTree.UNPACKED_DIR_SUFFIX
     )
 
     # older (pre 1.0) versions of dvc used to generate this dir

--- a/tests/func/test_repro.py
+++ b/tests/func/test_repro.py
@@ -26,7 +26,7 @@ from dvc.exceptions import (
 from dvc.main import main
 from dvc.output.base import BaseOutput
 from dvc.path_info import URLInfo
-from dvc.remote.local import LocalRemote, LocalRemoteTree
+from dvc.remote.local import LocalRemoteTree
 from dvc.repo import Repo as DvcRepo
 from dvc.stage import Stage
 from dvc.stage.exceptions import StageFileDoesNotExistError
@@ -782,8 +782,8 @@ class TestReproChangedDirData(SingleStageRun, TestDvc):
 class TestReproMissingMd5InStageFile(TestRepro):
     def test(self):
         d = load_yaml(self.file1_stage)
-        del d[Stage.PARAM_OUTS][0][LocalRemote.PARAM_CHECKSUM]
-        del d[Stage.PARAM_DEPS][0][LocalRemote.PARAM_CHECKSUM]
+        del d[Stage.PARAM_OUTS][0][LocalRemoteTree.PARAM_CHECKSUM]
+        del d[Stage.PARAM_DEPS][0][LocalRemoteTree.PARAM_CHECKSUM]
         dump_yaml(self.file1_stage, d)
 
         stages = self.dvc.reproduce(self.file1_stage)

--- a/tests/func/test_s3.py
+++ b/tests/func/test_s3.py
@@ -5,7 +5,8 @@ import moto.s3.models as s3model
 import pytest
 from moto import mock_s3
 
-from dvc.remote.s3 import S3Cache, S3Remote, S3RemoteTree
+from dvc.remote.base import CloudCache
+from dvc.remote.s3 import S3RemoteTree
 from tests.remotes import S3
 
 # from https://github.com/spulec/moto/blob/v1.3.5/tests/test_s3/test_s3.py#L40
@@ -54,7 +55,8 @@ def test_copy_singlepart_preserve_etag():
     ],
 )
 def test_link_created_on_non_nested_path(base_info, tmp_dir, dvc, scm):
-    cache = S3Cache(dvc, {"url": str(base_info.parent)})
+    tree = S3RemoteTree(dvc, {"url": str(base_info.parent)})
+    cache = CloudCache(tree)
     s3 = cache.tree.s3
     s3.create_bucket(Bucket=base_info.bucket)
     s3.put_object(
@@ -69,8 +71,8 @@ def test_link_created_on_non_nested_path(base_info, tmp_dir, dvc, scm):
 @mock_s3
 def test_makedirs_doesnot_try_on_top_level_paths(tmp_dir, dvc, scm):
     base_info = S3RemoteTree.PATH_CLS("s3://bucket/")
-    remote = S3Remote(dvc, {"url": str(base_info)})
-    remote.tree.makedirs(base_info)
+    tree = S3RemoteTree(dvc, {"url": str(base_info)})
+    tree.makedirs(base_info)
 
 
 def _upload_multipart(s3, Bucket, Key):

--- a/tests/func/test_stage.py
+++ b/tests/func/test_stage.py
@@ -6,7 +6,7 @@ import pytest
 from dvc.dvcfile import SingleStageFile
 from dvc.main import main
 from dvc.output.local import LocalOutput
-from dvc.remote.local import LocalRemote
+from dvc.remote.local import LocalRemoteTree
 from dvc.repo import Repo
 from dvc.stage import PipelineStage, Stage
 from dvc.stage.exceptions import StageFileFormatError
@@ -54,8 +54,8 @@ def test_empty_list():
 
 def test_list():
     lst = [
-        {LocalOutput.PARAM_PATH: "foo", LocalRemote.PARAM_CHECKSUM: "123"},
-        {LocalOutput.PARAM_PATH: "bar", LocalRemote.PARAM_CHECKSUM: None},
+        {LocalOutput.PARAM_PATH: "foo", LocalRemoteTree.PARAM_CHECKSUM: "123"},
+        {LocalOutput.PARAM_PATH: "bar", LocalRemoteTree.PARAM_CHECKSUM: None},
         {LocalOutput.PARAM_PATH: "baz"},
     ]
     d = {Stage.PARAM_DEPS: lst}

--- a/tests/func/test_tree.py
+++ b/tests/func/test_tree.py
@@ -192,7 +192,7 @@ def test_repotree_walk_fetch(tmp_dir, dvc, scm, setup_remote):
 
     assert os.path.exists(out.cache_path)
     for entry in out.dir_cache:
-        checksum = entry[out.remote.PARAM_CHECKSUM]
+        checksum = entry[out.remote.tree.PARAM_CHECKSUM]
         assert os.path.exists(dvc.cache.local.checksum_to_path_info(checksum))
 
 

--- a/tests/remotes.py
+++ b/tests/remotes.py
@@ -7,9 +7,10 @@ from subprocess import CalledProcessError, Popen, check_output
 
 from moto.s3 import mock_s3
 
-from dvc.remote.gdrive import GDriveRemote, GDriveRemoteTree
-from dvc.remote.gs import GSRemote
-from dvc.remote.s3 import S3Remote
+from dvc.remote.base import Remote
+from dvc.remote.gdrive import GDriveRemoteTree
+from dvc.remote.gs import GSRemoteTree
+from dvc.remote.s3 import S3RemoteTree
 from dvc.utils import env2bool
 from tests.basic_env import TestDvc
 
@@ -79,7 +80,7 @@ class S3Mocked(S3):
     @contextmanager
     def remote(cls, repo):
         with mock_s3():
-            yield S3Remote(repo, {"url": cls.get_url()})
+            yield Remote(S3RemoteTree(repo, {"url": cls.get_url()}))
 
     @staticmethod
     def put_objects(remote, objects):
@@ -127,7 +128,7 @@ class GCP:
     @classmethod
     @contextmanager
     def remote(cls, repo):
-        yield GSRemote(repo, {"url": cls.get_url()})
+        yield Remote(GSRemoteTree(repo, {"url": cls.get_url()}))
 
     @staticmethod
     def put_objects(remote, objects):
@@ -150,8 +151,8 @@ class GDrive:
             "gdrive_service_account_p12_file_path": "test.p12",
             "gdrive_use_service_account": True,
         }
-        remote = GDriveRemote(dvc, config)
-        remote.tree._gdrive_create_dir("root", remote.path_info.path)
+        tree = GDriveRemoteTree(dvc, config)
+        tree._gdrive_create_dir("root", tree.path_info.path)
 
     @staticmethod
     def get_storagepath():

--- a/tests/unit/remote/ssh/test_ssh.py
+++ b/tests/unit/remote/ssh/test_ssh.py
@@ -5,7 +5,7 @@ import sys
 import pytest
 from mock import mock_open, patch
 
-from dvc.remote.ssh import SSHRemote, SSHRemoteTree
+from dvc.remote.ssh import SSHRemoteTree
 from dvc.system import System
 from tests.remotes import SSHMocked
 
@@ -20,21 +20,21 @@ def test_url(dvc):
     url = f"ssh://{user}@{host}:{port}{path}"
     config = {"url": url}
 
-    remote = SSHRemote(dvc, config)
-    assert remote.path_info == url
+    tree = SSHRemoteTree(dvc, config)
+    assert tree.path_info == url
 
     # SCP-like URL ssh://[user@]host.xz:/absolute/path
     url = f"ssh://{user}@{host}:{path}"
     config = {"url": url}
 
-    remote = SSHRemote(dvc, config)
-    assert remote.tree.path_info == url
+    tree = SSHRemoteTree(dvc, config)
+    assert tree.path_info == url
 
 
 def test_no_path(dvc):
     config = {"url": "ssh://127.0.0.1"}
-    remote = SSHRemote(dvc, config)
-    assert remote.tree.path_info.path == ""
+    tree = SSHRemoteTree(dvc, config)
+    assert tree.path_info.path == ""
 
 
 mock_ssh_config = """
@@ -67,11 +67,11 @@ else:
 def test_ssh_host_override_from_config(
     mock_file, mock_exists, dvc, config, expected_host
 ):
-    remote = SSHRemote(dvc, config)
+    tree = SSHRemoteTree(dvc, config)
 
     mock_exists.assert_called_with(SSHRemoteTree.ssh_config_filename())
     mock_file.assert_called_with(SSHRemoteTree.ssh_config_filename())
-    assert remote.tree.path_info.host == expected_host
+    assert tree.path_info.host == expected_host
 
 
 @pytest.mark.parametrize(
@@ -95,11 +95,11 @@ def test_ssh_host_override_from_config(
     read_data=mock_ssh_config,
 )
 def test_ssh_user(mock_file, mock_exists, dvc, config, expected_user):
-    remote = SSHRemote(dvc, config)
+    tree = SSHRemoteTree(dvc, config)
 
     mock_exists.assert_called_with(SSHRemoteTree.ssh_config_filename())
     mock_file.assert_called_with(SSHRemoteTree.ssh_config_filename())
-    assert remote.tree.path_info.user == expected_user
+    assert tree.path_info.user == expected_user
 
 
 @pytest.mark.parametrize(
@@ -120,11 +120,11 @@ def test_ssh_user(mock_file, mock_exists, dvc, config, expected_user):
     read_data=mock_ssh_config,
 )
 def test_ssh_port(mock_file, mock_exists, dvc, config, expected_port):
-    remote = SSHRemote(dvc, config)
+    tree = SSHRemoteTree(dvc, config)
 
     mock_exists.assert_called_with(SSHRemoteTree.ssh_config_filename())
     mock_file.assert_called_with(SSHRemoteTree.ssh_config_filename())
-    assert remote.path_info.port == expected_port
+    assert tree.path_info.port == expected_port
 
 
 @pytest.mark.parametrize(
@@ -155,11 +155,11 @@ def test_ssh_port(mock_file, mock_exists, dvc, config, expected_port):
     read_data=mock_ssh_config,
 )
 def test_ssh_keyfile(mock_file, mock_exists, dvc, config, expected_keyfile):
-    remote = SSHRemote(dvc, config)
+    tree = SSHRemoteTree(dvc, config)
 
     mock_exists.assert_called_with(SSHRemoteTree.ssh_config_filename())
     mock_file.assert_called_with(SSHRemoteTree.ssh_config_filename())
-    assert remote.tree.keyfile == expected_keyfile
+    assert tree.keyfile == expected_keyfile
 
 
 @pytest.mark.parametrize(
@@ -177,11 +177,11 @@ def test_ssh_keyfile(mock_file, mock_exists, dvc, config, expected_keyfile):
     read_data=mock_ssh_config,
 )
 def test_ssh_gss_auth(mock_file, mock_exists, dvc, config, expected_gss_auth):
-    remote = SSHRemote(dvc, config)
+    tree = SSHRemoteTree(dvc, config)
 
     mock_exists.assert_called_with(SSHRemoteTree.ssh_config_filename())
     mock_file.assert_called_with(SSHRemoteTree.ssh_config_filename())
-    assert remote.tree.gss_auth == expected_gss_auth
+    assert tree.gss_auth == expected_gss_auth
 
 
 def test_hardlink_optimization(dvc, tmp_dir, ssh_server):
@@ -194,12 +194,12 @@ def test_hardlink_optimization(dvc, tmp_dir, ssh_server):
         "user": user,
         "keyfile": ssh_server.test_creds["key_filename"],
     }
-    remote = SSHRemote(dvc, config)
+    tree = SSHRemoteTree(dvc, config)
 
-    from_info = remote.path_info / "empty"
-    to_info = remote.path_info / "link"
+    from_info = tree.path_info / "empty"
+    to_info = tree.path_info / "link"
 
-    with remote.open(from_info, "wb"):
+    with tree.open(from_info, "wb"):
         pass
 
     if os.name == "nt":
@@ -207,5 +207,5 @@ def test_hardlink_optimization(dvc, tmp_dir, ssh_server):
     else:
         link_path = to_info.path
 
-    remote.tree.hardlink(from_info, to_info)
+    tree.hardlink(from_info, to_info)
     assert not System.is_hardlink(link_path)

--- a/tests/unit/remote/test_azure.py
+++ b/tests/unit/remote/test_azure.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dvc.path_info import PathInfo
-from dvc.remote.azure import AzureRemote
+from dvc.remote.azure import AzureRemoteTree
 from tests.remotes import Azure
 
 container_name = "container-name"
@@ -18,18 +18,18 @@ def test_init_env_var(monkeypatch, dvc):
     monkeypatch.setenv("AZURE_STORAGE_CONNECTION_STRING", connection_string)
 
     config = {"url": "azure://"}
-    remote = AzureRemote(dvc, config)
-    assert remote.tree.path_info == "azure://" + container_name
-    assert remote.tree.connection_string == connection_string
+    tree = AzureRemoteTree(dvc, config)
+    assert tree.path_info == "azure://" + container_name
+    assert tree.connection_string == connection_string
 
 
 def test_init(dvc):
     prefix = "some/prefix"
     url = f"azure://{container_name}/{prefix}"
     config = {"url": url, "connection_string": connection_string}
-    remote = AzureRemote(dvc, config)
-    assert remote.tree.path_info == url
-    assert remote.tree.connection_string == connection_string
+    tree = AzureRemoteTree(dvc, config)
+    assert tree.path_info == url
+    assert tree.connection_string == connection_string
 
 
 def test_get_file_checksum(tmp_dir):
@@ -38,11 +38,11 @@ def test_get_file_checksum(tmp_dir):
 
     tmp_dir.gen("foo", "foo")
 
-    remote = AzureRemote(None, {})
-    to_info = remote.tree.PATH_CLS(Azure.get_url())
-    remote.tree.upload(PathInfo("foo"), to_info)
-    assert remote.tree.exists(to_info)
-    checksum = remote.tree.get_file_checksum(to_info)
+    tree = AzureRemoteTree(None, {})
+    to_info = tree.PATH_CLS(Azure.get_url())
+    tree.upload(PathInfo("foo"), to_info)
+    assert tree.exists(to_info)
+    checksum = tree.get_file_checksum(to_info)
     assert checksum
     assert isinstance(checksum, str)
     assert checksum.strip("'").strip('"') == checksum

--- a/tests/unit/remote/test_base.py
+++ b/tests/unit/remote/test_base.py
@@ -4,7 +4,12 @@ import mock
 import pytest
 
 from dvc.path_info import PathInfo
-from dvc.remote.base import BaseRemote, RemoteCmdError, RemoteMissingDepsError
+from dvc.remote.base import (
+    BaseRemoteTree,
+    Remote,
+    RemoteCmdError,
+    RemoteMissingDepsError,
+)
 
 
 class _CallableOrNone:
@@ -15,14 +20,13 @@ class _CallableOrNone:
 
 
 CallableOrNone = _CallableOrNone()
-REMOTE_CLS = BaseRemote
 
 
 def test_missing_deps(dvc):
     requires = {"missing": "missing"}
-    with mock.patch.object(REMOTE_CLS, "REQUIRES", requires):
+    with mock.patch.object(BaseRemoteTree, "REQUIRES", requires):
         with pytest.raises(RemoteMissingDepsError):
-            REMOTE_CLS(dvc, {})
+            BaseRemoteTree(dvc, {})
 
 
 def test_cmd_error(dvc):
@@ -33,44 +37,44 @@ def test_cmd_error(dvc):
     err = "sed: expression #1, char 2: extra characters after command"
 
     with mock.patch.object(
-        REMOTE_CLS.TREE_CLS,
+        BaseRemoteTree,
         "remove",
         side_effect=RemoteCmdError("base", cmd, ret, err),
     ):
         with pytest.raises(RemoteCmdError):
-            REMOTE_CLS(dvc, config).tree.remove("file")
+            BaseRemoteTree(dvc, config).remove("file")
 
 
-@mock.patch.object(BaseRemote, "_list_checksums_traverse")
-@mock.patch.object(BaseRemote, "_list_checksums_exists")
+@mock.patch.object(BaseRemoteTree, "list_checksums_traverse")
+@mock.patch.object(BaseRemoteTree, "list_checksums_exists")
 def test_checksums_exist(object_exists, traverse, dvc):
-    remote = BaseRemote(dvc, {})
+    remote = Remote(BaseRemoteTree(dvc, {}))
 
     # remote does not support traverse
-    remote.CAN_TRAVERSE = False
+    remote.tree.CAN_TRAVERSE = False
     with mock.patch.object(
-        remote, "list_checksums", return_value=list(range(256))
+        remote.tree, "list_checksums", return_value=list(range(256))
     ):
         checksums = set(range(1000))
         remote.checksums_exist(checksums)
         object_exists.assert_called_with(checksums, None, None)
         traverse.assert_not_called()
 
-    remote.CAN_TRAVERSE = True
+    remote.tree.CAN_TRAVERSE = True
 
     # large remote, small local
     object_exists.reset_mock()
     traverse.reset_mock()
     with mock.patch.object(
-        remote, "list_checksums", return_value=list(range(256))
+        remote.tree, "list_checksums", return_value=list(range(256))
     ):
         checksums = list(range(1000))
         remote.checksums_exist(checksums)
         # verify that _cache_paths_with_max() short circuits
         # before returning all 256 remote checksums
         max_checksums = math.ceil(
-            remote._max_estimation_size(checksums)
-            / pow(16, remote.TRAVERSE_PREFIX_LEN)
+            remote.tree._max_estimation_size(checksums)
+            / pow(16, remote.tree.TRAVERSE_PREFIX_LEN)
         )
         assert max_checksums < 256
         object_exists.assert_called_with(
@@ -81,15 +85,15 @@ def test_checksums_exist(object_exists, traverse, dvc):
     # large remote, large local
     object_exists.reset_mock()
     traverse.reset_mock()
-    remote.JOBS = 16
+    remote.tree.JOBS = 16
     with mock.patch.object(
-        remote, "list_checksums", return_value=list(range(256))
+        remote.tree, "list_checksums", return_value=list(range(256))
     ):
         checksums = list(range(1000000))
         remote.checksums_exist(checksums)
         object_exists.assert_not_called()
         traverse.assert_called_with(
-            256 * pow(16, remote.TRAVERSE_PREFIX_LEN),
+            256 * pow(16, remote.tree.TRAVERSE_PREFIX_LEN),
             set(range(256)),
             None,
             None,
@@ -97,18 +101,18 @@ def test_checksums_exist(object_exists, traverse, dvc):
 
 
 @mock.patch.object(
-    BaseRemote, "list_checksums", return_value=[],
+    BaseRemoteTree, "list_checksums", return_value=[],
 )
 @mock.patch.object(
-    BaseRemote, "path_to_checksum", side_effect=lambda x: x,
+    BaseRemoteTree, "path_to_checksum", side_effect=lambda x: x,
 )
 def test_list_checksums_traverse(path_to_checksum, list_checksums, dvc):
-    remote = BaseRemote(dvc, {})
-    remote.tree.path_info = PathInfo("foo")
+    tree = BaseRemoteTree(dvc, {})
+    tree.path_info = PathInfo("foo")
 
     # parallel traverse
-    size = 256 / remote.JOBS * remote.LIST_OBJECT_PAGE_SIZE
-    list(remote._list_checksums_traverse(size, {0}))
+    size = 256 / tree.JOBS * tree.LIST_OBJECT_PAGE_SIZE
+    list(tree.list_checksums_traverse(size, {0}))
     for i in range(1, 16):
         list_checksums.assert_any_call(
             prefix=f"{i:03x}", progress_callback=CallableOrNone
@@ -121,20 +125,20 @@ def test_list_checksums_traverse(path_to_checksum, list_checksums, dvc):
     # default traverse (small remote)
     size -= 1
     list_checksums.reset_mock()
-    list(remote._list_checksums_traverse(size - 1, {0}))
+    list(tree.list_checksums_traverse(size - 1, {0}))
     list_checksums.assert_called_with(
         prefix=None, progress_callback=CallableOrNone
     )
 
 
 def test_list_checksums(dvc):
-    remote = BaseRemote(dvc, {})
-    remote.tree.path_info = PathInfo("foo")
+    tree = BaseRemoteTree(dvc, {})
+    tree.path_info = PathInfo("foo")
 
     with mock.patch.object(
-        remote, "list_paths", return_value=["12/3456", "bar"]
+        tree, "list_paths", return_value=["12/3456", "bar"]
     ):
-        checksums = list(remote.list_checksums())
+        checksums = list(tree.list_checksums())
         assert checksums == ["123456"]
 
 
@@ -143,4 +147,4 @@ def test_list_checksums(dvc):
     [(None, False), ("", False), ("3456.dir", True), ("3456", False)],
 )
 def test_is_dir_checksum(checksum, result):
-    assert BaseRemote.is_dir_checksum(checksum) == result
+    assert BaseRemoteTree.is_dir_checksum(checksum) == result

--- a/tests/unit/remote/test_gdrive.py
+++ b/tests/unit/remote/test_gdrive.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from dvc.remote.gdrive import GDriveAuthError, GDriveRemote, GDriveRemoteTree
+from dvc.remote.gdrive import GDriveAuthError, GDriveRemoteTree
 
 USER_CREDS_TOKEN_REFRESH_ERROR = '{"access_token": "", "client_id": "", "client_secret": "", "refresh_token": "", "token_expiry": "", "token_uri": "https://oauth2.googleapis.com/token", "user_agent": null, "revoke_uri": "https://oauth2.googleapis.com/revoke", "id_token": null, "id_token_jwt": null, "token_response": {"access_token": "", "expires_in": 3600, "scope": "https://www.googleapis.com/auth/drive.appdata https://www.googleapis.com/auth/drive", "token_type": "Bearer"}, "scopes": ["https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/drive.appdata"], "token_info_uri": "https://oauth2.googleapis.com/tokeninfo", "invalid": true, "_class": "OAuth2Credentials", "_module": "oauth2client.client"}'  # noqa: E501
 
@@ -17,21 +17,21 @@ class TestRemoteGDrive:
     }
 
     def test_init(self, dvc):
-        remote = GDriveRemote(dvc, self.CONFIG)
-        assert str(remote.tree.path_info) == self.CONFIG["url"]
+        tree = GDriveRemoteTree(dvc, self.CONFIG)
+        assert str(tree.path_info) == self.CONFIG["url"]
 
     def test_drive(self, dvc):
-        remote = GDriveRemote(dvc, self.CONFIG)
+        tree = GDriveRemoteTree(dvc, self.CONFIG)
         os.environ[
             GDriveRemoteTree.GDRIVE_CREDENTIALS_DATA
         ] = USER_CREDS_TOKEN_REFRESH_ERROR
         with pytest.raises(GDriveAuthError):
-            remote.tree._drive
+            tree._drive
 
         os.environ[GDriveRemoteTree.GDRIVE_CREDENTIALS_DATA] = ""
-        remote = GDriveRemote(dvc, self.CONFIG)
+        tree = GDriveRemoteTree(dvc, self.CONFIG)
         os.environ[
             GDriveRemoteTree.GDRIVE_CREDENTIALS_DATA
         ] = USER_CREDS_MISSED_KEY_ERROR
         with pytest.raises(GDriveAuthError):
-            remote.tree._drive
+            tree._drive

--- a/tests/unit/remote/test_gs.py
+++ b/tests/unit/remote/test_gs.py
@@ -2,7 +2,7 @@ import mock
 import pytest
 import requests
 
-from dvc.remote.gs import GSRemote, dynamic_chunk_size
+from dvc.remote.gs import GSRemoteTree, dynamic_chunk_size
 
 BUCKET = "bucket"
 PREFIX = "prefix"
@@ -17,17 +17,17 @@ CONFIG = {
 
 
 def test_init(dvc):
-    remote = GSRemote(dvc, CONFIG)
-    assert remote.tree.path_info == URL
-    assert remote.tree.projectname == PROJECT
-    assert remote.tree.credentialpath == CREDENTIALPATH
+    tree = GSRemoteTree(dvc, CONFIG)
+    assert tree.path_info == URL
+    assert tree.projectname == PROJECT
+    assert tree.credentialpath == CREDENTIALPATH
 
 
 @mock.patch("google.cloud.storage.Client.from_service_account_json")
 def test_gs(mock_client, dvc):
-    remote = GSRemote(dvc, CONFIG)
-    assert remote.tree.credentialpath
-    remote.tree.gs()
+    tree = GSRemoteTree(dvc, CONFIG)
+    assert tree.credentialpath
+    tree.gs()
     mock_client.assert_called_once_with(CREDENTIALPATH)
 
 
@@ -35,8 +35,8 @@ def test_gs(mock_client, dvc):
 def test_gs_no_credspath(mock_client, dvc):
     config = CONFIG.copy()
     del config["credentialpath"]
-    remote = GSRemote(dvc, config)
-    remote.tree.gs()
+    tree = GSRemoteTree(dvc, config)
+    tree.gs()
     mock_client.assert_called_with(PROJECT)
 
 

--- a/tests/unit/remote/test_http.py
+++ b/tests/unit/remote/test_http.py
@@ -2,7 +2,7 @@ import pytest
 
 from dvc.exceptions import HTTPError
 from dvc.path_info import URLInfo
-from dvc.remote.http import HTTPRemote
+from dvc.remote.http import HTTPRemoteTree
 from tests.utils.httpd import StaticFileServer
 
 
@@ -11,10 +11,10 @@ def test_download_fails_on_error_code(dvc):
         url = f"http://localhost:{httpd.server_port}/"
         config = {"url": url}
 
-        remote = HTTPRemote(dvc, config)
+        tree = HTTPRemoteTree(dvc, config)
 
         with pytest.raises(HTTPError):
-            remote.tree._download(URLInfo(url) / "missing.txt", "missing.txt")
+            tree._download(URLInfo(url) / "missing.txt", "missing.txt")
 
 
 def test_public_auth_method(dvc):
@@ -25,9 +25,9 @@ def test_public_auth_method(dvc):
         "password": "",
     }
 
-    remote = HTTPRemote(dvc, config)
+    tree = HTTPRemoteTree(dvc, config)
 
-    assert remote.tree._auth_method() is None
+    assert tree._auth_method() is None
 
 
 def test_basic_auth_method(dvc):
@@ -44,10 +44,10 @@ def test_basic_auth_method(dvc):
         "password": password,
     }
 
-    remote = HTTPRemote(dvc, config)
+    tree = HTTPRemoteTree(dvc, config)
 
-    assert remote.tree._auth_method() == auth
-    assert isinstance(remote.tree._auth_method(), HTTPBasicAuth)
+    assert tree._auth_method() == auth
+    assert isinstance(tree._auth_method(), HTTPBasicAuth)
 
 
 def test_digest_auth_method(dvc):
@@ -64,10 +64,10 @@ def test_digest_auth_method(dvc):
         "password": password,
     }
 
-    remote = HTTPRemote(dvc, config)
+    tree = HTTPRemoteTree(dvc, config)
 
-    assert remote.tree._auth_method() == auth
-    assert isinstance(remote.tree._auth_method(), HTTPDigestAuth)
+    assert tree._auth_method() == auth
+    assert isinstance(tree._auth_method(), HTTPDigestAuth)
 
 
 def test_custom_auth_method(dvc):
@@ -81,8 +81,8 @@ def test_custom_auth_method(dvc):
         "password": password,
     }
 
-    remote = HTTPRemote(dvc, config)
+    tree = HTTPRemoteTree(dvc, config)
 
-    assert remote.tree._auth_method() is None
-    assert header in remote.tree.headers
-    assert remote.tree.headers[header] == password
+    assert tree._auth_method() is None
+    assert header in tree.headers
+    assert tree.headers[header] == password

--- a/tests/unit/remote/test_local.py
+++ b/tests/unit/remote/test_local.py
@@ -5,7 +5,8 @@ import pytest
 
 from dvc.cache import NamedCache
 from dvc.path_info import PathInfo
-from dvc.remote.local import LocalCache
+from dvc.remote.index import RemoteIndexNoop
+from dvc.remote.local import LocalCache, LocalRemoteTree
 
 
 def test_status_download_optimization(mocker, dvc):
@@ -13,7 +14,7 @@ def test_status_download_optimization(mocker, dvc):
         And the desired files to fetch are already on the local cache,
         Don't check the existence of the desired files on the remote cache
     """
-    cache = LocalCache(dvc, {})
+    cache = LocalCache(LocalRemoteTree(dvc, {}))
 
     infos = NamedCache()
     infos.add("local", "acbd18db4cc2f85cedef654fccc4a4d8", "foo")
@@ -25,6 +26,7 @@ def test_status_download_optimization(mocker, dvc):
     other_remote = mocker.Mock()
     other_remote.url = "other_remote"
     other_remote.checksums_exist.return_value = []
+    other_remote.index = RemoteIndexNoop()
 
     cache.status(infos, other_remote, download=True)
 
@@ -33,8 +35,8 @@ def test_status_download_optimization(mocker, dvc):
 
 @pytest.mark.parametrize("link_name", ["hardlink", "symlink"])
 def test_is_protected(tmp_dir, dvc, link_name):
-    cache = LocalCache(dvc, {})
-    link_method = getattr(cache.tree, link_name)
+    tree = LocalRemoteTree(dvc, {})
+    link_method = getattr(tree, link_name)
 
     (tmp_dir / "foo").write_text("foo")
 
@@ -43,47 +45,47 @@ def test_is_protected(tmp_dir, dvc, link_name):
 
     link_method(foo, link)
 
-    assert not cache.is_protected(foo)
-    assert not cache.is_protected(link)
+    assert not tree.is_protected(foo)
+    assert not tree.is_protected(link)
 
-    cache.protect(foo)
+    tree.protect(foo)
 
-    assert cache.is_protected(foo)
-    assert cache.is_protected(link)
+    assert tree.is_protected(foo)
+    assert tree.is_protected(link)
 
-    cache.unprotect(link)
+    tree.unprotect(link)
 
-    assert not cache.is_protected(link)
+    assert not tree.is_protected(link)
     if os.name == "nt" and link_name == "hardlink":
         # NOTE: NTFS doesn't allow deleting read-only files, which forces us to
         # set write perms on the link, which propagates to the source.
-        assert not cache.is_protected(foo)
+        assert not tree.is_protected(foo)
     else:
-        assert cache.is_protected(foo)
+        assert tree.is_protected(foo)
 
 
 @pytest.mark.parametrize("err", [errno.EPERM, errno.EACCES])
 def test_protect_ignore_errors(tmp_dir, mocker, err):
     tmp_dir.gen("foo", "foo")
     foo = PathInfo("foo")
-    cache = LocalCache(None, {})
+    tree = LocalRemoteTree(None, {})
 
-    cache.protect(foo)
+    tree.protect(foo)
 
     mock_chmod = mocker.patch(
         "os.chmod", side_effect=OSError(err, "something")
     )
-    cache.protect(foo)
+    tree.protect(foo)
     assert mock_chmod.called
 
 
 def test_protect_ignore_erofs(tmp_dir, mocker):
     tmp_dir.gen("foo", "foo")
     foo = PathInfo("foo")
-    cache = LocalCache(None, {})
+    tree = LocalRemoteTree(None, {})
 
     mock_chmod = mocker.patch(
         "os.chmod", side_effect=OSError(errno.EROFS, "read-only fs")
     )
-    cache.protect(foo)
+    tree.protect(foo)
     assert mock_chmod.called

--- a/tests/unit/remote/test_oss.py
+++ b/tests/unit/remote/test_oss.py
@@ -1,4 +1,4 @@
-from dvc.remote.oss import OSSRemote
+from dvc.remote.oss import OSSRemoteTree
 
 bucket_name = "bucket-name"
 endpoint = "endpoint"
@@ -15,8 +15,8 @@ def test_init(dvc):
         "oss_key_secret": key_secret,
         "oss_endpoint": endpoint,
     }
-    remote = OSSRemote(dvc, config)
-    assert remote.tree.path_info == url
-    assert remote.tree.endpoint == endpoint
-    assert remote.tree.key_id == key_id
-    assert remote.tree.key_secret == key_secret
+    tree = OSSRemoteTree(dvc, config)
+    assert tree.path_info == url
+    assert tree.endpoint == endpoint
+    assert tree.key_id == key_id
+    assert tree.key_secret == key_secret

--- a/tests/unit/remote/test_remote_tree.py
+++ b/tests/unit/remote/test_remote_tree.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 from dvc.path_info import PathInfo
-from dvc.remote.s3 import S3Remote, S3RemoteTree
+from dvc.remote.s3 import S3RemoteTree
 from dvc.utils.fs import walk_files
 from tests.remotes import GCP, S3Mocked
 
@@ -91,7 +91,7 @@ def test_copy_preserve_etag_across_buckets(remote, dvc):
     s3 = remote.tree.s3
     s3.create_bucket(Bucket="another")
 
-    another = S3Remote(dvc, {"url": "s3://another", "region": "us-east-1"})
+    another = S3RemoteTree(dvc, {"url": "s3://another", "region": "us-east-1"})
 
     from_info = remote.path_info / "foo"
     to_info = another.path_info / "foo"

--- a/tests/unit/remote/test_s3.py
+++ b/tests/unit/remote/test_s3.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dvc.config import ConfigError
-from dvc.remote.s3 import S3Remote
+from dvc.remote.s3 import S3RemoteTree
 
 bucket_name = "bucket-name"
 prefix = "some/prefix"
@@ -20,9 +20,9 @@ def grants():
 
 def test_init(dvc):
     config = {"url": url}
-    remote = S3Remote(dvc, config)
+    tree = S3RemoteTree(dvc, config)
 
-    assert remote.tree.path_info == url
+    assert tree.path_info == url
 
 
 def test_grants(dvc):
@@ -33,8 +33,7 @@ def test_grants(dvc):
         "grant_write_acp": "id=write-acp-permission-id",
         "grant_full_control": "id=full-control-permission-id",
     }
-    remote = S3Remote(dvc, config)
-    tree = remote.tree
+    tree = S3RemoteTree(dvc, config)
 
     assert (
         tree.extra_args["GrantRead"]
@@ -52,9 +51,9 @@ def test_grants_mutually_exclusive_acl_error(dvc, grants):
         config = {"url": url, "acl": "public-read", grant_option: grant_value}
 
         with pytest.raises(ConfigError):
-            S3Remote(dvc, config)
+            S3RemoteTree(dvc, config)
 
 
 def test_sse_kms_key_id(dvc):
-    remote = S3Remote(dvc, {"url": url, "sse_kms_key_id": "key"})
-    assert remote.tree.extra_args["SSEKMSKeyId"] == "key"
+    tree = S3RemoteTree(dvc, {"url": url, "sse_kms_key_id": "key"})
+    assert tree.extra_args["SSEKMSKeyId"] == "key"

--- a/tests/unit/repo/test_repo_tree.py
+++ b/tests/unit/repo/test_repo_tree.py
@@ -22,8 +22,9 @@ def test_open(tmp_dir, dvc):
     (tmp_dir / "foo").unlink()
 
     tree = RepoTree(dvc)
-    with tree.open("foo", "r") as fobj:
-        assert fobj.read() == "foo"
+    with dvc.state:
+        with tree.open("foo", "r") as fobj:
+            assert fobj.read() == "foo"
 
 
 def test_open_dirty_hash(tmp_dir, dvc):

--- a/tests/unit/repo/test_tree.py
+++ b/tests/unit/repo/test_tree.py
@@ -22,8 +22,9 @@ def test_open(tmp_dir, dvc):
     (tmp_dir / "foo").unlink()
 
     tree = DvcTree(dvc)
-    with tree.open("foo", "r") as fobj:
-        assert fobj.read() == "foo"
+    with dvc.state:
+        with tree.open("foo", "r") as fobj:
+            assert fobj.read() == "foo"
 
 
 def test_open_dirty_hash(tmp_dir, dvc):


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Related to #3882.

* Replaces `remote.Remote` and `remote.Cache` helper functions with actual `Remote` and `CloudCache` classes
* `Remote` and `CloudCache` constructors take a RemoteTree parameter
* `remote.get_cloud_tree` helper method can be used to return the proper tree for a given URL
* output/dependency/cache updated to use the new functionality