### PR TITLE
tree: open: handle dirty state in RepoTree

### DIFF
--- a/dvc/tree/dvc.py
+++ b/dvc/tree/dvc.py
@@ -66,10 +66,6 @@ class DvcTree(BaseTree):  # pylint:disable=abstract-method
         except OutputNotFoundError as exc:
             raise FileNotFoundError from exc
 
-        # NOTE: this handles both dirty and checkout-ed out at the same time
-        if self.repo.tree.exists(path):
-            return self.repo.tree.open(path, mode=mode, encoding=encoding)
-
         if len(outs) != 1 or (
             outs[0].is_dir_checksum and path == outs[0].path_info
         ):

--- a/dvc/tree/repo.py
+++ b/dvc/tree/repo.py
@@ -151,9 +151,13 @@ class RepoTree(BaseTree):  # pylint:disable=abstract-method
             encoding = None
 
         tree, dvc_tree = self._get_tree_pair(path)
-        if dvc_tree and dvc_tree.exists(path):
-            return dvc_tree.open(path, mode=mode, encoding=encoding, **kwargs)
-        return tree.open(path, mode=mode, encoding=encoding)
+        try:
+            return tree.open(path, mode=mode, encoding=encoding)
+        except FileNotFoundError:
+            if not dvc_tree:
+                raise
+
+        return dvc_tree.open(path, mode=mode, encoding=encoding, **kwargs)
 
     def exists(
         self, path, use_dvcignore=True

--- a/tests/unit/tree/test_dvc.py
+++ b/tests/unit/tree/test_dvc.py
@@ -34,7 +34,9 @@ def test_open_dirty_hash(tmp_dir, dvc):
 
     tree = DvcTree(dvc)
     with tree.open("file", "r") as fobj:
-        assert fobj.read() == "something"
+        # NOTE: Unlike RepoTree, DvcTree should not
+        # be affected by a dirty workspace.
+        assert fobj.read() == "file"
 
 
 def test_open_dirty_no_hash(tmp_dir, dvc):
@@ -42,8 +44,11 @@ def test_open_dirty_no_hash(tmp_dir, dvc):
     (tmp_dir / "file.dvc").write_text("outs:\n- path: file\n")
 
     tree = DvcTree(dvc)
-    with tree.open("file", "r") as fobj:
-        assert fobj.read() == "file"
+    # NOTE: Unlike RepoTree, DvcTree should not
+    # be affected by a dirty workspace.
+    with pytest.raises(FileNotFoundError):
+        with tree.open("file", "r"):
+            pass
 
 
 def test_open_in_history(tmp_dir, scm, dvc):


### PR DESCRIPTION
We used to use that logic in DvcTree back before we had proper trees.
Now we have a RepoTree, that combines git/workspace tree with the
DvcTree and dirty state clearly belongs to the git/workspace and not
the dvc itself, as dvc state only depends on dvc-files and lock-files.

Prerequisite for #4523

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
