### PR TITLE
experiments: make `dvc exp show` more consistent w/viewer

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -102,19 +102,18 @@ def _collect_rows(
         row = []
         style = None
         queued = "*" if exp.get("queued", False) else ""
-        if no_timestamp:
-            timestamp = ""
-        else:
-            timestamp = _format_time(exp.get("timestamp"))
 
         if rev == "baseline":
             name = exp.get("name", base_rev)
-            row.append(f"{name}{timestamp}")
+            row.append(f"{name}")
             style = "bold"
         elif i < len(experiments) - 1:
-            row.append(f"├── {queued}{rev[:7]}{timestamp}")
+            row.append(f"├── {queued}{rev[:7]}")
         else:
-            row.append(f"└── {queued}{rev[:7]}{timestamp}")
+            row.append(f"└── {queued}{rev[:7]}")
+
+        if not no_timestamp:
+            row.append(_format_time(exp.get("timestamp")))
 
         _extend_row(
             row, metric_names, exp.get("metrics", {}).items(), precision
@@ -126,12 +125,12 @@ def _collect_rows(
 
 def _format_time(timestamp):
     if timestamp is None:
-        return ""
+        return "-"
     if timestamp.date() == date.today():
         fmt = "%I:%M %p"
     else:
         fmt = "%b %d, %Y"
-    return " ({})".format(timestamp.strftime(fmt))
+    return timestamp.strftime(fmt)
 
 
 def _extend_row(row, names, items, precision):
@@ -192,6 +191,8 @@ def _show_experiments(all_experiments, console, **kwargs):
 
     table = Table()
     table.add_column("Experiment", no_wrap=True)
+    if not kwargs.get("no_timestamp", False):
+        table.add_column("Created")
     for name in metric_names:
         table.add_column(name, justify="right", no_wrap=True)
     for name in param_names:

--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -2,6 +2,7 @@ import argparse
 import io
 import logging
 from collections import OrderedDict
+from datetime import date
 from itertools import groupby
 from typing import Iterable, Optional
 
@@ -104,11 +105,11 @@ def _collect_rows(
         if no_timestamp:
             timestamp = ""
         else:
-            commit_time = exp.get("timestamp")
-            timestamp = f" ({commit_time})" if commit_time is not None else ""
+            timestamp = _format_time(exp.get("timestamp"))
 
         if rev == "baseline":
-            row.append(f"{base_rev}{timestamp}")
+            name = exp.get("name", base_rev)
+            row.append(f"{name}{timestamp}")
             style = "bold"
         elif i < len(experiments) - 1:
             row.append(f"├── {queued}{rev[:7]}{timestamp}")
@@ -121,6 +122,16 @@ def _collect_rows(
         _extend_row(row, param_names, exp.get("params", {}).items(), precision)
 
         yield row, style
+
+
+def _format_time(timestamp):
+    if timestamp is None:
+        return ""
+    if timestamp.date() == date.today():
+        fmt = "%I:%M %p"
+    else:
+        fmt = "%b %d, %Y"
+    return " ({})".format(timestamp.strftime(fmt))
 
 
 def _extend_row(row, names, items, precision):
@@ -212,6 +223,7 @@ class CmdExperimentsShow(CmdBase):
                 all_branches=self.args.all_branches,
                 all_tags=self.args.all_tags,
                 all_commits=self.args.all_commits,
+                sha_only=self.args.sha,
             )
 
             if self.args.no_pager:
@@ -413,6 +425,12 @@ def add_parser(subparsers, parent_parser):
         action="store_true",
         default=False,
         help="Do not show experiment timestamps.",
+    )
+    experiments_show_parser.add_argument(
+        "--sha",
+        action="store_true",
+        default=False,
+        help="Always show git commit SHAs instead of branch/tag names.",
     )
     experiments_show_parser.set_defaults(func=CmdExperimentsShow)
 

--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -9,9 +9,6 @@ from dvc.repo.params.show import _collect_configs, _read_params
 logger = logging.getLogger(__name__)
 
 
-EXP_RE = re.compile(r"(?P<rev_sha>[a-f0-9]{7})-(?P<exp_sha>[a-f0-9]+)")
-
-
 def _collect_experiment(repo, branch, stash=False, sha_only=True):
     from git.exc import GitCommandError
 

--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -48,6 +48,7 @@ def test_show_experiment(tmp_dir, scm, dvc):
         "params": {"params.yaml": {"foo": 1}},
         "queued": False,
         "timestamp": timestamp,
+        "name": "master",
     }
     expected_params = {"foo": 2}
 

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -37,6 +37,7 @@ def test_experiments_show(dvc, mocker):
             "--all-tags",
             "--all-branches",
             "--all-commits",
+            "--sha",
         ]
     )
     assert cli_args.func == CmdExperimentsShow
@@ -47,5 +48,9 @@ def test_experiments_show(dvc, mocker):
     assert cmd.run() == 0
 
     m.assert_called_once_with(
-        cmd.repo, all_tags=True, all_branches=True, all_commits=True
+        cmd.repo,
+        all_tags=True,
+        all_branches=True,
+        all_commits=True,
+        sha_only=True,
     )


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

* Show git tag/branch names instead of SHAs where applicable
    * SHAs can still be displayed using `dvc exp show --sha ...`
* Make timestamp formatting less verbose

```
❯ dvc exp show --all-commits --include-params=featurize --no-pager
┏━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Experiment            ┃ Created      ┃     auc ┃ featurize.m… ┃ featurize.ng… ┃
┡━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ workspace             │ -            │ 0.50822 │ 1500         │ 4             │
│ executor-tree         │ 05:31 PM     │ 0.50822 │ 1500         │ 4             │
│ └── *41a9f4b          │ 05:34 PM     │       - │ 456          │ 5             │
│ 6d18fc1               │ Aug 24, 2020 │ 0.58164 │ 1500         │ 3             │
│ ├── 3c8db11           │ Aug 24, 2020 │ 0.50298 │ 500          │ 4             │
│ ├── 5840202           │ Aug 24, 2020 │ 0.50822 │ 1500         │ 4             │
│ └── *3b6e442          │ Aug 25, 2020 │       - │ 123          │ 5             │
│ 0562956               │ Aug 24, 2020 │ 0.61314 │ 1500         │ 2             │
│ ├── e6d1716           │ Aug 24, 2020 │ 0.58164 │ 1500         │ 3             │
│ └── *c34fd7e          │ Aug 25, 2020 │       - │ 456          │ 5             │
│ acd59eb               │ Jul 22, 2020 │ 0.61314 │ 1500         │ 2             │
│ 11-bigrams-experiment │ Jun 20, 2020 │ 0.61314 │ 1500         │ 2             │
│ 10-bigrams-model      │ Jun 20, 2020 │ 0.54175 │ 1500         │ 2             │
...
│ 0-git-init            │ Jun 20, 2020 │       - │ 1500         │ 4             │
└───────────────────────┴──────────────┴─────────┴──────────────┴───────────────┘
```