### PR TITLE
dvc: only config logger if main() called

### DIFF
--- a/dvc/logger.py
+++ b/dvc/logger.py
@@ -180,10 +180,12 @@ def disable_other_loggers():
             logger.disabled = True
 
 
-def setup(level=logging.INFO):
+def setup():
     colorama.init()
-
     addLoggingLevel("TRACE", logging.DEBUG - 5)
+
+
+def config():
     logging.config.dictConfig(
         {
             "version": 1,
@@ -224,7 +226,7 @@ def setup(level=logging.INFO):
             },
             "loggers": {
                 "dvc": {
-                    "level": level,
+                    "level": "INFO",
                     "handlers": [
                         "console_info",
                         "console_debug",

--- a/dvc/main.py
+++ b/dvc/main.py
@@ -9,7 +9,9 @@ from dvc.cli import parse_args
 from dvc.config import ConfigError
 from dvc.exceptions import DvcException, DvcParserError, NotDvcRepoError
 from dvc.external_repo import clean_repos
-from dvc.logger import FOOTER, disable_other_loggers
+from dvc.logger import FOOTER
+from dvc.logger import config as config_logger
+from dvc.logger import disable_other_loggers
 from dvc.tree.pool import close_pools
 from dvc.utils import format_link
 
@@ -52,6 +54,7 @@ def main(argv=None):  # noqa: C901
     """
     args = None
     disable_other_loggers()
+    config_logger()
 
     outerLogLevel = logger.level
     try:


### PR DESCRIPTION
Makes it more friendly to be used as a library. Some setup part is still
called on import, e.g. adding trace logging level.