### PR TITLE
deps/outs: get rid of self.info

### DIFF
--- a/dvc/cache/base.py
+++ b/dvc/cache/base.py
@@ -620,17 +620,16 @@ class CloudCache:
         assert their_info
 
         if ancestor_info:
-            ancestor_hash = ancestor_info[self.tree.PARAM_CHECKSUM]
+            ancestor_hash = ancestor_info.value
             ancestor = self.get_dir_cache(ancestor_hash)
         else:
             ancestor = []
 
-        our_hash = our_info[self.tree.PARAM_CHECKSUM]
+        our_hash = our_info.value
         our = self.get_dir_cache(our_hash)
 
-        their_hash = their_info[self.tree.PARAM_CHECKSUM]
+        their_hash = their_info.value
         their = self.get_dir_cache(their_hash)
 
         merged = self._merge_dirs(ancestor, our, their)
-        hash_info = self.tree.save_dir_info(merged)
-        return {hash_info.name: hash_info.value}
+        return self.tree.save_dir_info(merged)

--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -138,13 +138,13 @@ class BaseExternalRepo:
         def download_update(result):
             download_results.append(result)
 
-        save_infos = []
+        hash_infos = []
         for path in paths:
             if not self.repo_tree.exists(path):
                 raise PathMissingError(path, self.url)
-            hash_info = self.repo_tree.save_info(
+            hash_info = self.repo_tree.get_hash(
                 path, download_callback=download_update
-            )
+            ).to_dict()
             self.local_cache.save(
                 path,
                 self.repo_tree,
@@ -152,9 +152,9 @@ class BaseExternalRepo:
                 save_link=False,
                 download_callback=download_update,
             )
-            save_infos.append(hash_info)
+            hash_infos.append(hash_info)
 
-        return sum(download_results), failed, save_infos
+        return sum(download_results), failed, hash_infos
 
     def get_external(self, path, dest):
         """Convenience wrapper for fetch_external and checkout."""

--- a/dvc/hash_info.py
+++ b/dvc/hash_info.py
@@ -8,3 +8,13 @@ class HashInfo:
 
     def __bool__(self):
         return bool(self.value)
+
+    @classmethod
+    def from_dict(cls, d):
+        if not d:
+            return cls(None, None)
+        ((name, value),) = d.items()
+        return cls(name, value)
+
+    def to_dict(self):
+        return {self.name: self.value} if self else {}

--- a/dvc/stage/loader.py
+++ b/dvc/stage/loader.py
@@ -6,6 +6,7 @@ from itertools import chain
 from funcy import get_in, lcat, project
 
 from dvc import dependency, output
+from dvc.hash_info import HashInfo
 
 from . import PipelineStage, Stage, loads_from
 from .exceptions import StageNameUnspecified, StageNotFound
@@ -42,9 +43,10 @@ class StageLoader(Mapping):
             if isinstance(item, dependency.ParamsDependency):
                 item.fill_values(get_in(lock_data, [stage.PARAM_PARAMS, path]))
                 continue
-            item.info = get_in(checksums, [key, path], {})
-            item.info = item.info.copy()
-            item.info.pop("path", None)
+            info = get_in(checksums, [key, path], {})
+            info = info.copy()
+            info.pop("path", None)
+            item.hash_info = HashInfo.from_dict(info)
 
     @classmethod
     def load_stage(cls, dvcfile, name, stage_data, lock_data=None):

--- a/dvc/stage/serialize.py
+++ b/dvc/stage/serialize.py
@@ -138,7 +138,12 @@ def to_single_stage_lockfile(stage: "Stage") -> dict:
     params, deps = split_params_deps(stage)
     deps, outs = [
         [
-            OrderedDict([(PARAM_PATH, item.def_path), *item.info.items()])
+            OrderedDict(
+                [
+                    (PARAM_PATH, item.def_path),
+                    *item.hash_info.to_dict().items(),
+                ]
+            )
             for item in sort_by_path(items)
         ]
         for items in [deps, stage.outs]

--- a/dvc/tree/base.py
+++ b/dvc/tree/base.py
@@ -294,10 +294,6 @@ class BaseTree:
 
         return "".join(parts)
 
-    def save_info(self, path_info, **kwargs):
-        hash_info = self.get_hash(path_info, **kwargs)
-        return {hash_info.name: hash_info.value}
-
     def _calculate_hashes(self, file_infos):
         file_infos = list(file_infos)
         with Tqdm(

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -18,6 +18,7 @@ from dvc.exceptions import (
     OverlappingOutputPathsError,
     RecursiveAddingWhileUsingFilename,
 )
+from dvc.hash_info import HashInfo
 from dvc.main import main
 from dvc.output.base import OutputAlreadyTrackedError, OutputIsStageFileError
 from dvc.repo import Repo as DvcRepo
@@ -42,7 +43,7 @@ def test_add(tmp_dir, dvc):
     assert len(stage.outs) == 1
     assert len(stage.deps) == 0
     assert stage.cmd is None
-    assert stage.outs[0].info["md5"] == md5
+    assert stage.outs[0].hash_info == HashInfo("md5", md5)
     assert stage.md5 is None
 
     assert load_yaml("foo.dvc") == {
@@ -71,7 +72,7 @@ def test_add_directory(tmp_dir, dvc):
     assert len(stage.deps) == 0
     assert len(stage.outs) == 1
 
-    md5 = stage.outs[0].info["md5"]
+    md5 = stage.outs[0].hash_info.value
 
     dir_info = dvc.cache.local.load_dir_cache(md5)
     for info in dir_info:

--- a/tests/func/test_run_cache.py
+++ b/tests/func/test_run_cache.py
@@ -76,7 +76,7 @@ def test_uncached_outs_are_cached(tmp_dir, dvc, run_copy):
         name="copy-foo-bar",
     )
     with dvc.state:
-        stage.outs[0].info = stage.outs[0].save_info()
+        stage.outs[0].hash_info = stage.outs[0].get_hash()
     assert os.path.exists(relpath(stage.outs[0].cache_path))
 
 

--- a/tests/func/test_tree.py
+++ b/tests/func/test_tree.py
@@ -226,7 +226,7 @@ def test_repotree_cache_save(tmp_dir, dvc, scm, erepo_dir, local_cloud):
         cache = dvc.cache.local
         with cache.tree.state:
             path_info = PathInfo(erepo_dir / "dir")
-            hash_info = cache.tree.save_info(path_info)
+            hash_info = cache.tree.get_hash(path_info).to_dict()
             cache.save(path_info, tree, hash_info)
 
     for hash_ in expected:

--- a/tests/unit/dependency/test_params.py
+++ b/tests/unit/dependency/test_params.py
@@ -32,17 +32,17 @@ def test_loads_params(dvc):
     assert isinstance(deps[0], ParamsDependency)
     assert deps[0].def_path == ParamsDependency.DEFAULT_PARAMS_FILE
     assert deps[0].params == ["foo", "bar"]
-    assert deps[0].info == {}
+    assert not deps[0].hash_info
 
     assert isinstance(deps[1], ParamsDependency)
     assert deps[1].def_path == "a_file"
     assert deps[1].params == ["baz", "bat", "foobar"]
-    assert deps[1].info == {}
+    assert not deps[1].hash_info
 
     assert isinstance(deps[2], ParamsDependency)
     assert deps[2].def_path == "b_file"
     assert deps[2].params == ["cat"]
-    assert deps[2].info == {}
+    assert not deps[2].hash_info
 
 
 @pytest.mark.parametrize("params", [[3], [{"b_file": "cat"}]])
@@ -58,7 +58,7 @@ def test_loadd_from(dvc):
     assert isinstance(deps[0], ParamsDependency)
     assert deps[0].def_path == ParamsDependency.DEFAULT_PARAMS_FILE
     assert deps[0].params == list(PARAMS.keys())
-    assert deps[0].info == PARAMS
+    assert deps[0].hash_info.value == PARAMS
 
 
 def test_dumpd_with_info(dvc):
@@ -119,17 +119,17 @@ def test_read_params_toml(tmp_dir, dvc):
     assert dep.read_params() == {"some.path.foo": ["val1", "val2"]}
 
 
-def test_save_info_missing_config(dvc):
+def test_get_hash_missing_config(dvc):
     dep = ParamsDependency(Stage(dvc), None, ["foo"])
     with pytest.raises(MissingParamsError):
-        dep.save_info()
+        dep.get_hash()
 
 
-def test_save_info_missing_param(tmp_dir, dvc):
+def test_get_hash_missing_param(tmp_dir, dvc):
     tmp_dir.gen(DEFAULT_PARAMS_FILE, "bar: baz")
     dep = ParamsDependency(Stage(dvc), None, ["foo"])
     with pytest.raises(MissingParamsError):
-        dep.save_info()
+        dep.get_hash()
 
 
 @pytest.mark.regression_4184

--- a/tests/unit/output/test_load.py
+++ b/tests/unit/output/test_load.py
@@ -39,7 +39,7 @@ def test_load_from_pipeline(dvc, out_type, type_test_func):
         assert out.def_path == f"file{i}"
         assert out.use_cache == (out.def_path in cached_outs)
         assert out.persist == (out.def_path in persisted_outs)
-        assert out.info == {}
+        assert not out.hash_info
         assert type_test_func(out)
 
 
@@ -57,7 +57,7 @@ def test_load_from_pipeline_accumulates_flag(dvc):
     for out in outs:
         assert isinstance(out, LocalOutput)
         assert not out.plot and not out.metric
-        assert out.info == {}
+        assert not out.hash_info
 
     assert outs[0].use_cache and not outs[0].persist
     assert not outs[1].use_cache and outs[1].persist
@@ -71,7 +71,7 @@ def test_load_remote_files_from_pipeline(dvc):
     assert isinstance(out, S3Output)
     assert not out.plot and out.metric
     assert not out.persist
-    assert out.info == {}
+    assert not out.hash_info
 
 
 @pytest.mark.parametrize("typ", [None, "", "illegal"])


### PR DESCRIPTION
By itself `self.info` is quite confusing, as it is not clear what it is
about. Using `hash_info` makes much more sense and is required to
support alternative hash types.

Related to #4144, #3069, #1676

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
