### PR TITLE
Derive WebDAVURLInfo from URLInfo instead of HTTPURLInfo

### DIFF
--- a/dvc/path_info.py
+++ b/dvc/path_info.py
@@ -317,15 +317,9 @@ class HTTPURLInfo(URLInfo):
         )
 
 
-# See https://github.com/shizacat/dvc/blob/remote-webdav/dvc/path_info.py
-class WebDAVURLInfo(HTTPURLInfo):
+class WebDAVURLInfo(URLInfo):
     @cached_property
     def url(self):
-        return "{}://{}{}{}{}{}".format(
-            self.scheme.replace("webdav", "http"),
-            self.netloc,
-            self._spath,
-            (";" + self.params) if self.params else "",
-            ("?" + self.query) if self.query else "",
-            ("#" + self.fragment) if self.fragment else "",
+        return "{}://{}{}".format(
+            self.scheme.replace("webdav", "http"), self.netloc, self._spath
         )


### PR DESCRIPTION
Unused, empty http extra parts (params,query,fragment) cause problems
with pushing/pulling - lead to violation of the assumption where to look
for hash values in file/path names.

Context:
    https://discordapp.com/channels/485586884165107732/485596304961962003/743454659733094520
    https://discordapp.com/channels/485586884165107732/485596304961962003/743497749290287215
    https://discordapp.com/channels/485586884165107732/485596304961962003/743571921622401136

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
