### PR TITLE
Exclude pylint==6.0 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,9 @@ all_remotes = gs + s3 + azure + ssh + oss + gdrive + hdfs
 tests_requirements = [
     "wheel>=0.31.1",
     # Test requirements:
-    "pytest>=4.6.0",
+    # https://github.com/pytest-dev/pytest/issues/7558
+    # FIXME: pylint complaining for pytest.mark.* on v6.0
+    "pytest>=4.6.0,<6.0",
     "pytest-docker>=0.7.2",
     "pytest-timeout>=1.3.3",
     "pytest-cov>=2.6.1",


### PR DESCRIPTION
https://github.com/pytest-dev/pytest/issues/7558
pylint throws error for `pytest.mark.*` functions in pytest6.

```
tests/unit/repo/test_repo.py:15:1: E1102: pytest.mark.parametrize is not callable (not-callable)
tests/unit/repo/test_repo.py:33:1: E1102: pytest.mark.parametrize is not callable (not-callable)
************* Module tests.unit.remote.ssh.test_connection
tests/unit/remote/ssh/test_connection.py:87:1: E1102: pytest.mark.skipif is not callable (not-callable)
tests/unit/remote/ssh/test_connection.py:100:1: E1102: pytest.mark.skipif is not callable (not-callable)
```
https://github.com/iterative/dvc/pull/4257#issuecomment-665474467

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
