### PR TITLE
tree: make get_hash return type and hash pair

### DIFF
--- a/dvc/cache/base.py
+++ b/dvc/cache/base.py
@@ -127,7 +127,9 @@ class CloudCache:
             logger.debug("cache for '%s'('%s') has changed.", path_info, hash_)
             return True
 
-        actual = self.tree.get_hash(path_info)
+        typ, actual = self.tree.get_hash(path_info)
+        assert typ == self.tree.PARAM_CHECKSUM
+
         if hash_ != actual:
             logger.debug(
                 "hash value '%s' for '%s' has changed (actual '%s').",
@@ -312,7 +314,7 @@ class CloudCache:
             )
             return False
 
-        actual = self.tree.get_hash(cache_info)
+        _, actual = self.tree.get_hash(cache_info)
 
         logger.debug(
             "cache '%s' expected '%s' actual '%s'", cache_info, hash_, actual,
@@ -358,7 +360,7 @@ class CloudCache:
         return self.changed_cache_file(hash_)
 
     def already_cached(self, path_info):
-        current = self.tree.get_hash(path_info)
+        _, current = self.tree.get_hash(path_info)
 
         if not current:
             return False

--- a/dvc/cache/local.py
+++ b/dvc/cache/local.py
@@ -91,7 +91,9 @@ class LocalCache(CloudCache):
     def already_cached(self, path_info):
         assert path_info.scheme in ["", "local"]
 
-        current_md5 = self.tree.get_hash(path_info)
+        typ, current_md5 = self.tree.get_hash(path_info)
+
+        assert typ == "md5"
 
         if not current_md5:
             return False

--- a/dvc/dependency/repo.py
+++ b/dvc/dependency/repo.py
@@ -64,7 +64,9 @@ class RepoDependency(LocalDependency):
 
                 # We are polluting our repo cache with some dir listing here
                 if tree.isdir(path):
-                    return self.repo.cache.local.tree.get_hash(path, tree=tree)
+                    return self.repo.cache.local.tree.get_hash(
+                        path, tree=tree
+                    )[1]
                 return tree.get_file_hash(path)
 
     def workspace_status(self):

--- a/dvc/output/base.py
+++ b/dvc/output/base.py
@@ -184,7 +184,7 @@ class BaseOutput:
         self.info[self.tree.PARAM_CHECKSUM] = checksum
 
     def get_checksum(self):
-        return self.tree.get_hash(self.path_info)
+        return self.tree.get_hash(self.path_info)[1]
 
     @property
     def is_dir_checksum(self):

--- a/dvc/repo/diff.py
+++ b/dvc/repo/diff.py
@@ -37,7 +37,7 @@ def diff(self, a_rev="HEAD", b_rev=None):
 
         def _to_checksum(output):
             if on_working_tree:
-                return self.cache.local.tree.get_hash(output.path_info)
+                return self.cache.local.tree.get_hash(output.path_info)[1]
             return output.checksum
 
         def _exists(output):

--- a/dvc/repo/tree.py
+++ b/dvc/repo/tree.py
@@ -238,8 +238,11 @@ class DvcTree(BaseTree):  # pylint:disable=abstract-method
             raise OutputNotFoundError
         out = outs[0]
         if out.is_dir_checksum:
-            return self._get_granular_checksum(path_info, out)
-        return out.checksum
+            return (
+                out.tree.PARAM_CHECKSUM,
+                self._get_granular_checksum(path_info, out),
+            )
+        return out.tree.PARAM_CHECKSUM, out.checksum
 
 
 class RepoTree(BaseTree):  # pylint:disable=abstract-method
@@ -504,7 +507,7 @@ class RepoTree(BaseTree):  # pylint:disable=abstract-method
                 return dvc_tree.get_file_hash(path_info)
             except OutputNotFoundError:
                 pass
-        return file_md5(path_info, self)[0]
+        return self.PARAM_CHECKSUM, file_md5(path_info, self)[0]
 
     def copytree(self, top, dest):
         top = PathInfo(top)

--- a/dvc/tree/azure.py
+++ b/dvc/tree/azure.py
@@ -153,7 +153,7 @@ class AzureTree(BaseTree):
         ).delete_blob()
 
     def get_file_hash(self, path_info):
-        return self.get_etag(path_info)
+        return self.PARAM_CHECKSUM, self.get_etag(path_info)
 
     def _upload(
         self, from_file, to_info, name=None, no_progress_bar=False, **_kwargs

--- a/dvc/tree/gs.py
+++ b/dvc/tree/gs.py
@@ -190,11 +190,14 @@ class GSTree(BaseTree):
         path = path_info.path
         blob = self.gs.bucket(bucket).get_blob(path)
         if not blob:
-            return None
+            return self.PARAM_CHECKSUM, None
 
         b64_md5 = blob.md5_hash
         md5 = base64.b64decode(b64_md5)
-        return codecs.getencoder("hex")(md5)[0].decode("utf-8")
+        return (
+            self.PARAM_CHECKSUM,
+            codecs.getencoder("hex")(md5)[0].decode("utf-8"),
+        )
 
     def _upload(self, from_file, to_info, name=None, no_progress_bar=False):
         bucket = self.gs.bucket(to_info.bucket)

--- a/dvc/tree/hdfs.py
+++ b/dvc/tree/hdfs.py
@@ -167,7 +167,7 @@ class HDFSTree(BaseTree):
         stdout = self.hadoop_fs(
             f"checksum {path_info.url}", user=path_info.user
         )
-        return self._group(regex, stdout, "checksum")
+        return self.PARAM_CHECKSUM, self._group(regex, stdout, "checksum")
 
     def _upload(self, from_file, to_info, **_kwargs):
         with self.hdfs(to_info) as hdfs:

--- a/dvc/tree/http.py
+++ b/dvc/tree/http.py
@@ -136,7 +136,7 @@ class HTTPTree(BaseTree):  # pylint:disable=abstract-method
                 "Content-MD5 header for '{url}'".format(url=url)
             )
 
-        return etag
+        return self.PARAM_CHECKSUM, etag
 
     def _download(self, from_info, to_file, name=None, no_progress_bar=False):
         response = self.request("GET", from_info.url, stream=True)

--- a/dvc/tree/local.py
+++ b/dvc/tree/local.py
@@ -309,7 +309,7 @@ class LocalTree(BaseTree):
         return stat.S_IMODE(mode) == self.CACHE_MODE
 
     def get_file_hash(self, path_info):
-        return file_md5(path_info)[0]
+        return self.PARAM_CHECKSUM, file_md5(path_info)[0]
 
     @staticmethod
     def getsize(path_info):

--- a/dvc/tree/s3.py
+++ b/dvc/tree/s3.py
@@ -318,7 +318,10 @@ class S3Tree(BaseTree):
             raise ETagMismatchError(etag, cached_etag)
 
     def get_file_hash(self, path_info):
-        return self.get_etag(self.s3, path_info.bucket, path_info.path)
+        return (
+            self.PARAM_CHECKSUM,
+            self.get_etag(self.s3, path_info.bucket, path_info.path),
+        )
 
     def _upload(self, from_file, to_info, name=None, no_progress_bar=False):
         total = os.path.getsize(from_file)

--- a/dvc/tree/ssh/__init__.py
+++ b/dvc/tree/ssh/__init__.py
@@ -238,7 +238,7 @@ class SSHTree(BaseTree):
             raise NotImplementedError
 
         with self.ssh(path_info) as ssh:
-            return ssh.md5(path_info.path)
+            return self.PARAM_CHECKSUM, ssh.md5(path_info.path)
 
     def getsize(self, path_info):
         with self.ssh(path_info) as ssh:

--- a/dvc/tree/webdav.py
+++ b/dvc/tree/webdav.py
@@ -142,7 +142,7 @@ class WebDAVTree(BaseTree):  # pylint:disable=abstract-method
                 "Content-MD5 header for '{url}'".format(url=path_info.url)
             )
 
-        return etag
+        return self.PARAM_CHECKSUM, etag
 
     # Checks whether path points to directory
     def isdir(self, path_info):

--- a/tests/func/test_tree.py
+++ b/tests/func/test_tree.py
@@ -211,7 +211,7 @@ def test_repotree_cache_save(tmp_dir, dvc, scm, erepo_dir, local_cloud):
     # into dvc.cache, not fetched or streamed from a remote
     tree = RepoTree(erepo_dir.dvc, stream=True)
     expected = [
-        tree.get_file_hash(PathInfo(erepo_dir / path))
+        tree.get_file_hash(PathInfo(erepo_dir / path))[1]
         for path in ("dir/bar", "dir/subdir/foo")
     ]
 

--- a/tests/unit/remote/test_azure.py
+++ b/tests/unit/remote/test_azure.py
@@ -36,7 +36,7 @@ def test_get_file_hash(tmp_dir, azure):
     to_info = azure
     tree.upload(PathInfo("foo"), to_info)
     assert tree.exists(to_info)
-    hash_ = tree.get_file_hash(to_info)
+    _, hash_ = tree.get_file_hash(to_info)
     assert hash_
     assert isinstance(hash_, str)
     assert hash_.strip("'").strip('"') == hash_


### PR DESCRIPTION
Currently we kinda assume that whatever is returned by `get_file_hash`
is of type self.PARAM_CHECKSUM, which is not actually true. E.g. for
http it might return `etag` or `md5`, but we don't distinguish between
those and call both `etag`. This is becoming more relevant for dir
hashes that are computed a few different ways (e.g. in-memory md5 or
upload to remote and get etag for the dir file).

Prerequisite for #4144 and #3069

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
