### PR TITLE
Two new modes `--all` and `--stdin` for check-ignore

### DIFF
--- a/dvc/command/check_ignore.py
+++ b/dvc/command/check_ignore.py
@@ -41,7 +41,7 @@ class CmdCheckIgnore(CmdBase):
             target = ask("")
             if target == "":
                 logger.info(
-                    "empty string is not a valid pathspec. please use . "
+                    "Empty string is not a valid pathspec. Please use . "
                     "instead if you meant to match all paths"
                 )
                 break

--- a/dvc/command/check_ignore.py
+++ b/dvc/command/check_ignore.py
@@ -61,7 +61,7 @@ class CmdCheckIgnore(CmdBase):
             raise DvcException("targets or --stdin needed")
 
         if self.args.stdin and self.args.targets:
-            raise DvcException("cannot have targets and --stdin both")
+            raise DvcException("cannot have both `targets` and `--stdin`")
 
         if self.args.non_matching and not self.args.details:
             raise DvcException("--non-matching is only valid with --details")

--- a/dvc/command/check_ignore.py
+++ b/dvc/command/check_ignore.py
@@ -56,7 +56,13 @@ class CmdCheckIgnore(CmdBase):
                 ret = 0
         return ret
 
-    def run(self):
+    def _check_args(self):
+        if not self.args.stdin and not self.args.targets:
+            raise DvcException("targets or --stdin needed")
+
+        if self.args.stdin and self.args.targets:
+            raise DvcException("cannot have targets and --stdin both")
+
         if self.args.non_matching and not self.args.details:
             raise DvcException("--non-matching is only valid with --details")
 
@@ -66,6 +72,8 @@ class CmdCheckIgnore(CmdBase):
         if self.args.quiet and self.args.details:
             raise DvcException("cannot both --details and --quiet")
 
+    def run(self):
+        self._check_args()
         if self.args.stdin:
             ret = self._interactive_mode()
         else:
@@ -115,7 +123,7 @@ def add_parser(subparsers, parent_parser):
     )
     parser.add_argument(
         "targets",
-        nargs="+",
+        nargs="*",
         help="Exact or wildcard paths of files or directories to check "
         "ignore patterns.",
     ).complete = completion.FILE

--- a/dvc/command/check_ignore.py
+++ b/dvc/command/check_ignore.py
@@ -42,7 +42,7 @@ class CmdCheckIgnore(CmdBase):
             if target == "":
                 logger.info(
                     "Empty string is not a valid pathspec. Please use . "
-                    "instead if you meant to match all paths"
+                    "instead if you meant to match all paths."
                 )
                 break
             if not self._check_one_file(target):

--- a/dvc/command/check_ignore.py
+++ b/dvc/command/check_ignore.py
@@ -70,7 +70,7 @@ class CmdCheckIgnore(CmdBase):
             raise DvcException("`--all` is only valid with `--details`")
 
         if self.args.quiet and self.args.details:
-            raise DvcException("cannot both --details and --quiet")
+            raise DvcException("cannot use both `--details` and `--quiet`")
 
     def run(self):
         self._check_args()

--- a/dvc/command/check_ignore.py
+++ b/dvc/command/check_ignore.py
@@ -64,7 +64,9 @@ class CmdCheckIgnore(CmdBase):
             raise DvcException("cannot have both `targets` and `--stdin`")
 
         if self.args.non_matching and not self.args.details:
-            raise DvcException("`--non-matching` is only valid with `--details`")
+            raise DvcException(
+                "`--non-matching` is only valid with `--details`"
+            )
 
         if self.args.all and not self.args.details:
             raise DvcException("`--all` is only valid with `--details`")

--- a/dvc/command/check_ignore.py
+++ b/dvc/command/check_ignore.py
@@ -64,7 +64,7 @@ class CmdCheckIgnore(CmdBase):
             raise DvcException("cannot have both `targets` and `--stdin`")
 
         if self.args.non_matching and not self.args.details:
-            raise DvcException("--non-matching is only valid with --details")
+            raise DvcException("`--non-matching` is only valid with `--details`")
 
         if self.args.all and not self.args.details:
             raise DvcException("`--all` is only valid with `--details`")

--- a/dvc/command/check_ignore.py
+++ b/dvc/command/check_ignore.py
@@ -67,7 +67,7 @@ class CmdCheckIgnore(CmdBase):
             raise DvcException("--non-matching is only valid with --details")
 
         if self.args.all and not self.args.details:
-            raise DvcException("--all is only valid with --details")
+            raise DvcException("`--all` is only valid with `--details`")
 
         if self.args.quiet and self.args.details:
             raise DvcException("cannot both --details and --quiet")

--- a/dvc/command/check_ignore.py
+++ b/dvc/command/check_ignore.py
@@ -58,7 +58,7 @@ class CmdCheckIgnore(CmdBase):
 
     def _check_args(self):
         if not self.args.stdin and not self.args.targets:
-            raise DvcException("targets or --stdin needed")
+            raise DvcException("`targets` or `--stdin` needed")
 
         if self.args.stdin and self.args.targets:
             raise DvcException("cannot have both `targets` and `--stdin`")

--- a/dvc/command/check_ignore.py
+++ b/dvc/command/check_ignore.py
@@ -4,7 +4,7 @@ import logging
 from dvc.command import completion
 from dvc.command.base import CmdBase, append_doc_link
 from dvc.exceptions import DvcException
-from dvc.prompt import path_input
+from dvc.prompt import ask
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +38,7 @@ class CmdCheckIgnore(CmdBase):
     def _interactive_mode(self):
         ret = 1
         while True:
-            target = path_input()
+            target = ask("")
             if target == "":
                 logger.info(
                     "empty string is not a valid pathspec. please use . "

--- a/dvc/command/check_ignore.py
+++ b/dvc/command/check_ignore.py
@@ -75,10 +75,8 @@ class CmdCheckIgnore(CmdBase):
     def run(self):
         self._check_args()
         if self.args.stdin:
-            ret = self._interactive_mode()
-        else:
-            ret = self._normal_mode()
-        return ret
+            return self._interactive_mode()
+        return self._normal_mode()
 
 
 def add_parser(subparsers, parent_parser):

--- a/dvc/prompt.py
+++ b/dvc/prompt.py
@@ -7,7 +7,7 @@ from getpass import getpass
 logger = logging.getLogger(__name__)
 
 
-def _ask(prompt, limited_to=None):
+def ask(prompt, limited_to=None):
     if not sys.stdout.isatty():
         return None
 
@@ -39,7 +39,7 @@ def confirm(statement):
         bool: whether or not specified statement was confirmed.
     """
     prompt = f"{statement} [y/n]"
-    answer = _ask(prompt, limited_to=["yes", "no", "y", "n"])
+    answer = ask(prompt, limited_to=["yes", "no", "y", "n"])
     return answer and answer.startswith("y")
 
 
@@ -54,12 +54,3 @@ def password(statement):
     """
     logger.info(f"{statement}: ")
     return getpass("")
-
-
-def path_input():
-    """Ask the user for a path.
-
-    Returns:
-        str: path entered by the user.
-    """
-    return _ask("")

--- a/dvc/prompt.py
+++ b/dvc/prompt.py
@@ -54,3 +54,12 @@ def password(statement):
     """
     logger.info(f"{statement}: ")
     return getpass("")
+
+
+def path_input():
+    """Ask the user for a path.
+
+    Returns:
+        str: path entered by the user.
+    """
+    return _ask("")

--- a/tests/func/test_check_ignore.py
+++ b/tests/func/test_check_ignore.py
@@ -49,9 +49,18 @@ def test_check_ignore_non_matching(tmp_dir, dvc, non_matching, output, caplog):
     assert output in caplog.text
 
 
-@pytest.mark.parametrize("args", [["-n"], ["-a"], ["-q", "-d"]])
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["-n", "file"],
+        ["-a", "file"],
+        ["-q", "-d", "file"],
+        ["--stdin", "file"],
+        [],
+    ],
+)
 def test_check_ignore_error_args_cases(tmp_dir, dvc, args):
-    assert main(["check-ignore"] + args + ["file"]) == 255
+    assert main(["check-ignore"] + args) == 255
 
 
 @pytest.mark.parametrize("path,ret", [({"dir": {}}, 0), ({"dir": "files"}, 1)])


### PR DESCRIPTION
Fix #4321

Introduce new arguments --all for dvc check-ignore
Add tests for dvc check-ignore --all

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
