### PR TITLE
scm: add config option to stage files automatically

### DIFF
--- a/dvc/config.py
+++ b/dvc/config.py
@@ -137,6 +137,7 @@ SCHEMA = {
         Optional("analytics", default=True): Bool,
         Optional("hardlink_lock", default=False): Bool,
         Optional("no_scm", default=False): Bool,
+        Optional("autostage", default=False): Bool,
         Optional("experiments", default=False): Bool,
         Optional("check_update", default=True): Bool,
     },

--- a/dvc/repo/scm_context.py
+++ b/dvc/repo/scm_context.py
@@ -3,8 +3,12 @@ def scm_context(method):
         try:
             result = method(repo, *args, **kw)
             repo.scm.reset_ignores()
-            repo.scm.remind_to_track()
-            repo.scm.reset_tracked_files()
+            auto_stage = repo.config.get("core", {}).get("autostage", False)
+            if auto_stage:
+                repo.scm.track_changed_files()
+            else:
+                repo.scm.remind_to_track()
+                repo.scm.reset_tracked_files()
             return result
         except Exception:
             repo.scm.cleanup_ignores()

--- a/dvc/repo/scm_context.py
+++ b/dvc/repo/scm_context.py
@@ -8,7 +8,7 @@ def scm_context(method):
                 repo.scm.track_changed_files()
             else:
                 repo.scm.remind_to_track()
-                repo.scm.reset_tracked_files()
+            repo.scm.reset_tracked_files()
             return result
         except Exception:
             repo.scm.cleanup_ignores()

--- a/dvc/repo/scm_context.py
+++ b/dvc/repo/scm_context.py
@@ -3,8 +3,8 @@ def scm_context(method):
         try:
             result = method(repo, *args, **kw)
             repo.scm.reset_ignores()
-            auto_stage = repo.config.get("core", {}).get("autostage", False)
-            if auto_stage:
+            autostage = repo.config.get("core", {}).get("autostage", False)
+            if autostage:
                 repo.scm.track_changed_files()
             else:
                 repo.scm.remind_to_track()

--- a/dvc/scm/base.py
+++ b/dvc/scm/base.py
@@ -154,6 +154,11 @@ class Base:
         Method to remind user to track newly created files handled by scm
         """
 
+    def track_changed_files(self):
+        """
+        Method to stage files that have changed
+        """
+
     def track_file(self, path):
         """
         Method to add file to mechanism that will remind user

--- a/dvc/scm/git.py
+++ b/dvc/scm/git.py
@@ -386,9 +386,6 @@ class Git(Base):
             return
 
         self.add(self.files_to_track)
-        self.reset_tracked_files()
-
-        logger.info("\nChanges staged to git.")
 
     def track_file(self, path):
         self.files_to_track.add(path)

--- a/dvc/scm/git.py
+++ b/dvc/scm/git.py
@@ -381,6 +381,15 @@ class Git(Base):
             "\tgit add {files}".format(files=files)
         )
 
+    def track_changed_files(self):
+        if not self.files_to_track:
+            return
+
+        self.add(self.files_to_track)
+        self.reset_tracked_files()
+
+        logger.info("\nChanges staged to git.")
+
     def track_file(self, path):
         self.files_to_track.add(path)
 

--- a/tests/unit/scm/test_scm.py
+++ b/tests/unit/scm/test_scm.py
@@ -9,7 +9,6 @@ from dvc.scm import NoSCM
 
 class TestScmContext(TestCase):
     def setUp(self):
-
         self.repo_mock = mock.Mock(spec=Repo)
         self.scm_mock = mock.Mock(spec=NoSCM)
         self.repo_mock.scm = self.scm_mock

--- a/tests/unit/scm/test_scm.py
+++ b/tests/unit/scm/test_scm.py
@@ -17,8 +17,7 @@ class TestScmContext(TestCase):
         method = mock.Mock()
         wrapped = scm_context(method)
 
-        config_noautostage_attrs = {"config": {"core": {"autostage": False}}}
-        self.repo_mock.configure_mock(**config_noautostage_attrs)
+        self.repo_mock.configure_mock(config={})
         wrapped(self.repo_mock)
 
         self.assertEqual(1, method.call_count)


### PR DESCRIPTION
Fixes #4330

I'd appreciate feedback on this.

- The name `scm_autostage` was arbitrary, but chosen to match `no_scm`. I wasn't sure if just `autostage` would be too generic or if `git_autostage` might not be future proof.
- Maybe `scm.remind_to_track` could be renamed `scm.handle_changes`? I didn't want to go there without feedback. It's named in tests, but not called anywhere else in the codebase outside the context of this patch.
- Alternatively, this change could be handled in `scm_context`. I thought altering the attribute/behavior in the scm class would be more straight-forward but, after writing out the previous point, maybe a separate maybe `scm_context` could read the attribute from the repo class and handle the logic there, calling a separate function if changes are to be staged.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.
  https://github.com/iterative/dvc.org/pull/1779

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
