### PR TITLE
tests: create `remote` fixture

### DIFF
--- a/tests/func/test_api.py
+++ b/tests/func/test_api.py
@@ -19,14 +19,12 @@ cloud_names = [
     "http",
 ]
 clouds = [pytest.lazy_fixture(cloud) for cloud in cloud_names]
-all_clouds = [pytest.lazy_fixture("local")] + clouds
-remotes = [pytest.lazy_fixture(f"{cloud}_remote") for cloud in cloud_names]
-all_remotes = [pytest.lazy_fixture("local_remote")] + remotes
+all_clouds = [pytest.lazy_fixture("local_cloud")] + clouds
 
 # `lazy_fixture` is confusing pylint, pylint: disable=unused-argument
 
 
-@pytest.mark.parametrize("remote", remotes)
+@pytest.mark.parametrize("remote", clouds, indirect=True)
 def test_get_url(tmp_dir, dvc, remote):
     tmp_dir.dvc_gen("foo", "foo")
 
@@ -56,7 +54,7 @@ def test_get_url_requires_dvc(tmp_dir, scm):
         api.get_url("foo", repo=f"file://{tmp_dir}")
 
 
-@pytest.mark.parametrize("remote", all_remotes)
+@pytest.mark.parametrize("remote", all_clouds, indirect=True)
 def test_open(tmp_dir, dvc, remote):
     tmp_dir.dvc_gen("foo", "foo-text")
     dvc.push()
@@ -107,7 +105,7 @@ def test_open_external(erepo_dir, cloud):
     assert api.read("version", repo=repo_url, rev="branch") == "branchver"
 
 
-@pytest.mark.parametrize("remote", all_remotes)
+@pytest.mark.parametrize("remote", all_clouds, indirect=True)
 def test_open_granular(tmp_dir, dvc, remote):
     tmp_dir.dvc_gen({"dir": {"foo": "foo-text"}})
     dvc.push()
@@ -122,7 +120,7 @@ def test_open_granular(tmp_dir, dvc, remote):
 @pytest.mark.parametrize(
     "remote",
     [
-        pytest.lazy_fixture(f"{cloud}_remote")
+        pytest.lazy_fixture(cloud)
         for cloud in [
             "real_s3",  # NOTE: moto's s3 fails in some tests
             "gs",
@@ -134,6 +132,7 @@ def test_open_granular(tmp_dir, dvc, remote):
             "http",
         ]
     ],
+    indirect=True,
 )
 def test_missing(tmp_dir, dvc, remote):
     tmp_dir.dvc_gen("foo", "foo")

--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -14,10 +14,10 @@ from dvc.stage.exceptions import StageNotFound
 from dvc.utils.fs import remove
 from dvc.utils.yaml import dump_yaml, load_yaml
 
-from .test_api import all_remotes
+from .test_api import all_clouds
 
 
-@pytest.mark.parametrize("remote", all_remotes)
+@pytest.mark.parametrize("remote", all_clouds, indirect=True)
 def test_cloud(tmp_dir, dvc, remote):  # pylint:disable=unused-argument
     (stage,) = tmp_dir.dvc_gen("foo", "foo")
     out = stage.outs[0]
@@ -95,7 +95,7 @@ def test_cloud(tmp_dir, dvc, remote):  # pylint:disable=unused-argument
         assert status_dir == expected
 
 
-@pytest.mark.parametrize("remote", all_remotes)
+@pytest.mark.parametrize("remote", all_clouds, indirect=True)
 def test_cloud_cli(tmp_dir, dvc, remote):
     args = ["-v", "-j", "2"]
 

--- a/tests/remotes/__init__.py
+++ b/tests/remotes/__init__.py
@@ -1,18 +1,11 @@
 import pytest
 
-from .azure import Azure, azure, azure_remote  # noqa: F401
-from .hdfs import HDFS, hdfs, hdfs_remote  # noqa: F401
-from .http import HTTP, http, http_remote, http_server  # noqa: F401
+from .azure import Azure, azure  # noqa: F401
+from .hdfs import HDFS, hdfs  # noqa: F401
+from .http import HTTP, http, http_server  # noqa: F401
 from .local import Local, local_cloud, local_remote  # noqa: F401
-from .oss import OSS, TEST_OSS_REPO_BUCKET, oss, oss_remote  # noqa: F401
-from .s3 import (  # noqa: F401
-    S3,
-    TEST_AWS_REPO_BUCKET,
-    real_s3,
-    real_s3_remote,
-    s3,
-    s3_remote,
-)
+from .oss import OSS, TEST_OSS_REPO_BUCKET, oss  # noqa: F401
+from .s3 import S3, TEST_AWS_REPO_BUCKET, real_s3, s3  # noqa: F401
 
 TEST_REMOTE = "upstream"
 TEST_CONFIG = {
@@ -26,23 +19,28 @@ from .gdrive import (  # noqa: F401; noqa: F401
     TEST_GDRIVE_REPO_BUCKET,
     GDrive,
     gdrive,
-    gdrive_remote,
 )
 from .gs import (  # noqa: F401; noqa: F401
     GCP,
     TEST_GCP_CREDS_FILE,
     TEST_GCP_REPO_BUCKET,
     gs,
-    gs_remote,
 )
 from .ssh import (  # noqa: F401; noqa: F401
     SSH,
     SSHMocked,
     ssh,
     ssh_connection,
-    ssh_remote,
     ssh_server,
 )
+
+
+@pytest.fixture
+def remote(tmp_dir, dvc, request):
+    cloud = request.param
+    assert cloud
+    tmp_dir.add_remote(config=cloud.config)
+    yield cloud
 
 
 @pytest.fixture

--- a/tests/remotes/azure.py
+++ b/tests/remotes/azure.py
@@ -34,9 +34,3 @@ def azure():
     if not Azure.should_test():
         pytest.skip("no azure running")
     yield Azure(Azure.get_url())
-
-
-@pytest.fixture
-def azure_remote(tmp_dir, dvc, azure):
-    tmp_dir.add_remote(config=azure.config)
-    yield azure

--- a/tests/remotes/gdrive.py
+++ b/tests/remotes/gdrive.py
@@ -49,9 +49,3 @@ def gdrive(make_tmp_dir):
     tree = GDriveRemoteTree(tmp_dir.dvc, ret.config)
     tree._gdrive_create_dir("root", tree.path_info.path)
     return ret
-
-
-@pytest.fixture
-def gdrive_remote(tmp_dir, dvc, gdrive):
-    tmp_dir.add_remote(config=gdrive.config)
-    return gdrive

--- a/tests/remotes/gs.py
+++ b/tests/remotes/gs.py
@@ -120,9 +120,3 @@ def gs():
     if not GCP.should_test():
         pytest.skip("no gs")
     yield GCP(GCP.get_url())
-
-
-@pytest.fixture
-def gs_remote(tmp_dir, dvc, gs):
-    tmp_dir.add_remote(config=gs.config)
-    yield gs

--- a/tests/remotes/hdfs.py
+++ b/tests/remotes/hdfs.py
@@ -108,9 +108,3 @@ def hdfs():
     if not HDFS.should_test():
         pytest.skip("no hadoop running")
     yield HDFS(HDFS.get_url())
-
-
-@pytest.fixture
-def hdfs_remote(tmp_dir, dvc, hdfs):
-    tmp_dir.add_remote(config=hdfs.config)
-    yield hdfs

--- a/tests/remotes/http.py
+++ b/tests/remotes/http.py
@@ -46,9 +46,3 @@ def http_server(tmp_path_factory):
 @pytest.fixture
 def http(http_server):
     yield HTTP(HTTP.get_url(http_server.server_port))
-
-
-@pytest.fixture
-def http_remote(tmp_dir, dvc, http):
-    tmp_dir.add_remote(config=http.config)
-    yield http

--- a/tests/remotes/oss.py
+++ b/tests/remotes/oss.py
@@ -39,9 +39,3 @@ def oss():
     if not OSS.should_test():
         pytest.skip("no oss running")
     yield OSS(OSS.get_url())
-
-
-@pytest.fixture
-def oss_remote(tmp_dir, dvc, oss):
-    tmp_dir.add_remote(config=oss.config)
-    yield oss

--- a/tests/remotes/s3.py
+++ b/tests/remotes/s3.py
@@ -103,19 +103,7 @@ def s3():
 
 
 @pytest.fixture
-def s3_remote(tmp_dir, dvc, s3):
-    tmp_dir.add_remote(config=s3.config)
-    yield s3
-
-
-@pytest.fixture
 def real_s3():
     if not S3.should_test():
         pytest.skip("no real s3")
     yield S3(S3.get_url())
-
-
-@pytest.fixture
-def real_s3_remote(tmp_dir, dvc, real_s3):
-    tmp_dir.add_remote(config=real_s3.config)
-    yield real_s3

--- a/tests/remotes/ssh.py
+++ b/tests/remotes/ssh.py
@@ -163,9 +163,3 @@ def ssh(ssh_server, monkeypatch):
     monkeypatch.setattr(SSHRemoteTree, "CAN_TRAVERSE", False)
 
     return SSHMocked(SSHMocked.get_url(TEST_SSH_USER, ssh_server.port))
-
-
-@pytest.fixture
-def ssh_remote(tmp_dir, dvc, ssh):
-    tmp_dir.add_remote(config=ssh.config)
-    yield ssh


### PR DESCRIPTION
Usually we need it to parametrize tests with, so there is no
reason to duplicate the code. I've left `local_remote` fixture
just because it is so convenient and often used in a lot of tests.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
