### PR TITLE
force YAML 1.1 syntax when dumping yaml files with ruamel

### DIFF
--- a/dvc/utils/yaml.py
+++ b/dvc/utils/yaml.py
@@ -44,6 +44,7 @@ def parse_yaml_for_update(text, path):
 def dump_yaml(path, data):
     with open(path, "w", encoding="utf-8") as fd:
         yaml = YAML()
+        yaml.version = (1, 1)  # Workaround for #4281
         yaml.default_flow_style = False
         # tell Dumper to represent OrderedDict as
         # normal dict


### PR DESCRIPTION
workaround for #4281 