### PR TITLE
Config to enable/disable updater 

### DIFF
--- a/dvc/config.py
+++ b/dvc/config.py
@@ -138,6 +138,7 @@ SCHEMA = {
         Optional("hardlink_lock", default=False): Bool,
         Optional("no_scm", default=False): Bool,
         Optional("experiments", default=False): Bool,
+        Optional("check_update", default=True): Bool,
     },
     "cache": {
         "local": str,

--- a/dvc/updater.py
+++ b/dvc/updater.py
@@ -47,7 +47,12 @@ class Updater:  # pragma: no cover
             logger.debug(msg.format(self.lock.lockfile, action))
 
     def check(self):
-        if os.getenv("CI") or env2bool("DVC_TEST") or PKG == "snap":
+        if (
+            os.getenv("CI")
+            or env2bool("DVC_TEST")
+            or PKG == "snap"
+            or not self.is_enabled()
+        ):
             return
 
         self._with_lock(self._check, "checking")

--- a/dvc/updater.py
+++ b/dvc/updater.py
@@ -7,6 +7,7 @@ import colorama
 from packaging import version
 
 from dvc import __version__
+from dvc.config import Config, to_bool
 from dvc.lock import LockError, make_lock
 from dvc.utils import boxify, env2bool
 from dvc.utils.pkg import PKG
@@ -144,3 +145,12 @@ class Updater:  # pragma: no cover
             package_manager = "binary"
 
         return instructions[package_manager]
+
+    def is_enabled(self):
+        enabled = to_bool(
+            Config(validate=False).get("core", {}).get("check_update", "true")
+        )
+        logger.debug(
+            "Check for update is {}abled.".format("en" if enabled else "dis")
+        )
+        return enabled

--- a/tests/unit/test_updater.py
+++ b/tests/unit/test_updater.py
@@ -58,6 +58,14 @@ def test_is_enabled(dvc, updater, core, result):
     assert result == updater.is_enabled()
 
 
+@pytest.mark.parametrize("result", [True, False])
+@mock.patch("dvc.updater.Updater._check")
+def test_check_update_respect_config(mock_check, result, updater, mocker):
+    mocker.patch.object(updater, "is_enabled", return_value=result)
+    updater.check()
+    assert result == mock_check.called
+
+
 @pytest.mark.parametrize(
     "current,latest,notify",
     [

--- a/tests/unit/test_updater.py
+++ b/tests/unit/test_updater.py
@@ -45,6 +45,20 @@ def test_fetch(mock_get, updater):
 
 
 @pytest.mark.parametrize(
+    "core, result",
+    [
+        ({}, True),
+        ({"check_update": "true"}, True),
+        ({"check_update": "false"}, False),
+    ],
+)
+def test_is_enabled(dvc, updater, core, result):
+    with dvc.config.edit("local") as conf:
+        conf["core"] = core
+    assert result == updater.is_enabled()
+
+
+@pytest.mark.parametrize(
     "current,latest,notify",
     [
         ("0.0.2", "0.0.2", False),


### PR DESCRIPTION
Fixes  #1894 
Approach:
- Add core config key `check_update` with default value `true`.
- Updater will skip checking if the flag is disabled.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

