### PR TITLE
Disable cprofile on exit in `profile`

### DIFF
--- a/dvc/main.py
+++ b/dvc/main.py
@@ -35,6 +35,7 @@ def profile(enable, dump):
 
     yield
 
+    prof.disable()
     if not dump:
         prof.print_stats(sort="cumtime")
         return


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Does not change anything, it's good to disable it just after `yield` to not show other stats by accident.