### PR TITLE
exception text: clarify error message

### DIFF
--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -268,8 +268,11 @@ class CheckoutError(DvcException):
         self.stats = stats
         targets = [str(t) for t in target_infos]
         m = (
-            "Checkout failed for following targets:\n{}\nDid you "
-            "forget to fetch?".format("\n".join(targets))
+            "Checkout failed for following targets:\n{}\nIs your "
+            "cache up to date?\n{}".format(
+                "\n".join(targets),
+                format_link("https://error.dvc.org/missing-files"),
+            )
         )
         super().__init__(m)
 


### PR DESCRIPTION
The default error message is often invoked from running `dvc pull` and
in this case it is generally caused by not pushing to the remote. I
spent some time thinking about a replacement message and this seems to
be the most appropriate text I could think of.

Fixes #4316

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.
  https://github.com/iterative/dvc.org/issues/1660

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
