### PR TITLE
experiments: more intelligent checkout behavior

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -146,9 +146,7 @@ class CmdExperimentsCheckout(CmdBase):
         if not self.repo.experiments:
             return 0
 
-        self.repo.experiments.checkout(
-            self.args.experiment, force=self.args.force
-        )
+        self.repo.experiments.checkout(self.args.experiment)
 
         return 0
 
@@ -286,14 +284,6 @@ def add_parser(subparsers, parent_parser):
         ),
         help=EXPERIMENTS_CHECKOUT_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
-    experiments_checkout_parser.add_argument(
-        "-f",
-        "--force",
-        action="store_true",
-        default=False,
-        help="Overwrite your current workspace with changes from the "
-        "experiment.",
     )
     experiments_checkout_parser.add_argument(
         "experiment", help="Checkout this experiment.",

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -3,6 +3,7 @@ import os
 import re
 import tempfile
 from concurrent.futures import ProcessPoolExecutor, as_completed
+from contextlib import contextmanager
 from typing import Iterable, Optional
 
 from funcy import cached_property
@@ -78,6 +79,13 @@ class Experiments:
         from dvc.repo import Repo
 
         return Repo(self.exp_dvc_dir)
+
+    @contextmanager
+    def chdir(self):
+        cwd = os.getcwd()
+        os.chdir(self.exp_dvc.root_dir)
+        yield self.exp_dvc.root_dir
+        os.chdir(cwd)
 
     @cached_property
     def args_file(self):


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Should fix #4289.

* No longer use `git reset --hard` when doing checkout.
* Changes from the experiment commit are preferred over workspace changes, but all other unrelated and unstaged/uncommitted workspace changes will now be preserved after `dvc experiments checkout`