### PR TITLE
gitignore: ignore /cache instead of cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,11 @@
 neatlynx.conf
 neatlynx/__pycache__
 .idea
-cache
+/cache
 *.pyc
 .env/
 .env2.7/
 
-cache
 .dvc.conf.lock
 .DS_Store
 build/


### PR DESCRIPTION
Currently `dvc/cache` is gitignored.

* [ ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
