### PR TITLE
experiments: abstract executor output collection using trees

### DIFF
--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -450,7 +450,7 @@ class Experiments:
         for from_info in executor.collect_output():
             from_infos.append(from_info)
             fname = from_info.relative_to(src_tree.path_info)
-            names.append(fname)
+            names.append(str(fname))
             to_info = dest_tree.path_info / fname
             to_infos.append(dest_tree.path_info / fname)
             logger.debug(f"from '{from_info}' to '{to_info}'")

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -437,10 +437,6 @@ class Experiments:
     def _collect_output(self, executor: ExperimentExecutor):
         """Copy (download) output from the executor tree into experiments
         workspace.
-
-        DVC outs will not be copied (only the .dvc file will be copied).
-        The actual DVC out should be pulled into cache from the executor.
-        (For local executors outs will already be available via shared cache.)
         """
         from dvc.cache.local import _log_exceptions
 

--- a/dvc/repo/experiments/executor.py
+++ b/dvc/repo/experiments/executor.py
@@ -6,6 +6,7 @@ from tempfile import TemporaryDirectory
 from funcy import cached_property
 
 from dvc.path_info import PathInfo
+from dvc.repo.tree import RepoTree
 from dvc.stage import PipelineStage
 from dvc.tree.base import BaseTree
 from dvc.utils import relpath
@@ -32,8 +33,16 @@ class ExperimentExecutor:
         self.repro_args = kwargs.pop("repro_args", [])
         self.repro_kwargs = kwargs.pop("repro_kwargs", {})
 
-    def run(self):
-        pass
+    @property
+    def tree(self) -> RepoTree:
+        """Return a RepoTree which can be used to collect output from this
+        executor.
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def reproduce(dvc_dir, cwd=None, **kwargs):
+        raise NotImplementedError
 
     def cleanup(self):
         pass
@@ -92,6 +101,10 @@ class LocalExecutor(ExperimentExecutor):
     @cached_property
     def path_info(self):
         return PathInfo(self.tmp_dir.name)
+
+    @property
+    def tree(self) -> RepoTree:
+        return RepoTree(self.dvc)
 
     @staticmethod
     def reproduce(dvc_dir, cwd=None, **kwargs):

--- a/dvc/repo/experiments/executor.py
+++ b/dvc/repo/experiments/executor.py
@@ -44,7 +44,13 @@ class ExperimentExecutor:
         raise NotImplementedError
 
     def collect_output(self) -> Iterable["PathInfo"]:
-        """Iterate over output pathnames for this executor."""
+        """Iterate over output pathnames for this executor.
+
+        For DVC outs, only the .dvc file path will be yielded. DVC outs
+        themselves should be fetched from remote executor cache in the normal
+        fetch/pull way. For local executors outs will already be available via
+        shared local cache.
+        """
         raise NotImplementedError
 
     def cleanup(self):
@@ -144,7 +150,6 @@ class LocalExecutor(ExperimentExecutor):
         return hash_exp(stages + unchanged)
 
     def collect_output(self) -> Iterable["PathInfo"]:
-        """Iterate over output pathnames for this executor."""
         repo_tree = RepoTree(self.dvc)
         for fname in repo_tree.walk_files(repo_tree.root_dir, dvcfiles=True):
             if not repo_tree.isdvc(fname):


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

* Executors return a list of output paths via `executor.collect_output()`
* Collected paths should then be downloaded to experiments workspace with `local_tree.download(...)`

still need to investigate why stages aren't pickable/returnable across multiprocessing calls, but any changes related to that will probably come in a future PR