### PR TITLE
api: refactor to use metadata and RepoTree

### DIFF
--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -116,3 +116,11 @@ class DataCloud:
         return self.repo.cache.local.status(
             cache, jobs=jobs, remote=remote, show_checksums=show_checksums
         )
+
+    def get_url_for(self, remote=None, checksum=None):
+        remote = self.get_remote(remote)
+        tree = remote.tree
+
+        if checksum:
+            return tree.hash_to_path_info(checksum).url
+        return tree.path_info.url

--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -291,19 +291,16 @@ class HTTPError(DvcException):
 
 
 class PathMissingError(DvcException):
-    default_msg = (
-        "The path '{}' does not exist in the target repository '{}'"
-        " neither as a DVC output nor as a Git-tracked file."
-    )
-    default_msg_dvc_only = (
-        "The path '{}' does not exist in the target repository '{}'"
-        " as an DVC output."
-    )
+    def __init__(self, path, repo=None, dvc_only=False):
+        msg = f"The path '{path}' does not exist in the"
+        msg += " repository" if not repo else f" target repository '{repo}'"
+        msg += " as a DVC output"
+        msg = f"{msg}." if dvc_only else f"{msg} nor as a Git-tracked file."
 
-    def __init__(self, path, repo, dvc_only=False):
-        msg = self.default_msg if not dvc_only else self.default_msg_dvc_only
-        super().__init__(msg.format(path, repo))
         self.dvc_only = dvc_only
+        self.repo = repo
+        self.path = path
+        super().__init__(msg)
 
 
 class RemoteCacheRequiredError(DvcException):

--- a/dvc/tree/_metadata.py
+++ b/dvc/tree/_metadata.py
@@ -1,8 +1,11 @@
 from dataclasses import dataclass, field
-from typing import List
+from typing import TYPE_CHECKING, List, Optional
 
 from dvc.output import BaseOutput
 from dvc.path_info import PathInfo
+
+if TYPE_CHECKING:
+    from dvc.repo import Repo
 
 
 @dataclass
@@ -30,6 +33,7 @@ class Metadata:
     isdir: bool = False  # is it a directory?
     is_exec: bool = False  # is it an executable?
     outs: List[BaseOutput] = field(default_factory=list)  # list of outputs
+    repo: Optional["Repo"] = None  # the repo path falls in
 
     def __post_init__(self):
         self.output_exists = bool(self.outs)

--- a/dvc/tree/dvc.py
+++ b/dvc/tree/dvc.py
@@ -45,7 +45,8 @@ class DvcTree(BaseTree):  # pylint:disable=abstract-method
         assert isinstance(path, PathInfo)
         if not self.fetch and not self.stream:
             raise FileNotFoundError
-        dir_cache = out.get_dir_cache(remote=remote)
+        with self.repo.state:
+            dir_cache = out.get_dir_cache(remote=remote)
         for entry in dir_cache:
             entry_relpath = entry[out.tree.PARAM_RELPATH]
             if os.name == "nt":
@@ -240,6 +241,6 @@ class DvcTree(BaseTree):  # pylint:disable=abstract-method
         path_info = PathInfo(os.path.abspath(path_info))
         outs = self._find_outs(path_info, strict=False, recursive=True)
 
-        meta = Metadata(path_info=path_info, outs=outs)
+        meta = Metadata(path_info=path_info, outs=outs, repo=self.repo)
         meta.isdir = meta.isdir or self.check_isdir(meta.path_info, meta.outs)
         return meta


### PR DESCRIPTION
This does not yet support subrepos as it requires us to work on setting up cache correctly which is pending.
After that, it should just be changing `subrepos=False` to `True`.

Still unsure about _proper_ exceptions here, but I did try to unify them somehow (still does not look good though).

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Closes #3182
