### PR TITLE
fix url signing when using GoogleStorage on GoogleComputeEngine

### DIFF
--- a/dvc/remote/gs.py
+++ b/dvc/remote/gs.py
@@ -91,13 +91,30 @@ class GSRemoteTree(BaseRemoteTree):
         )
 
     def _generate_download_url(self, path_info, expires=3600):
+        import google.auth
+        from google.auth import compute_engine
+
         expiration = timedelta(seconds=int(expires))
 
         bucket = self.gs.bucket(path_info.bucket)
         blob = bucket.get_blob(path_info.path)
         if blob is None:
             raise FileNotFoundError
-        return blob.generate_signed_url(expiration=expiration)
+
+        if isinstance(
+            blob.client._credentials, google.auth.credentials.Signing
+        ):
+            # sign if we're able to sign with credentials.
+            return blob.generate_signed_url(expiration=expiration)
+
+        auth_request = google.auth.transport.requests.Request()
+        # create signing credentials with the default credentials
+        # for use with Compute Engine and other environments where
+        # Client credentials cannot sign.
+        signing_credentials = compute_engine.IDTokenCredentials(
+            auth_request, ""
+        )
+        return signing_credentials.signer.sign(blob)
 
     def exists(self, path_info):
         """Check if the blob exists. If it does not exist,


### PR DESCRIPTION
Fixes #4056

`GoogleStorageTree._generate_download_url` needs to create it's own url signing credentials when the current google auth credentials cannot be used for signing.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
