### PR TITLE
cache: use get_file_hash instead of get_hash

### DIFF
--- a/dvc/cache/base.py
+++ b/dvc/cache/base.py
@@ -273,7 +273,7 @@ class CloudCache:
         to_info = self.tree.path_info / tmp_fname("")
         self.tree.upload(from_info, to_info, no_progress_bar=True)
 
-        hash_info = self.tree.get_hash(to_info)
+        hash_info = self.tree.get_file_hash(to_info)
         hash_info.value += self.tree.CHECKSUM_DIR_SUFFIX
         hash_info.dir_info = dir_info
 


### PR DESCRIPTION
This is what we've been doing before. No need to try to pull it up from
the state db, as this is a clearly newly generated file that will get
deleted.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
