### PR TITLE
pager: use --R/--RAW-CONTROL-CHARS with less

### DIFF
--- a/dvc/utils/pager.py
+++ b/dvc/utils/pager.py
@@ -12,8 +12,8 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_PAGER = "less"
-DEFAULT_PAGER_FORMATTED = "{} --chop-long-lines --clear-screen".format(
-    DEFAULT_PAGER
+DEFAULT_PAGER_FORMATTED = (
+    f"{DEFAULT_PAGER} --chop-long-lines --clear-screen --RAW-CONTROL-CHARS"
 )
 
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

* Enables support for ANSI terminal color escape sequences in `less` (needed eventually for experiments)