### PR TITLE
cache relpath on stage

### DIFF
--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -3,7 +3,7 @@ import os
 import string
 from collections import defaultdict
 
-from funcy import project
+from funcy import cached_property, project
 
 import dvc.dependency as dependency
 import dvc.prompt as prompt
@@ -127,6 +127,8 @@ class Stage(params.StageParams):
     @path.setter
     def path(self, path):
         self._path = path
+        self.__dict__.pop("path_in_repo", None)
+        self.__dict__.pop("relpath", None)
 
     @property
     def dvcfile(self):
@@ -172,11 +174,11 @@ class Stage(params.StageParams):
             and self.path_in_repo == other.path_in_repo
         )
 
-    @property
+    @cached_property
     def path_in_repo(self):
         return relpath(self.path, self.repo.root_dir)
 
-    @property
+    @cached_property
     def relpath(self):
         return relpath(self.path)
 

--- a/tests/func/test_stage.py
+++ b/tests/func/test_stage.py
@@ -220,6 +220,10 @@ def test_stage_strings_representation(tmp_dir, dvc, run_copy):
     folder = tmp_dir / "dir"
     folder.mkdir()
     with folder.chdir():
+        # `Stage` caches `relpath` results, forcing it to reset
+        stage1.path = stage1.path
+        stage2.path = stage2.path
+
         rel_path = os.path.relpath(stage1.path)
         assert stage1.addressing == rel_path
         assert repr(stage1) == f"Stage: '{rel_path}'"


### PR DESCRIPTION
~~On top of #4052~~

A lot of `relpath` calls were being used by `networkx` indirectly through `Stage::__eq__()` and `Stage::__hash__()`. They would call `relpath` and `abspath` calls. This PR caches them.

Compare with #4052 with following:

![Screenshot from 2020-06-16 20-26-29](https://user-images.githubusercontent.com/18718008/84789567-16ff0b00-b010-11ea-9a5a-bf6b9fa32a01.png)

Related #3653 

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
