### PR TITLE
tree: repo: handle dirty state

### DIFF
--- a/dvc/ignore.py
+++ b/dvc/ignore.py
@@ -172,6 +172,9 @@ class DvcIgnoreFilterNoop:
     def check_ignore(self, path):
         return _no_match(path)
 
+    def is_ignored(self, _):
+        return False
+
 
 class DvcIgnoreFilter:
     @staticmethod
@@ -330,6 +333,11 @@ class DvcIgnoreFilter:
                 if matches:
                     return CheckIgnoreResult(target, True, matches)
         return _no_match(target)
+
+    def is_ignored(self, path):
+        # NOTE: can't use self.check_ignore(path).match for now, see
+        # https://github.com/iterative/dvc/issues/4555
+        return self.is_ignored_dir(path) or self.is_ignored_file(path)
 
 
 def init(path):

--- a/dvc/tree/git.py
+++ b/dvc/tree/git.py
@@ -215,6 +215,9 @@ class GitTree(BaseTree):  # pylint:disable=abstract-method
             sec, nano_sec = git_time
             return sec + nano_sec / 1000000000
 
+        if self.dvcignore.is_ignored(path):
+            raise FileNotFoundError
+
         obj = self._git_object_by_path(path)
         if obj is None:
             raise OSError(errno.ENOENT, "No such file")

--- a/dvc/tree/local.py
+++ b/dvc/tree/local.py
@@ -160,8 +160,10 @@ class LocalTree(BaseTree):
         mode = os.stat(path).st_mode
         return is_exec(mode)
 
-    @staticmethod
-    def stat(path):
+    def stat(self, path):
+        if self.dvcignore.is_ignored(path):
+            raise FileNotFoundError
+
         return os.stat(path)
 
     def move(self, from_info, to_info, mode=None):

--- a/tests/func/test_tree.py
+++ b/tests/func/test_tree.py
@@ -191,6 +191,7 @@ def test_repotree_walk_fetch(tmp_dir, dvc, scm, local_remote):
     out = tmp_dir.dvc_gen({"dir": {"foo": "foo"}}, commit="init")[0].outs[0]
     dvc.push()
     remove(dvc.cache.local.cache_dir)
+    remove(tmp_dir / "dir")
 
     tree = RepoTree(dvc, fetch=True)
     with dvc.state:

--- a/tests/unit/tree/test_dvc.py
+++ b/tests/unit/tree/test_dvc.py
@@ -242,3 +242,26 @@ def test_get_hash_granular(tmp_dir, dvc):
         assert tree.get_hash(subdir / "data") == HashInfo(
             "md5", "8d777f385d3dfec8815d20f7496026dc",
         )
+
+
+def test_get_hash_dirty_file(tmp_dir, dvc):
+    tmp_dir.dvc_gen("file", "file")
+    (tmp_dir / "file").write_text("something")
+
+    tree = DvcTree(dvc)
+    with dvc.state:
+        actual = tree.get_hash(PathInfo(tmp_dir) / "file")
+    expected = HashInfo("md5", "8c7dd922ad47494fc02c388e12c00eac")
+    assert actual == expected
+
+
+def test_get_hash_dirty_dir(tmp_dir, dvc):
+    tmp_dir.dvc_gen({"dir": {"foo": "foo", "bar": "bar"}})
+    (tmp_dir / "dir" / "baz").write_text("baz")
+
+    tree = DvcTree(dvc)
+    with dvc.state:
+        actual = tree.get_hash(PathInfo(tmp_dir) / "dir")
+    expected = HashInfo("md5", "5ea40360f5b4ec688df672a4db9c17d1.dir")
+
+    assert actual == expected


### PR DESCRIPTION
DvcTree itself shouldn't care about the dirty state at all, as there is really no such thing for it, since its state is determined by the dvcfiles and lockfiles present.

What's a little weird here is that if a cached file/directory doesn't exist in the workspace, it is not considered dirty and we just treat it as a dvc output. But if it is modified, then we do consider it as dirty. Have to think about this a bit more... 

Fixes #4523 

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
