### PR TITLE
erepo: --rev BRANCH: shallow clone

### DIFF
--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -289,6 +289,16 @@ def _clone_default_branch(url, rev, for_write=False):
                     git.repo.git.fetch(unshallow=True)
                     shallow = False
                     CLONES[url] = (clone_path, shallow)
+                    if git.repo.head.is_detached:
+                        # If this is a detached head (i.e. we shallow
+                        # cloned a tag) checkout the default branch
+                        origin_refs = git.repo.remotes["origin"].refs
+                        ref = origin_refs["HEAD"].reference
+                        branch_name = ref.name.split("/")[-1]
+                        branch = git.repo.create_head(branch_name, ref)
+                        branch.set_tracking_branch(ref)
+                        branch.checkout()
+
                 logger.debug("erepo: git pull '%s'", url)
                 git.pull()
         else:

--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -32,7 +32,7 @@ def external_repo(url, rev=None, for_write=False):
     logger.debug("Creating external repo %s@%s", url, rev)
     path = _cached_clone(url, rev, for_write=for_write)
     if not rev:
-        rev = "HEAD"
+        rev = "refs/remotes/origin/HEAD"
     try:
         repo = ExternalRepo(path, url, rev, for_write=for_write)
     except NotDvcRepoError:

--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -19,6 +19,7 @@ from dvc.exceptions import (
 from dvc.path_info import PathInfo
 from dvc.repo import Repo
 from dvc.repo.tree import RepoTree
+from dvc.scm.base import CloneError
 from dvc.scm.git import Git
 from dvc.tree.local import LocalTree
 from dvc.utils.fs import remove
@@ -59,7 +60,7 @@ CACHE_DIRS = {}
 
 def clean_repos():
     # Outside code should not see cache while we are removing
-    paths = list(CLONES.values()) + list(CACHE_DIRS.values())
+    paths = [path for path, _ in CLONES.values()] + list(CACHE_DIRS.values())
     CLONES.clear()
     CACHE_DIRS.clear()
 
@@ -251,10 +252,10 @@ def _cached_clone(url, rev, for_write=False):
     """
     # even if we have already cloned this repo, we may need to
     # fetch/fast-forward to get specified rev
-    clone_path = _clone_default_branch(url, rev)
+    clone_path, shallow = _clone_default_branch(url, rev, for_write=for_write)
 
     if not for_write and (url) in CLONES:
-        return CLONES[url]
+        return CLONES[url][0]
 
     # Copy to a new dir to keep the clone clean
     repo_path = tempfile.mkdtemp("dvc-erepo")
@@ -265,17 +266,17 @@ def _cached_clone(url, rev, for_write=False):
     if for_write:
         _git_checkout(repo_path, rev)
     else:
-        CLONES[url] = repo_path
+        CLONES[url] = (repo_path, shallow)
     return repo_path
 
 
 @wrap_with(threading.Lock())
-def _clone_default_branch(url, rev):
+def _clone_default_branch(url, rev, for_write=False):
     """Get or create a clean clone of the url.
 
     The cloned is reactualized with git pull unless rev is a known sha.
     """
-    clone_path = CLONES.get(url)
+    clone_path, shallow = CLONES.get(url, (None, False))
 
     git = None
     try:
@@ -283,18 +284,35 @@ def _clone_default_branch(url, rev):
             git = Git(clone_path)
             # Do not pull for known shas, branches and tags might move
             if not Git.is_sha(rev) or not git.has_rev(rev):
-                logger.debug("erepo: git pull %s", url)
+                if shallow:
+                    logger.debug("erepo: unshallowing clone for '%s'", url)
+                    git.repo.git.fetch(unshallow=True)
+                    shallow = False
+                    CLONES[url] = (clone_path, shallow)
+                logger.debug("erepo: git pull '%s'", url)
                 git.pull()
         else:
-            logger.debug("erepo: git clone %s to a temporary dir", url)
+            logger.debug("erepo: git clone '%s' to a temporary dir", url)
             clone_path = tempfile.mkdtemp("dvc-clone")
-            git = Git.clone(url, clone_path)
-            CLONES[url] = clone_path
+            if not for_write and rev and not Git.is_sha(rev):
+                # If rev is a tag or branch name try shallow clone first
+                try:
+                    git = Git.clone(url, clone_path, shallow_branch=rev)
+                    shallow = True
+                    logger.debug(
+                        "erepo: using shallow clone for branch '%s'", rev
+                    )
+                except CloneError:
+                    pass
+            if not git:
+                git = Git.clone(url, clone_path)
+                shallow = False
+            CLONES[url] = (clone_path, shallow)
     finally:
         if git:
             git.close()
 
-    return clone_path
+    return clone_path, shallow
 
 
 def _git_checkout(repo_path, rev):

--- a/dvc/scm/git.py
+++ b/dvc/scm/git.py
@@ -260,8 +260,8 @@ class Git(Base):
         else:
             self.repo.git.checkout(branch)
 
-    def pull(self):
-        infos = self.repo.remote().pull()
+    def pull(self, **kwargs):
+        infos = self.repo.remote().pull(**kwargs)
         for info in infos:
             if info.flags & info.ERROR:
                 raise SCMError(f"pull failed: {info.note}")

--- a/dvc/scm/git.py
+++ b/dvc/scm/git.py
@@ -3,9 +3,10 @@
 import logging
 import os
 import shlex
+from functools import partial
 
 import yaml
-from funcy import cached_property, partial
+from funcy import cached_property
 from pathspec.patterns import GitWildMatchPattern
 
 from dvc.exceptions import GitHookAlreadyExistsError

--- a/tests/func/test_external_repo.py
+++ b/tests/func/test_external_repo.py
@@ -1,8 +1,8 @@
 import os
 
-from mock import patch
+from mock import ANY, patch
 
-from dvc.external_repo import external_repo
+from dvc.external_repo import CLONES, external_repo
 from dvc.path_info import PathInfo
 from dvc.scm.git import Git
 from dvc.tree.local import LocalTree
@@ -121,3 +121,55 @@ def test_relative_remote(erepo_dir, tmp_dir):
         assert os.path.isdir(repo.config["remote"]["upstream"]["url"])
         with repo.open_by_relpath("file") as fd:
             assert fd.read() == "contents"
+
+
+def test_shallow_clone_branch(erepo_dir):
+    with erepo_dir.chdir():
+        with erepo_dir.branch("branch", new=True):
+            erepo_dir.dvc_gen("file", "branch", commit="create file on branch")
+        erepo_dir.dvc_gen("file", "master", commit="create file on master")
+
+    url = os.fspath(erepo_dir)
+
+    with patch.object(Git, "clone", wraps=Git.clone) as mock_clone:
+        with external_repo(url, rev="branch") as repo:
+            with repo.open_by_relpath("file") as fd:
+                assert fd.read() == "branch"
+
+        mock_clone.assert_called_with(url, ANY, shallow_branch="branch")
+        _, shallow = CLONES[url]
+        assert shallow
+
+        with external_repo(url, rev="master") as repo:
+            with repo.open_by_relpath("file") as fd:
+                assert fd.read() == "master"
+
+        assert mock_clone.call_count == 1
+        _, shallow = CLONES[url]
+        assert not shallow
+
+
+def test_shallow_clone_tag(erepo_dir):
+    with erepo_dir.chdir():
+        erepo_dir.dvc_gen("file", "foo", commit="init")
+        erepo_dir.scm.tag("v1")
+        erepo_dir.dvc_gen("file", "bar", commit="update file")
+
+    url = os.fspath(erepo_dir)
+
+    with patch.object(Git, "clone", wraps=Git.clone) as mock_clone:
+        with external_repo(url, rev="v1") as repo:
+            with repo.open_by_relpath("file") as fd:
+                assert fd.read() == "foo"
+
+        mock_clone.assert_called_with(url, ANY, shallow_branch="v1")
+        _, shallow = CLONES[url]
+        assert shallow
+
+        with external_repo(url, rev="master") as repo:
+            with repo.open_by_relpath("file") as fd:
+                assert fd.read() == "bar"
+
+        assert mock_clone.call_count == 1
+        _, shallow = CLONES[url]
+        assert not shallow

--- a/tests/func/test_external_repo.py
+++ b/tests/func/test_external_repo.py
@@ -140,7 +140,7 @@ def test_shallow_clone_branch(erepo_dir):
         _, shallow = CLONES[url]
         assert shallow
 
-        with external_repo(url, rev="master") as repo:
+        with external_repo(url) as repo:
             with repo.open_by_relpath("file") as fd:
                 assert fd.read() == "master"
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Follow up to #3585.
Should fix #3473.

* erepo now clones with `--no-single-branch --depth=1 --branch=<branch>` when initialized with a valid branch or tag name (i.e. for `get/import --rev`)
    * if erepo is init'd with `for_write=True` (i.e. dvcx) we use the old full clone + writeable copy behavior
    * If shallow clone fails, we fallback to default full clone behavior
* If we reuse an already cloned repo and don't have the necessary revision, we expand the clone with `git fetch --unshallow` and then treat it like normal full clone

This does not address these other potential changes to erepo clone behavior:
* persistent cache #3496 
* sparse checkouts #3438 