### PR TITLE
hooks: pylint: fix pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,13 +23,14 @@ repos:
           - flake8-string-format
     repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.9
-  - repo: local
-    hooks:
-    - id: pylint
-      name: pylint
-      entry: pylint
-      language: system
-      types: [python]
+  - hooks:
+      - id: pylint
+        language_version: python3
+        additional_dependencies:
+          - pylint-pytest
+          - pylint-plugin-utils
+    repo: https://github.com/PyCQA/pylint
+    rev: pylint-2.5.3
   - hooks:
       - args:
           - -i


### PR DESCRIPTION
- [x] correctly define `pylint` pre-commit hook

`.pre-commit-config.yaml` states that the `pylint` hook is defined locally, yet `.pre-commit-hooks.yaml` fails to define it. As a result, attempting to commit will result in an error.

Defining the hook's language as `system` and asking devs to manually run `pip install .[tests]` goes against fundamental principles of pre-commit hooks. None of the other hooks require this.

In any case `pylint` itself defines https://github.com/PyCQA/pylint/blob/master/.pre-commit-hooks.yaml so we should just use theirs.

- fixes #4145