### PR TITLE
add py support for ParamsDependency

### DIFF
--- a/dvc/utils/serialize/__init__.py
+++ b/dvc/utils/serialize/__init__.py
@@ -12,4 +12,10 @@ LOADERS.update(
 )
 
 MODIFIERS = defaultdict(lambda: modify_yaml)  # noqa: F405
-MODIFIERS.update({".toml": modify_toml, ".json": modify_json})  # noqa: F405
+MODIFIERS.update(
+    {
+        ".toml": modify_toml,  # noqa: F405
+        ".json": modify_json,  # noqa: F405
+        ".py": modify_py,  # noqa: F405
+    }
+)

--- a/dvc/utils/serialize/__init__.py
+++ b/dvc/utils/serialize/__init__.py
@@ -2,11 +2,14 @@ from collections import defaultdict
 
 from ._common import *  # noqa, pylint: disable=wildcard-import
 from ._json import *  # noqa, pylint: disable=wildcard-import
+from ._py import *  # noqa, pylint: disable=wildcard-import
 from ._toml import *  # noqa, pylint: disable=wildcard-import
 from ._yaml import *  # noqa, pylint: disable=wildcard-import
 
 LOADERS = defaultdict(lambda: load_yaml)  # noqa: F405
-LOADERS.update({".toml": load_toml, ".json": load_json})  # noqa: F405
+LOADERS.update(
+    {".toml": load_toml, ".json": load_json, ".py": load_py}  # noqa: F405
+)
 
 MODIFIERS = defaultdict(lambda: modify_yaml)  # noqa: F405
 MODIFIERS.update({".toml": modify_toml, ".json": modify_json})  # noqa: F405

--- a/dvc/utils/serialize/_py.py
+++ b/dvc/utils/serialize/_py.py
@@ -1,0 +1,94 @@
+import ast
+
+from funcy import reraise
+
+from ._common import ParseError, _load_data
+
+
+class PythonFileCorruptedError(ParseError):
+    def __init__(self, path, message="PY file structure is corrupted"):
+        super().__init__(path, message)
+
+
+def load_py(path, tree=None):
+    return _load_data(path, parser=parse_py, tree=tree)
+
+
+def parse_py(text, path):
+    """Parses text from .py file into Python structure."""
+    with reraise(SyntaxError, PythonFileCorruptedError(path)):
+        tree = ast.parse(text, filename=path)
+
+    result = _ast_tree_to_dict(tree)
+    return result
+
+
+def _ast_tree_to_dict(tree, only_self_params=False):
+    """Parses ast trees to dict."""
+    result = {}
+    for _body in tree.body:
+        try:
+            if isinstance(_body, (ast.Assign, ast.AnnAssign)):
+                result.update(_ast_assign_to_dict(_body, only_self_params))
+            elif isinstance(_body, ast.ClassDef):
+                result.update({_body.name: _ast_tree_to_dict(_body)})
+            elif (
+                isinstance(_body, ast.FunctionDef) and _body.name == "__init__"
+            ):
+                result.update(_ast_tree_to_dict(_body, only_self_params=True))
+        except ValueError:
+            continue
+        except AttributeError:
+            continue
+    return result
+
+
+def _ast_assign_to_dict(assign, only_self_params=False):
+    result = {}
+
+    if isinstance(assign, ast.AnnAssign):
+        name = _get_ast_name(assign.target, only_self_params)
+    elif len(assign.targets) == 1:
+        name = _get_ast_name(assign.targets[0], only_self_params)
+    else:
+        raise AttributeError
+
+    if isinstance(assign.value, ast.Dict):
+        _dct = {}
+        for key, val in zip(assign.value.keys, assign.value.values):
+            _dct[_get_ast_value(key)] = _get_ast_value(val)
+        result[name] = _dct
+    elif isinstance(assign.value, ast.List):
+        result[name] = [_get_ast_value(val) for val in assign.value.elts]
+    elif isinstance(assign.value, ast.Set):
+        values = [_get_ast_value(val) for val in assign.value.elts]
+        result[name] = set(values)
+    elif isinstance(assign.value, ast.Tuple):
+        values = [_get_ast_value(val) for val in assign.value.elts]
+        result[name] = tuple(values)
+    else:
+        result[name] = _get_ast_value(assign.value)
+
+    return result
+
+
+def _get_ast_name(target, only_self_params=False):
+    if hasattr(target, "id") and not only_self_params:
+        result = target.id
+    elif hasattr(target, "attr") and target.value.id == "self":
+        result = target.attr
+    else:
+        raise AttributeError
+    return result
+
+
+def _get_ast_value(value):
+    if isinstance(value, ast.Num):
+        result = value.n
+    elif isinstance(value, ast.Str):
+        result = value.s
+    elif isinstance(value, ast.NameConstant):
+        result = value.value
+    else:
+        raise ValueError
+    return result

--- a/dvc/utils/serialize/_py.py
+++ b/dvc/utils/serialize/_py.py
@@ -1,12 +1,16 @@
 import ast
+from contextlib import contextmanager
 
 from funcy import reraise
 
-from ._common import ParseError, _load_data
+from ._common import ParseError, _dump_data, _load_data, _modify_data
+
+_PARAMS_KEY = "__params_old_key_for_update__"
+_PARAMS_TEXT_KEY = "__params_text_key_for_update__"
 
 
 class PythonFileCorruptedError(ParseError):
-    def __init__(self, path, message="PY file structure is corrupted"):
+    def __init__(self, path, message="Python file structure is corrupted"):
         super().__init__(path, message)
 
 
@@ -23,19 +27,92 @@ def parse_py(text, path):
     return result
 
 
-def _ast_tree_to_dict(tree, only_self_params=False):
-    """Parses ast trees to dict."""
+def parse_py_for_update(text, path):
+    """Parses text into dict for update params."""
+    with reraise(SyntaxError, PythonFileCorruptedError(path)):
+        tree = ast.parse(text, filename=path)
+
+    result = _ast_tree_to_dict(tree)
+    result.update({_PARAMS_KEY: _ast_tree_to_dict(tree, lineno=True)})
+    result.update({_PARAMS_TEXT_KEY: text})
+    return result
+
+
+def _dump(data, stream):
+
+    old_params = data[_PARAMS_KEY]
+    new_params = {
+        key: value
+        for key, value in data.items()
+        if key not in [_PARAMS_KEY, _PARAMS_TEXT_KEY]
+    }
+    old_lines = data[_PARAMS_TEXT_KEY].splitlines(True)
+
+    def _update_lines(lines, old_dct, new_dct):
+        for key, value in new_dct.items():
+            if isinstance(value, dict):
+                lines = _update_lines(lines, old_dct[key], value)
+            elif value != old_dct[key]["value"]:
+                lineno = old_dct[key]["lineno"]
+                lines[lineno] = lines[lineno].replace(
+                    f" = {old_dct[key]['value']}", f" = {value}"
+                )
+            else:
+                continue
+        return lines
+
+    new_lines = _update_lines(old_lines, old_params, new_params)
+    new_text = "".join(new_lines)
+
+    try:
+        ast.parse(new_text)
+    except SyntaxError:
+        raise PythonFileCorruptedError(
+            stream.name,
+            "Python file structure is corrupted after update params",
+        )
+
+    stream.write(new_text)
+    stream.close()
+
+
+def dump_py(path, data, tree=None):
+    return _dump_data(path, data, dumper=_dump, tree=tree)
+
+
+@contextmanager
+def modify_py(path, tree=None):
+    with _modify_data(path, parse_py_for_update, dump_py, tree=tree) as d:
+        yield d
+
+
+def _ast_tree_to_dict(tree, only_self_params=False, lineno=False):
+    """Parses ast trees to dict.
+
+    :param tree: ast.Tree
+    :param only_self_params: get only self params from class __init__ function
+    :param lineno: add params line number (needed for update)
+    :return:
+    """
     result = {}
     for _body in tree.body:
         try:
             if isinstance(_body, (ast.Assign, ast.AnnAssign)):
-                result.update(_ast_assign_to_dict(_body, only_self_params))
+                result.update(
+                    _ast_assign_to_dict(_body, only_self_params, lineno)
+                )
             elif isinstance(_body, ast.ClassDef):
-                result.update({_body.name: _ast_tree_to_dict(_body)})
+                result.update(
+                    {_body.name: _ast_tree_to_dict(_body, lineno=lineno)}
+                )
             elif (
                 isinstance(_body, ast.FunctionDef) and _body.name == "__init__"
             ):
-                result.update(_ast_tree_to_dict(_body, only_self_params=True))
+                result.update(
+                    _ast_tree_to_dict(
+                        _body, only_self_params=True, lineno=lineno
+                    )
+                )
         except ValueError:
             continue
         except AttributeError:
@@ -43,7 +120,7 @@ def _ast_tree_to_dict(tree, only_self_params=False):
     return result
 
 
-def _ast_assign_to_dict(assign, only_self_params=False):
+def _ast_assign_to_dict(assign, only_self_params=False, lineno=False):
     result = {}
 
     if isinstance(assign, ast.AnnAssign):
@@ -54,20 +131,30 @@ def _ast_assign_to_dict(assign, only_self_params=False):
         raise AttributeError
 
     if isinstance(assign.value, ast.Dict):
-        _dct = {}
+        value = {}
         for key, val in zip(assign.value.keys, assign.value.values):
-            _dct[_get_ast_value(key)] = _get_ast_value(val)
-        result[name] = _dct
+            if lineno:
+                value[_get_ast_value(key)] = {
+                    "lineno": assign.lineno - 1,
+                    "value": _get_ast_value(val),
+                }
+            else:
+                value[_get_ast_value(key)] = _get_ast_value(val)
     elif isinstance(assign.value, ast.List):
-        result[name] = [_get_ast_value(val) for val in assign.value.elts]
+        value = [_get_ast_value(val) for val in assign.value.elts]
     elif isinstance(assign.value, ast.Set):
         values = [_get_ast_value(val) for val in assign.value.elts]
-        result[name] = set(values)
+        value = set(values)
     elif isinstance(assign.value, ast.Tuple):
         values = [_get_ast_value(val) for val in assign.value.elts]
-        result[name] = tuple(values)
+        value = tuple(values)
     else:
-        result[name] = _get_ast_value(assign.value)
+        value = _get_ast_value(assign.value)
+
+    if lineno and not isinstance(assign.value, ast.Dict):
+        result[name] = {"lineno": assign.lineno - 1, "value": value}
+    else:
+        result[name] = value
 
     return result
 

--- a/tests/func/params/test_show.py
+++ b/tests/func/params/test_show.py
@@ -24,6 +24,21 @@ def test_show_toml(tmp_dir, dvc):
     }
 
 
+def test_show_py(tmp_dir, dvc):
+    tmp_dir.gen(
+        "params.py",
+        "CONST = 1\nIS_DIR: bool = True\n\n\nclass Config:\n    foo = 42\n",
+    )
+    dvc.run(
+        cmd="echo params.py",
+        params=["params.py:CONST,IS_DIR,Config.foo"],
+        single_stage=True,
+    )
+    assert dvc.params.show() == {
+        "": {"params.py": {"CONST": 1, "IS_DIR": True, "Config": {"foo": 42}}}
+    }
+
+
 def test_show_multiple(tmp_dir, dvc):
     tmp_dir.gen("params.yaml", "foo: bar\nbaz: qux\n")
     dvc.run(


### PR DESCRIPTION
* add py support for ParamsDependency

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

This PR adds support for parameters file in ".py" format. Example:

```
dvc run -n train -d stages/train.py -p params.py:SEED,Train python stages/train.py
```

Where params.py looks something like this:
```
SEED = 1

class Train:
    lr = 0.0041
    epochs = 75
    layers = 9
```

dvc.lock looks like this:
```
train:
  cmd: python stages/train.py
  deps:
  - path: stages/train.py
    md5: 23be4307b23dcd740763d5fc67993f11
  params:
    params.py:
      SEED: 1
      Train:
        epochs: 75
        layers: 9
        lr: 0.0041
```