### PR TITLE
Allow config option for HTTP method for uploads (Artifactory)

### DIFF
--- a/dvc/config.py
+++ b/dvc/config.py
@@ -119,6 +119,7 @@ HTTP_COMMON = {
     "password": str,
     "ask_password": Bool,
     "ssl_verify": Bool,
+    "method": str,
 }
 WEBDAV_COMMON = {
     "user": str,

--- a/dvc/tree/http.py
+++ b/dvc/tree/http.py
@@ -54,7 +54,7 @@ class HTTPTree(BaseTree):  # pylint:disable=abstract-method
         self.ask_password = config.get("ask_password", False)
         self.headers = {}
         self.ssl_verify = config.get("ssl_verify", True)
-        self.method = config.get("http_method", "POST")
+        self.method = config.get("method", "POST")
 
     def _auth_method(self, path_info=None):
         from requests.auth import HTTPBasicAuth, HTTPDigestAuth

--- a/dvc/tree/http.py
+++ b/dvc/tree/http.py
@@ -54,7 +54,7 @@ class HTTPTree(BaseTree):  # pylint:disable=abstract-method
         self.ask_password = config.get("ask_password", False)
         self.headers = {}
         self.ssl_verify = config.get("ssl_verify", True)
-        self.http_method = config.get("http_method", "POST")
+        self.method = config.get("http_method", "POST")
 
     def _auth_method(self, path_info=None):
         from requests.auth import HTTPBasicAuth, HTTPDigestAuth
@@ -195,7 +195,7 @@ class HTTPTree(BaseTree):  # pylint:disable=abstract-method
                             break
                         yield chunk
 
-        response = self.request(self.http_method, to_info.url, data=chunks())
+        response = self.request(self.method, to_info.url, data=chunks())
         if response.status_code not in (200, 201):
             raise HTTPError(response.status_code, response.reason)
 

--- a/dvc/tree/http.py
+++ b/dvc/tree/http.py
@@ -54,6 +54,7 @@ class HTTPTree(BaseTree):  # pylint:disable=abstract-method
         self.ask_password = config.get("ask_password", False)
         self.headers = {}
         self.ssl_verify = config.get("ssl_verify", True)
+        self.http_method = config.get("http_method", "POST")
 
     def _auth_method(self, path_info=None):
         from requests.auth import HTTPBasicAuth, HTTPDigestAuth
@@ -194,7 +195,7 @@ class HTTPTree(BaseTree):  # pylint:disable=abstract-method
                             break
                         yield chunk
 
-        response = self.request("POST", to_info.url, data=chunks())
+        response = self.request(self.http_method, to_info.url, data=chunks())
         if response.status_code not in (200, 201):
             raise HTTPError(response.status_code, response.reason)
 

--- a/tests/unit/remote/test_http.py
+++ b/tests/unit/remote/test_http.py
@@ -117,11 +117,11 @@ def test_http_method(dvc):
         "auth": "basic",
         "user": user,
         "password": password,
-        "HTTP_method": "PUT",
+        "method": "PUT",
     }
 
     tree = HTTPTree(dvc, config)
 
     assert tree._auth_method() == auth
-    assert tree.http_method == "PUT"
+    assert tree.method == "PUT"
     assert isinstance(tree._auth_method(), HTTPBasicAuth)

--- a/tests/unit/remote/test_http.py
+++ b/tests/unit/remote/test_http.py
@@ -103,3 +103,25 @@ def test_ssl_verify_disable(dvc):
     tree = HTTPTree(dvc, config)
 
     assert tree._session.verify is False
+
+
+def test_http_method(dvc):
+    from requests.auth import HTTPBasicAuth
+
+    user = "username"
+    password = "password"
+    auth = HTTPBasicAuth(user, password)
+    config = {
+        "url": "http://example.com/",
+        "path_info": "file.html",
+        "auth": "basic",
+        "user": user,
+        "password": password,
+        "HTTP_method": "PUT",
+    }
+
+    tree = HTTPTree(dvc, config)
+
+    assert tree._auth_method() == auth
+    assert tree.http_method == "PUT"
+    assert isinstance(tree._auth_method(), HTTPBasicAuth)


### PR DESCRIPTION
# Use case

Our MLE team at Expedia Group uses JFrog's Artifactory for storing binary artifacts. While Artifactory supports an HTTP/HTTPS interface, instead of POST it only accepts PUT for the new artifacts. This PR provides an alternative in this case.

Documentation change:
https://github.com/iterative/dvc.org/pull/1769

[JFrog Artifactory HTTP REST API](https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API)

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iterative/dvc/4553)
<!-- Reviewable:end -->
