### PR TITLE
Update pytest to >=6.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,9 +105,7 @@ all_remotes = gs + s3 + azure + ssh + oss + gdrive + hdfs + webdav
 tests_requirements = [
     "wheel>=0.31.1",
     # Test requirements:
-    # https://github.com/pytest-dev/pytest/issues/7558
-    # FIXME: pylint complaining for pytest.mark.* on v6.0
-    "pytest>=4.6.0,<6.0",
+    "pytest>=6.0.1",
     "pytest-docker>=0.7.2",
     "pytest-timeout>=1.3.3",
     "pytest-cov>=2.6.1",


### PR DESCRIPTION
pytest 6.0.0 had issue with `pylint`, complaining for `pytest.mark.*` being `not-callable`. Ref: https://github.com/pytest-dev/pytest/issues/7558

[pytest6.0.1 has just been released](https://github.com/pytest-dev/pytest/releases/tag/6.0.1).

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
