### PR TITLE
config: use wtree for non-repo configs

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 from dvc.config import Config
+from dvc.tree.local import LocalTree
 
 
 @pytest.mark.parametrize(
@@ -16,3 +17,19 @@ from dvc.config import Config
 )
 def test_to_relpath(path, expected):
     assert Config._to_relpath(os.path.join(".", "config"), path) == expected
+
+
+def test_get_tree(tmp_dir, scm):
+    tmp_dir.scm_gen("foo", "foo", commit="add foo")
+
+    tree = scm.get_tree("master")
+    config = Config(tree=tree)
+
+    assert config.tree == tree
+    assert config.wtree != tree
+    assert isinstance(config.wtree, LocalTree)
+
+    assert config._get_tree("repo") == tree
+    assert config._get_tree("local") == config.wtree
+    assert config._get_tree("global") == config.wtree
+    assert config._get_tree("system") == config.wtree


### PR DESCRIPTION
config: use wtree for non-repo configs                                                  
                                                                                        
For example, when `dvc import`ing something, dvc won't see stuff                        
declared in system and global configs, because GitTree doesn't see stuff                
that is outside of the git repo.                                                        
                                                                                        
Discord context:                                                                        
https://discordapp.com/channels/485586884165107732/563406153334128681/740543492417126521

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
