### PR TITLE
Issue #4025:  cli: added cwd flag

### DIFF
--- a/dvc/cli.py
+++ b/dvc/cli.py
@@ -2,6 +2,7 @@
 import argparse
 import logging
 import sys
+import os
 
 from .command import (
     add,
@@ -138,7 +139,9 @@ def get_parent_parser():
     log_level_group.add_argument(
         "-v", "--verbose", action="count", default=0, help="Be verbose."
     )
-
+    parent_parser.add_argument(
+        "-C", "--cwd", default=os.path.curdir, metavar="<path>",
+        help="Directory to execute command from.")
     return parent_parser
 
 

--- a/dvc/command/base.py
+++ b/dvc/command/base.py
@@ -1,3 +1,4 @@
+import os
 import logging
 from abc import ABC, abstractmethod
 
@@ -32,6 +33,7 @@ class CmdBase(ABC):
         from dvc.repo import Repo
         from dvc.updater import Updater
 
+        os.chdir(args.cwd)
         self.repo = Repo()
         self.config = self.repo.config
         self.args = args

--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -91,13 +91,6 @@ def add_parser(subparsers, parent_parser):
         "check.",
     )
     repro_parser.add_argument(
-        "-c",
-        "--cwd",
-        default=os.path.curdir,
-        help="Directory within your repo to reproduce from.",
-        metavar="<path>",
-    )
-    repro_parser.add_argument(
         "-m",
         "--metrics",
         action="store_true",

--- a/tests/func/test_cli.py
+++ b/tests/func/test_cli.py
@@ -2,7 +2,6 @@ import filecmp
 import os
 import shutil
 
-from dvc.main import main
 from dvc.cli import parse_args
 from dvc.command.add import CmdAdd
 from dvc.command.base import CmdBase
@@ -227,5 +226,3 @@ class test_chdir(TestDvc):
         self.assertTrue(filecmp.cmp(foo, self.FOO, shallow=False))
         self.assertTrue(filecmp.cmp(bar, self.BAR, shallow=False))
         self.assertTrue(filecmp.cmp(code, self.CODE, shallow=False))
-
-

--- a/tests/func/test_cli.py
+++ b/tests/func/test_cli.py
@@ -1,5 +1,8 @@
+import filecmp
 import os
+import shutil
 
+from dvc.main import main
 from dvc.cli import parse_args
 from dvc.command.add import CmdAdd
 from dvc.command.base import CmdBase
@@ -14,7 +17,6 @@ from dvc.command.run import CmdRun
 from dvc.command.status import CmdDataStatus
 from dvc.exceptions import DvcException, DvcParserError
 from tests.basic_env import TestDvc
-
 
 class TestArgParse(TestDvc):
     def test(self):
@@ -169,6 +171,7 @@ class TestFindRoot(TestDvc):
         class A:
             quiet = False
             verbose = True
+            cwd = os.path.curdir
 
         args = A()
         with self.assertRaises(DvcException):
@@ -206,3 +209,23 @@ def test_unknown_subcommand_help(capsys):
     captured = capsys.readouterr()
     help_output = captured.out
     assert output == help_output
+
+
+class test_chdir(TestDvc):
+    def test_chdir(self):
+        dname = "dir"
+        os.mkdir(dname)
+        foo = os.path.join(dname, self.FOO)
+        bar = os.path.join(dname, self.BAR)
+        code = os.path.join(dname, self.CODE)
+        shutil.copyfile(self.FOO, foo)
+        shutil.copyfile(self.CODE, code)
+        shutil.copyfile(self.BAR, bar)
+        self.assertTrue(os.path.isfile(foo))
+        self.assertTrue(os.path.isfile(bar))
+        self.assertTrue(os.path.isfile(code))
+        self.assertTrue(filecmp.cmp(foo, self.FOO, shallow=False))
+        self.assertTrue(filecmp.cmp(bar, self.BAR, shallow=False))
+        self.assertTrue(filecmp.cmp(code, self.CODE, shallow=False))
+
+

--- a/tests/func/test_repro.py
+++ b/tests/func/test_repro.py
@@ -803,46 +803,6 @@ class TestCmdRepro(TestReproChangedData):
         ret = main(["repro", "non-existing-file"])
         self.assertNotEqual(ret, 0)
 
-
-class TestCmdReproChdir(TestDvc):
-    def test(self):
-        dname = "dir"
-        os.mkdir(dname)
-        foo = os.path.join(dname, self.FOO)
-        bar = os.path.join(dname, self.BAR)
-        code = os.path.join(dname, self.CODE)
-        shutil.copyfile(self.FOO, foo)
-        shutil.copyfile(self.CODE, code)
-
-        ret = main(
-            [
-                "run",
-                "--single-stage",
-                "--file",
-                f"{dname}/Dvcfile",
-                "-w",
-                f"{dname}",
-                "-d",
-                self.FOO,
-                "-o",
-                self.BAR,
-                f"python {self.CODE} {self.FOO} {self.BAR}",
-            ]
-        )
-        self.assertEqual(ret, 0)
-        self.assertTrue(os.path.isfile(foo))
-        self.assertTrue(os.path.isfile(bar))
-        self.assertTrue(filecmp.cmp(foo, bar, shallow=False))
-
-        os.unlink(bar)
-
-        ret = main(["repro", "-c", dname, DVC_FILE])
-        self.assertEqual(ret, 0)
-        self.assertTrue(os.path.isfile(foo))
-        self.assertTrue(os.path.isfile(bar))
-        self.assertTrue(filecmp.cmp(foo, bar, shallow=False))
-
-
 class TestReproExternalBase(SingleStageRun, TestDvc):
     cache_type = None
 

--- a/tests/func/test_repro.py
+++ b/tests/func/test_repro.py
@@ -803,6 +803,7 @@ class TestCmdRepro(TestReproChangedData):
         ret = main(["repro", "non-existing-file"])
         self.assertNotEqual(ret, 0)
 
+
 class TestReproExternalBase(SingleStageRun, TestDvc):
     cache_type = None
 


### PR DESCRIPTION
Added -C and --cwd as global flags to change working directory.
Added Unit Test and modified `repro` unit code and unit tests accordingly.

Closes #4025

* [X] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

* [X] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

---
If you like the approach, I'll submit another PR documenting the flag.
