### PR TITLE
experiments: support column ordering & sorting in `dvc exp show`

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -149,10 +149,8 @@ def _sort_exp(experiments, sort_by, typ, reverse):
                 item = {fname: item}
             if sort_by in item:
                 val = item[sort_by]
-                break
-        else:
-            val = None
-        return (val is None, val)
+                return (val is None, val)
+        return (True, None)
 
     ret.update(sorted(experiments.items(), key=_sort, reverse=reverse))
     return ret


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will close #4346.

* When using `--include-metrics/--include-params`, columns will be displayed left-to-right in the order specified by the `--include` option.
* `--sort-by <column_name>` and `--sort-order asc|desc` can be used to sort related experiments on the specified metric or param column.
    * Only nested experiments will be sorted, baseline (formal) commits will still be displayed in the git history order.
    * `--sort-order` defaults to ascending
    * Only sorting by a single column is supported

```
❯ dvc exp show --include-params=train.seed,featurize --sort-by=featurize.max_features --sort-order desc --all-commits --no-pager
┏━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┓
┃ Experiment            ┃ Created      ┃     auc ┃ train.seed ┃ featurize.max_features ┃ featurize.ngrams ┃
┡━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━┩
│ workspace             │ -            │ 0.58164 │ 20170428   │ 1500                   │ 3                │
│ executor-tree         │ Aug 28, 2020 │ 0.50822 │ 20170428   │ 1500                   │ 4                │
│ └── *41a9f4b          │ Aug 28, 2020 │       - │ 20170428   │ 456                    │ 5                │
│ 6d18fc1               │ Aug 24, 2020 │ 0.58164 │ 20170428   │ 1500                   │ 3                │
│ ├── 5840202           │ Aug 24, 2020 │ 0.50822 │ 20170428   │ 1500                   │ 4                │
│ ├── 3c8db11           │ Aug 24, 2020 │ 0.50298 │ 20170428   │ 500                    │ 4                │
│ └── *3b6e442          │ Aug 25, 2020 │       - │ 20170428   │ 123                    │ 5                │
│ 0562956               │ Aug 24, 2020 │ 0.61314 │ 20170428   │ 1500                   │ 2                │
│ ├── e6d1716           │ Aug 24, 2020 │ 0.58164 │ 20170428   │ 1500                   │ 3                │
│ └── *c34fd7e          │ Aug 25, 2020 │       - │ 20170428   │ 456                    │ 5                │
│ acd59eb               │ Jul 22, 2020 │ 0.61314 │ 20170428   │ 1500                   │ 2                │
...
│ 0-git-init            │ Jun 20, 2020 │       - │ 20170428   │ 1500                   │ 3                │
└───────────────────────┴──────────────┴─────────┴────────────┴────────────────────────┴──────────────────┘
```