### PR TITLE
experiments: support local parallel execution in temp directories

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -48,6 +48,10 @@ def _collect_rows(
         return val
 
     def _extend(row, names, items):
+        if not items:
+            row.extend(["-"] * len(names))
+            return
+
         for fname, item in items:
             if isinstance(item, dict):
                 item = flatten(item, ".")
@@ -62,13 +66,14 @@ def _collect_rows(
     for i, (rev, exp) in enumerate(experiments.items()):
         row = []
         style = None
+        queued = "*" if exp.get("queued", False) else ""
         if rev == "baseline":
             row.append(f"{base_rev}")
             style = "bold"
         elif i < len(experiments) - 1:
-            row.append(f"├── {rev[:7]}")
+            row.append(f"├── {queued}{rev[:7]}")
         else:
-            row.append(f"└── {rev[:7]}")
+            row.append(f"└── {queued}{rev[:7]}")
 
         _extend(row, metric_names, exp.get("metrics", {}).items())
         _extend(row, param_names, exp.get("params", {}).items())

--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -229,6 +229,7 @@ def add_parser(subparsers, parent_parser):
     experiments_parser = subparsers.add_parser(
         "experiments",
         parents=[parent_parser],
+        aliases=["exp"],
         description=append_doc_link(EXPERIMENTS_HELP, "experiments"),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -41,6 +41,9 @@ class CmdRepro(CmdBase):
                     recursive=self.args.recursive,
                     force_downstream=self.args.force_downstream,
                     experiment=self.args.experiment,
+                    queue=self.args.queue,
+                    run_all=self.args.run_all,
+                    jobs=self.args.jobs,
                 )
 
                 if len(stages) == 0:
@@ -173,5 +176,17 @@ def add_parser(subparsers, parent_parser):
         action="store_true",
         default=False,
         help=argparse.SUPPRESS,
+    )
+    repro_parser.add_argument(
+        "--queue", action="store_true", default=False, help=argparse.SUPPRESS
+    )
+    repro_parser.add_argument(
+        "--run-all",
+        action="store_true",
+        default=False,
+        help=argparse.SUPPRESS,
+    )
+    repro_parser.add_argument(
+        "-j", "--jobs", type=int, help=argparse.SUPPRESS, metavar="<number>"
     )
     repro_parser.set_defaults(func=CmdRepro)

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -180,7 +180,7 @@ class Experiments:
         stash_rev = self.new(**kwargs)
         if queue:
             logger.info(
-                "Queued experiment '%s' for future execution.", stash_rev
+                "Queued experiment '%s' for future execution.", stash_rev[:7]
             )
             return []
         results = self.reproduce([stash_rev], keep_stash=False)
@@ -195,7 +195,7 @@ class Experiments:
         if results:
             revs = [f"{rev[:7]}" for rev in results]
             logger.info(
-                "Successfully reproduced experiments '%s'.\n"
+                "Successfully reproduced experiment(s) '%s'.\n"
                 "Use `dvc exp checkout <exp_rev>` to apply the results of "
                 "a specific experiment to your workspace.",
                 ", ".join(revs),

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -94,8 +94,11 @@ class Experiments:
 
     def _scm_checkout(self, rev):
         self.scm.repo.git.reset(hard=True)
+        if self.scm.repo.head.is_detached:
+            # switch back to default branch
+            self.scm.repo.heads[0].checkout()
         if not Git.is_sha(rev) or not self.scm.has_rev(rev):
-            self.scm.fetch(all=True)
+            self.scm.pull()
         logger.debug("Checking out base experiment commit '%s'", rev)
         self.scm.checkout(rev)
 

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -2,7 +2,7 @@ import logging
 import os
 import re
 import tempfile
-from concurrent.futures import ProcessPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from typing import Iterable, Optional
 
@@ -289,7 +289,7 @@ class Experiments:
         """
         result = {}
 
-        with ProcessPoolExecutor(max_workers=jobs) as workers:
+        with ThreadPoolExecutor(max_workers=jobs) as workers:
             futures = {
                 workers.submit(executor.reproduce): (rev, executor)
                 for rev, executor in executors.items()

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -3,7 +3,6 @@ import os
 import re
 import tempfile
 from concurrent.futures import ProcessPoolExecutor, as_completed
-from contextlib import contextmanager
 from typing import Iterable, Optional
 
 from funcy import cached_property
@@ -98,13 +97,6 @@ class Experiments:
             if m:
                 revs[entry.newhexsha] = (i, m.group("baseline_rev"))
         return revs
-
-    @contextmanager
-    def chdir(self):
-        cwd = os.getcwd()
-        os.chdir(self.exp_dvc.root_dir)
-        yield
-        os.chdir(cwd)
 
     def _init_clone(self):
         src_dir = self.repo.scm.root_dir

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -155,10 +155,8 @@ class Experiments:
         else:
             # configure params via command line here
             pass
-        stages = self._run_local(rev, *args, **kwargs)
-        # self.exp_dvc.checkout()
-        # stages = self._reproduce(*args, **kwargs)
-        exp_rev = self._commit(stages, rev=rev)
+        stages, unchanged = self._run_local(rev, *args, **kwargs)
+        exp_rev = self._commit(stages + unchanged, rev=rev)
         self.checkout_exp(exp_rev, force=True)
         logger.info("Generated experiment '%s'.", exp_rev[:7])
         return stages
@@ -170,13 +168,13 @@ class Experiments:
             dvc_dir=self.dvc_dir,
             cache_dir=self.repo.cache.local.cache_dir,
         )
-        stages = executor.run(*args, **kwargs)
+        stages, unchanged = executor.run(*args, **kwargs)
         logger.debug("copying tmp output from '%s'", executor.tmp_dir)
         for fname in tree.walk_files(tree.tree_root):
             src = executor.path_info / relpath(fname, tree.tree_root)
             copyfile(src, fname)
         executor.cleanup()
-        return stages
+        return stages, unchanged
 
     def checkout_exp(self, rev, force=False):
         """Checkout an experiment to the user's workspace."""

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -2,7 +2,7 @@ import logging
 import os
 import re
 import tempfile
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from contextlib import contextmanager
 from typing import Iterable, Optional
 
@@ -281,9 +281,9 @@ class Experiments:
         """
         result = {}
 
-        with ThreadPoolExecutor(max_workers=jobs) as thread_exec:
+        with ProcessPoolExecutor(max_workers=jobs) as workers:
             futures = {
-                thread_exec.submit(executor.reproduce): (rev, executor)
+                workers.submit(executor.reproduce): (rev, executor)
                 for rev, executor in executors.items()
             }
             for future in as_completed(futures):

--- a/dvc/repo/experiments/executor.py
+++ b/dvc/repo/experiments/executor.py
@@ -1,0 +1,81 @@
+import logging
+import os
+from contextlib import contextmanager
+from tempfile import TemporaryDirectory
+
+from funcy import cached_property
+
+from dvc.path_info import PathInfo
+from dvc.tree.base import BaseTree
+from dvc.utils import relpath
+from dvc.utils.fs import copyfile, makedirs
+
+logger = logging.getLogger(__name__)
+
+
+class ExperimentExecutor:
+    """Base class for executing experiments in parallel."""
+
+    def __init__(self, src_tree: BaseTree, **kwargs):
+        pass
+
+    def run(self, *args, **kwargs):
+        pass
+
+    def cleanup(self):
+        pass
+
+
+class LocalExecutor(ExperimentExecutor):
+    def __init__(self, src_tree: BaseTree, **kwargs):
+        dvc_dir = kwargs.pop("dvc_dir")
+        cache_dir = kwargs.pop("cache_dir")
+        super().__init__(src_tree, **kwargs)
+        self.tmp_dir = TemporaryDirectory()
+        logger.debug("Init local executor in dir '%s'.", self.tmp_dir)
+        self.dvc_dir = os.path.join(self.tmp_dir.name, dvc_dir)
+        try:
+            for fname in src_tree.walk_files(src_tree.tree_root):
+                dest = self.path_info / relpath(fname, src_tree.tree_root)
+                if not os.path.exists(dest.parent):
+                    makedirs(dest.parent)
+                copyfile(fname, dest)
+        except Exception:
+            self.tmp_dir.cleanup()
+            raise
+        self._config(cache_dir)
+
+    def _config(self, cache_dir):
+        local_config = os.path.join(self.dvc_dir, "config.local")
+        logger.debug("Writing experiments local config '%s'", local_config)
+        with open(local_config, "w") as fobj:
+            fobj.write("[core]\n    no_scm = true\n")
+            fobj.write(f"[cache]\n    dir = {cache_dir}")
+
+    @cached_property
+    def dvc(self):
+        from dvc.repo import Repo
+
+        return Repo(self.dvc_dir)
+
+    @cached_property
+    def path_info(self):
+        return PathInfo(self.tmp_dir.name)
+
+    @contextmanager
+    def chdir(self):
+        cwd = os.getcwd()
+        os.chdir(self.dvc.root_dir)
+        yield
+        os.chdir(cwd)
+
+    def run(self, *args, **kwargs):
+        logger.debug("Running repro in '%s'", self.tmp_dir)
+        with self.chdir():
+            self.dvc.checkout()
+            return self.dvc.reproduce(*args, **kwargs)
+
+    def cleanup(self):
+        logger.debug("Removing tmpdir '%s'", self.tmp_dir)
+        self.tmp_dir.cleanup()
+        super().cleanup()

--- a/dvc/repo/experiments/executor.py
+++ b/dvc/repo/experiments/executor.py
@@ -45,6 +45,8 @@ class LocalExecutor(ExperimentExecutor):
             self.tmp_dir.cleanup()
             raise
         self._config(cache_dir)
+        self._stages = None
+        self._unchanged = None
 
     def _config(self, cache_dir):
         local_config = os.path.join(self.dvc_dir, "config.local")
@@ -62,6 +64,10 @@ class LocalExecutor(ExperimentExecutor):
     @cached_property
     def path_info(self):
         return PathInfo(self.tmp_dir.name)
+
+    @property
+    def result(self):
+        return self._stages, self._unchanged
 
     @contextmanager
     def chdir(self):
@@ -83,7 +89,8 @@ class LocalExecutor(ExperimentExecutor):
             stages = self.dvc.reproduce(
                 *args, on_unchanged=filter_pipeline, **kwargs,
             )
-            return stages, unchanged
+        self._stages = stages
+        self._unchanged = unchanged
 
     def cleanup(self):
         logger.debug("Removing tmpdir '%s'", self.tmp_dir)

--- a/dvc/repo/experiments/executor.py
+++ b/dvc/repo/experiments/executor.py
@@ -9,7 +9,7 @@ from dvc.path_info import PathInfo
 from dvc.stage import PipelineStage
 from dvc.tree.base import BaseTree
 from dvc.utils import relpath
-from dvc.utils.fs import copyfile, makedirs
+from dvc.utils.fs import copy_fobj_to_file, makedirs
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +40,8 @@ class LocalExecutor(ExperimentExecutor):
                 dest = self.path_info / relpath(fname, src_tree.tree_root)
                 if not os.path.exists(dest.parent):
                     makedirs(dest.parent)
-                copyfile(fname, dest)
+                with src_tree.open(fname, "rb") as fobj:
+                    copy_fobj_to_file(fobj, dest)
         except Exception:
             self.tmp_dir.cleanup()
             raise

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -73,7 +73,7 @@ def reproduce(
     experiment = kwargs.pop("experiment", False)
     if experiment and self.experiments:
         try:
-            return self.experiments.new(
+            return self.experiments.reproduce_one(
                 target=target,
                 recursive=recursive,
                 all_pipelines=all_pipelines,

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -71,13 +71,20 @@ def reproduce(
         )
 
     experiment = kwargs.pop("experiment", False)
+    queue = kwargs.pop("queue", False)
+    run_all = kwargs.pop("run_all", False)
+    jobs = kwargs.pop("jobs", 1)
     if experiment and self.experiments:
         try:
-            return self.experiments.reproduce_one(
+            return _reproduce_experiments(
+                self,
                 target=target,
                 recursive=recursive,
                 all_pipelines=all_pipelines,
-                **kwargs
+                queue=queue,
+                run_all=run_all,
+                jobs=jobs,
+                **kwargs,
             )
         except UnchangedExperimentError:
             # If experiment contains no changes, just run regular repro
@@ -107,6 +114,12 @@ def reproduce(
         targets = self.collect(target, recursive=recursive, graph=active_graph)
 
     return _reproduce_stages(active_graph, targets, **kwargs)
+
+
+def _reproduce_experiments(repo, run_all=False, jobs=1, **kwargs):
+    if run_all:
+        return repo.experiments.reproduce_all(jobs=jobs)
+    return repo.experiments.reproduce_one(**kwargs)
 
 
 def _reproduce_stages(

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -74,7 +74,7 @@ def reproduce(
     queue = kwargs.pop("queue", False)
     run_all = kwargs.pop("run_all", False)
     jobs = kwargs.pop("jobs", 1)
-    if experiment and self.experiments:
+    if (experiment or run_all) and self.experiments:
         try:
             return _reproduce_experiments(
                 self,
@@ -118,7 +118,7 @@ def reproduce(
 
 def _reproduce_experiments(repo, run_all=False, jobs=1, **kwargs):
     if run_all:
-        return repo.experiments.reproduce_all(jobs=jobs)
+        return repo.experiments.reproduce_queued(jobs=jobs)
     return repo.experiments.reproduce_one(**kwargs)
 
 

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -110,7 +110,7 @@ def reproduce(
 
 
 def _reproduce_stages(
-    G, stages, downstream=False, single_item=False, **kwargs
+    G, stages, downstream=False, single_item=False, on_unchanged=None, **kwargs
 ):
     r"""Derive the evaluation of the given node for the given graph.
 
@@ -194,7 +194,10 @@ def _reproduce_stages(
                 # dependencies didn't change.
                 kwargs["force"] = True
 
-            result.extend(ret)
+            if ret:
+                result.extend(ret)
+            elif on_unchanged is not None:
+                on_unchanged(stage)
         except Exception as exc:
             raise ReproductionError(stage.relpath) from exc
 

--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -15,5 +15,6 @@ def test_show_simple(tmp_dir, scm, dvc):
         "baseline": {
             "metrics": {"metrics.yaml": {"foo": 1}},
             "params": {"params.yaml": {"foo": 1}},
+            "queued": False,
         }
     }

--- a/tests/unit/command/test_repro.py
+++ b/tests/unit/command/test_repro.py
@@ -15,6 +15,9 @@ default_arguments = {
     "recursive": False,
     "force_downstream": False,
     "experiment": False,
+    "queue": False,
+    "run_all": False,
+    "jobs": None,
 }
 
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

* [x] ❌ I will check DeepSource, CodeClimate, and other sanity checks below. (We consider them recommendatory and don't expect everything to be addressed. Please fix things that actually improve code or fix bugs.)

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Related to #2799.

* Adds local temp directory executor and support for running experiments in parallel.
    * Only `dvc repro` is currently supported
    * Individual `dvc run` stages within a single `repro` command cannot be run in parallel
* `dvc repro --experiment --queue` can be used to add an experiment to the execution queue
* `dvc repro --run-all` will run all experiments currently in the queue
    * `-j/--jobs` can be used to run experiments in parallel, currently defaults to 1 (run sequentially), will need to decide if we should default to cpu count for this?
* Queued experiments are listed in `dvc exp show` and denoted with `*`

Next steps:
* Reorganize executor output collection (currently collection is done manually in the `experiments` classes rather than reading output from an executor's tree)
* Clean up executor classes so that they can be more easily extended to support other types of executors