### PR TITLE
git: handle rev_parse exception

### DIFF
--- a/dvc/scm/git.py
+++ b/dvc/scm/git.py
@@ -405,6 +405,8 @@ class Git(Base):
                 except NotImplementedError:
                     # Fall back to `git rev-parse` for advanced features
                     return self.repo.git.rev_parse(name)
+                except ValueError:
+                    raise RevError(f"unknown Git revision '{name}'")
 
         # Resolve across local names
         sha = _resolve_rev(rev)


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

GitPython raises ValueError if `git rev-parse` is called with something that looks like an actual git SHA but does not match any known Git commits/objects. (this will happen if experiments workspace needs to be updated because the SHA is a commit from the parent repo and has not been pulled into the experiments repo yet)