### PR TITLE
Solve result inconsistency of the DvcIgnoreFilter

### DIFF
--- a/dvc/ignore.py
+++ b/dvc/ignore.py
@@ -274,7 +274,7 @@ class DvcIgnoreFilter:
 
     def _is_ignored(self, path, is_dir=False):
         if self._outside_repo(path):
-            return True
+            return False
         dirname, basename = os.path.split(os.path.normpath(path))
         ignore_pattern = self._get_trie_pattern(dirname)
         if ignore_pattern:
@@ -296,6 +296,7 @@ class DvcIgnoreFilter:
         return self._is_ignored(path, True)
 
     def is_ignored_file(self, path):
+        path = os.path.abspath(path)
         return self._is_ignored(path, False)
 
     def _outside_repo(self, path):

--- a/tests/func/test_ignore.py
+++ b/tests/func/test_ignore.py
@@ -158,10 +158,17 @@ def test_match_nested(tmp_dir, dvc):
 def test_ignore_external(tmp_dir, scm, dvc, tmp_path_factory):
     tmp_dir.gen(".dvcignore", "*.backup\ntmp")
     ext_dir = TmpDir(os.fspath(tmp_path_factory.mktemp("external_dir")))
-    ext_dir.gen({"y.backup": "y", "tmp": "ext tmp"})
+    ext_dir.gen({"y.backup": "y", "tmp": {"file": "ext tmp"}})
 
     result = {relpath(f, ext_dir) for f in dvc.tree.walk_files(ext_dir)}
-    assert result == {"y.backup", "tmp"}
+    assert result == {"y.backup", os.path.join("tmp", "file")}
+    assert (
+        dvc.tree.dvcignore.is_ignored_dir(os.fspath(ext_dir / "tmp")) is False
+    )
+    assert (
+        dvc.tree.dvcignore.is_ignored_file(os.fspath(ext_dir / "y.backup"))
+        is False
+    )
 
 
 def test_ignore_subrepo(tmp_dir, scm, dvc):


### PR DESCRIPTION
Fix #4333, as `is_ignored_file` and `is_ignored_dir` and `__call__`
share the same call `DvcIgnorePatterns.matches`, we only need to focus
on the out of repo situation.
1. Add tests for the `is_ignored_file` and `is_ignored_dir` for the out
of repo condition.
2. Now `is_ignored_file` and `is_ignored_dir` returns false for those
files outside the repo.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
