### PR TITLE
push: do not push .dir file for directory with missing files

### DIFF
--- a/tests/func/test_remote.py
+++ b/tests/func/test_remote.py
@@ -4,6 +4,7 @@ import stat
 
 import configobj
 import pytest
+from funcy import first
 from mock import patch
 
 from dvc.config import Config
@@ -412,3 +413,19 @@ def test_protect_local_remote(tmp_dir, dvc, local_remote):
 
     assert os.path.exists(remote_cache_file)
     assert stat.S_IMODE(os.stat(remote_cache_file).st_mode) == 0o444
+
+
+def test_push_incomplete_dir(tmp_dir, dvc, mocker, local_remote):
+    (stage,) = tmp_dir.dvc_gen({"dir": {"foo": "foo", "bar": "bar"}})
+    remote = dvc.cloud.get_remote("upstream")
+
+    cache = dvc.cache.local
+    dir_hash = stage.outs[0].checksum
+    used = stage.get_used_cache(remote=remote)
+
+    # remove one of the cache files for directory
+    file_hash = first(used.child_keys(cache.tree.scheme, dir_hash))
+    remove(cache.tree.hash_to_path_info(file_hash))
+
+    dvc.push()
+    assert not remote.tree.exists(remote.tree.hash_to_path_info(dir_hash))

--- a/tests/func/test_remote.py
+++ b/tests/func/test_remote.py
@@ -4,7 +4,6 @@ import stat
 
 import configobj
 import pytest
-from funcy import first
 from mock import patch
 
 from dvc.config import Config
@@ -424,8 +423,12 @@ def test_push_incomplete_dir(tmp_dir, dvc, mocker, local_remote):
     used = stage.get_used_cache(remote=remote)
 
     # remove one of the cache files for directory
-    file_hash = first(used.child_keys(cache.tree.scheme, dir_hash))
-    remove(cache.tree.hash_to_path_info(file_hash))
+    file_hashes = list(used.child_keys(cache.tree.scheme, dir_hash))
+    remove(cache.tree.hash_to_path_info(file_hashes[0]))
 
     dvc.push()
     assert not remote.tree.exists(remote.tree.hash_to_path_info(dir_hash))
+    assert not remote.tree.exists(
+        remote.tree.hash_to_path_info(file_hashes[0])
+    )
+    assert remote.tree.exists(remote.tree.hash_to_path_info(file_hashes[1]))


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Fixes #4343.

If a directory has files missing in both local cache and on the remote, we should still try to push the files we have locally, but should not push the `.dir` file. Otherwise, index will think the full directory is present in the remote after the partial push.