### PR TITLE
status: no warnings for missing state

### DIFF
--- a/dvc/cache/local.py
+++ b/dvc/cache/local.py
@@ -114,6 +114,7 @@ class LocalCache(CloudCache):
         jobs=None,
         show_checksums=False,
         download=False,
+        log_missing=True,
     ):
         # Return flattened dict containing all status info
         dir_status, file_status, _ = self._status(
@@ -122,6 +123,7 @@ class LocalCache(CloudCache):
             jobs=jobs,
             show_checksums=show_checksums,
             download=download,
+            log_missing=log_missing,
         )
         return dict(dir_status, **file_status)
 
@@ -132,6 +134,7 @@ class LocalCache(CloudCache):
         jobs=None,
         show_checksums=False,
         download=False,
+        log_missing=True,
     ):
         """Return a tuple of (dir_status_info, file_status_info, dir_contents).
 
@@ -172,11 +175,20 @@ class LocalCache(CloudCache):
                     )
                 )
         return self._make_status(
-            named_cache, show_checksums, local_exists, remote_exists
+            named_cache,
+            show_checksums,
+            local_exists,
+            remote_exists,
+            log_missing,
         )
 
     def _make_status(
-        self, named_cache, show_checksums, local_exists, remote_exists
+        self,
+        named_cache,
+        show_checksums,
+        local_exists,
+        remote_exists,
+        log_missing,
     ):
         def make_names(hash_, names):
             return {"name": hash_ if show_checksums else " ".join(names)}
@@ -199,7 +211,8 @@ class LocalCache(CloudCache):
         self._fill_statuses(dir_status, local_exists, remote_exists)
         self._fill_statuses(file_status, local_exists, remote_exists)
 
-        self._log_missing_caches(dict(dir_status, **file_status))
+        if log_missing:
+            self._log_missing_caches(dict(dir_status, **file_status))
 
         return dir_status, file_status, dir_contents
 

--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -100,7 +100,14 @@ class DataCloud:
                 # (see `RemoteBASE.download()`)
                 self.repo.state.save(cache_file, checksum)
 
-    def status(self, cache, jobs=None, remote=None, show_checksums=False):
+    def status(
+        self,
+        cache,
+        jobs=None,
+        remote=None,
+        show_checksums=False,
+        log_missing=True,
+    ):
         """Check status of data items in a cloud-agnostic way.
 
         Args:
@@ -111,8 +118,14 @@ class DataCloud:
                 is used.
             show_checksums (bool): show checksums instead of file names in
                 information messages.
+            log_missing (bool): log warning messages if file doesn't exist
+                neither in cache, neither in cloud.
         """
         remote = self.get_remote(remote, "status")
         return self.repo.cache.local.status(
-            cache, jobs=jobs, remote=remote, show_checksums=show_checksums
+            cache,
+            jobs=jobs,
+            remote=remote,
+            show_checksums=show_checksums,
+            log_missing=log_missing,
         )

--- a/dvc/repo/status.py
+++ b/dvc/repo/status.py
@@ -53,6 +53,7 @@ def _cloud_status(
 
     - new: Remote doesn't have the file
     - deleted: File is no longer in the local cache
+    - missing: File doesn't exist neither in the cache, neither in remote
 
     Example:
             Given the following commands:
@@ -90,7 +91,9 @@ def _cloud_status(
     )
 
     ret = {}
-    status_info = self.cloud.status(used, jobs, remote=remote)
+    status_info = self.cloud.status(
+        used, jobs, remote=remote, log_missing=False
+    )
     for info in status_info.values():
         name = info["name"]
         status_ = info["status"]

--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -248,10 +248,10 @@ def test_missing_cache(tmp_dir, dvc, local_remote, caplog):
     assert bar in caplog.text
 
     caplog.clear()
-    dvc.status(cloud=True)
-    assert header in caplog.text
-    assert foo in caplog.text
-    assert bar in caplog.text
+    assert dvc.status(cloud=True) == {"bar": "missing", "foo": "missing"}
+    assert header not in caplog.text
+    assert foo not in caplog.text
+    assert bar not in caplog.text
 
 
 def test_verify_hashes(


### PR DESCRIPTION
Fixes #4383 (again)

After  PR #4398 it occured, that `dvc status -c` output is bloated and informs about "missing" files twice (took from https://github.com/iterative/dvc/pull/4398#issuecomment-678673973):

> ```
> $ dvc status -c -R .
> WARNING: Some of the cache files do not exist neither locally nor on remote. Missing cache files:
> name: data-in-cache2-not-in-remote.txt, md5: 599b9eea7a2c4f97be18c077d2df4789
> 	new:                data-in-cache-1-not-in-remote.txt
> 	missing:            data-in-cache-2-not-in-remote.txt
> ```
>If `missing` is now an expected status, the WARNING is probably no longer needed. So it could just output something like:
>
> ```
> $ dvc status -c  # Assumes default remote exists, otherwise -r myremote
> new:                data-in-cache-1-not-in-remote.txt
> missing:            data-in-cache2-not-in-remote.txt
> ```

The WARNING shouldn't shown for `dvc status -c`. However it should be shown for all other commands (`fetch`, `gc`, etc.). This PR implements such behavior.

**P.R.:** I didn't come up with anything better than adding `log_missing=True` param into `dvc.data_cloud.DataCloud.status` and passing it all the way down `dvc.cache.local._make_status`. It's ugly. If there any better way please inform me about it. 

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

issue in dvc.or repo already exist: https://github.com/iterative/dvc.org/issues/1701

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
