### PR TITLE
Remove error message when exiting `--stdin` mode

### DIFF
--- a/dvc/command/check_ignore.py
+++ b/dvc/command/check_ignore.py
@@ -38,12 +38,11 @@ class CmdCheckIgnore(CmdBase):
     def _interactive_mode(self):
         ret = 1
         while True:
-            target = ask("")
+            try:
+                target = ask("")
+            except (KeyboardInterrupt, EOFError):
+                break
             if target == "":
-                logger.info(
-                    "Empty string is not a valid pathspec. Please use . "
-                    "instead if you meant to match all paths."
-                )
                 break
             if not self._check_one_file(target):
                 ret = 0


### PR DESCRIPTION
fix #4361
1. Remove error message when input a empty string
2. Remove error message when read input from stream
3. Remove error message when interrupt by `CTRL-C`

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
