### PR TITLE
Keep `status` output format consistents

### DIFF
--- a/dvc/repo/status.py
+++ b/dvc/repo/status.py
@@ -19,11 +19,9 @@ def _joint_status(pairs):
                 "{} is frozen. Its dependencies are"
                 " not going to be shown in the status output.".format(stage)
             )
-        if not filter_info:
-            status_info.update(stage.status(check_updates=True))
-        else:
-            for out in stage.filter_outs(filter_info):
-                status_info.update(out.status())
+        status_info.update(
+            stage.status(check_updates=True, filter_info=filter_info)
+        )
 
     return status_info
 

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -469,13 +469,13 @@ class Stage(params.StageParams):
             return "failed", exc.target_infos
 
     @rwlocked(read=["deps", "outs"])
-    def status(self, check_updates=False):
+    def status(self, check_updates=False, filter_info=None):
         ret = []
         show_import = self.is_repo_import and check_updates
 
         if not self.frozen or show_import:
             self._status_deps(ret)
-        self._status_outs(ret)
+        self._status_outs(ret, filter_info=filter_info)
         self._status_always_changed(ret)
         self._status_stage(ret)
         return {self.addressing: ret} if ret else {}
@@ -494,8 +494,9 @@ class Stage(params.StageParams):
         if deps_status:
             ret.append({"changed deps": deps_status})
 
-    def _status_outs(self, ret):
-        outs_status = self._status(self.outs)
+    def _status_outs(self, ret, filter_info):
+        filter_outs = self.filter_outs(filter_info)
+        outs_status = self._status(filter_outs)
         if outs_status:
             ret.append({"changed outs": outs_status})
 

--- a/tests/func/test_status.py
+++ b/tests/func/test_status.py
@@ -136,4 +136,6 @@ def test_status_outputs(tmp_dir, dvc):
         ]
     }
 
-    assert dvc.status(targets=["alice"]) == {"alice": "modified"}
+    assert dvc.status(targets=["alice"]) == {
+        "alice_bob": [{"changed outs": {"alice": "modified"}}]
+    }


### PR DESCRIPTION
fix #4482 
According to the discussion. Make `DVC status [outputs]` output format the same with `DVC status [stages]` instead of `DVC status -c [outputs]`

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
