### PR TITLE
dvc: get rid of CleanTree

### DIFF
--- a/dvc/config.py
+++ b/dvc/config.py
@@ -249,7 +249,7 @@ class Config(dict):
             self.dvc_dir = os.path.abspath(os.path.realpath(dvc_dir))
 
         self.wtree = LocalRemoteTree(None, {"url": self.dvc_dir})
-        self.tree = tree.tree if tree else self.wtree
+        self.tree = tree or self.wtree
 
         self.load(validate=validate)
 

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -109,17 +109,17 @@ def add(
 def _find_all_targets(repo, target, recursive):
     if os.path.isdir(target) and recursive:
         return [
-            fname
-            for fname in Tqdm(
+            os.fspath(path)
+            for path in Tqdm(
                 repo.tree.walk_files(target),
                 desc="Searching " + target,
                 bar_format=Tqdm.BAR_FMT_NOTOTAL,
                 unit="file",
             )
-            if not repo.is_dvc_internal(fname)
-            if not is_dvc_file(fname)
-            if not repo.scm.belongs_to_scm(fname)
-            if not repo.scm.is_tracked(fname)
+            if not repo.is_dvc_internal(os.fspath(path))
+            if not is_dvc_file(os.fspath(path))
+            if not repo.scm.belongs_to_scm(os.fspath(path))
+            if not repo.scm.is_tracked(os.fspath(path))
         ]
     return [target]
 

--- a/dvc/repo/brancher.py
+++ b/dvc/repo/brancher.py
@@ -29,7 +29,9 @@ def brancher(  # noqa: E302
 
     scm = self.scm
 
-    self.tree = LocalRemoteTree(self, {"url": self.root_dir})
+    self.tree = LocalRemoteTree(
+        self, {"url": self.root_dir}, use_dvcignore=True
+    )
     yield "workspace"
 
     if revs and "workspace" in revs:
@@ -47,7 +49,9 @@ def brancher(  # noqa: E302
     try:
         if revs:
             for sha, names in group_by(scm.resolve_rev, revs).items():
-                self.tree = scm.get_tree(sha)
+                self.tree = scm.get_tree(
+                    sha, use_dvcignore=True, dvcignore_root=self.root_dir
+                )
                 # ignore revs that don't contain repo root
                 # (i.e. revs from before a subdir=True repo was init'ed)
                 if self.tree.exists(self.root_dir):

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -375,8 +375,8 @@ class Git(Base):
         path_parts = os.path.normpath(path).split(os.path.sep)
         return basename == self.ignore_file or Git.GIT_DIR in path_parts
 
-    def get_tree(self, rev):
-        return GitTree(self.repo, self.resolve_rev(rev))
+    def get_tree(self, rev, **kwargs):
+        return GitTree(self.repo, self.resolve_rev(rev), **kwargs)
 
     def get_rev(self):
         return self.repo.rev_parse("HEAD").hexsha

--- a/dvc/state.py
+++ b/dvc/state.py
@@ -94,7 +94,7 @@ class State:  # pylint: disable=too-many-instance-attributes
         repo = local_cache.repo
         self.repo = repo
         self.root_dir = repo.root_dir
-        self.tree = LocalRemoteTree(None, {})
+        self.tree = LocalRemoteTree(None, {"url": self.root_dir})
 
         state_config = repo.config.get("state", {})
         self.row_limit = state_config.get("row_limit", self.STATE_ROW_LIMIT)

--- a/dvc/tree/base.py
+++ b/dvc/tree/base.py
@@ -8,6 +8,8 @@ from multiprocessing import cpu_count
 from operator import itemgetter
 from urllib.parse import urlparse
 
+from funcy import cached_property
+
 from dvc.exceptions import (
     DvcException,
     DvcIgnoreInCollectedDirError,
@@ -86,13 +88,16 @@ class BaseRemoteTree:
         shared = config.get("shared")
         self._file_mode, self._dir_mode = self.SHARED_MODE_MAP[shared]
 
-        self.hash_jobs = (
-            config.get("hash_jobs")
+        self.verify = config.get("verify", self.DEFAULT_VERIFY)
+        self.path_info = None
+
+    @cached_property
+    def hash_jobs(self):
+        return (
+            self.config.get("hash_jobs")
             or (self.repo and self.repo.config["core"].get("hash_jobs"))
             or self.HASH_JOBS
         )
-        self.verify = config.get("verify", self.DEFAULT_VERIFY)
-        self.path_info = None
 
     @classmethod
     def get_missing_deps(cls):

--- a/tests/func/test_tree.py
+++ b/tests/func/test_tree.py
@@ -1,7 +1,6 @@
 import os
 from os.path import join
 
-from dvc.ignore import CleanTree
 from dvc.path_info import PathInfo
 from dvc.repo import Repo
 from dvc.repo.tree import RepoTree
@@ -137,7 +136,9 @@ class TestWalkInNoSCM(AssertWalkEqualMixin, TestDir):
 
 class TestWalkInGit(AssertWalkEqualMixin, TestGit):
     def test_nobranch(self):
-        tree = CleanTree(LocalRemoteTree(None, {"url": self._root_dir}))
+        tree = LocalRemoteTree(
+            None, {"url": self._root_dir}, use_dvcignore=True
+        )
         self.assertWalkEqual(
             tree.walk("."),
             [
@@ -232,13 +233,13 @@ def test_cleantree_subrepo(tmp_dir, dvc, scm, monkeypatch):
 
     path = PathInfo(subrepo_dir)
 
-    assert isinstance(dvc.tree, CleanTree)
+    assert dvc.tree.use_dvcignore
     assert not dvc.tree.exists(path / "foo")
     assert not dvc.tree.isfile(path / "foo")
     assert not dvc.tree.exists(path / "dir")
     assert not dvc.tree.isdir(path / "dir")
 
-    assert isinstance(subrepo.tree, CleanTree)
+    assert subrepo.tree.use_dvcignore
     assert subrepo.tree.exists(path / "foo")
     assert subrepo.tree.isfile(path / "foo")
     assert subrepo.tree.exists(path / "dir")

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -6,7 +6,6 @@ import pytest
 from mock import patch
 
 import dvc
-from dvc.ignore import CleanTree
 from dvc.path_info import PathInfo
 from dvc.system import System
 from dvc.tree.local import LocalRemoteTree
@@ -29,7 +28,9 @@ from tests.basic_env import TestDir
 
 class TestMtimeAndSize(TestDir):
     def test(self):
-        tree = CleanTree(LocalRemoteTree(None, {"url": self.root_dir}))
+        tree = LocalRemoteTree(
+            None, {"url": self.root_dir}, use_dvcignore=True
+        )
         file_time, file_size = get_mtime_and_size(self.DATA, tree)
         dir_time, dir_size = get_mtime_and_size(self.DATA_DIR, tree)
 
@@ -130,7 +131,9 @@ def test_path_object_and_str_are_valid_types_get_mtime_and_size(tmp_dir):
     tmp_dir.gen(
         {"dir": {"dir_file": "dir file content"}, "file": "file_content"}
     )
-    tree = CleanTree(LocalRemoteTree(None, {"url": os.fspath(tmp_dir)}))
+    tree = LocalRemoteTree(
+        None, {"url": os.fspath(tmp_dir)}, use_dvcignore=True
+    )
 
     time, size = get_mtime_and_size("dir", tree)
     object_time, object_size = get_mtime_and_size(PathInfo("dir"), tree)


### PR DESCRIPTION
CleanTree is a very awkward wrapper that spreads the context across
the codebase and results in unexpected behaviour when using it.

This PR starts moving dvcignore-related logic into the trees themselves
(it makes a lot of sense, kinda like `state`) so they could deal with
it however they like.

There are at least two temporary ugly parts about this PR:

1) dvcignore is used by individual trees and not packed into
tree/base.py yet;

2) `dvcignore_root` argument. This one is caused by the dvcignore trying
to collect everything topdown starting from the certain root dir. What
it should do instead is for a certain path that is being checked look up
the tree through the parents until it finds repo root (.dvc dir) and
then stop. That would handle subrepos as well. At the same time we need
to leverage existing dvcignore trie structure to cache those results.

Related to #4050

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
