### PR TITLE
brancher: make brancher part of scm

### DIFF
--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -398,7 +398,7 @@ class Repo:
                 for target in targets
             )
 
-            suffix = f"({branch})" if branch else ""
+            suffix = f"({branch})" if branch != "workspace" else ""
             for stage, filter_info in pairs:
                 used_cache = stage.get_used_cache(
                     remote=remote,

--- a/dvc/repo/brancher.py
+++ b/dvc/repo/brancher.py
@@ -1,6 +1,4 @@
-from funcy import group_by
-
-from dvc.tree.local import LocalTree
+from dvc.tree import LocalTree
 
 
 def brancher(  # noqa: E302
@@ -17,42 +15,26 @@ def brancher(  # noqa: E302
     Yields:
         str: the display name for the currently selected tree, it could be:
             - a git revision identifier
-            - empty string it there is no branches to iterate over
-            - "workspace" if there are uncommitted changes in the SCM repo
+            - "workspace" for current state of repository
     """
-    if not any([revs, all_branches, all_tags, all_commits]):
-        yield ""
-        return
-
     saved_tree = self.tree
-    revs = revs.copy() if revs else []
-
-    scm = self.scm
 
     self.tree = LocalTree(self, {"url": self.root_dir}, use_dvcignore=True)
     yield "workspace"
 
-    if revs and "workspace" in revs:
-        revs.remove("workspace")
-
-    if all_commits:
-        revs = scm.list_all_commits()
-    else:
-        if all_branches:
-            revs.extend(scm.list_branches())
-
-        if all_tags:
-            revs.extend(scm.list_tags())
-
     try:
-        if revs:
-            for sha, names in group_by(scm.resolve_rev, revs).items():
-                self.tree = scm.get_tree(
-                    sha, use_dvcignore=True, dvcignore_root=self.root_dir
-                )
+        for name, tree in self.scm.brancher(
+            self.root_dir,
+            revs=revs,
+            all_branches=all_branches,
+            all_tags=all_tags,
+            all_commits=all_commits,
+        ):
+            if name != "workspace":
+                self.tree = tree
                 # ignore revs that don't contain repo root
                 # (i.e. revs from before a subdir=True repo was init'ed)
                 if self.tree.exists(self.root_dir):
-                    yield ", ".join(names)
+                    yield name
     finally:
         self.tree = saved_tree

--- a/dvc/repo/metrics/diff.py
+++ b/dvc/repo/metrics/diff.py
@@ -8,7 +8,7 @@ def _get_metrics(repo, *args, rev=None, **kwargs):
         metrics = repo.metrics.show(
             *args, **kwargs, revs=[rev] if rev else None
         )
-        return metrics.get(rev or "", {})
+        return metrics.get(rev or "workspace", {})
     except NoMetricsError:
         return {}
 

--- a/dvc/repo/params/diff.py
+++ b/dvc/repo/params/diff.py
@@ -7,7 +7,7 @@ from .show import NoParamsError
 def _get_params(repo, *args, rev=None, **kwargs):
     try:
         params = repo.params.show(*args, **kwargs, revs=[rev] if rev else None)
-        return params.get(rev or "", {})
+        return params.get(rev or "workspace", {})
     except NoParamsError:
         return {}
 

--- a/dvc/repo/plots/__init__.py
+++ b/dvc/repo/plots/__init__.py
@@ -42,7 +42,6 @@ class Plots:
             # .brancher() adds unwanted workspace
             if revs is not None and rev not in revs:
                 continue
-            rev = rev or "workspace"
 
             tree = RepoTree(self.repo)
             plots = _collect_plots(self.repo, targets, rev)

--- a/dvc/scm/base.py
+++ b/dvc/scm/base.py
@@ -3,6 +3,7 @@
 import os
 
 from dvc.exceptions import DvcException
+from dvc.tree import LocalTree
 
 
 class SCMError(DvcException):
@@ -165,3 +166,15 @@ class Base:
 
     def close(self):
         """ Method to close the files """
+
+    def brancher(
+        self,
+        root_dir,
+        revs=None,
+        all_branches=False,
+        all_tags=False,
+        all_commits=False,
+    ):  # pylint: disable=no-self-use, unused-argument
+        yield "workspace", LocalTree(
+            None, {"url": root_dir}, use_dvcignore=True
+        )

--- a/tests/func/metrics/test_show.py
+++ b/tests/func/metrics/test_show.py
@@ -17,7 +17,7 @@ def test_show_simple(tmp_dir, dvc, run_copy_metrics):
     run_copy_metrics(
         "metrics_t.yaml", "metrics.yaml", metrics=["metrics.yaml"],
     )
-    assert dvc.metrics.show() == {"": {"metrics.yaml": 1.1}}
+    assert dvc.metrics.show() == {"workspace": {"metrics.yaml": 1.1}}
 
 
 def test_show(tmp_dir, dvc, run_copy_metrics):
@@ -25,7 +25,7 @@ def test_show(tmp_dir, dvc, run_copy_metrics):
     run_copy_metrics(
         "metrics_t.yaml", "metrics.yaml", metrics=["metrics.yaml"],
     )
-    assert dvc.metrics.show() == {"": {"metrics.yaml": {"foo": 1.1}}}
+    assert dvc.metrics.show() == {"workspace": {"metrics.yaml": {"foo": 1.1}}}
 
 
 def test_show_multiple(tmp_dir, dvc, run_copy_metrics):
@@ -33,7 +33,9 @@ def test_show_multiple(tmp_dir, dvc, run_copy_metrics):
     tmp_dir.gen("baz_temp", "baz: 2\n")
     run_copy_metrics("foo_temp", "foo", fname="foo.dvc", metrics=["foo"])
     run_copy_metrics("baz_temp", "baz", fname="baz.dvc", metrics=["baz"])
-    assert dvc.metrics.show() == {"": {"foo": {"foo": 1}, "baz": {"baz": 2}}}
+    assert dvc.metrics.show() == {
+        "workspace": {"foo": {"foo": 1}, "baz": {"baz": 2}}
+    }
 
 
 def test_show_invalid_metric(tmp_dir, dvc, run_copy_metrics):
@@ -109,4 +111,4 @@ def test_missing_cache(tmp_dir, dvc, run_copy_metrics):
     remove(stage.outs[0].fspath)
     remove(stage.outs[0].cache_path)
 
-    assert dvc.metrics.show() == {"": {"metrics.yaml": 1.1}}
+    assert dvc.metrics.show() == {"workspace": {"metrics.yaml": 1.1}}

--- a/tests/func/params/test_show.py
+++ b/tests/func/params/test_show.py
@@ -11,7 +11,7 @@ def test_show_empty(dvc):
 def test_show(tmp_dir, dvc):
     tmp_dir.gen("params.yaml", "foo: bar")
     dvc.run(cmd="echo params.yaml", params=["foo"], single_stage=True)
-    assert dvc.params.show() == {"": {"params.yaml": {"foo": "bar"}}}
+    assert dvc.params.show() == {"workspace": {"params.yaml": {"foo": "bar"}}}
 
 
 def test_show_toml(tmp_dir, dvc):
@@ -20,7 +20,7 @@ def test_show_toml(tmp_dir, dvc):
         cmd="echo params.toml", params=["params.toml:foo"], single_stage=True
     )
     assert dvc.params.show() == {
-        "": {"params.toml": {"foo": {"bar": 42, "baz": [1, 2]}}}
+        "workspace": {"params.toml": {"foo": {"bar": 42, "baz": [1, 2]}}}
     }
 
 
@@ -39,14 +39,16 @@ def test_show_multiple(tmp_dir, dvc):
         single_stage=True,
     )
     assert dvc.params.show() == {
-        "": {"params.yaml": {"foo": "bar", "baz": "qux"}}
+        "workspace": {"params.yaml": {"foo": "bar", "baz": "qux"}}
     }
 
 
 def test_show_list(tmp_dir, dvc):
     tmp_dir.gen("params.yaml", "foo:\n- bar\n- baz\n")
     dvc.run(cmd="echo params.yaml", params=["foo"], single_stage=True)
-    assert dvc.params.show() == {"": {"params.yaml": {"foo": ["bar", "baz"]}}}
+    assert dvc.params.show() == {
+        "workspace": {"params.yaml": {"foo": ["bar", "baz"]}}
+    }
 
 
 def test_show_branch(tmp_dir, scm, dvc):


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Prerequisite for #4446 

In order to make plots/metrics/params `diff` accept any viable target, we need to make brancher repo agnostic. Considering that `diff` makes sense only in case of some kind of `scm`, it makes sense to make brancher part of `scm`.
