### PR TITLE
Remove dvcignore reset in `repo._reset`

### DIFF
--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -615,4 +615,3 @@ class Repo:
         self.__dict__.pop("graph", None)
         self.__dict__.pop("stages", None)
         self.__dict__.pop("pipelines", None)
-        self.tree.__dict__.pop("dvcignore", None)

--- a/tests/func/test_tree.py
+++ b/tests/func/test_tree.py
@@ -258,6 +258,7 @@ def test_walk_dont_ignore_subrepos(tmp_dir, scm, dvc):
     scm.commit("Add subrepo")
 
     dvc_tree = dvc.tree
+    dvc_tree.__dict__.pop("dvcignore")
     scm_tree = scm.get_tree("HEAD", use_dvcignore=True)
     path = os.fspath(tmp_dir)
     get_dirs = itemgetter(1)


### PR DESCRIPTION
fix #3869
Repo `add`,`checkout`,etc will not change `.dvcignore`, and can remove dvcignore reset after these operations.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

No performance improvement in `dvc status`(only influence commands using `repo._reset()`) 
![Screenshot from 2020-08-10 22-47-39](https://user-images.githubusercontent.com/6745454/89795909-8ea66d80-db5b-11ea-9196-934f00d8dcb2.png)

@pared  Excuse me, my `dvc add` tests failed.
On origin/master, clone the local repo to `./` then edit `hashes.txt` manually and run `asv run HASHFILE:hashes.txt`. And these is my error message.
![Screenshot from 2020-08-10 22-54-53](https://user-images.githubusercontent.com/6745454/89796731-91ee2900-db5c-11ea-8e39-f88d2c677211.png)
