### PR TITLE
trees: handle tree.walk errors the same way as os.walk

### DIFF
--- a/dvc/ignore.py
+++ b/dvc/ignore.py
@@ -229,8 +229,10 @@ class CleanTree(BaseTree):
                 return False
         return True
 
-    def walk(self, top, topdown=True):
-        for root, dirs, files in self.tree.walk(top, topdown):
+    def walk(self, top, topdown=True, onerror=None):
+        for root, dirs, files in self.tree.walk(
+            top, topdown=topdown, onerror=onerror
+        ):
             dirs[:], files[:] = self.dvcignore(
                 os.path.abspath(root), dirs, files
             )

--- a/dvc/repo/ls.py
+++ b/dvc/repo/ls.py
@@ -50,13 +50,18 @@ def ls(
 def _ls(repo, path_info, recursive=None, dvc_only=False):
     from dvc.repo.tree import RepoTree
 
+    def onerror(exc):
+        raise exc
+
     # use our own RepoTree instance instead of repo.repo_tree since we do not
     # want fetch/stream enabled for ls
     tree = RepoTree(repo)
 
     ret = {}
     try:
-        for root, dirs, files in tree.walk(path_info.fspath, dvcfiles=True):
+        for root, dirs, files in tree.walk(
+            path_info.fspath, onerror=onerror, dvcfiles=True
+        ):
             for fname in files:
                 info = PathInfo(root) / fname
                 dvc = tree.isdvc(info)

--- a/dvc/scm/tree.py
+++ b/dvc/scm/tree.py
@@ -21,12 +21,11 @@ class BaseTree:
     def isfile(self, path):
         """Test whether a path is a regular file"""
 
-    def walk(self, top, topdown=True):
+    def walk(self, top, topdown=True, onerror=None):
         """Directory tree generator.
 
         See `os.walk` for the docs. Differences:
         - no support for symlinks
-        - it could raise exceptions, there is no onerror argument
         """
 
     def walk_files(self, top):
@@ -64,17 +63,12 @@ class WorkingTree(BaseTree):
         """Test whether a path is a regular file"""
         return os.path.isfile(path)
 
-    def walk(self, top, topdown=True):
+    def walk(self, top, topdown=True, onerror=None):
         """Directory tree generator.
 
         See `os.walk` for the docs. Differences:
         - no support for symlinks
-        - it could raise exceptions, there is no onerror argument
         """
-
-        def onerror(e):
-            raise e
-
         for root, dirs, files in os.walk(
             top, topdown=topdown, onerror=onerror
         ):

--- a/tests/unit/repo/test_repo_tree.py
+++ b/tests/unit/repo/test_repo_tree.py
@@ -145,6 +145,28 @@ def test_walk(tmp_dir, dvc, dvcfiles, extra_expected):
     assert len(actual) == len(expected)
 
 
+def test_walk_onerror(tmp_dir, dvc):
+    def onerror(exc):
+        raise exc
+
+    tmp_dir.dvc_gen("foo", "foo")
+    tree = RepoTree(dvc)
+
+    # path does not exist
+    for _ in tree.walk("dir"):
+        pass
+    with pytest.raises(OSError):
+        for _ in tree.walk("dir", onerror=onerror):
+            pass
+
+    # path is not a directory
+    for _ in tree.walk("foo"):
+        pass
+    with pytest.raises(OSError):
+        for _ in tree.walk("foo", onerror=onerror):
+            pass
+
+
 def test_isdvc(tmp_dir, dvc):
     tmp_dir.gen({"foo": "foo", "bar": "bar", "dir": {"baz": "baz"}})
     dvc.add("foo")

--- a/tests/unit/repo/test_tree.py
+++ b/tests/unit/repo/test_tree.py
@@ -173,6 +173,28 @@ def test_walk_dir(tmp_dir, dvc, fetch, expected):
     assert len(actual) == len(expected)
 
 
+def test_walk_onerror(tmp_dir, dvc):
+    def onerror(exc):
+        raise exc
+
+    tmp_dir.dvc_gen("foo", "foo")
+    tree = DvcTree(dvc)
+
+    # path does not exist
+    for _ in tree.walk("dir"):
+        pass
+    with pytest.raises(OSError):
+        for _ in tree.walk("dir", onerror=onerror):
+            pass
+
+    # path is not a directory
+    for _ in tree.walk("foo"):
+        pass
+    with pytest.raises(OSError):
+        for _ in tree.walk("foo", onerror=onerror):
+            pass
+
+
 def test_isdvc(tmp_dir, dvc):
     tmp_dir.gen({"foo": "foo", "bar": "bar"})
     dvc.add("foo")


### PR DESCRIPTION
`BaseTree.walk` now handles errors the same way as `os.walk`. Errors will be ignored unless `onerror` callback function is provided.

Fixes #4055.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here. If the CLI API is changed, I have updated [tab completion scripts](https://github.com/iterative/dvc/tree/master/scripts/completion).

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
