### PR TITLE
git: do not ask for gpg signoff on merge

### DIFF
--- a/tests/func/test_install.py
+++ b/tests/func/test_install.py
@@ -84,7 +84,7 @@ def test_merge_driver_no_ancestor(tmp_dir, scm, dvc):
     scm.checkout("two", create_new=True)
     tmp_dir.dvc_gen({"data": {"bar": "bar"}}, commit="two: add data")
 
-    scm.repo.git.merge("one", m="merged")
+    scm.repo.git.merge("one", m="merged", no_gpg_sign=True, no_signoff=True)
 
     # NOTE: dvc shouldn't checkout automatically as it might take a long time
     assert (tmp_dir / "data").read_text() == {"bar": "bar"}
@@ -114,7 +114,7 @@ def test_merge_driver(tmp_dir, scm, dvc):
     scm.checkout("two", create_new=True)
     tmp_dir.dvc_gen({"data": {"two": "two"}}, commit="two: add data")
 
-    scm.repo.git.merge("one", m="merged")
+    scm.repo.git.merge("one", m="merged", no_gpg_sign=True, no_signoff=True)
 
     # NOTE: dvc shouldn't checkout automatically as it might take a long time
     assert (tmp_dir / "data").read_text() == {"master": "master", "two": "two"}


### PR DESCRIPTION
The tests started to ask for gpg signoff. Could this be done without `git`?

Refer https://git-scm.com/docs/git-merge#Documentation/git-merge.txt---no-gpg-sign

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
