### PR TITLE
tests: speedup lock tests

### DIFF
--- a/tests/func/test_lock.py
+++ b/tests/func/test_lock.py
@@ -1,23 +1,23 @@
-import os
+import pytest
 
-from dvc.lock import Lock, LockError
+from dvc.lock import FAILED_TO_LOCK_MESSAGE, Lock, LockError
 from dvc.main import main
-from tests.basic_env import TestDvc
 
 
-class TestLock(TestDvc):
-    def test_with(self):
-        lockfile = os.path.join(self.dvc.dvc_dir, "tmp", "lock")
-        lock = Lock(lockfile)
-        with lock:
-            with self.assertRaises(LockError):
-                lock2 = Lock(lockfile)
-                with lock2:
-                    pass
+def test_with(tmp_dir, dvc, mocker):
+    # patching to speedup tests
+    mocker.patch("dvc.lock.DEFAULT_TIMEOUT", 0.1)
 
-    def test_cli(self):
-        lockfile = os.path.join(self.dvc.dvc_dir, "tmp", "lock")
-        lock = Lock(lockfile)
-        with lock:
-            ret = main(["add", self.FOO])
-            self.assertEqual(ret, 1)
+    lockfile = tmp_dir / dvc.tmp_dir / "lock"
+    with Lock(lockfile):
+        with pytest.raises(LockError), Lock(lockfile):
+            pass
+
+
+def test_cli(tmp_dir, dvc, mocker, caplog):
+    # patching to speedup tests
+    mocker.patch("dvc.lock.DEFAULT_TIMEOUT", 0.1)
+
+    with Lock(tmp_dir / dvc.tmp_dir / "lock"):
+        assert main(["add", "foo"]) == 1
+    assert FAILED_TO_LOCK_MESSAGE in caplog.text

--- a/tests/func/test_lock.py
+++ b/tests/func/test_lock.py
@@ -6,7 +6,7 @@ from dvc.main import main
 
 def test_with(tmp_dir, dvc, mocker):
     # patching to speedup tests
-    mocker.patch("dvc.lock.DEFAULT_TIMEOUT", 0.1)
+    mocker.patch("dvc.lock.DEFAULT_TIMEOUT", 0.01)
 
     lockfile = tmp_dir / dvc.tmp_dir / "lock"
     with Lock(lockfile):
@@ -16,7 +16,7 @@ def test_with(tmp_dir, dvc, mocker):
 
 def test_cli(tmp_dir, dvc, mocker, caplog):
     # patching to speedup tests
-    mocker.patch("dvc.lock.DEFAULT_TIMEOUT", 0.1)
+    mocker.patch("dvc.lock.DEFAULT_TIMEOUT", 0.01)
 
     with Lock(tmp_dir / dvc.tmp_dir / "lock"):
         assert main(["add", "foo"]) == 1


### PR DESCRIPTION
Patched to reduce timeout from default 5s to 0.01s

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

#### Before
```console
$ pytest tests/func/test_lock.py
2 passed in 10.20s
```

#### After
```console
$ pytest tests/func/test_lock.py
2 passed in 0.20s
```
