### PR TITLE
Solve check-ignore broken in a Linux pipeline

### DIFF
--- a/dvc/command/check_ignore.py
+++ b/dvc/command/check_ignore.py
@@ -4,7 +4,6 @@ import logging
 from dvc.command import completion
 from dvc.command.base import CmdBase, append_doc_link
 from dvc.exceptions import DvcException
-from dvc.prompt import ask
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +38,7 @@ class CmdCheckIgnore(CmdBase):
         ret = 1
         while True:
             try:
-                target = ask("")
+                target = input()
             except (KeyboardInterrupt, EOFError):
                 break
             if target == "":

--- a/tests/func/test_check_ignore.py
+++ b/tests/func/test_check_ignore.py
@@ -130,8 +130,6 @@ def test_check_ignore_stdin_mode(
 ):
     tmp_dir.gen(DvcIgnore.DVCIGNORE_FILE, "ignored")
     mocker.patch("builtins.input", side_effect=[file, ""])
-    stdout_mock = mocker.patch("sys.stdout")
-    stdout_mock.isatty.return_value = True
 
     assert main(["check-ignore", "--stdin"]) == ret
     assert (file in caplog.text) is output


### PR DESCRIPTION
fix #4407
1. Update test, now it can simulate a pipeline situation.
2. Solve remove `isatty` check in `dvc check-ignore --stdin` command.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
