### PR TITLE
Make repo lock reentrable and provide a context manager

### DIFF
--- a/dvc/repo/checkout.py
+++ b/dvc/repo/checkout.py
@@ -9,6 +9,8 @@ from dvc.exceptions import (
 from dvc.progress import Tqdm
 from dvc.utils import relpath
 
+from . import locked
+
 logger = logging.getLogger(__name__)
 
 
@@ -36,7 +38,8 @@ def get_all_files_numbers(pairs):
     )
 
 
-def _checkout(
+@locked
+def checkout(
     self,
     targets=None,
     with_deps=False,

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -515,7 +515,7 @@ class Experiments:
         """Checkout an experiment to the user's workspace."""
         from git.exc import GitCommandError
 
-        from dvc.repo.checkout import _checkout as dvc_checkout
+        from dvc.repo.checkout import checkout as dvc_checkout
 
         self._check_baseline(rev)
         self._scm_checkout(rev)

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -4,10 +4,13 @@ from dvc.config import NoRemoteError
 from dvc.exceptions import DownloadError
 from dvc.scm.base import CloneError
 
+from . import locked
+
 logger = logging.getLogger(__name__)
 
 
-def _fetch(
+@locked
+def fetch(
     self,
     targets=None,
     jobs=None,

--- a/dvc/repo/pull.py
+++ b/dvc/repo/pull.py
@@ -22,7 +22,7 @@ def pull(
     if isinstance(targets, str):
         targets = [targets]
 
-    processed_files_count = self._fetch(  # pylint: disable=protected-access
+    processed_files_count = self.fetch(
         targets,
         jobs,
         remote=remote,
@@ -33,7 +33,7 @@ def pull(
         recursive=recursive,
         run_cache=run_cache,
     )
-    stats = self._checkout(  # pylint: disable=protected-access
+    stats = self.checkout(
         targets=targets, with_deps=with_deps, force=force, recursive=recursive
     )
 

--- a/tests/unit/repo/test_repo.py
+++ b/tests/unit/repo/test_repo.py
@@ -60,9 +60,10 @@ def test_used_cache(tmp_dir, dvc, path):
 
 def test_locked(mocker):
     repo = mocker.MagicMock()
+    repo._lock_depth = 0
     repo.method = locked(repo.method)
 
-    args = {}
+    args = ()
     kwargs = {}
     repo.method(repo, args, kwargs)
 


### PR DESCRIPTION
Can make `locked()` work both ways by:
```python
def locked(f):
    if isinstance(f, Repo):
        return lock_repo(f)

    ...
```

Or provide `Repo.locked()` context manager sharing implementation - less things to import.