### PR TITLE
experiments: add options to include/exclude columns in `exp show`

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -141,6 +141,10 @@ def _collect_rows(
 def _parse_list(param_list):
     ret = []
     for param_str in param_list:
+        # we don't care about filename prefixes for show, silently
+        # ignore it if provided to keep usage consistent with other
+        # metric/param list command options
+        _, _, param_str = param_str.rpartition(":")
         ret.extend(param_str.split(","))
     return ret
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Related to #4346

* Adds `--include-metrics/--exclude-metrics` and `--include-params/--exclude-params` options to `dvc exp show`.
* Options take comma-separated list of metrics/params columns to include or exclude from the output table.
* If `--include...` is used, only columns specified in the list will be displayed. If `--exclude...` is used, all columns except those specified in the list will be displayed.
* Matches nested metrics/params, so `--include-params featurize` will match `featurize.max_features`, `featurize.ngrams`, etc
* Params and metrics columns lists are handled separately, so `dvc exp show --include-params=foo` will display all metrics columns plus the single param column `foo`.