### PR TITLE
snap: deploy: fix major channels not being pushed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -160,11 +160,3 @@ deploy:
       condition: "$(./scripts/ci/deploy_condition.sh dvc_*.snap) && ($TRAVIS_BRANCH = master || -n $TRAVIS_TAG) && -n $SNAP_CHANNEL"
       repo: iterative/dvc
       stage: build
-  - provider: script
-    skip_cleanup: true
-    script: "(echo $SNAP_TOKEN | snapcraft login --with -) && timeout 600 snapcraft push dvc_*.snap --release $SNAP_CHANNEL_MAJOR || echo timed out"
-    on:
-      all_branches: true
-      condition: "$(./scripts/ci/deploy_condition.sh dvc_*.snap) && ($TRAVIS_BRANCH = master || -n $TRAVIS_TAG) && -n $SNAP_CHANNEL_MAJOR"
-      repo: iterative/dvc
-      stage: build

--- a/scripts/ci/before_install.sh
+++ b/scripts/ci/before_install.sh
@@ -40,17 +40,14 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
 
   if [[ -n "$TRAVIS_TAG" ]]; then
     if [[ $(echo "$TRAVIS_TAG" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$') ]]; then
-      echo "export SNAP_CHANNEL=stable" >>env.sh
-      echo "export SNAP_CHANNEL_MAJOR=v$TAG_MAJOR/stable" >>env.sh
+      SNAP_CHANNEL=stable
     else
-      echo "export SNAP_CHANNEL=beta" >>env.sh
-      echo "export SNAP_CHANNEL_MAJOR=v$TAG_MAJOR/beta" >>env.sh
+      SNAP_CHANNEL=beta
     fi
   else
-    echo "export SNAP_CHANNEL=edge" >>env.sh
-    echo "export SNAP_CHANNEL_MAJOR=v$TAG_MAJOR/edge" >>env.sh
+    SNAP_CHANNEL=edge
   fi
-
+  echo "export SNAP_CHANNEL=${SNAP_CHANNEL},v${TAG_MAJOR}/${SNAP_CHANNEL}" >>env.sh
   # NOTE: after deprecating this major version branch, uncomment this line
-  # echo "unset SNAP_CHANNEL" >>env.sh
+  # echo "export SNAP_CHANNEL=v${TAG_MAJOR}/${SNAP_CHANNEL}" >>env.sh
 fi


### PR DESCRIPTION
- [x] push to snap channels in one (rather than two) deploy step(s)
- [x] in the meantime update the current `v1` channels to match `latest`
```bash
snapcraft release dvc 626 v1/stable  # updates 1.1.7 to 1.1.10
snapcraft release dvc 641 v1/edge    # updates 1.1.7 to 1.1.10-15-g91f3036c
```

fixes https://travis-ci.com/github/iterative/dvc/jobs/360297196#L2901-L2902

```
The store was unable to accept this snap.
  - binary_sha3_384: A file with this exact same content has already been uploaded
```


