### PR TITLE
Experiments proof of concept

### DIFF
--- a/.dvc/.gitignore
+++ b/.dvc/.gitignore
@@ -9,3 +9,4 @@
 /pkg
 /repos
 /tmp
+/experiments

--- a/dvc/cli.py
+++ b/dvc/cli.py
@@ -15,6 +15,7 @@ from .command import (
     data_sync,
     destroy,
     diff,
+    experiments,
     freeze,
     gc,
     get,
@@ -77,6 +78,7 @@ COMMANDS = [
     update,
     git_hook,
     plots,
+    experiments,
 ]
 
 

--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -136,6 +136,15 @@ class CmdExperimentsShow(CmdBase):
         return 0
 
 
+class CmdExperimentsCheckout(CmdBase):
+    def run(self):
+        self.repo.experiments.checkout(
+            self.args.experiment, force=self.args.force
+        )
+
+        return 0
+
+
 def add_parser(subparsers, parent_parser):
     EXPERIMENTS_HELP = "Commands to display and compare experiments."
 
@@ -184,3 +193,26 @@ def add_parser(subparsers, parent_parser):
         help="Show metrics for all commits.",
     )
     experiments_show_parser.set_defaults(func=CmdExperimentsShow)
+
+    EXPERIMENTS_CHECKOUT_HELP = "Checkout experiments."
+    experiments_checkout_parser = experiments_subparsers.add_parser(
+        "checkout",
+        parents=[parent_parser],
+        description=append_doc_link(
+            EXPERIMENTS_CHECKOUT_HELP, "experiments/checkout"
+        ),
+        help=EXPERIMENTS_CHECKOUT_HELP,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    experiments_checkout_parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        default=False,
+        help="Overwrite your current workspace with changes from the "
+        "experiment.",
+    )
+    experiments_checkout_parser.add_argument(
+        "experiment", help="Checkout this experiment.",
+    )
+    experiments_checkout_parser.set_defaults(func=CmdExperimentsCheckout)

--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -114,6 +114,9 @@ class CmdExperimentsShow(CmdBase):
         from rich.console import Console
         from dvc.utils.pager import pager
 
+        if not self.repo.experiments:
+            return 0
+
         try:
             all_experiments = self.repo.experiments.show(
                 all_branches=self.args.all_branches,
@@ -139,6 +142,9 @@ class CmdExperimentsShow(CmdBase):
 
 class CmdExperimentsCheckout(CmdBase):
     def run(self):
+        if not self.repo.experiments:
+            return 0
+
         self.repo.experiments.checkout(
             self.args.experiment, force=self.args.force
         )
@@ -185,6 +191,9 @@ def _show_diff(
 
 class CmdExperimentsDiff(CmdBase):
     def run(self):
+        if not self.repo.experiments:
+            return 0
+
         try:
             diff = self.repo.experiments.diff(
                 a_rev=self.args.a_rev,

--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -225,7 +225,6 @@ def add_parser(subparsers, parent_parser):
         "experiments",
         parents=[parent_parser],
         description=append_doc_link(EXPERIMENTS_HELP, "experiments"),
-        help=EXPERIMENTS_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 

--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -1,0 +1,179 @@
+import argparse
+import io
+import logging
+
+from dvc.command.base import CmdBase, append_doc_link, fix_subparsers
+from dvc.exceptions import DvcException
+
+logger = logging.getLogger(__name__)
+
+
+def _update_names(names, items):
+    from flatten_json import flatten
+
+    for name, item in items:
+        if isinstance(item, dict):
+            item = flatten(item, ".")
+            names.update(item.keys())
+        else:
+            names.add(name)
+
+
+def _collect_names(experiments):
+    metric_names = set()
+    param_names = set()
+
+    for exp in experiments.values():
+        _update_names(metric_names, exp.get("metrics", {}).items())
+        _update_names(param_names, exp.get("params", {}).items())
+
+    return sorted(metric_names), sorted(param_names)
+
+
+def _collect_rows(
+    experiments, metric_names, param_names, include_rev=False, precision=None
+):
+    from flatten_json import flatten
+    from dvc.command.metrics import DEFAULT_PRECISION
+
+    if precision is None:
+        precision = DEFAULT_PRECISION
+
+    def _round(val):
+        if isinstance(val, float):
+            return round(val, precision)
+
+        return val
+
+    def _extend(row, names, items):
+        for fname, item in items:
+            if isinstance(item, dict):
+                item = flatten(item, ".")
+            else:
+                item = {fname: item}
+            for name in names:
+                if name in item:
+                    row.append(str(_round(item[name])))
+                else:
+                    row.append("-")
+
+    for rev, exp in experiments.items():
+        row = []
+        if include_rev:
+            row.append(rev)
+        else:
+            row.append(None)
+
+        _extend(row, metric_names, exp.get("metrics", {}).items())
+        _extend(row, param_names, exp.get("params", {}).items())
+
+        yield row
+
+
+def _show_experiments(
+    experiments,
+    all_branches=False,
+    all_tags=False,
+    all_commits=False,
+    precision=None,
+):
+    from rich.console import Console
+    from rich.table import Table
+    from dvc.utils.pager import pager
+
+    metric_names, param_names = _collect_names(experiments)
+    include_rev = all_branches or all_tags or all_commits
+
+    table = Table(show_lines=True)
+    table.add_column("Commit")
+    for name in metric_names:
+        table.add_column(name, justify="right")
+    for name in param_names:
+        table.add_column(name, justify="left")
+
+    for row in _collect_rows(
+        experiments,
+        metric_names,
+        param_names,
+        include_rev=include_rev,
+        precision=precision,
+    ):
+        table.add_row(*row)
+
+    # Note: rich does not currently include a native way to force infinite
+    # width for use with a pager
+    console = Console(file=io.StringIO(), force_terminal=True, width=9999)
+    console.print(table)
+    pager(console.file.getvalue())
+
+
+class CmdExperimentsShow(CmdBase):
+    def run(self):
+        try:
+            experiments = self.repo.experiments.show(
+                all_branches=self.args.all_branches,
+                all_tags=self.args.all_tags,
+                all_commits=self.args.all_commits,
+            )
+
+            _show_experiments(
+                experiments,
+                self.args.all_branches,
+                self.args.all_tags,
+                self.args.all_commits,
+            )
+        except DvcException:
+            logger.exception("failed to show experiments")
+            return 1
+
+        return 0
+
+
+def add_parser(subparsers, parent_parser):
+    EXPERIMENTS_HELP = "Commands to display and compare experiments."
+
+    experiments_parser = subparsers.add_parser(
+        "experiments",
+        parents=[parent_parser],
+        description=append_doc_link(EXPERIMENTS_HELP, "experiments"),
+        help=EXPERIMENTS_HELP,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    experiments_subparsers = experiments_parser.add_subparsers(
+        dest="cmd",
+        help="Use `dvc experiments CMD --help` to display "
+        "command-specific help.",
+    )
+
+    fix_subparsers(experiments_subparsers)
+
+    EXPERIMENTS_SHOW_HELP = "Print experiments."
+    experiments_show_parser = experiments_subparsers.add_parser(
+        "show",
+        parents=[parent_parser],
+        description=append_doc_link(EXPERIMENTS_SHOW_HELP, "experiments/show"),
+        help=EXPERIMENTS_SHOW_HELP,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    experiments_show_parser.add_argument(
+        "-a",
+        "--all-branches",
+        action="store_true",
+        default=False,
+        help="Show metrics for all branches.",
+    )
+    experiments_show_parser.add_argument(
+        "-T",
+        "--all-tags",
+        action="store_true",
+        default=False,
+        help="Show metrics for all tags.",
+    )
+    experiments_show_parser.add_argument(
+        "--all-commits",
+        action="store_true",
+        default=False,
+        help="Show metrics for all commits.",
+    )
+    experiments_show_parser.set_defaults(func=CmdExperimentsShow)

--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -40,6 +40,7 @@ class CmdRepro(CmdBase):
                     downstream=self.args.downstream,
                     recursive=self.args.recursive,
                     force_downstream=self.args.force_downstream,
+                    experiment=self.args.experiment,
                 )
 
                 if len(stages) == 0:
@@ -165,5 +166,12 @@ def add_parser(subparsers, parent_parser):
         action="store_true",
         default=False,
         help="Start from the specified stages when reproducing pipelines.",
+    )
+    repro_parser.add_argument(
+        "-e",
+        "--experiment",
+        action="store_true",
+        default=False,
+        help="Save reproduction results as an experiment.",
     )
     repro_parser.set_defaults(func=CmdRepro)

--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -172,6 +172,6 @@ def add_parser(subparsers, parent_parser):
         "--experiment",
         action="store_true",
         default=False,
-        help="Save reproduction results as an experiment.",
+        help=argparse.SUPPRESS,
     )
     repro_parser.set_defaults(func=CmdRepro)

--- a/dvc/config.py
+++ b/dvc/config.py
@@ -127,6 +127,7 @@ SCHEMA = {
         Optional("analytics", default=True): Bool,
         Optional("hardlink_lock", default=False): Bool,
         Optional("no_scm", default=False): Bool,
+        Optional("experiments", default=False): Bool,
     },
     "cache": {
         "local": str,

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -193,7 +193,11 @@ class Repo:
         return self.cache.local.tree.unprotect(PathInfo(target))
 
     def _ignore(self):
-        flist = [self.config.files["local"], self.tmp_dir]
+        flist = [
+            self.config.files["local"],
+            self.tmp_dir,
+            self.experiments.exp_dir,
+        ]
 
         if path_isin(self.cache.local.cache_dir, self.root_dir):
             flist += [self.cache.local.cache_dir]

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -127,7 +127,10 @@ class Repo:
         self.plots = Plots(self)
         self.params = Params(self)
 
-        self.experiments = Experiments(self)
+        try:
+            self.experiments = Experiments(self)
+        except NotImplementedError:
+            self.experiments = None
 
         self._ignore()
 
@@ -196,8 +199,9 @@ class Repo:
         flist = [
             self.config.files["local"],
             self.tmp_dir,
-            self.experiments.exp_dir,
         ]
+        if self.experiments:
+            flist.append(self.experiments.exp_dir)
 
         if path_isin(self.cache.local.cache_dir, self.root_dir):
             flist += [self.cache.local.cache_dir]

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -74,6 +74,7 @@ class Repo:
         from dvc.scm import SCM
         from dvc.cache import Cache
         from dvc.data_cloud import DataCloud
+        from dvc.repo.experiments import Experiments
         from dvc.repo.metrics import Metrics
         from dvc.repo.plots import Plots
         from dvc.repo.params import Params
@@ -125,6 +126,8 @@ class Repo:
         self.metrics = Metrics(self)
         self.plots = Plots(self)
         self.params = Params(self)
+
+        self.experiments = Experiments(self)
 
         self._ignore()
 

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -1,11 +1,111 @@
+import logging
+import os
+import tempfile
+from contextlib import contextmanager
+
+from funcy import cached_property
+
+from dvc.exceptions import DvcException
+from dvc.scm.git import Git
+from dvc.utils import relpath
+from dvc.utils.fs import remove
+
+logger = logging.getLogger(__name__)
+
+
+class UnchangedExperimentError(DvcException):
+    pass
+
+
 class Experiments:
+    """Class that manages experiments in a DVC repo.
+
+    Args:
+        repo (dvc.repo.Repo): repo instance that these experiments belong to.
+    """
+
+    EXPERIMENTS_DIR = "experiments"
+
     def __init__(self, repo):
         self.repo = repo
+
+    @cached_property
+    def exp_dir(self):
+        return os.path.join(self.repo.dvc_dir, self.EXPERIMENTS_DIR)
+
+    @cached_property
+    def scm(self):
+        """Experiments clone scm instance."""
+        if os.path.exists(self.exp_dir):
+            return Git(self.exp_dir)
+        return self._init_clone()
+
+    @cached_property
+    def exp_dvc_dir(self):
+        dvc_dir = relpath(self.repo.dvc_dir, self.repo.scm.root_dir)
+        return os.path.join(self.exp_dir, dvc_dir)
+
+    @cached_property
+    def exp_dvc(self):
+        """Return clone dvc Repo instance."""
+        from dvc.repo import Repo
+
+        return Repo(self.exp_dvc_dir)
+
+    @contextmanager
+    def _chdir(self):
+        cwd = os.getcwd()
+        os.chdir(self.exp_dvc.root_dir)
+        yield
+        os.chdir(cwd)
+
+    def _init_clone(self):
+        src_dir = self.repo.scm.root_dir
+        logger.debug("Initializing experiments clone")
+        git = Git.clone(src_dir, self.exp_dir)
+        self._config_clone()
+        return git
+
+    def _config_clone(self):
+        dvc_dir = relpath(self.repo.dvc_dir, self.repo.scm.root_dir)
+        local_config = os.path.join(self.exp_dir, dvc_dir, "config.local")
+        cache_dir = self.repo.cache.local.cache_dir
+        logger.debug("Writing experiments local config '%s'", local_config)
+        with open(local_config, "w") as fobj:
+            fobj.write(f"[cache]\n    dir = {cache_dir}")
+
+    def _scm_checkout(self, rev):
+        self.scm.repo.git.reset(hard=True)
+        if not Git.is_sha(rev) or not self.scm.has_rev(rev):
+            self.scm.pull()
+        logger.debug("Checking out base experiment commit '%s'", rev)
+        self.scm.checkout(rev)
+
+    def _patch_exp(self):
+        """Create a patch based on the current (parent) workspace and apply it
+        to the experiment workspace.
+        """
+        logger.debug("Patching experiment workspace")
+        tmp = tempfile.NamedTemporaryFile(delete=False).name
+        self.repo.scm.repo.git.diff(patch=True, output=tmp)
+        self.scm.repo.git.apply(tmp)
+        remove(tmp)
+
+    def reproduce(self, *args, **kwargs):
+        rev = self.repo.scm.get_rev()
+        self._scm_checkout(rev)
+        self._patch_exp()
+        with self._chdir():
+            self.exp_dvc.checkout()
+            return self.exp_dvc.reproduce(*args, **kwargs)
+
+    def diff(self, *args, **kwargs):
+        pass
+
+    def list(self, *args, **kwargs):
+        pass
 
     def show(self, *args, **kwargs):
         from dvc.repo.experiments.show import show
 
         return show(self.repo, *args, **kwargs)
-
-    def list(self, *args, **kwargs):
-        pass

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -134,7 +134,11 @@ class Experiments:
         rev = self.repo.scm.get_rev()
         self._scm_checkout(rev)
         if workspace:
-            self._patch_exp()
+            try:
+                self._patch_exp()
+            except UnchangedExperimentError as exc:
+                logger.info("Reproducing existing experiment '%s'.", rev[:7])
+                raise exc
         else:
             # configure params via command line here
             pass
@@ -142,6 +146,7 @@ class Experiments:
         stages = self._reproduce(*args, **kwargs)
         exp_rev = self._commit(stages, rev=rev)
         self.checkout_exp(exp_rev, force=True)
+        logger.info("Generated experiment '%s'.", exp_rev[:7])
         return stages
 
     def checkout_exp(self, rev, force=False):

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -8,7 +8,7 @@ from funcy import cached_property
 from dvc.exceptions import DvcException
 from dvc.scm.git import Git
 from dvc.stage.serialize import to_lockfile
-from dvc.utils import dict_sha256, relpath
+from dvc.utils import dict_sha256, env2bool, relpath
 from dvc.utils.fs import remove
 
 logger = logging.getLogger(__name__)
@@ -28,6 +28,12 @@ class Experiments:
     EXPERIMENTS_DIR = "experiments"
 
     def __init__(self, repo):
+        if not (
+            env2bool("DVC_TEST")
+            or repo.config["core"].get("experiments", False)
+        ):
+            raise NotImplementedError
+
         self.repo = repo
 
     @cached_property

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -90,8 +90,8 @@ class Experiments:
 
     def _scm_checkout(self, rev):
         self.scm.repo.git.reset(hard=True)
-        # if not Git.is_sha(rev) or not self.scm.has_rev(rev):
-        #     self.scm.pull()
+        if not Git.is_sha(rev) or not self.scm.has_rev(rev):
+            self.scm.fetch(all=True)
         logger.debug("Checking out base experiment commit '%s'", rev)
         self.scm.checkout(rev)
 

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -142,9 +142,6 @@ class Experiments:
     def diff(self, *args, **kwargs):
         pass
 
-    def list(self, *args, **kwargs):
-        pass
-
     def show(self, *args, **kwargs):
         from dvc.repo.experiments.show import show
 

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -61,7 +61,7 @@ class Experiments:
         return dict_sha256(exp_data)
 
     @contextmanager
-    def _chdir(self):
+    def chdir(self):
         cwd = os.getcwd()
         os.chdir(self.exp_dvc.root_dir)
         yield
@@ -122,7 +122,7 @@ class Experiments:
 
     def _reproduce(self, *args, **kwargs):
         """Run `dvc repro` inside the experiments workspace."""
-        with self._chdir():
+        with self.chdir():
             return self.exp_dvc.reproduce(*args, **kwargs)
 
     def new(self, *args, workspace=True, **kwargs):
@@ -176,7 +176,9 @@ class Experiments:
         return checkout(self.repo, *args, **kwargs)
 
     def diff(self, *args, **kwargs):
-        pass
+        from dvc.repo.experiments.diff import diff
+
+        return diff(self.repo, *args, **kwargs)
 
     def show(self, *args, **kwargs):
         from dvc.repo.experiments.show import show

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -1,0 +1,11 @@
+class Experiments:
+    def __init__(self, repo):
+        self.repo = repo
+
+    def show(self, *args, **kwargs):
+        from dvc.repo.experiments.show import show
+
+        return show(self.repo, *args, **kwargs)
+
+    def list(self, *args, **kwargs):
+        pass

--- a/dvc/repo/experiments/checkout.py
+++ b/dvc/repo/experiments/checkout.py
@@ -1,0 +1,17 @@
+import logging
+
+from dvc.repo import locked
+from dvc.repo.scm_context import scm_context
+
+logger = logging.getLogger(__name__)
+
+
+@locked
+@scm_context
+def checkout(repo, rev, *args, **kwargs):
+    repo.experiments.checkout_exp(rev, *args, **kwargs)
+    logger.info(
+        "Changes for experiment '%s' have been applied to your current "
+        "workspace.",
+        rev,
+    )

--- a/dvc/repo/experiments/diff.py
+++ b/dvc/repo/experiments/diff.py
@@ -1,0 +1,36 @@
+import logging
+
+from dvc.utils.diff import diff as _diff
+from dvc.utils.diff import format_dict
+
+logger = logging.getLogger(__name__)
+
+
+def diff(repo, *args, a_rev=None, b_rev=None, **kwargs):
+    from dvc.repo.experiments.show import _collect_experiment
+
+    if repo.scm.no_commits:
+        return {}
+
+    if a_rev:
+        with repo.experiments.chdir():
+            old = _collect_experiment(repo.experiments.exp_dvc, a_rev)
+    else:
+        old = _collect_experiment(repo, "HEAD")
+
+    if b_rev:
+        with repo.experiments.chdir():
+            new = _collect_experiment(repo.experiments.exp_dvc, b_rev)
+    else:
+        new = _collect_experiment(repo, "workspace")
+
+    with_unchanged = kwargs.pop("all", False)
+
+    return {
+        key: _diff(
+            format_dict(old[key]),
+            format_dict(new[key]),
+            with_unchanged=with_unchanged,
+        )
+        for key in ["metrics", "params"]
+    }

--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -1,0 +1,45 @@
+import logging
+from collections import defaultdict
+
+from dvc.exceptions import DvcException
+from dvc.repo import locked
+
+logger = logging.getLogger(__name__)
+
+
+@locked
+def show(
+    repo, all_branches=False, all_tags=False, revs=None, all_commits=False
+):
+    from dvc.repo.metrics.show import _collect_metrics, _read_metrics
+    from dvc.repo.params.show import _collect_configs, _read_params
+
+    res = defaultdict(dict)
+    for rev in repo.brancher(
+        revs=revs,
+        all_branches=all_branches,
+        all_tags=all_tags,
+        all_commits=all_commits,
+    ):
+        configs = _collect_configs(repo)
+        params = _read_params(repo, configs, rev)
+        if params:
+            res[rev]["params"] = params
+
+        metrics = _collect_metrics(repo, None, False)
+        vals = _read_metrics(repo, metrics, rev)
+        if vals:
+            res[rev]["metrics"] = vals
+
+    if not res:
+        raise DvcException("no metrics or params in this repository")
+
+    try:
+        active_branch = repo.scm.active_branch()
+    except TypeError:
+        pass  # Detached head
+    else:
+        if res.get("workspace") == res.get(active_branch):
+            res.pop("workspace", None)
+
+    return res

--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -55,9 +55,10 @@ def show(
             rev = repo.scm.resolve_rev(m.group("rev_sha"))
             if rev in revs:
                 exp_rev = repo.experiments.scm.resolve_rev(exp_branch)
-                experiment = _collect_experiment(
-                    repo.experiments.exp_dvc, exp_branch
-                )
+                with repo.experiments.chdir():
+                    experiment = _collect_experiment(
+                        repo.experiments.exp_dvc, exp_branch
+                    )
                 res[rev][exp_rev] = experiment
 
     return res

--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -54,9 +54,10 @@ def show(
         if m:
             rev = repo.scm.resolve_rev(m.group("rev_sha"))
             if rev in revs:
+                exp_rev = repo.experiments.scm.resolve_rev(exp_branch)
                 experiment = _collect_experiment(
                     repo.experiments.exp_dvc, exp_branch
                 )
-                res[rev][m.group("exp_sha")] = experiment
+                res[rev][exp_rev] = experiment
 
     return res

--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -1,45 +1,62 @@
 import logging
-from collections import defaultdict
+import re
+from collections import OrderedDict, defaultdict
 
-from dvc.exceptions import DvcException
 from dvc.repo import locked
+from dvc.repo.metrics.show import _collect_metrics, _read_metrics
+from dvc.repo.params.show import _collect_configs, _read_params
 
 logger = logging.getLogger(__name__)
+
+
+EXP_RE = re.compile(r"(?P<rev_sha>[a-f0-9]{7})-(?P<exp_sha>[a-f0-9]+)")
+
+
+def _collect_experiment(repo, branch):
+    res = defaultdict(dict)
+    for rev in repo.brancher(revs=[branch]):
+        configs = _collect_configs(repo)
+        params = _read_params(repo, configs, rev)
+        if params:
+            res["params"] = params
+
+        metrics = _collect_metrics(repo, None, False)
+        vals = _read_metrics(repo, metrics, rev)
+        if vals:
+            res["metrics"] = vals
+
+    return res
 
 
 @locked
 def show(
     repo, all_branches=False, all_tags=False, revs=None, all_commits=False
 ):
-    from dvc.repo.metrics.show import _collect_metrics, _read_metrics
-    from dvc.repo.params.show import _collect_configs, _read_params
+    res = defaultdict(OrderedDict)
 
-    res = defaultdict(dict)
-    for rev in repo.brancher(
-        revs=revs,
-        all_branches=all_branches,
-        all_tags=all_tags,
-        all_commits=all_commits,
-    ):
-        configs = _collect_configs(repo)
-        params = _read_params(repo, configs, rev)
-        if params:
-            res[rev]["params"] = params
+    if revs is None:
+        revs = [repo.scm.get_rev()]
 
-        metrics = _collect_metrics(repo, None, False)
-        vals = _read_metrics(repo, metrics, rev)
-        if vals:
-            res[rev]["metrics"] = vals
+    revs = set(
+        repo.brancher(
+            revs=revs,
+            all_branches=all_branches,
+            all_tags=all_tags,
+            all_commits=all_commits,
+        )
+    )
 
-    if not res:
-        raise DvcException("no metrics or params in this repository")
+    for rev in revs:
+        res[rev]["baseline"] = _collect_experiment(repo, rev)
 
-    try:
-        active_branch = repo.scm.active_branch()
-    except TypeError:
-        pass  # Detached head
-    else:
-        if res.get("workspace") == res.get(active_branch):
-            res.pop("workspace", None)
+    for exp_branch in repo.experiments.scm.list_branches():
+        m = re.match(EXP_RE, exp_branch)
+        if m:
+            rev = repo.scm.resolve_rev(m.group("rev_sha"))
+            if rev in revs:
+                experiment = _collect_experiment(
+                    repo.experiments.exp_dvc, exp_branch
+                )
+                res[rev][m.group("exp_sha")] = experiment
 
     return res

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -69,6 +69,15 @@ def reproduce(
             "Neither `target` nor `--all-pipelines` are specified."
         )
 
+    experiment = kwargs.pop("experiment", False)
+    if experiment:
+        return self.experiments.reproduce(
+            target=target,
+            recursive=recursive,
+            all_pipelines=all_pipelines,
+            **kwargs
+        )
+
     interactive = kwargs.get("interactive", False)
     if not interactive:
         kwargs["interactive"] = self.config["core"].get("interactive", False)

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -71,7 +71,7 @@ def reproduce(
         )
 
     experiment = kwargs.pop("experiment", False)
-    if experiment:
+    if experiment and self.experiments:
         try:
             return self.experiments.new(
                 target=target,

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -1,6 +1,7 @@
 import logging
 
 from dvc.exceptions import InvalidArgumentError, ReproductionError
+from dvc.repo.experiments import UnchangedExperimentError
 from dvc.repo.scm_context import scm_context
 
 from . import locked
@@ -71,12 +72,16 @@ def reproduce(
 
     experiment = kwargs.pop("experiment", False)
     if experiment:
-        return self.experiments.new(
-            target=target,
-            recursive=recursive,
-            all_pipelines=all_pipelines,
-            **kwargs
-        )
+        try:
+            return self.experiments.new(
+                target=target,
+                recursive=recursive,
+                all_pipelines=all_pipelines,
+                **kwargs
+            )
+        except UnchangedExperimentError as exc:
+            # If experiment contains no changes, just run regular repro
+            logger.debug(exc)
 
     interactive = kwargs.get("interactive", False)
     if not interactive:

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -71,7 +71,7 @@ def reproduce(
 
     experiment = kwargs.pop("experiment", False)
     if experiment:
-        return self.experiments.reproduce(
+        return self.experiments.new(
             target=target,
             recursive=recursive,
             all_pipelines=all_pipelines,

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -79,9 +79,9 @@ def reproduce(
                 all_pipelines=all_pipelines,
                 **kwargs
             )
-        except UnchangedExperimentError as exc:
+        except UnchangedExperimentError:
             # If experiment contains no changes, just run regular repro
-            logger.debug(exc)
+            pass
 
     interactive = kwargs.get("interactive", False)
     if not interactive:

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ install_requires = [
     "pygtrie==2.3.2",
     "dpath>=2.0.1,<3",
     "shtab>=1.1.0,<2",
+    "rich>=3.0.5",
 ]
 
 

--- a/tests/func/experiments/test_experiments.py
+++ b/tests/func/experiments/test_experiments.py
@@ -1,0 +1,24 @@
+from tests.func.test_repro_multistage import COPY_SCRIPT
+
+
+def test_new_simple(tmp_dir, scm, dvc, mocker):
+    tmp_dir.gen("copy.py", COPY_SCRIPT)
+    tmp_dir.gen("params.yaml", "foo: 1")
+    stage = dvc.run(
+        cmd="python copy.py params.yaml metrics.yaml",
+        metrics_no_cache=["metrics.yaml"],
+        params=["foo"],
+        name="copy-file",
+    )
+    scm.add(["dvc.yaml", "dvc.lock", "copy.py", "params.yaml", "metrics.yaml"])
+    scm.commit("init")
+
+    tmp_dir.gen("params.yaml", "foo: 2")
+
+    new_mock = mocker.spy(dvc.experiments, "new")
+    dvc.reproduce(stage.addressing, experiment=True)
+
+    new_mock.assert_called_once()
+    assert (
+        tmp_dir / ".dvc" / "experiments" / "metrics.yaml"
+    ).read_text() == "foo: 2"

--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -1,0 +1,19 @@
+from tests.func.test_repro_multistage import COPY_SCRIPT
+
+
+def test_show_simple(tmp_dir, scm, dvc):
+    tmp_dir.gen("copy.py", COPY_SCRIPT)
+    tmp_dir.gen("params.yaml", "foo: 1")
+    dvc.run(
+        cmd="python copy.py params.yaml metrics.yaml",
+        metrics_no_cache=["metrics.yaml"],
+        params=["foo"],
+        single_stage=True,
+    )
+
+    assert dvc.experiments.show()["workspace"] == {
+        "baseline": {
+            "metrics": {"metrics.yaml": {"foo": 1}},
+            "params": {"params.yaml": {"foo": 1}},
+        }
+    }

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -1,0 +1,51 @@
+from dvc.cli import parse_args
+from dvc.command.experiments import CmdExperimentsDiff, CmdExperimentsShow
+
+
+def test_experiments_diff(dvc, mocker):
+    cli_args = parse_args(
+        [
+            "experiments",
+            "diff",
+            "HEAD~10",
+            "HEAD~1",
+            "--all",
+            "--show-json",
+            "--show-md",
+            "--old",
+            "--precision",
+            "10",
+        ]
+    )
+    assert cli_args.func == CmdExperimentsDiff
+
+    cmd = cli_args.func(cli_args)
+    m = mocker.patch("dvc.repo.experiments.diff.diff", return_value={})
+
+    assert cmd.run() == 0
+
+    m.assert_called_once_with(
+        cmd.repo, a_rev="HEAD~10", b_rev="HEAD~1", all=True
+    )
+
+
+def test_experiments_show(dvc, mocker):
+    cli_args = parse_args(
+        [
+            "experiments",
+            "show",
+            "--all-tags",
+            "--all-branches",
+            "--all-commits",
+        ]
+    )
+    assert cli_args.func == CmdExperimentsShow
+
+    cmd = cli_args.func(cli_args)
+    m = mocker.patch("dvc.repo.experiments.show.show", return_value={})
+
+    assert cmd.run() == 0
+
+    m.assert_called_once_with(
+        cmd.repo, all_tags=True, all_branches=True, all_commits=True
+    )

--- a/tests/unit/command/test_repro.py
+++ b/tests/unit/command/test_repro.py
@@ -14,6 +14,7 @@ default_arguments = {
     "single_item": False,
     "recursive": False,
     "force_downstream": False,
+    "experiment": False,
 }
 
 


### PR DESCRIPTION
Related to #2799.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Implements initial POC support using a single git clone. UI is rough expected to change a lot.

* `dvc repro -e/--experiment` - creates a new experiment. Experiment is derived from the current HEAD commit in the user's repo and contains any changes in the user's current workspace.
* `dvc experiments show` - show experiment table. By default table includes the user's workspace, the current HEAD commit and any experiments derived from HEAD. `--all-commits/--all-tags/--all-branches` can be used to display more experiments.
* `dvc experiments diff` - diff 2 experiments. Currently just concats the output from `dvc metrics diff` and `dvc plots diff`.
* `dvc experiments checkout <experiment_rev>` - applies the changes from the specified experiment to the user's current workspace. If the changes would generate a git merge conflict, this command does nothing. `--force` can be used to replace the user's current workspace with the experiment changes. This has only been tested in cases where user checks out an experiment into a workspace with the original commit the experiment was derived from.
  **Note: using `--force` currently does a `git reset --hard` in your workspace**, the behavior you most likely want is to `git stash` your workspace changes before using `dvc experiments checkout`
* Experiments support is disabled by default.
    * Experiment related commands and args are hidden from the normal `dvc --help` output, but running `dvc experiments --help` can be used to show the usage for the experiments commands.
    * Experiments commands do nothing unless the `core.experiments` config option is set to true (or if DVC is run inside a testing/CI environment).

General thoughts/questions for next iteration:
* What is the desired behavior for `experiments diff` - mimic `metrics/params diff` formats or use the `show` table with added deltas?
* How to show data/code changes between experiments?
* `experiments checkout` feels a bit awkward to use, maybe it should be a `repro --experiment <rev>` command to reproduce a specific experiment instead?
* What kind of workflow to use for "promoting" an experiment commit to a "real" commit or branch in the main repo?