### PR TITLE
RepoTree: preserve relative paths in copytree()

### DIFF
--- a/dvc/repo/tree.py
+++ b/dvc/repo/tree.py
@@ -428,11 +428,12 @@ class RepoTree(BaseTree):
 
         for root, _, files in self.walk(top):
             root = PathInfo(root)
-            makedirs(dest, exist_ok=True)
+            dest_dir = dest / root.relative_to(top)
+            makedirs(dest_dir, exist_ok=True)
             for fname in files:
                 src = root / fname
                 with self.open(src, mode="rb") as fobj:
-                    copy_fobj_to_file(fobj, dest / fname)
+                    copy_fobj_to_file(fobj, dest_dir / fname)
 
     @property
     def hash_jobs(self):

--- a/tests/func/test_get.py
+++ b/tests/func/test_get.py
@@ -55,7 +55,9 @@ def test_get_git_dir(tmp_dir, erepo):
     src = "some_directory"
     dst = "some_directory_imported"
 
-    erepo.scm_gen({src: {"file.txt": "hello"}}, commit="add a regular dir")
+    erepo.scm_gen(
+        {src: {"dir": {"file.txt": "hello"}}}, commit="add a regular dir"
+    )
 
     Repo.get(os.fspath(erepo), src, dst)
 


### PR DESCRIPTION
Partial fix for #4131 (resolves the `dvc get` bug only).

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
