### PR TITLE
add toml support for ParamsDependency

### DIFF
--- a/dvc/repo/params/show.py
+++ b/dvc/repo/params/show.py
@@ -1,5 +1,6 @@
 import logging
 
+import toml
 import yaml
 
 from dvc.dependency.param import ParamsDependency
@@ -34,8 +35,10 @@ def _read_params(repo, configs, rev):
 
         with repo.tree.open(config, "r") as fobj:
             try:
-                res[str(config)] = yaml.safe_load(fobj)
-            except yaml.YAMLError:
+                res[str(config)] = ParamsDependency.PARAMS_FILE_LOADERS[
+                    config.suffix.lower()
+                ](fobj)
+            except (yaml.YAMLError, toml.TomlDecodeError):
                 logger.debug(
                     "failed to read '%s' on '%s'", config, rev, exc_info=True
                 )

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ count=true
 [isort]
 include_trailing_comma=true
 known_first_party=dvc,tests
-known_third_party=PyInstaller,RangeHTTPServer,boto3,colorama,configobj,distro,dpath,flaky,flufl,funcy,git,grandalf,mock,moto,nanotime,networkx,packaging,pathspec,pygtrie,pylint,pytest,requests,ruamel,setuptools,shortuuid,shtab,tqdm,voluptuous,yaml,zc
+known_third_party=PyInstaller,RangeHTTPServer,boto3,colorama,configobj,distro,dpath,flaky,flufl,funcy,git,grandalf,mock,moto,nanotime,networkx,packaging,pathspec,pygtrie,pylint,pytest,requests,ruamel,setuptools,shortuuid,shtab,toml,tqdm,voluptuous,yaml,zc
 line_length=79
 force_grid_wrap=0
 use_parentheses=True

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ install_requires = [
     "appdirs>=1.4.3",
     "PyYAML>=5.1.2,<5.4",  # Compatibility with awscli
     "ruamel.yaml>=0.16.1",
+    "toml>=0.10.1",
     "funcy>=1.14",
     "pathspec>=0.6.0",
     "shortuuid>=0.5.0",

--- a/tests/func/params/test_show.py
+++ b/tests/func/params/test_show.py
@@ -14,6 +14,16 @@ def test_show(tmp_dir, dvc):
     assert dvc.params.show() == {"": {"params.yaml": {"foo": "bar"}}}
 
 
+def test_show_toml(tmp_dir, dvc):
+    tmp_dir.gen("params.toml", "[foo]\nbar = 42\nbaz = [1, 2]\n")
+    dvc.run(
+        cmd="echo params.toml", params=["params.toml:foo"], single_stage=True
+    )
+    assert dvc.params.show() == {
+        "": {"params.toml": {"foo": {"bar": 42, "baz": [1, 2]}}}
+    }
+
+
 def test_show_multiple(tmp_dir, dvc):
     tmp_dir.gen("params.yaml", "foo: bar\nbaz: qux\n")
     dvc.run(

--- a/tests/unit/dependency/test_params.py
+++ b/tests/unit/dependency/test_params.py
@@ -1,4 +1,5 @@
 import pytest
+import toml
 import yaml
 
 from dvc.dependency import ParamsDependency, loadd_from, loads_params
@@ -96,6 +97,37 @@ def test_read_params_nested(tmp_dir, dvc):
         yaml.dump({"some": {"path": {"foo": ["val1", "val2"]}}}),
     )
     dep = ParamsDependency(Stage(dvc), None, ["some.path.foo"])
+    assert dep.read_params() == {"some.path.foo": ["val1", "val2"]}
+
+
+def test_read_params_default_loader(tmp_dir, dvc):
+    parameters_file = "parameters.foo"
+    tmp_dir.gen(
+        parameters_file,
+        yaml.dump({"some": {"path": {"foo": ["val1", "val2"]}}}),
+    )
+    dep = ParamsDependency(Stage(dvc), parameters_file, ["some.path.foo"])
+    assert dep.read_params() == {"some.path.foo": ["val1", "val2"]}
+
+
+def test_read_params_wrong_suffix(tmp_dir, dvc):
+    parameters_file = "parameters.toml"
+    tmp_dir.gen(
+        parameters_file,
+        yaml.dump({"some": {"path": {"foo": ["val1", "val2"]}}}),
+    )
+    dep = ParamsDependency(Stage(dvc), parameters_file, ["some.path.foo"])
+    with pytest.raises(BadParamFileError):
+        dep.read_params()
+
+
+def test_read_params_toml(tmp_dir, dvc):
+    parameters_file = "parameters.toml"
+    tmp_dir.gen(
+        parameters_file,
+        toml.dumps({"some": {"path": {"foo": ["val1", "val2"]}}}),
+    )
+    dep = ParamsDependency(Stage(dvc), parameters_file, ["some.path.foo"])
     assert dep.read_params() == {"some.path.foo": ["val1", "val2"]}
 
 


### PR DESCRIPTION
We've been testing DVC with a few of our projects and for some of those we use a toml config to store parameters.
This PR adds support for parameters file in toml format. Example:

```
dvc run -n train                      \
-d data/input.csv                   \
-o model/model.h5                \
-M model/train_history.csv   \
-p params.toml:model.training \
python train.py
```

Where `params.toml` looks something like this:

> [transformers.numerical_quantile_transformer]
> n_quantiles = 300
> output_distribution = "uniform"
> 
> [model.training]
> epochs = 50
> verbose = 1