### PR TITLE
deps/outs: get rid of remotes in favor of trees

### DIFF
--- a/dvc/dependency/__init__.py
+++ b/dvc/dependency/__init__.py
@@ -12,7 +12,7 @@ from dvc.dependency.param import ParamsDependency
 from dvc.dependency.s3 import S3Dependency
 from dvc.dependency.ssh import SSHDependency
 from dvc.output.base import BaseOutput
-from dvc.remote import get_remote
+from dvc.remote import get_cloud_tree
 from dvc.scheme import Schemes
 
 from .repo import RepoDependency
@@ -54,8 +54,8 @@ SCHEMA.update(ParamsDependency.PARAM_SCHEMA)
 def _get(stage, p, info):
     parsed = urlparse(p) if p else None
     if parsed and parsed.scheme == "remote":
-        remote = get_remote(stage.repo, name=parsed.netloc)
-        return DEP_MAP[remote.scheme](stage, p, info, remote=remote)
+        tree = get_cloud_tree(stage.repo, name=parsed.netloc)
+        return DEP_MAP[tree.scheme](stage, p, info, tree=tree)
 
     if info and info.get(RepoDependency.PARAM_REPO):
         repo = info.pop(RepoDependency.PARAM_REPO)

--- a/dvc/dependency/repo.py
+++ b/dvc/dependency/repo.py
@@ -26,7 +26,7 @@ class RepoDependency(LocalDependency):
         self.def_repo = def_repo
         super().__init__(stage, *args, **kwargs)
 
-    def _parse_path(self, remote, path):
+    def _parse_path(self, tree, path):
         return None
 
     @property

--- a/dvc/output/__init__.py
+++ b/dvc/output/__init__.py
@@ -10,7 +10,7 @@ from dvc.output.hdfs import HDFSOutput
 from dvc.output.local import LocalOutput
 from dvc.output.s3 import S3Output
 from dvc.output.ssh import SSHOutput
-from dvc.remote import get_remote
+from dvc.remote import get_cloud_tree
 from dvc.remote.hdfs import HDFSRemoteTree
 from dvc.remote.local import LocalRemoteTree
 from dvc.remote.s3 import S3RemoteTree
@@ -66,13 +66,13 @@ def _get(
     parsed = urlparse(p)
 
     if parsed.scheme == "remote":
-        remote = get_remote(stage.repo, name=parsed.netloc)
-        return OUTS_MAP[remote.scheme](
+        tree = get_cloud_tree(stage.repo, name=parsed.netloc)
+        return OUTS_MAP[tree.scheme](
             stage,
             p,
             info,
             cache=cache,
-            remote=remote,
+            tree=tree,
             metric=metric,
             plot=plot,
             persist=persist,
@@ -85,7 +85,7 @@ def _get(
                 p,
                 info,
                 cache=cache,
-                remote=None,
+                tree=None,
                 metric=metric,
                 plot=plot,
                 persist=persist,
@@ -95,7 +95,7 @@ def _get(
         p,
         info,
         cache=cache,
-        remote=None,
+        tree=None,
         metric=metric,
         plot=plot,
         persist=persist,

--- a/dvc/output/local.py
+++ b/dvc/output/local.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 from dvc.exceptions import DvcException
 from dvc.istextfile import istextfile
 from dvc.output.base import BaseOutput
-from dvc.remote.local import LocalRemote, LocalRemoteTree
+from dvc.remote.local import LocalRemoteTree
 from dvc.utils import relpath
 from dvc.utils.fs import path_isin
 
@@ -13,7 +13,6 @@ logger = logging.getLogger(__name__)
 
 
 class LocalOutput(BaseOutput):
-    REMOTE_CLS = LocalRemote
     TREE_CLS = LocalRemoteTree
     sep = os.sep
 
@@ -23,10 +22,10 @@ class LocalOutput(BaseOutput):
 
         super().__init__(stage, path, *args, **kwargs)
 
-    def _parse_path(self, remote, path):
+    def _parse_path(self, tree, path):
         parsed = urlparse(path)
         if parsed.scheme == "remote":
-            p = remote.path_info / parsed.path.lstrip("/")
+            p = tree.path_info / parsed.path.lstrip("/")
         else:
             # NOTE: we can path either from command line or .dvc file,
             # so we should expect both posix and windows style paths.

--- a/dvc/output/ssh.py
+++ b/dvc/output/ssh.py
@@ -1,7 +1,6 @@
 from dvc.output.base import BaseOutput
-from dvc.remote.ssh import SSHRemote, SSHRemoteTree
+from dvc.remote.ssh import SSHRemoteTree
 
 
 class SSHOutput(BaseOutput):
-    REMOTE_CLS = SSHRemote
     TREE_CLS = SSHRemoteTree

--- a/dvc/repo/tree.py
+++ b/dvc/repo/tree.py
@@ -49,11 +49,11 @@ class DvcTree(BaseTree):  # pylint:disable=abstract-method
             raise FileNotFoundError
         dir_cache = out.get_dir_cache(remote=remote)
         for entry in dir_cache:
-            entry_relpath = entry[out.remote.tree.PARAM_RELPATH]
+            entry_relpath = entry[out.tree.PARAM_RELPATH]
             if os.name == "nt":
                 entry_relpath = entry_relpath.replace("/", os.sep)
             if path == out.path_info / entry_relpath:
-                return entry[out.remote.tree.PARAM_CHECKSUM]
+                return entry[out.tree.PARAM_CHECKSUM]
         raise FileNotFoundError
 
     def open(
@@ -156,7 +156,7 @@ class DvcTree(BaseTree):  # pylint:disable=abstract-method
                     download_callback(downloaded)
 
         for entry in dir_cache:
-            entry_relpath = entry[out.remote.tree.PARAM_RELPATH]
+            entry_relpath = entry[out.tree.PARAM_RELPATH]
             if os.name == "nt":
                 entry_relpath = entry_relpath.replace("/", os.sep)
             path_info = out.path_info / entry_relpath

--- a/tests/func/test_tree.py
+++ b/tests/func/test_tree.py
@@ -192,7 +192,7 @@ def test_repotree_walk_fetch(tmp_dir, dvc, scm, local_remote):
 
     assert os.path.exists(out.cache_path)
     for entry in out.dir_cache:
-        hash_ = entry[out.remote.tree.PARAM_CHECKSUM]
+        hash_ = entry[out.tree.PARAM_CHECKSUM]
         assert os.path.exists(dvc.cache.local.hash_to_path_info(hash_))
 
 

--- a/tests/unit/dependency/test_local.py
+++ b/tests/unit/dependency/test_local.py
@@ -15,6 +15,6 @@ class TestLocalDependency(TestDvc):
 
     def test_save_missing(self):
         d = self._get_dependency()
-        with mock.patch.object(d.remote.tree, "exists", return_value=False):
+        with mock.patch.object(d.tree, "exists", return_value=False):
             with self.assertRaises(d.DoesNotExistError):
                 d.save()

--- a/tests/unit/output/test_local.py
+++ b/tests/unit/output/test_local.py
@@ -19,7 +19,7 @@ class TestLocalOutput(TestDvc):
 
     def test_save_missing(self):
         o = self._get_output()
-        with patch.object(o.remote.tree, "exists", return_value=False):
+        with patch.object(o.tree, "exists", return_value=False):
             with self.assertRaises(o.DoesNotExistError):
                 o.save()
 


### PR DESCRIPTION
Outputs and dependencies don't really care about the remotes, as they
don't do any pushing or pulling. What they really need are the trees,
so let's use them directly.

Part of #4050

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
