### PR TITLE
RepoTree: add support for subrepo traversal

### DIFF
--- a/dvc/repo/ls.py
+++ b/dvc/repo/ls.py
@@ -76,9 +76,9 @@ def _ls(repo, path_info, recursive=None, dvc_only=False):
             if not recursive:
                 for dname in dirs:
                     info = PathInfo(root) / dname
-                    if not dvc_only or (
-                        tree.dvctree and tree.dvctree.exists(info)
-                    ):
+                    # pylint:disable=protected-access
+                    _, dvctree = tree._get_tree_pairs(info)  # noqa
+                    if not dvc_only or (dvctree and dvctree.exists(info)):
                         dvc = tree.isdvc(info)
                         path = str(info.relative_to(path_info))
                         ret[path] = {

--- a/dvc/tree/git.py
+++ b/dvc/tree/git.py
@@ -240,3 +240,6 @@ class GitTree(BaseTree):  # pylint:disable=abstract-method
             for file in files:
                 # NOTE: os.path.join is ~5.5 times slower
                 yield f"{root}{os.sep}{file}"
+
+    def _reset(self):
+        return self.__dict__.pop("dvcignore", None)

--- a/dvc/tree/local.py
+++ b/dvc/tree/local.py
@@ -357,3 +357,6 @@ class LocalTree(BaseTree):
         info = self.hash_to_path_info(hash_)
         path_info = info.with_name(info.name + self.UNPACKED_DIR_SUFFIX)
         self.remove(path_info)
+
+    def _reset(self):
+        return self.__dict__.pop("dvcignore", None)

--- a/tests/func/test_tree.py
+++ b/tests/func/test_tree.py
@@ -258,7 +258,7 @@ def test_walk_dont_ignore_subrepos(tmp_dir, scm, dvc):
     scm.commit("Add subrepo")
 
     dvc_tree = dvc.tree
-    dvc_tree.__dict__.pop("dvcignore")
+    dvc_tree._reset()
     scm_tree = scm.get_tree("HEAD", use_dvcignore=True)
     path = os.fspath(tmp_dir)
     get_dirs = itemgetter(1)

--- a/tests/unit/repo/test_repo_tree.py
+++ b/tests/unit/repo/test_repo_tree.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+from unittest import mock
 
 import pytest
 
@@ -177,3 +178,181 @@ def test_isdvc(tmp_dir, dvc):
     assert tree.isdvc("dir")
     assert not tree.isdvc("dir/baz")
     assert tree.isdvc("dir/baz", recursive=True, strict=False)
+
+
+def make_subrepo(dir_, scm, config=None):
+    dir_.mkdir(parents=True)
+    with dir_.chdir():
+        dir_.scm = scm
+        dir_.init(dvc=True, subdir=True)
+        if config:
+            dir_.add_remote(config=config)
+
+
+def test_subrepos(tmp_dir, scm, dvc):
+    tmp_dir.scm_gen(
+        {"dir": {"repo.txt": "file to confuse RepoTree"}},
+        commit="dir/repo.txt",
+    )
+
+    subrepo1 = tmp_dir / "dir" / "repo"
+    subrepo2 = tmp_dir / "dir" / "repo2"
+
+    for repo in [subrepo1, subrepo2]:
+        make_subrepo(repo, scm)
+
+    subrepo1.dvc_gen({"foo": "foo", "dir1": {"bar": "bar"}}, commit="FOO")
+    subrepo2.dvc_gen(
+        {"lorem": "lorem", "dir2": {"ipsum": "ipsum"}}, commit="BAR"
+    )
+
+    dvc.tree._reset()
+    tree = RepoTree(dvc, subrepos=True, fetch=True)
+
+    def assert_tree_belongs_to_repo(ret_val):
+        method = tree._get_repo
+
+        def f(*args, **kwargs):
+            r = method(*args, **kwargs)
+            assert r.root_dir == ret_val.root_dir
+            return r
+
+        return f
+
+    with mock.patch.object(
+        tree,
+        "_get_repo",
+        side_effect=assert_tree_belongs_to_repo(subrepo1.dvc),
+    ):
+        assert tree.exists(subrepo1 / "foo") is True
+        assert tree.exists(subrepo1 / "bar") is False
+
+        assert tree.isfile(subrepo1 / "foo") is True
+        assert tree.isfile(subrepo1 / "foo") is True
+        assert tree.isfile(subrepo1 / "dir1" / "bar") is True
+        assert tree.isfile(subrepo1 / "dir1") is False
+
+        assert tree.isdir(subrepo1 / "dir1") is True
+        assert tree.isdir(subrepo1 / "dir1" / "bar") is False
+        assert tree.isdvc(subrepo1 / "foo") is True
+
+    with mock.patch.object(
+        tree,
+        "_get_repo",
+        side_effect=assert_tree_belongs_to_repo(subrepo2.dvc),
+    ):
+        assert tree.exists(subrepo2 / "lorem") is True
+        assert tree.exists(subrepo2 / "ipsum") is False
+
+        assert tree.isfile(subrepo2 / "lorem") is True
+        assert tree.isfile(subrepo2 / "lorem") is True
+        assert tree.isfile(subrepo2 / "dir2" / "ipsum") is True
+        assert tree.isfile(subrepo2 / "dir2") is False
+
+        assert tree.isdir(subrepo2 / "dir2") is True
+        assert tree.isdir(subrepo2 / "dir2" / "ipsum") is False
+        assert tree.isdvc(subrepo2 / "lorem") is True
+
+
+@pytest.mark.parametrize(
+    "dvcfiles,extra_expected",
+    [
+        (False, []),
+        (
+            True,
+            [
+                PathInfo("dir") / "repo" / "foo.dvc",
+                PathInfo("dir") / "repo" / "dir1.dvc",
+                PathInfo("dir") / "repo2" / "lorem.dvc",
+                PathInfo("dir") / "repo2" / "dir2.dvc",
+            ],
+        ),
+    ],
+)
+def test_subrepo_walk(tmp_dir, scm, dvc, dvcfiles, extra_expected):
+    tmp_dir.scm_gen(
+        {"dir": {"repo.txt": "file to confuse RepoTree"}},
+        commit="dir/repo.txt",
+    )
+
+    subrepo1 = tmp_dir / "dir" / "repo"
+    subrepo2 = tmp_dir / "dir" / "repo2"
+
+    subdirs = [subrepo1, subrepo2]
+    for dir_ in subdirs:
+        make_subrepo(dir_, scm)
+
+    subrepo1.dvc_gen({"foo": "foo", "dir1": {"bar": "bar"}}, commit="FOO")
+    subrepo2.dvc_gen(
+        {"lorem": "lorem", "dir2": {"ipsum": "ipsum"}}, commit="BAR"
+    )
+
+    # using tree that does not have dvcignore
+    dvc.tree._reset()
+    tree = RepoTree(dvc, subrepos=True, fetch=True)
+    expected = [
+        PathInfo("dir") / "repo",
+        PathInfo("dir") / "repo.txt",
+        PathInfo("dir") / "repo2",
+        PathInfo("dir") / "repo" / ".gitignore",
+        PathInfo("dir") / "repo" / "foo",
+        PathInfo("dir") / "repo" / "dir1",
+        PathInfo("dir") / "repo" / "dir1" / "bar",
+        PathInfo("dir") / "repo2" / ".gitignore",
+        PathInfo("dir") / "repo2" / "lorem",
+        PathInfo("dir") / "repo2" / "dir2",
+        PathInfo("dir") / "repo2" / "dir2" / "ipsum",
+    ]
+
+    actual = []
+    for root, dirs, files in tree.walk("dir", dvcfiles=dvcfiles):
+        for entry in dirs + files:
+            actual.append(os.path.join(root, entry))
+
+    expected = [str(path) for path in expected + extra_expected]
+    assert set(actual) == set(expected)
+    assert len(actual) == len(expected)
+
+
+def test_repo_tree_no_subrepos(tmp_dir, dvc, scm):
+    tmp_dir.scm_gen(
+        {"dir": {"repo.txt": "file to confuse RepoTree"}},
+        commit="dir/repo.txt",
+    )
+    tmp_dir.dvc_gen({"lorem": "lorem"}, commit="add foo")
+
+    subrepo = tmp_dir / "dir" / "repo"
+    make_subrepo(subrepo, scm)
+    subrepo.dvc_gen({"foo": "foo", "dir1": {"bar": "bar"}}, commit="FOO")
+    subrepo.scm_gen({"ipsum": "ipsum"}, commit="BAR")
+
+    # using tree that does not have dvcignore
+    dvc.tree._reset()
+    tree = RepoTree(dvc, subrepos=False, fetch=True)
+    expected = [
+        tmp_dir / ".gitignore",
+        tmp_dir / "lorem",
+        tmp_dir / "lorem.dvc",
+        tmp_dir / "dir",
+        tmp_dir / "dir" / "repo.txt",
+    ]
+
+    actual = []
+    for root, dirs, files in tree.walk(tmp_dir, dvcfiles=True):
+        for entry in dirs + files:
+            actual.append(os.path.normpath(os.path.join(root, entry)))
+
+    expected = [str(path) for path in expected]
+    assert set(actual) == set(expected)
+    assert len(actual) == len(expected)
+
+    assert tree.isfile(tmp_dir / "lorem") is True
+    assert tree.isfile(tmp_dir / "dir" / "repo" / "foo") is False
+    assert tree.isdir(tmp_dir / "dir" / "repo") is False
+    assert tree.isdir(tmp_dir / "dir") is True
+
+    assert tree.isdvc(tmp_dir / "lorem") is True
+    assert tree.isdvc(tmp_dir / "dir" / "repo" / "dir1") is False
+
+    assert tree.exists(tmp_dir / "dir" / "repo.txt") is True
+    assert tree.exists(tmp_dir / "repo" / "ipsum") is False


### PR DESCRIPTION
Right now, no actual "functionality" is surfaced as
`subrepos` is always set to False by default for now.

Subrepos are collected dynamically and trie is created to track those repos inside `RepoTree`, and this does not incur any cost
as `.dvcignore` is shared among subrepos and `RepoTree` just utilizes them.

#### Possible alternative design
1. Create "MotherOfTree" that will be prefix-based and can switch between those just based on prefix. So, some separate tree class that works on top of RepoTree or  GitTree for submodules.
    cons: Hard to traverse, especially heirarchial traversal required for dvc repos, etc.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
