### PR TITLE
import: fix importing into subdirectory bug

### DIFF
--- a/dvc/repo/imp_url.py
+++ b/dvc/repo/imp_url.py
@@ -2,7 +2,7 @@ import os
 
 from dvc.repo.scm_context import scm_context
 from dvc.utils import relpath, resolve_output, resolve_paths
-from dvc.utils.fs import makedirs, path_isin
+from dvc.utils.fs import path_isin
 
 from ..exceptions import OutputDuplicationError
 from . import locked
@@ -26,9 +26,6 @@ def imp_url(
         and path_isin(os.path.abspath(url), self.root_dir)
     ):
         url = relpath(url, wdir)
-
-    if not os.path.exists(wdir):
-        makedirs(wdir)
 
     stage = create_stage(
         Stage,

--- a/dvc/repo/imp_url.py
+++ b/dvc/repo/imp_url.py
@@ -2,7 +2,7 @@ import os
 
 from dvc.repo.scm_context import scm_context
 from dvc.utils import relpath, resolve_output, resolve_paths
-from dvc.utils.fs import path_isin
+from dvc.utils.fs import makedirs, path_isin
 
 from ..exceptions import OutputDuplicationError
 from . import locked
@@ -26,6 +26,9 @@ def imp_url(
         and path_isin(os.path.abspath(url), self.root_dir)
     ):
         url = relpath(url, wdir)
+
+    if not os.path.exists(wdir):
+        makedirs(wdir)
 
     stage = create_stage(
         Stage,

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -373,11 +373,9 @@ def resolve_paths(repo, out):
 
     # NOTE: `out` might not exist yet, so using `dirname`(aka `wdir`) to check
     # if it is a local path.
-    if (
-        os.path.exists(dirname)  # out might not exist yet, so
-        and PathInfo(abspath).isin_or_eq(repo.root_dir)
-        and not contains_symlink_up_to(abspath, repo.root_dir)
-    ):
+    if PathInfo(abspath).isin_or_eq(
+        repo.root_dir
+    ) and not contains_symlink_up_to(abspath, repo.root_dir):
         wdir = dirname
         out = base
     else:

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -368,13 +368,17 @@ def resolve_paths(repo, out):
     from ..path_info import PathInfo
     from .fs import contains_symlink_up_to
 
-    abspath = os.path.abspath(out)
+    abspath = PathInfo(os.path.abspath(out))
     dirname = os.path.dirname(abspath)
     base = os.path.basename(os.path.normpath(out))
 
+    scheme = urlparse(out).scheme
+    if os.name == "nt" and scheme == abspath.drive[0].lower():
+        # urlparse interprets windows drive letters as URL scheme
+        scheme = ""
     if (
-        not urlparse(out).scheme
-        and PathInfo(abspath).isin_or_eq(repo.root_dir)
+        not scheme
+        and abspath.isin_or_eq(repo.root_dir)
         and not contains_symlink_up_to(abspath, repo.root_dir)
     ):
         wdir = dirname

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -363,6 +363,7 @@ def resolve_output(inp, out):
 
 
 def resolve_paths(repo, out):
+    from urllib.parse import urlparse
     from ..dvcfile import DVC_FILE_SUFFIX
     from ..path_info import PathInfo
     from .fs import contains_symlink_up_to
@@ -371,11 +372,11 @@ def resolve_paths(repo, out):
     dirname = os.path.dirname(abspath)
     base = os.path.basename(os.path.normpath(out))
 
-    # NOTE: `out` might not exist yet, so using `dirname`(aka `wdir`) to check
-    # if it is a local path.
-    if PathInfo(abspath).isin_or_eq(
-        repo.root_dir
-    ) and not contains_symlink_up_to(abspath, repo.root_dir):
+    if (
+        not urlparse(out).scheme
+        and PathInfo(abspath).isin_or_eq(repo.root_dir)
+        and not contains_symlink_up_to(abspath, repo.root_dir)
+    ):
         wdir = dirname
         out = base
     else:

--- a/tests/func/test_import.py
+++ b/tests/func/test_import.py
@@ -132,6 +132,23 @@ def test_import_file_from_dir(tmp_dir, scm, dvc, erepo_dir):
     assert (tmp_dir / "X.dvc").exists()
 
 
+@pytest.mark.parametrize("dir_exists", [True, False])
+def test_import_file_from_dir_to_dir(tmp_dir, scm, dvc, erepo_dir, dir_exists):
+    with erepo_dir.chdir():
+        erepo_dir.dvc_gen({"dir": {"foo": "foo"}}, commit="create dir")
+    if dir_exists:
+        tmp_dir.gen({"dir": {}})
+
+    dvc.imp(
+        os.fspath(erepo_dir),
+        os.path.join("dir", "foo"),
+        out=os.path.join("dir", "foo"),
+    )
+    assert not (tmp_dir / "foo.dvc").exists()
+    assert (tmp_dir / "dir" / "foo").read_text() == "foo"
+    assert (tmp_dir / "dir" / "foo.dvc").exists()
+
+
 def test_import_non_cached(erepo_dir, tmp_dir, dvc, scm):
     src = "non_cached_output"
     dst = src + "_imported"


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Fixes #4169.

Makes `dvc import ... -o subdir/file` behave the same whether or not `subdir` already exists (new output will be `subdir/file.dvc`)

docs: https://github.com/iterative/dvc.org/pull/1668