### PR TITLE
tree: add overwrite parameter in tree.upload

### DIFF
--- a/dvc/tree/azure.py
+++ b/dvc/tree/azure.py
@@ -167,7 +167,7 @@ class AzureTree(BaseTree):
             with Tqdm.wrapattr(
                 fobj, "read", desc=name, total=total, disable=no_progress_bar
             ) as wrapped:
-                blob_client.upload_blob(wrapped)
+                blob_client.upload_blob(wrapped, overwrite=True)
 
     def _download(
         self, from_info, to_file, name=None, no_progress_bar=False, **_kwargs

--- a/dvc/tree/base.py
+++ b/dvc/tree/base.py
@@ -374,7 +374,14 @@ class BaseTree:
         typ, hash_ = tree.get_file_hash(to_info)
         return typ, hash_ + self.CHECKSUM_DIR_SUFFIX, to_info
 
-    def upload(self, from_info, to_info, name=None, no_progress_bar=False):
+    def upload(
+        self,
+        from_info,
+        to_info,
+        name=None,
+        no_progress_bar=False,
+        overwrite=False,
+    ):
         if not hasattr(self, "_upload"):
             raise RemoteActionNotImplemented("upload", self.scheme)
 
@@ -383,6 +390,9 @@ class BaseTree:
 
         if from_info.scheme != "local":
             raise NotImplementedError
+
+        if not overwrite and self.exists(to_info):
+            raise FileExistsError(to_info)
 
         logger.debug("Uploading '%s' to '%s'", from_info, to_info)
 

--- a/dvc/tree/local.py
+++ b/dvc/tree/local.py
@@ -326,7 +326,7 @@ class LocalTree(BaseTree):
         )
 
         self.protect(tmp_file)
-        os.rename(tmp_file, to_info)
+        os.replace(tmp_file, to_info)
 
     @staticmethod
     def _download(


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

(pushing this PR to upstream since we need to run all of the cloud tests)

From https://github.com/iterative/dvc/pull/4432#discussion_r473892090

Currently we have inconsistent behavior between clouds when using `tree.upload` directly. For AzureTree and Windows LocalTree, `tree.upload` will fail if the destination path already exists. On all other platforms the destination path will be always be overwritten if it already exists.

Changes:
* Check for file existence in `tree.upload` if `overwrite=False` and fail if the file already exists.
* `_upload` on all platforms now overwrites by default (since the check for file existence is done in the calling `upload` method).