### PR TITLE
snap: deprecate v0

### DIFF
--- a/scripts/ci/before_install.sh
+++ b/scripts/ci/before_install.sh
@@ -73,5 +73,5 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
   fi
 
   # NOTE: after deprecating this branch, uncomment this line
-  # echo "unset SNAP_CHANNEL" >>env.sh
+  echo "unset SNAP_CHANNEL" >>env.sh
 fi


### PR DESCRIPTION
Don't push v0 to default tracks.

This PR does not require a new 0.x tagged release.

This PR is to make sure any future 0.x tagged release (presumably a security fix) doesn't get pushed to >=1.x users.

- fixes #3872 (finally and completely!)
