### PR TITLE
get/list/import/api: subrepo support

### DIFF
--- a/dvc/api.py
+++ b/dvc/api.py
@@ -8,7 +8,7 @@ from dvc.exceptions import (
     NotDvcRepoError,
     PathMissingError,
 )
-from dvc.external_repo import external_repo
+from dvc.external_repo import ExternalDVCRepo, ExternalGitRepo, external_repo
 from dvc.repo import Repo
 
 
@@ -33,7 +33,7 @@ def get_url(path, repo=None, rev=None, remote=None):
     with _make_repo(repo, rev=rev) as _repo:
         # pylint: disable=no-member
         path = os.path.join(_repo.root_dir, path)
-        is_erepo = not isinstance(_repo, Repo)
+        is_erepo = isinstance(_repo, (ExternalDVCRepo, ExternalGitRepo))
         r = _repo.in_repo(path) if is_erepo else _repo
         if is_erepo and not r:
             raise UrlNotDvcRepoError(_repo.url)

--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -8,6 +8,7 @@ from typing import Iterable
 
 from funcy import cached_property, retry, wrap_with
 
+from dvc import subrepos
 from dvc.config import NoRemoteError, NotDvcRepoError
 from dvc.exceptions import (
     FileMissingError,
@@ -21,14 +22,14 @@ from dvc.repo import Repo
 from dvc.repo.tree import RepoTree
 from dvc.scm.base import CloneError
 from dvc.scm.git import Git
-from dvc.tree.local import LocalTree
+from dvc.tree import LocalTree
 from dvc.utils.fs import remove
 
 logger = logging.getLogger(__name__)
 
 
 @contextmanager
-def external_repo(url, rev=None, for_write=False):
+def external_repo(url, rev=None, for_write=False, **kwargs):
     logger.debug("Creating external repo %s@%s", url, rev)
     path = _cached_clone(url, rev, for_write=for_write)
     if not rev:
@@ -36,11 +37,11 @@ def external_repo(url, rev=None, for_write=False):
         # (which may not be the default branch), use origin/HEAD here to get
         # the tip of the default branch
         rev = "refs/remotes/origin/HEAD"
-    try:
-        repo = ExternalRepo(path, url, rev, for_write=for_write)
-    except NotDvcRepoError:
-        repo = ExternalGitRepo(path, url, rev)
 
+    # TODO: What to do with for the `dvcx`?
+    #  something like following, perhaps?
+    #  repo = ExternalDVCRepo if _is_dvc_main_repo(path, rev) else ExternalRepo
+    repo = ExternalRepo(path, url, rev, for_write=for_write, **kwargs)
     try:
         yield repo
     except NoRemoteError:
@@ -71,53 +72,124 @@ def clean_repos():
         _remove(path)
 
 
-class BaseExternalRepo:
-    # pylint: disable=no-member
+def _fix_local_remote(orig_repo, src_repo, remote_name):
+    # If a remote URL is relative to the source repo,
+    # it will have changed upon config load and made
+    # relative to this new repo. Restore the old one here.
+    new_remote = orig_repo.config["remote"][remote_name]
+    old_remote = src_repo.config["remote"][remote_name]
+    if new_remote["url"] != old_remote["url"]:
+        new_remote["url"] = old_remote["url"]
 
-    _local_cache = None
 
-    def __str__(self):
-        return self.url
+def _add_upstream(orig_repo, src_repo):
+    # Fill the empty upstream entry with a new remote pointing to the
+    # original repo's cache location.
+    orig_repo.config["remote"]["auto-generated-upstream"] = {
+        "url": src_repo.cache.local.cache_dir
+    }
+    orig_repo.config["core"]["remote"] = "auto-generated-upstream"
 
-    @property
-    def local_cache(self):
-        if hasattr(self, "cache"):
-            return self.cache.local
-        return self._local_cache
 
-    @contextmanager
-    def use_cache(self, cache):
-        """Use the specified cache in place of default tmpdir cache for
-        download operations.
-        """
-        if hasattr(self, "cache"):
-            save_cache = self.cache.local
-            self.cache.local = cache
-        self._local_cache = cache
+class ExternalRepo:
+    def __init__(
+        self, root_dir, url, rev, for_write=False, fetch=True, **kwargs
+    ):
+        self.root_dir = os.path.abspath(root_dir)
+        self.scm = Git(root_dir)
+        self.url = url
+        self.config = {"fetch": fetch, **kwargs}
+        self.for_write = for_write
 
-        yield
+        repo_kw = {}
+        if for_write:
+            tree = LocalTree(None, {"url": self.root_dir})
+        else:
+            # .dvc folders are ignored by dvcignore which is required for
+            # `subrepos.find()`, hence using a separate tree
+            tree = self.scm.get_tree(rev)
+            repo_kw = dict(scm=self.scm, rev=rev)
 
-        if hasattr(self, "cache"):
-            self.cache.local = save_cache
-        self._local_cache = None
+        paths = subrepos.find(tree)
+        self.repos = [Repo(path, **repo_kw) for path in paths]
+        self._setup_cache_dir()
+        self.rev = rev
+
+        for repo in self.repos:
+            repo.cache.local.cache_dir = self.cache_dir
+            if os.path.isdir(self.url):
+                self._fix_upstream(repo)
+
+    @wrap_with(threading.Lock())
+    def _setup_cache_dir(self):
+        # share same cache_dir among all subrepos
+        try:
+            self.cache_dir = CACHE_DIRS[self.url]
+        except KeyError:
+            self.cache_dir = CACHE_DIRS[self.url] = tempfile.mkdtemp(
+                "dvc-cache"
+            )
 
     @cached_property
-    def repo_tree(self):
-        return RepoTree(self, fetch=True)
+    def tree(self):
+        kwargs = dict(
+            use_dvcignore=True,
+            dvcignore_root=self.root_dir,
+            ignore_subrepo=False,
+        )
+        if self.for_write:
+            return LocalTree(None, {"url": self.root_dir}, **kwargs)
+        return self.scm.get_tree(rev=self.rev, **kwargs)
 
-    def get_rev(self):
-        if isinstance(self.tree, LocalTree):
-            return self.scm.get_rev()
-        return self.tree.rev
+    @cached_property
+    def repo_tree(self) -> "RepoTree":
+        return RepoTree(self.tree, subrepos=self.repos, **self.config)
 
-    def fetch_external(self, paths: Iterable, **kwargs):
+    @wrap_with(threading.Lock())
+    @contextmanager
+    def with_cache(self, cache_dir, link_types=None):
+        for repo in self.repos:
+            repo.cache.local.cache_dir = cache_dir
+            if link_types:
+                # FIXME: not rolling back, should be fine for now
+                repo.cache.local.cache_types = link_types
+        yield
+        for repo in self.repos:
+            repo.cache.local.cache_dir = self.cache_dir
+
+    def _fix_upstream(self, orig_repo):
+        try:
+            rel_path = os.path.relpath(orig_repo.root_dir, self.root_dir)
+            src_repo = Repo(PathInfo(self.url) / rel_path)
+        except NotDvcRepoError:
+            # If ExternalRepo does not throw NotDvcRepoError and Repo does,
+            # the self.url might be a bare git repo.
+            # NOTE: This will fail to resolve remote with relative path,
+            # same as if it was a remote DVC repo.
+            return
+
+        try:
+            remote_name = orig_repo.config["core"].get("remote")
+            if remote_name:
+                _fix_local_remote(orig_repo, src_repo, remote_name)
+            else:
+                _add_upstream(orig_repo, src_repo)
+        finally:
+            src_repo.close()
+
+    def close(self):
+        for repo in self.repos:
+            repo.close()
+        self.scm.close()
+
+    def fetch_external(self, paths: Iterable, cache, **kwargs):
         """Fetch specified external repo paths into cache.
 
-        Returns 3-tuple in the form
-            (downloaded, failed, list(cache_infos))
-        where cache_infos can be used as checkout targets for the
-        fetched paths.
-        """
+         Returns 3-tuple in the form
+             (downloaded, failed, list(cache_infos))
+         where cache_infos can be used as checkout targets for the
+         fetched paths.
+         """
         download_results = []
         failed = 0
 
@@ -130,120 +202,48 @@ class BaseExternalRepo:
         for path in paths:
             if not self.repo_tree.exists(path):
                 raise PathMissingError(path, self.url)
-            save_info = self.local_cache.save(
-                path,
-                self.repo_tree,
-                None,
-                save_link=False,
-                download_callback=download_update,
-            )
+            with self.with_cache(cache.cache_dir):
+                save_info = cache.save(
+                    path,
+                    self.repo_tree,
+                    None,
+                    save_link=False,
+                    download_callback=download_update,
+                )
             save_infos.append(save_info)
 
         return sum(download_results), failed, save_infos
 
-    def get_external(self, path, dest):
+    def get_external(self, src, dest):
         """Convenience wrapper for fetch_external and checkout."""
-        if self.local_cache:
-            # fetch DVC and git files to tmpdir cache, then checkout
-            _, _, save_infos = self.fetch_external([path])
-            self.local_cache.checkout(PathInfo(dest), save_infos[0])
+        repo = self.in_repo(src)
+        if repo:
+            cache = repo.cache.local
+            _, _, save_infos = self.fetch_external([src], cache)
+            cache.checkout(PathInfo(dest), save_infos[0])
         else:
-            # git-only erepo with no cache, just copy files directly
-            # to dest
-            path = PathInfo(self.root_dir) / path
+            path = PathInfo(self.root_dir) / src
             if not self.repo_tree.exists(path):
-                raise PathMissingError(path, self.url)
+                raise PathMissingError(src, self.url)
             self.repo_tree.copytree(path, dest)
 
+    def get_rev(self):
+        if isinstance(self.tree, LocalTree):
+            return self.scm.get_rev()
+        return self.tree.rev
 
-class ExternalRepo(Repo, BaseExternalRepo):
-    def __init__(self, root_dir, url, rev, for_write=False):
-        if for_write:
-            super().__init__(root_dir)
-        else:
-            root_dir = os.path.realpath(root_dir)
-            super().__init__(root_dir, scm=Git(root_dir), rev=rev)
-        self.url = url
-        self._set_cache_dir()
-        self._fix_upstream()
+    def get_checksum(self, path_info, cache):
+        if self.repo_tree.isdir(path_info):
+            return cache.tree.get_hash(path_info, tree=self.repo_tree)
+        return self.repo_tree.get_file_hash(path_info)
 
-    @wrap_with(threading.Lock())
-    def _set_cache_dir(self):
-        try:
-            cache_dir = CACHE_DIRS[self.url]
-        except KeyError:
-            cache_dir = CACHE_DIRS[self.url] = tempfile.mkdtemp("dvc-cache")
+    def in_repo(self, path):
+        tree = self.repo_tree.in_subtree(path)
+        return tree.repo if tree else None
 
-        self.cache.local.cache_dir = cache_dir
-        self._local_cache = self.cache.local
-
-    def _fix_upstream(self):
-        if not os.path.isdir(self.url):
-            return
-
-        try:
-            src_repo = Repo(self.url)
-        except NotDvcRepoError:
-            # If ExternalRepo does not throw NotDvcRepoError and Repo does,
-            # the self.url might be a bare git repo.
-            # NOTE: This will fail to resolve remote with relative path,
-            # same as if it was a remote DVC repo.
-            return
-
-        try:
-            remote_name = self.config["core"].get("remote")
-            if remote_name:
-                self._fix_local_remote(src_repo, remote_name)
-            else:
-                self._add_upstream(src_repo)
-        finally:
-            src_repo.close()
-
-    def _fix_local_remote(self, src_repo, remote_name):
-        # If a remote URL is relative to the source repo,
-        # it will have changed upon config load and made
-        # relative to this new repo. Restore the old one here.
-        new_remote = self.config["remote"][remote_name]
-        old_remote = src_repo.config["remote"][remote_name]
-        if new_remote["url"] != old_remote["url"]:
-            new_remote["url"] = old_remote["url"]
-
-    def _add_upstream(self, src_repo):
-        # Fill the empty upstream entry with a new remote pointing to the
-        # original repo's cache location.
-        cache_dir = src_repo.cache.local.cache_dir
-        self.config["remote"]["auto-generated-upstream"] = {"url": cache_dir}
-        self.config["core"]["remote"] = "auto-generated-upstream"
-
-
-class ExternalGitRepo(BaseExternalRepo):
-    def __init__(self, root_dir, url, rev):
-        self.root_dir = os.path.realpath(root_dir)
-        self.url = url
-        self.tree = self.scm.get_tree(rev)
-
-    @cached_property
-    def scm(self):
-        return Git(self.root_dir)
-
-    def close(self):
-        if "scm" in self.__dict__:
-            self.scm.close()
-
-    def find_out_by_relpath(self, path):
-        raise OutputNotFoundError(path, self)
-
-    @contextmanager
-    def open_by_relpath(self, path, mode="r", encoding=None, **kwargs):
-        """Opens a specified resource as a file object."""
-        tree = RepoTree(self)
-        try:
-            with tree.open(
-                path, mode=mode, encoding=encoding, **kwargs
-            ) as fobj:
-                yield fobj
-        except FileNotFoundError:
-            raise PathMissingError(path, self.url)
+    @property
+    def main_repo(self):
+        return self.in_repo(os.curdir)
 
 
 def _cached_clone(url, rev, for_write=False):

--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -95,15 +95,15 @@ class ExternalRepo:
     def __init__(
         self, root_dir, url, rev, for_write=False, fetch=True, **kwargs
     ):
-        self.root_dir = os.path.abspath(root_dir)
-        self.scm = Git(root_dir)
+        self.root_dir = os.path.realpath(root_dir)
+        self.scm = Git(self.root_dir)
         self.url = url
         self.config = {"fetch": fetch, **kwargs}
         self.for_write = for_write
 
         repo_kw = {}
         if for_write:
-            tree = LocalTree(None, {"url": self.root_dir})
+            tree = LocalTree(None, {"url": root_dir})
         else:
             # .dvc folders are ignored by dvcignore which is required for
             # `subrepos.find()`, hence using a separate tree

--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -183,6 +183,12 @@ class ExternalRepo:
         self.scm.close()
 
     def fetch_external(self, paths: Iterable, cache, **kwargs):
+        # `RepoTree` will try downloading it to the repo's cache
+        # instead of `cache_dir`, need to change on all instances
+        with self.with_cache(cache.cache_dir):
+            return self._fetch_to_cache(paths, cache, **kwargs)
+
+    def _fetch_to_cache(self, paths: Iterable, cache, **kwargs):
         """Fetch specified external repo paths into cache.
 
          Returns 3-tuple in the form
@@ -202,14 +208,13 @@ class ExternalRepo:
         for path in paths:
             if not self.repo_tree.exists(path):
                 raise PathMissingError(path, self.url)
-            with self.with_cache(cache.cache_dir):
-                save_info = cache.save(
-                    path,
-                    self.repo_tree,
-                    None,
-                    save_link=False,
-                    download_callback=download_update,
-                )
+            save_info = cache.save(
+                path,
+                self.repo_tree,
+                None,
+                save_link=False,
+                download_callback=download_update,
+            )
             save_infos.append(save_info)
 
         return sum(download_results), failed, save_infos
@@ -219,7 +224,7 @@ class ExternalRepo:
         repo = self.in_repo(src)
         if repo:
             cache = repo.cache.local
-            _, _, save_infos = self.fetch_external([src], cache)
+            _, _, save_infos = self._fetch_to_cache([src], cache)
             cache.checkout(PathInfo(dest), save_infos[0])
         else:
             path = PathInfo(self.root_dir) / src
@@ -238,7 +243,7 @@ class ExternalRepo:
         return self.repo_tree.get_file_hash(path_info)
 
     def in_repo(self, path):
-        tree = self.repo_tree.in_subtree(path)
+        tree = self.repo_tree.in_subtree(PathInfo(self.root_dir) / path)
         return tree.repo if tree else None
 
     @property

--- a/dvc/ignore.py
+++ b/dvc/ignore.py
@@ -120,7 +120,7 @@ class DvcIgnoreFilter:
 
         return os.path.isdir(os.path.join(root, directory, Repo.DVC_DIR))
 
-    def __init__(self, tree, root_dir):
+    def __init__(self, tree, root_dir, ignore_subrepo=True):
         from dvc.repo import Repo
 
         default_ignore_patterns = [".hg/", ".git/", "{}/".format(Repo.DVC_DIR)]
@@ -135,7 +135,8 @@ class DvcIgnoreFilter:
             self.root_dir, use_dvcignore=False
         ):
             self._update(root)
-            self._update_sub_repo(root, dirs)
+            if ignore_subrepo:
+                self._update_sub_repo(root, dirs)
             dirs[:], _ = self(root, dirs, [])
 
     def _update(self, dirname):

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -81,10 +81,9 @@ def _fetch_external(self, repo_url, repo_rev, files, jobs):
     failed, downloaded = 0, 0
     try:
         with external_repo(repo_url, repo_rev) as repo:
-            with repo.use_cache(self.cache.local):
-                d, f, _ = repo.fetch_external(files, jobs=jobs)
-                downloaded += d
-                failed += f
+            d, f, _ = repo.fetch_external(files, self.cache.local, jobs=jobs)
+            downloaded += d
+            failed += f
     except CloneError:
         failed += 1
         logger.exception(

--- a/dvc/repo/get.py
+++ b/dvc/repo/get.py
@@ -37,19 +37,17 @@ def get(url, path, out=None, rev=None):
     tmp_dir = os.path.join(dpath, "." + str(shortuuid.uuid()))
     try:
         with external_repo(url=url, rev=rev) as repo:
-            if hasattr(repo, "cache"):
-                repo.cache.local.cache_dir = tmp_dir
-
-                # Try any links possible to avoid data duplication.
-                #
-                # Not using symlink, because we need to remove cache after we
-                # are done, and to make that work we would have to copy data
-                # over anyway before removing the cache, so we might just copy
-                # it right away.
-                #
-                # Also, we can't use theoretical "move" link type here, because
-                # the same cache file might be used a few times in a directory.
-                repo.cache.local.cache_types = ["reflink", "hardlink", "copy"]
-            repo.get_external(path, out)
+            # Try any links possible to avoid data duplication.
+            #
+            # Not using symlink, because we need to remove cache after we
+            # are done, and to make that work we would have to copy data
+            # over anyway before removing the cache, so we might just copy
+            # it right away.
+            #
+            # Also, we can't use theoretical "move" link type here, because
+            # the same cache file might be used a few times in a directory.
+            link_types = ["reflink", "hardlink", "copy"]
+            with repo.with_cache(tmp_dir, link_types=link_types):
+                repo.get_external(path, out)
     finally:
         remove(tmp_dir)

--- a/dvc/repo/metrics/show.py
+++ b/dvc/repo/metrics/show.py
@@ -53,7 +53,7 @@ def _extract_metrics(metrics):
 
 
 def _read_metrics(repo, metrics, rev):
-    tree = RepoTree(repo)
+    tree = RepoTree(repo.tree, [repo])
 
     res = {}
     for metric in metrics:

--- a/dvc/repo/plots/__init__.py
+++ b/dvc/repo/plots/__init__.py
@@ -44,7 +44,7 @@ class Plots:
                 continue
             rev = rev or "workspace"
 
-            tree = RepoTree(self.repo)
+            tree = RepoTree(self.repo.tree, [self.repo])
             plots = _collect_plots(self.repo, targets, rev)
             for path_info, props in plots.items():
                 datafile = relpath(path_info, self.repo.root_dir)

--- a/dvc/repo/tree.py
+++ b/dvc/repo/tree.py
@@ -253,12 +253,15 @@ class RepoTree(BaseTree):  # pylint:disable=abstract-method
     ):  # pylint: disable=super-init-not-called
         subrepos = subrepos or []
         subrepos.sort(key=lambda r: len(r.root_dir), reverse=True)
-        dvctrees = [DvcTree(repo, **kwargs) for repo in subrepos]
-        self._kwargs = kwargs
-        self._dvctrees = {
-            os.path.abspath(tree.repo.root_dir): tree for tree in dvctrees
-        }
+        dvctrees = [
+            (os.path.abspath(repo.root_dir), DvcTree(repo, **kwargs))
+            for repo in subrepos
+        ]
+        self._dvctrees = dict(
+            sorted(dvctrees, key=lambda v: len(v[0]), reverse=True)
+        )
         self.tree = tree
+        self._kwargs = kwargs
 
     @property
     def fetch(self):
@@ -275,7 +278,7 @@ class RepoTree(BaseTree):  # pylint:disable=abstract-method
         # dvctrees is already ordered from low to high
         path_prefix = os.path.abspath(path)
         for pref, tree in self._dvctrees.items():
-            if os.path.abspath(path_prefix).startswith(pref):
+            if path_prefix.startswith(pref):
                 return pref, tree
         return "", None
 

--- a/dvc/repo/tree.py
+++ b/dvc/repo/tree.py
@@ -294,7 +294,7 @@ class RepoTree(BaseTree):  # pylint:disable=abstract-method
         return self.tree.open(path, mode=mode, encoding=encoding)
 
     def open_by_relpath(self, path, *args, **kwargs):
-        return self.open(PathInfo(self.tree.tree_root, path), *args, **kwargs)
+        return self.open(PathInfo(self.tree.tree_root) / path, *args, **kwargs)
 
     def exists(self, path):  # pylint: disable=arguments-differ
         subtree = self._find_subtree(path)

--- a/dvc/repo/tree.py
+++ b/dvc/repo/tree.py
@@ -291,6 +291,8 @@ class RepoTree(BaseTree):  # pylint:disable=abstract-method
     ):  # pylint: disable=arguments-differ
         if "b" in mode:
             encoding = None
+        else:
+            encoding = encoding or "utf-8"
 
         subtree = self._find_subtree(path)
         if subtree and subtree.exists(path):

--- a/dvc/subrepos.py
+++ b/dvc/subrepos.py
@@ -4,8 +4,10 @@ from funcy import collecting
 
 
 @collecting
-def find(tree, top=None):
+def find(tree, top=None, skip_top_level=True):
     top = top or tree.tree_root
     for root, _, _ in tree.walk(top):
+        if skip_top_level and top == root:
+            continue
         if tree.isdir(os.path.join(root, ".dvc")):
             yield root

--- a/dvc/subrepos.py
+++ b/dvc/subrepos.py
@@ -1,0 +1,11 @@
+import os
+
+from funcy import collecting
+
+
+@collecting
+def find(tree, top=None):
+    top = top or tree.tree_root
+    for root, _, _ in tree.walk(top):
+        if tree.isdir(os.path.join(root, ".dvc")):
+            yield root

--- a/dvc/tree/_debug.py
+++ b/dvc/tree/_debug.py
@@ -1,0 +1,22 @@
+import os
+
+from funcy import post_processing
+
+
+@post_processing("\r\n".join)
+def visualize(tree, top, **kwargs):
+    """`tree`-like output, useful for debugging/visualizing, needs `walk()`"""
+    indent = 4
+    spacing = " " * indent
+    tee = "├── "
+    last = "└── "
+    for root, _, files in tree.walk(top, **kwargs):
+        level = root.replace(top, "").count(os.sep)
+        indent = spacing * level
+        yield "{}{}/".format(indent, os.path.basename(root))
+        sub_indent = spacing * (level + 1)
+        length = len(files)
+        for i, f in enumerate(files):
+            yield "{}{}{}".format(
+                sub_indent, tee if i + 1 != length else last, f
+            )

--- a/dvc/tree/git.py
+++ b/dvc/tree/git.py
@@ -24,7 +24,14 @@ def _item_basename(item):
 class GitTree(BaseTree):  # pylint:disable=abstract-method
     """Proxies the repo file access methods to Git objects"""
 
-    def __init__(self, git, rev, use_dvcignore=False, dvcignore_root=None):
+    def __init__(
+        self,
+        git,
+        rev,
+        use_dvcignore=False,
+        dvcignore_root=None,
+        ignore_subrepo=True,
+    ):
         """Create GitTree instance
 
         Args:
@@ -36,6 +43,7 @@ class GitTree(BaseTree):  # pylint:disable=abstract-method
         self.rev = rev
         self.use_dvcignore = use_dvcignore
         self.dvcignore_root = dvcignore_root
+        self.ignore_subrepo = ignore_subrepo
 
     @property
     def tree_root(self):
@@ -46,8 +54,11 @@ class GitTree(BaseTree):  # pylint:disable=abstract-method
         from dvc.ignore import DvcIgnoreFilter, DvcIgnoreFilterNoop
 
         root = self.dvcignore_root or self.tree_root
-        cls = DvcIgnoreFilter if self.use_dvcignore else DvcIgnoreFilterNoop
-        return cls(self, root)
+        if self.use_dvcignore:
+            return DvcIgnoreFilter(
+                self, root, ignore_subrepo=self.ignore_subrepo
+            )
+        return DvcIgnoreFilterNoop(self, root)
 
     def open(
         self, path, mode="r", encoding="utf-8"

--- a/dvc/tree/git.py
+++ b/dvc/tree/git.py
@@ -64,6 +64,8 @@ class GitTree(BaseTree):  # pylint:disable=abstract-method
         self, path, mode="r", encoding="utf-8"
     ):  # pylint: disable=arguments-differ
         assert mode in {"r", "rb"}
+        if "b" not in mode:
+            encoding = encoding or "utf-8"
 
         relative_path = relpath(path, self.git.working_dir)
 

--- a/dvc/tree/local.py
+++ b/dvc/tree/local.py
@@ -36,12 +36,20 @@ class LocalTree(BaseTree):
     CACHE_MODE = 0o444
     SHARED_MODE_MAP = {None: (0o644, 0o755), "group": (0o664, 0o775)}
 
-    def __init__(self, repo, config, use_dvcignore=False, dvcignore_root=None):
+    def __init__(
+        self,
+        repo,
+        config,
+        use_dvcignore=False,
+        dvcignore_root=None,
+        ignore_subrepo=False,
+    ):
         super().__init__(repo, config)
         url = config.get("url")
         self.path_info = self.PATH_CLS(url) if url else None
         self.use_dvcignore = use_dvcignore
         self.dvcignore_root = dvcignore_root
+        self.ignore_subrepo = ignore_subrepo
 
     @property
     def tree_root(self):
@@ -58,8 +66,11 @@ class LocalTree(BaseTree):
         from dvc.ignore import DvcIgnoreFilter, DvcIgnoreFilterNoop
 
         root = self.dvcignore_root or self.tree_root
-        cls = DvcIgnoreFilter if self.use_dvcignore else DvcIgnoreFilterNoop
-        return cls(self, root)
+        if self.use_dvcignore:
+            return DvcIgnoreFilter(
+                self, root, ignore_subrepo=self.ignore_subrepo
+            )
+        return DvcIgnoreFilterNoop(self, root)
 
     @staticmethod
     def open(path_info, mode="r", encoding=None):

--- a/dvc/tree/local.py
+++ b/dvc/tree/local.py
@@ -42,7 +42,7 @@ class LocalTree(BaseTree):
         config,
         use_dvcignore=False,
         dvcignore_root=None,
-        ignore_subrepo=False,
+        ignore_subrepo=True,
     ):
         super().__init__(repo, config)
         url = config.get("url")

--- a/tests/func/test_api.py
+++ b/tests/func/test_api.py
@@ -186,7 +186,7 @@ def test_read_with_subrepos(tmp_dir, scm, local_cloud):
         make_subrepo(repo, scm, config=local_cloud.config)
         with repo.chdir():
             text = os.fspath((repo / "foo.txt").relative_to(tmp_dir)).replace(
-                "/", "-"
+                os.sep, "-"
             )
             repo.dvc_gen({"foo.txt": text}, commit=f"commit for path {path}")
             repo.dvc.push()

--- a/tests/func/test_external_repo.py
+++ b/tests/func/test_external_repo.py
@@ -3,7 +3,6 @@ import os
 from mock import ANY, patch
 
 from dvc.external_repo import CLONES, external_repo
-from dvc.path_info import PathInfo
 from dvc.scm.git import Git
 from dvc.tree.local import LocalTree
 from dvc.utils import relpath
@@ -20,11 +19,11 @@ def test_external_repo(erepo_dir):
 
     with patch.object(Git, "clone", wraps=Git.clone) as mock:
         with external_repo(url) as repo:
-            with repo.open_by_relpath("file") as fd:
+            with repo.repo_tree.open_by_relpath("file") as fd:
                 assert fd.read() == "master"
 
         with external_repo(url, rev="branch") as repo:
-            with repo.open_by_relpath("file") as fd:
+            with repo.repo_tree.open_by_relpath("file") as fd:
                 assert fd.read() == "branch"
 
         assert mock.call_count == 1
@@ -43,7 +42,7 @@ def test_source_change(erepo_dir):
     assert old_rev != new_rev
 
 
-def test_cache_reused(erepo_dir, mocker, local_cloud):
+def test_cache_reused(tmp_dir, erepo_dir, mocker, local_cloud):
     erepo_dir.add_remote(config=local_cloud.config)
     with erepo_dir.chdir():
         erepo_dir.dvc_gen("file", "text", commit="add file")
@@ -54,13 +53,13 @@ def test_cache_reused(erepo_dir, mocker, local_cloud):
     # Use URL to prevent any fishy optimizations
     url = f"file://{erepo_dir}"
     with external_repo(url) as repo:
-        repo.fetch()
+        repo.get_external("file", tmp_dir / "file1")
         assert download_spy.mock.call_count == 1
 
     # Should not download second time
     erepo_dir.scm.branch("branch")
     with external_repo(url, "branch") as repo:
-        repo.fetch()
+        repo.get_external("file", tmp_dir / "file2")
         assert download_spy.mock.call_count == 1
 
 
@@ -90,10 +89,7 @@ def test_pull_subdir_file(tmp_dir, erepo_dir):
 
     dest = tmp_dir / "file"
     with external_repo(os.fspath(erepo_dir)) as repo:
-        _, _, save_infos = repo.fetch_external(
-            [os.path.join("subdir", "file")]
-        )
-        repo.cache.local.checkout(PathInfo(dest), save_infos[0])
+        repo.get_external(os.path.join("subdir", "file"), dest)
 
     assert dest.is_file()
     assert dest.read_text() == "contents"
@@ -117,9 +113,10 @@ def test_relative_remote(erepo_dir, tmp_dir):
     url = os.fspath(erepo_dir)
 
     with external_repo(url) as repo:
-        assert os.path.isabs(repo.config["remote"]["upstream"]["url"])
-        assert os.path.isdir(repo.config["remote"]["upstream"]["url"])
-        with repo.open_by_relpath("file") as fd:
+        for subrepo in repo.repos:
+            assert os.path.isabs(subrepo.config["remote"]["upstream"]["url"])
+            assert os.path.isdir(subrepo.config["remote"]["upstream"]["url"])
+        with repo.repo_tree.open_by_relpath("file") as fd:
             assert fd.read() == "contents"
 
 

--- a/tests/func/test_external_repo.py
+++ b/tests/func/test_external_repo.py
@@ -130,7 +130,7 @@ def test_shallow_clone_branch(erepo_dir):
 
     with patch.object(Git, "clone", wraps=Git.clone) as mock_clone:
         with external_repo(url, rev="branch") as repo:
-            with repo.open_by_relpath("file") as fd:
+            with repo.repo_tree.open_by_relpath("file") as fd:
                 assert fd.read() == "branch"
 
         mock_clone.assert_called_with(url, ANY, shallow_branch="branch")
@@ -138,7 +138,7 @@ def test_shallow_clone_branch(erepo_dir):
         assert shallow
 
         with external_repo(url) as repo:
-            with repo.open_by_relpath("file") as fd:
+            with repo.repo_tree.open_by_relpath("file") as fd:
                 assert fd.read() == "master"
 
         assert mock_clone.call_count == 1
@@ -156,7 +156,7 @@ def test_shallow_clone_tag(erepo_dir):
 
     with patch.object(Git, "clone", wraps=Git.clone) as mock_clone:
         with external_repo(url, rev="v1") as repo:
-            with repo.open_by_relpath("file") as fd:
+            with repo.repo_tree.open_by_relpath("file") as fd:
                 assert fd.read() == "foo"
 
         mock_clone.assert_called_with(url, ANY, shallow_branch="v1")
@@ -164,7 +164,7 @@ def test_shallow_clone_tag(erepo_dir):
         assert shallow
 
         with external_repo(url, rev="master") as repo:
-            with repo.open_by_relpath("file") as fd:
+            with repo.repo_tree.open_by_relpath("file") as fd:
                 assert fd.read() == "bar"
 
         assert mock_clone.call_count == 1

--- a/tests/func/test_get.py
+++ b/tests/func/test_get.py
@@ -98,22 +98,6 @@ def test_get_a_dvc_file(tmp_dir, erepo_dir):
         Repo.get(os.fspath(erepo_dir), "some_file.dvc")
 
 
-# https://github.com/iterative/dvc/pull/2837#discussion_r352123053
-def test_get_full_dvc_path(tmp_dir, erepo_dir, tmp_path_factory):
-    path = tmp_path_factory.mktemp("ext")
-    external_data = path / "ext_data"
-    external_data.write_text("ext_data")
-
-    with erepo_dir.chdir():
-        erepo_dir.dvc.add(os.fspath(external_data), external=True)
-        erepo_dir.scm_add("ext_data.dvc", commit="add external data")
-
-    Repo.get(
-        os.fspath(erepo_dir), os.fspath(external_data), "ext_data_imported"
-    )
-    assert (tmp_dir / "ext_data_imported").read_text() == "ext_data"
-
-
 def test_non_cached_output(tmp_dir, erepo_dir):
     src = "non_cached_file"
     dst = src + "_imported"

--- a/tests/func/test_get.py
+++ b/tests/func/test_get.py
@@ -9,7 +9,7 @@ from dvc.main import main
 from dvc.repo import Repo
 from dvc.repo.get import GetDVCFileError
 from dvc.system import System
-from dvc.utils.fs import makedirs
+from dvc.utils.fs import makedirs, remove
 
 
 def test_get_repo_file(tmp_dir, erepo_dir):
@@ -248,39 +248,42 @@ def make_subrepo(dir_, scm, config=None):
 
 
 @pytest.mark.parametrize(
-    "output",
-    [
-        "foo",
-        {"foo": "foo", "bar": "bar"},
-        {"subdir": {"foo": "foo", "bar": "bar"}},
-    ],
-    ids=["file", "dir", "nested_dir"],
+    "erepo",
+    [pytest.lazy_fixture("erepo_dir"), pytest.lazy_fixture("git_dir")],
 )
-@pytest.mark.parametrize(
-    "erepo", [pytest.lazy_fixture("erepo_dir"), pytest.lazy_fixture("git_dir")]
-)
-@pytest.mark.parametrize(
-    "subrepo_paths",
-    [
-        (os.path.join("sub", "subdir1"), os.path.join("sub", "subdir2")),
-        (os.path.join("sub"), os.path.join("sub", "subdir1")),
-    ],
-    ids=["isolated", "nested"],
-)
-def test_subrepo_multiple(
-    tmp_dir, scm, output, subrepo_paths, erepo, local_cloud
-):
-    sub_repos = [erepo / path for path in subrepo_paths]
-    filename = "output"
-    for repo in sub_repos:
+def test_subrepo(tmp_dir, erepo, local_cloud):
+    def scm_framework(p):
+        return {
+            "foo": p + "foo-scm",
+            "scm_dir": {"lorem": p + "scm-lorem"}
+        }
+
+    def output_framework(p):
+        return {
+            "bar": p + "dvc-bar",
+            "dvc_dir": {"ipsum": p + "dvc-ipsum"}
+        }
+
+    subrepo = ["sub1", "sub2", os.path.join("sub1", "nested")]
+    for path in subrepo:
+        repo = erepo / path
         make_subrepo(repo, erepo.scm, local_cloud.config)
-        repo.dvc_gen({filename: output}, commit="add subrepo")
+        repo.dvc_gen(output_framework(path), commit="add dvc outputs")
+        repo.scm_gen(scm_framework(path), commit="add git files")
         repo.dvc.push()
 
-    for i, repo in enumerate(sub_repos):
-        Repo.get(
-            f"file:///{erepo}",
-            str((repo / filename).relative_to(erepo)),
-            out=f"{filename}-{i}",
-        )
-        assert (tmp_dir / f"{filename}-{i}").read_text() == output
+    for is_dvc, file in [
+        (False, "foo"),
+        (True, "dvc_dir"),
+        (False, "scm_dir"),
+        (True, "bar"),
+    ]:
+        for repo in subrepo:
+            Repo.get(
+                f"{erepo}", os.path.join(repo, file),
+            )
+            framework = output_framework if is_dvc else scm_framework
+            assert (tmp_dir / file).read_text() == framework(repo)[
+                file
+            ], f"Failed for repo: {repo} for file: {file}"
+            remove(tmp_dir / file)

--- a/tests/func/test_get.py
+++ b/tests/func/test_get.py
@@ -253,16 +253,10 @@ def make_subrepo(dir_, scm, config=None):
 )
 def test_subrepo(tmp_dir, erepo, local_cloud):
     def scm_framework(p):
-        return {
-            "foo": p + "foo-scm",
-            "scm_dir": {"lorem": p + "scm-lorem"}
-        }
+        return {"foo": p + "foo-scm", "scm_dir": {"lorem": p + "scm-lorem"}}
 
     def output_framework(p):
-        return {
-            "bar": p + "dvc-bar",
-            "dvc_dir": {"ipsum": p + "dvc-ipsum"}
-        }
+        return {"bar": p + "dvc-bar", "dvc_dir": {"ipsum": p + "dvc-ipsum"}}
 
     subrepo = ["sub1", "sub2", os.path.join("sub1", "nested")]
     for path in subrepo:

--- a/tests/func/test_get.py
+++ b/tests/func/test_get.py
@@ -238,12 +238,13 @@ def test_get_pipeline_tracked_outs(
         assert (git_dir / "baz").read_text() == "foo"
 
 
-def make_subrepo(dir_, scm, config):
+def make_subrepo(dir_, scm, config=None):
     dir_.mkdir(parents=True)
     with dir_.chdir():
         dir_.scm = scm
         dir_.init(dvc=True, subdir=True)
-        dir_.add_remote(config=config)
+        if config:
+            dir_.add_remote(config=config)
 
 
 @pytest.mark.parametrize(

--- a/tests/func/test_tree.py
+++ b/tests/func/test_tree.py
@@ -184,7 +184,7 @@ def test_repotree_walk_fetch(tmp_dir, dvc, scm, local_remote):
     dvc.push()
     remove(dvc.cache.local.cache_dir)
 
-    tree = RepoTree(dvc, fetch=True)
+    tree = RepoTree(dvc.tree, [dvc], fetch=True)
     with dvc.state:
         for _, _, _ in tree.walk("dir"):
             pass
@@ -208,7 +208,7 @@ def test_repotree_cache_save(tmp_dir, dvc, scm, erepo_dir, local_cloud):
     #
     # for this test, all file objects are being opened() and copied from tree
     # into dvc.cache, not fetched or streamed from a remote
-    tree = RepoTree(erepo_dir.dvc, stream=True)
+    tree = RepoTree(erepo_dir.dvc.tree, [erepo_dir.dvc], stream=True)
     expected = [
         tree.get_file_hash(PathInfo(erepo_dir / path))
         for path in ("dir/bar", "dir/subdir/foo")

--- a/tests/unit/repo/test_repo_tree.py
+++ b/tests/unit/repo/test_repo_tree.py
@@ -12,7 +12,7 @@ def test_exists(tmp_dir, dvc):
     dvc.add("foo")
     (tmp_dir / "foo").unlink()
 
-    tree = RepoTree(dvc)
+    tree = RepoTree(dvc.tree, [dvc])
     assert tree.exists("foo")
 
 
@@ -21,7 +21,7 @@ def test_open(tmp_dir, dvc):
     dvc.add("foo")
     (tmp_dir / "foo").unlink()
 
-    tree = RepoTree(dvc)
+    tree = RepoTree(dvc.tree, [dvc])
     with dvc.state:
         with tree.open("foo", "r") as fobj:
             assert fobj.read() == "foo"
@@ -31,7 +31,7 @@ def test_open_dirty_hash(tmp_dir, dvc):
     tmp_dir.dvc_gen("file", "file")
     (tmp_dir / "file").write_text("something")
 
-    tree = RepoTree(dvc)
+    tree = RepoTree(dvc.tree, [dvc])
     with tree.open("file", "r") as fobj:
         assert fobj.read() == "something"
 
@@ -40,7 +40,7 @@ def test_open_dirty_no_hash(tmp_dir, dvc):
     tmp_dir.gen("file", "file")
     (tmp_dir / "file.dvc").write_text("outs:\n- path: file\n")
 
-    tree = RepoTree(dvc)
+    tree = RepoTree(dvc.tree, [dvc])
     with tree.open("file", "r") as fobj:
         assert fobj.read() == "file"
 
@@ -60,7 +60,7 @@ def test_open_in_history(tmp_dir, scm, dvc):
         if rev == "workspace":
             continue
 
-        tree = RepoTree(dvc)
+        tree = RepoTree(dvc.tree, [dvc])
         with tree.open("foo", "r") as fobj:
             assert fobj.read() == "foo"
 
@@ -68,7 +68,7 @@ def test_open_in_history(tmp_dir, scm, dvc):
 def test_isdir_isfile(tmp_dir, dvc):
     tmp_dir.gen({"datafile": "data", "datadir": {"foo": "foo", "bar": "bar"}})
 
-    tree = RepoTree(dvc)
+    tree = RepoTree(dvc.tree, [dvc])
     assert tree.isdir("datadir")
     assert not tree.isfile("datadir")
     assert not tree.isdvc("datadir")
@@ -93,7 +93,7 @@ def test_isdir_mixed(tmp_dir, dvc):
 
     dvc.add(str(tmp_dir / "dir" / "foo"))
 
-    tree = RepoTree(dvc)
+    tree = RepoTree(dvc.tree, [dvc])
     assert tree.isdir("dir")
     assert not tree.isfile("dir")
 
@@ -123,7 +123,7 @@ def test_walk(tmp_dir, dvc, dvcfiles, extra_expected):
     )
     dvc.add(str(tmp_dir / "dir"), recursive=True)
     tmp_dir.gen({"dir": {"foo": "foo", "bar": "bar"}})
-    tree = RepoTree(dvc)
+    tree = RepoTree(dvc.tree, [dvc])
 
     expected = [
         PathInfo("dir") / "subdir1",
@@ -150,7 +150,7 @@ def test_walk_onerror(tmp_dir, dvc):
         raise exc
 
     tmp_dir.dvc_gen("foo", "foo")
-    tree = RepoTree(dvc)
+    tree = RepoTree(dvc.tree, [dvc])
 
     # path does not exist
     for _ in tree.walk("dir"):
@@ -171,7 +171,7 @@ def test_isdvc(tmp_dir, dvc):
     tmp_dir.gen({"foo": "foo", "bar": "bar", "dir": {"baz": "baz"}})
     dvc.add("foo")
     dvc.add("dir")
-    tree = RepoTree(dvc)
+    tree = RepoTree(dvc.tree, [dvc])
     assert tree.isdvc("foo")
     assert not tree.isdvc("bar")
     assert tree.isdvc("dir")


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

This PR at this time only works with ExternalRepo (should `Repo()` needs subrepo support, or should that be via `RepoTree`? probably both).

### TODO:
- [x] More tests
- [ ] `subrepo` support inside `Repo`
- [x] What should be done for `dvcx`? Currently, it seems it's broken, well before this PR. And, `dvcx` depends on git repo to have a top-level `dvc` repo, which this PR does not work with at all.

### Possible future works
- [ ] Implement `RepoTree.stat()`?
- [ ] Granular configs for dvctree and dvcignore
- [ ] Subrepo support in DvcRepo?

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
