### PR TITLE
utils.serialize: modify_yaml contextmanager to reduce boilerplate

### DIFF
--- a/dvc/utils/serialize/__init__.py
+++ b/dvc/utils/serialize/__init__.py
@@ -6,3 +6,6 @@ from ._yaml import *  # noqa, pylint: disable=wildcard-import
 
 LOADERS = defaultdict(lambda: load_yaml)  # noqa: F405
 LOADERS.update({".toml": load_toml})  # noqa: F405
+
+MODIFIERS = defaultdict(lambda: modify_yaml)  # noqa: F405
+MODIFIERS.update({".toml": modify_toml})  # noqa: F405

--- a/dvc/utils/serialize/_common.py
+++ b/dvc/utils/serialize/_common.py
@@ -1,4 +1,6 @@
 """Common utilities for serialize."""
+import os
+from contextlib import contextmanager
 
 from dvc.exceptions import DvcException
 from dvc.utils import relpath
@@ -22,3 +24,11 @@ def _dump_data(path, data, dumper, tree=None):
     open_fn = tree.open if tree else open
     with open_fn(path, "w+", encoding="utf-8") as fd:
         dumper(data, fd)
+
+
+@contextmanager
+def _modify_data(path, parser, dumper, tree=None):
+    exists = tree.exists if tree else os.path.exists
+    data = _load_data(path, parser=parser, tree=tree) if exists(path) else {}
+    yield data
+    dumper(path, data, tree=tree)

--- a/dvc/utils/serialize/_toml.py
+++ b/dvc/utils/serialize/_toml.py
@@ -1,7 +1,9 @@
+from contextlib import contextmanager
+
 import toml
 from funcy import reraise
 
-from ._common import ParseError, _dump_data, _load_data
+from ._common import ParseError, _dump_data, _load_data, _modify_data
 
 
 class TOMLFileCorruptedError(ParseError):
@@ -35,3 +37,9 @@ def _dump(data, stream):
 
 def dump_toml(path, data, tree=None):
     return _dump_data(path, data, dumper=_dump, tree=tree)
+
+
+@contextmanager
+def modify_toml(path, tree=None):
+    with _modify_data(path, parse_toml_for_update, dump_toml, tree=tree) as d:
+        yield d

--- a/dvc/utils/serialize/_yaml.py
+++ b/dvc/utils/serialize/_yaml.py
@@ -1,11 +1,12 @@
 import io
 from collections import OrderedDict
+from contextlib import contextmanager
 
 from funcy import reraise
 from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
 
-from ._common import ParseError, _dump_data, _load_data
+from ._common import ParseError, _dump_data, _load_data, _modify_data
 
 
 class YAMLFileCorruptedError(ParseError):
@@ -60,6 +61,11 @@ def loads_yaml(s, typ="safe"):
 
 def dumps_yaml(d):
     stream = io.StringIO()
-    yaml = _get_yaml()
-    yaml.dump(d, stream)
+    _dump(d, stream)
     return stream.getvalue()
+
+
+@contextmanager
+def modify_yaml(path, tree=None):
+    with _modify_data(path, parse_yaml_for_update, dump_yaml, tree=tree) as d:
+        yield d


### PR DESCRIPTION
Reduce boilerplate of create + load + dump during serialization/deserialization
```python
with modify_yaml(config_path, tree=repo.tree) as config:
    config["repos"] = config.get("repos", [])
    config["repos"].append(entry)
```

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

On top of #4425, see https://github.com/iterative/dvc/pull/4415#discussion_r472117862