### PR TITLE
dvc: get rid of WorkingTree

### DIFF
--- a/dvc/config.py
+++ b/dvc/config.py
@@ -234,7 +234,7 @@ class Config(dict):
     def __init__(
         self, dvc_dir=None, validate=True, tree=None,
     ):  # pylint: disable=super-init-not-called
-        from dvc.scm.tree import WorkingTree
+        from dvc.tree.local import LocalRemoteTree
 
         self.dvc_dir = dvc_dir
 
@@ -248,7 +248,7 @@ class Config(dict):
         else:
             self.dvc_dir = os.path.abspath(os.path.realpath(dvc_dir))
 
-        self.wtree = WorkingTree(self.dvc_dir)
+        self.wtree = LocalRemoteTree(None, {"url": self.dvc_dir})
         self.tree = tree.tree if tree else self.wtree
 
         self.load(validate=validate)
@@ -326,7 +326,7 @@ class Config(dict):
 
         logger.debug(f"Writing '{filename}'.")
 
-        tree.makedirs(os.path.dirname(filename), exist_ok=True)
+        tree.makedirs(os.path.dirname(filename))
 
         config = configobj.ConfigObj(_pack_remotes(conf_dict))
         with tree.open(filename, "wb") as fobj:

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -77,12 +77,11 @@ class Repo:
         from dvc.repo.metrics import Metrics
         from dvc.repo.plots import Plots
         from dvc.repo.params import Params
-        from dvc.scm.tree import WorkingTree
+        from dvc.tree.local import LocalRemoteTree
         from dvc.utils.fs import makedirs
         from dvc.stage.cache import StageCache
 
         if scm:
-            # use GitTree instead of WorkingTree as default repo tree instance
             tree = scm.get_tree(rev)
             self.root_dir = self.find_root(root_dir, tree)
             self.scm = scm
@@ -91,7 +90,7 @@ class Repo:
         else:
             root_dir = self.find_root(root_dir)
             self.root_dir = os.path.abspath(os.path.realpath(root_dir))
-            self.tree = WorkingTree(self.root_dir)
+            self.tree = LocalRemoteTree(None, {"url": self.root_dir})
 
         self.dvc_dir = os.path.join(self.root_dir, self.DVC_DIR)
         self.config = Config(self.dvc_dir, tree=self.tree)

--- a/dvc/repo/brancher.py
+++ b/dvc/repo/brancher.py
@@ -1,6 +1,6 @@
 from funcy import group_by
 
-from dvc.scm.tree import WorkingTree
+from dvc.tree.local import LocalRemoteTree
 
 
 def brancher(  # noqa: E302
@@ -29,7 +29,7 @@ def brancher(  # noqa: E302
 
     scm = self.scm
 
-    self.tree = WorkingTree(self.root_dir)
+    self.tree = LocalRemoteTree(self, {"url": self.root_dir})
     yield "workspace"
 
     if revs and "workspace" in revs:

--- a/dvc/scm/tree.py
+++ b/dvc/scm/tree.py
@@ -1,8 +1,4 @@
 import os
-import stat
-from multiprocessing import cpu_count
-
-from funcy import cached_property
 
 
 class BaseTree:
@@ -41,63 +37,9 @@ class BaseTree:
         raise NotImplementedError
 
 
-class WorkingTree(BaseTree):
-    """Proxies the repo file access methods to working tree files"""
-
-    def __init__(self, repo_root=None):
-        repo_root = repo_root or os.getcwd()
-        self.repo_root = repo_root
-
-    @property
-    def tree_root(self):
-        return self.repo_root
-
-    def open(self, path, mode="r", encoding="utf-8"):
-        """Open file and return a stream."""
-        if "b" in mode:
-            encoding = None
-        return open(path, mode=mode, encoding=encoding)
-
-    def exists(self, path):
-        """Test whether a path exists."""
-        return os.path.lexists(path)
-
-    def isdir(self, path):
-        """Return true if the pathname refers to an existing directory."""
-        return os.path.isdir(path)
-
-    def isfile(self, path):
-        """Test whether a path is a regular file"""
-        return os.path.isfile(path)
-
-    def walk(self, top, topdown=True, onerror=None):
-        """Directory tree generator.
-
-        See `os.walk` for the docs. Differences:
-        - no support for symlinks
-        """
-        for root, dirs, files in os.walk(
-            top, topdown=topdown, onerror=onerror
-        ):
-            yield os.path.normpath(root), dirs, files
-
-    def isexec(self, path):
-        mode = os.stat(path).st_mode
-        return mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-
-    @staticmethod
-    def stat(path):
-        return os.stat(path)
-
-    @cached_property
-    def hash_jobs(self):
-        return max(1, min(4, cpu_count() // 2))
-
-    def makedirs(self, path, mode=0o777, exist_ok=True):
-        os.makedirs(path, mode=mode, exist_ok=exist_ok)
-
-
 def is_working_tree(tree):
-    return isinstance(tree, WorkingTree) or isinstance(
-        getattr(tree, "tree", None), WorkingTree
+    from dvc.tree.local import LocalRemoteTree
+
+    return isinstance(tree, LocalRemoteTree) or isinstance(
+        getattr(tree, "tree", None), LocalRemoteTree
     )

--- a/dvc/state.py
+++ b/dvc/state.py
@@ -89,10 +89,12 @@ class State:  # pylint: disable=too-many-instance-attributes
     MAX_UINT = 2 ** 64 - 2
 
     def __init__(self, local_cache):
+        from dvc.tree.local import LocalRemoteTree
+
         repo = local_cache.repo
         self.repo = repo
         self.root_dir = repo.root_dir
-        self.tree = local_cache.tree.work_tree
+        self.tree = LocalRemoteTree(None, {})
 
         state_config = repo.config.get("state", {})
         self.row_limit = state_config.get("row_limit", self.STATE_ROW_LIMIT)
@@ -394,8 +396,8 @@ class State:  # pylint: disable=too-many-instance-attributes
         assert isinstance(path_info, str) or path_info.scheme == "local"
         path = os.fspath(path_info)
 
-        # NOTE: use os.path.exists instead of WorkingTree.exists
-        # WorkingTree.exists uses lexists() and will return True for broken
+        # NOTE: use os.path.exists instead of LocalRemoteTree.exists
+        # because it uses lexists() and will return True for broken
         # symlinks that we cannot stat() in get_mtime_and_size
         if not os.path.exists(path):
             return None

--- a/dvc/utils/fs.py
+++ b/dvc/utils/fs.py
@@ -44,7 +44,7 @@ def get_mtime_and_size(path, tree):
                     raise
                 continue
             size += stats.st_size
-            files_mtimes[file_path] = stats.st_mtime
+            files_mtimes[os.fspath(file_path)] = stats.st_mtime
 
         # We track file changes and moves, which cannot be detected with simply
         # max(mtime(f) for f in non_ignored_files)

--- a/tests/func/test_ignore.py
+++ b/tests/func/test_ignore.py
@@ -11,8 +11,9 @@ from dvc.ignore import (
     DvcIgnorePatternsTrie,
     DvcIgnoreRepo,
 )
+from dvc.path_info import PathInfo
 from dvc.repo import Repo
-from dvc.scm.tree import WorkingTree
+from dvc.tree.local import LocalRemoteTree
 from dvc.utils import relpath
 from dvc.utils.fs import get_mtime_and_size
 from tests.dir_helpers import TmpDir
@@ -107,7 +108,8 @@ def test_ignore_collecting_dvcignores(tmp_dir, dvc, dname):
     assert ignore_pattern_trie is not None
     assert (
         DvcIgnorePatterns.from_files(
-            os.fspath(top_ignore_file), WorkingTree(dvc.root_dir)
+            os.fspath(top_ignore_file),
+            LocalRemoteTree(None, {"url": dvc.root_dir}),
         )
         == ignore_pattern_trie[os.fspath(ignore_file)]
     )
@@ -165,7 +167,7 @@ def test_ignore_subrepo(tmp_dir, scm, dvc):
     scm.commit("init parent dvcignore")
 
     subrepo_dir = tmp_dir / "subdir"
-    assert not dvc.tree.exists(subrepo_dir / "foo")
+    assert not dvc.tree.exists(PathInfo(subrepo_dir / "foo"))
 
     with subrepo_dir.chdir():
         subrepo = Repo.init(subdir=True)
@@ -173,7 +175,7 @@ def test_ignore_subrepo(tmp_dir, scm, dvc):
         scm.commit("subrepo init")
 
     for _ in subrepo.brancher(all_commits=True):
-        assert subrepo.tree.exists(subrepo_dir / "foo")
+        assert subrepo.tree.exists(PathInfo(subrepo_dir / "foo"))
 
 
 def test_ignore_blank_line(tmp_dir, dvc):

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -8,8 +8,8 @@ from mock import patch
 import dvc
 from dvc.ignore import CleanTree
 from dvc.path_info import PathInfo
-from dvc.scm.tree import WorkingTree
 from dvc.system import System
+from dvc.tree.local import LocalRemoteTree
 from dvc.utils import relpath
 from dvc.utils.fs import (
     BasePathNotInCheckedPathException,
@@ -29,7 +29,7 @@ from tests.basic_env import TestDir
 
 class TestMtimeAndSize(TestDir):
     def test(self):
-        tree = CleanTree(WorkingTree(self.root_dir))
+        tree = CleanTree(LocalRemoteTree(None, {"url": self.root_dir}))
         file_time, file_size = get_mtime_and_size(self.DATA, tree)
         dir_time, dir_size = get_mtime_and_size(self.DATA_DIR, tree)
 
@@ -130,7 +130,7 @@ def test_path_object_and_str_are_valid_types_get_mtime_and_size(tmp_dir):
     tmp_dir.gen(
         {"dir": {"dir_file": "dir file content"}, "file": "file_content"}
     )
-    tree = CleanTree(WorkingTree(tmp_dir))
+    tree = CleanTree(LocalRemoteTree(None, {"url": os.fspath(tmp_dir)}))
 
     time, size = get_mtime_and_size("dir", tree)
     object_time, object_size = get_mtime_and_size(PathInfo("dir"), tree)


### PR DESCRIPTION
Working tree is really just a regular local tree and should be
used by outputs when trying to compute a hash for themselves.
We didn't use it previously because local tree was embeded into
the local remote class.

Related to #4050

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
