### PR TITLE
repro: update status message for dvc-added files

### DIFF
--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -306,7 +306,10 @@ class Stage(params.StageParams):
     @rwlocked(read=["deps"], write=["outs"])
     def reproduce(self, interactive=False, **kwargs):
         if not (kwargs.get("force", False) or self.changed()):
-            logger.info("Stage '%s' didn't change, skipping", self.addressing)
+            if '.dvc' in self.adressing:
+                logger.info("'%s' didn't change, skipping", self.addressing)
+            else:
+                logger.info("Stage '%s' didn't change, skipping", self.addressing)
             return None
 
         msg = (


### PR DESCRIPTION
The reason for updating the status message is that `.dvc` files are not stages and hence we can just remove the prefix "Stage" from the output whenever a `.dvc` file would be detected.

References #4233 