### PR TITLE
tests: fix regex

### DIFF
--- a/tests/func/test_version.py
+++ b/tests/func/test_version.py
@@ -17,7 +17,7 @@ def test_info_in_repo(scm_init, tmp_dir, caplog):
     assert main(["version"]) == 0
 
     assert re.search(r"DVC version: \d+\.\d+\.\d+.*", caplog.text)
-    assert re.search(r"Platform: Python \d\.\d\.\d on .*", caplog.text)
+    assert re.search(r"Platform: Python \d\.\d+\.\d+ on .*", caplog.text)
     assert re.search(r"Supports: .*", caplog.text)
     assert re.search(r"Cache types: .*", caplog.text)
 
@@ -61,7 +61,7 @@ def test_info_outside_of_repo(tmp_dir, caplog):
     assert main(["version"]) == 0
 
     assert re.search(r"DVC version: \d+\.\d+\.\d+.*", caplog.text)
-    assert re.search(r"Platform: Python \d\.\d\.\d on .*", caplog.text)
+    assert re.search(r"Platform: Python \d\.\d+\.\d+ on .*", caplog.text)
     assert re.search(r"Supports: .*", caplog.text)
     assert not re.search(r"Cache types: .*", caplog.text)
     assert "Repo:" not in caplog.text


### PR DESCRIPTION
Tests had checks for python version number, expecting it to be only
single digits, which was failing for me on 3.6.10 and might fail
in the future with Python 3.10.

I adjusted it to expect minor and patch version to be of multiple digits.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
