### PR TITLE
optimize: remove `fsync` when dumping rwlock data

### DIFF
--- a/dvc/rwlock.py
+++ b/dvc/rwlock.py
@@ -51,9 +51,6 @@ def _edit_rwlock(lock_dir):
     yield lock
     with open(path, "w+") as fobj:
         json.dump(lock, fobj)
-        # NOTE: flush and fsync to ensure that rwlock contents are saved
-        fobj.flush()
-        os.fsync(fobj.fileno())
 
 
 def _infos_to_str(infos):

--- a/tests/func/test_repro_multistage.py
+++ b/tests/func/test_repro_multistage.py
@@ -449,7 +449,7 @@ def test_repro_when_new_outs_added_does_not_exist(tmp_dir, dvc):
         {
             "stages": {
                 "run-copy": {
-                    "cmd": "python copy {} {}".format("foo", "foobar"),
+                    "cmd": "python copy.py {} {}".format("foo", "foobar"),
                     "deps": ["foo"],
                     "outs": ["foobar", "bar"],
                 }


### PR DESCRIPTION
Fixes #3653

#### Before:
![Screenshot from 2020-06-16 20-00-43](https://user-images.githubusercontent.com/18718008/84786170-1b292980-b00c-11ea-82df-865dbe8e0fca.png)

### After:
![Screenshot from 2020-06-16 20-02-49](https://user-images.githubusercontent.com/18718008/84786355-5f1c2e80-b00c-11ea-91a6-4dbb4b4031cb.png)

(146s with 124.9s spent on fsync vs 14.8s cumulative)

Still 5-6 seconds are spent on 178461 `relpath()` calls. Will be handled on a separate PR.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
