### PR TITLE
Enable profiling from cli

### DIFF
--- a/dvc/cli.py
+++ b/dvc/cli.py
@@ -137,6 +137,14 @@ def get_parent_parser():
     """
     parent_parser = argparse.ArgumentParser(add_help=False)
 
+    parent_parser.add_argument(
+        "--cprofile",
+        action="store_true",
+        default=False,
+        help=argparse.SUPPRESS,
+    )
+    parent_parser.add_argument("--cprofile-dump", help=argparse.SUPPRESS)
+
     log_level_group = parent_parser.add_mutually_exclusive_group()
     log_level_group.add_argument(
         "-q", "--quiet", action="count", default=0, help="Be quiet."


### PR DESCRIPTION
```console
$ dvc list . --cprofile
# prints all stats
$ dvc list . --cprofile dvc.prof
# dumps cprofile results in a dvc.prof file
```

Just a simple patch that I was using locally, thought I'd share.

#### Why not `python -m cProfile -m dvc`?
Not available on Python3.6 :(. I'm fine keeping it just for me as well. :smile: 
And, that command feels like it's quite far.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
