### PR TITLE
pull: target message

### DIFF
--- a/dvc/command/checkout.py
+++ b/dvc/command/checkout.py
@@ -112,7 +112,9 @@ def add_parser(subparsers, parent_parser):
     checkout_parser.add_argument(
         "targets",
         nargs="*",
-        help="DVC-files to checkout. Optional. "
-        "(Finds all DVC-files in the workspace by default.)",
+        help=(
+            "Limit command scope to these tracked files/directories, "
+            ".dvc files, or stage names."
+        ),
     ).complete = completion.DVC_FILE
     checkout_parser.set_defaults(func=CmdCheckout)

--- a/dvc/command/data_sync.py
+++ b/dvc/command/data_sync.py
@@ -103,7 +103,10 @@ def shared_parent_parser():
     parent_parser.add_argument(
         "targets",
         nargs="*",
-        help="Limit command scope to these files, directories or DVC-files. ",
+        help=(
+            "Limit command scope to these tracked files/directories, "
+            ".dvc files, or stage names."
+        ),
     ).complete = completion.DVC_FILE
 
     return parent_parser

--- a/dvc/command/data_sync.py
+++ b/dvc/command/data_sync.py
@@ -103,8 +103,7 @@ def shared_parent_parser():
     parent_parser.add_argument(
         "targets",
         nargs="*",
-        help="Limit command scope to these DVC-files. "
-        "Using -R, directories to search DVC-files in can also be given.",
+        help="Limit command scope to these files, directories or DVC-files. ",
     ).complete = completion.DVC_FILE
 
     return parent_parser


### PR DESCRIPTION
I heard about this issue from 2 independent users. They didn't know that dvc support pull for a file.

`-R` option is minor and looks a bit confusing. Let's remove it from the target description.

- [x] Update docs if needed
https://github.com/iterative/dvc.org/pull/1384