### PR TITLE
`check-ignore` show sub-repo patterns

### DIFF
--- a/dvc/ignore.py
+++ b/dvc/ignore.py
@@ -231,7 +231,7 @@ class DvcIgnoreFilter:
                     root, set()
                 ) | {d}
                 pattern_info = PatternInfo(
-                    f"/{d}/", "(inside sub_repo:{})".format(d)
+                    f"/{d}/", "in sub_repo:{}".format(d)
                 )
                 new_pattern = DvcIgnorePatterns([pattern_info], root)
                 old_pattern = self.ignores_trie_tree.longest_prefix(root).value

--- a/dvc/ignore.py
+++ b/dvc/ignore.py
@@ -230,7 +230,10 @@ class DvcIgnoreFilter:
                 self._ignored_subrepos[root] = self._ignored_subrepos.get(
                     root, set()
                 ) | {d}
-                new_pattern = DvcIgnorePatterns([f"/{d}/"], root)
+                pattern_info = PatternInfo(
+                    f"/{d}/", "(inside sub_repo:{})".format(d)
+                )
+                new_pattern = DvcIgnorePatterns([pattern_info], root)
                 old_pattern = self.ignores_trie_tree.longest_prefix(root).value
                 if old_pattern:
                     self.ignores_trie_tree[root] = DvcIgnorePatterns(

--- a/tests/func/test_check_ignore.py
+++ b/tests/func/test_check_ignore.py
@@ -90,7 +90,7 @@ def test_check_ignore_sub_repo(tmp_dir, dvc, caplog):
 
     assert main(["check-ignore", "-d", os.path.join("dir", "foo")]) == 0
     assert (
-        "(inside sub_repo:{})\t{}".format("dir", os.path.join("dir", "foo"),)
+        "in sub_repo:{}\t{}".format("dir", os.path.join("dir", "foo"),)
         in caplog.text
     )
 

--- a/tests/func/test_check_ignore.py
+++ b/tests/func/test_check_ignore.py
@@ -83,12 +83,16 @@ def test_check_ignore_out_side_repo(tmp_dir, dvc):
     assert main(["check-ignore", "-q", "../file"]) == 1
 
 
-def test_check_ignore_sub_repo(tmp_dir, dvc):
+def test_check_ignore_sub_repo(tmp_dir, dvc, caplog):
     tmp_dir.gen(
         {DvcIgnore.DVCIGNORE_FILE: "other", "dir": {".dvc": {}, "foo": "bar"}}
     )
 
-    assert main(["check-ignore", "-q", os.path.join("dir", "foo")]) == 1
+    assert main(["check-ignore", "-d", os.path.join("dir", "foo")]) == 0
+    assert (
+        "(inside sub_repo:{})\t{}".format("dir", os.path.join("dir", "foo"),)
+        in caplog.text
+    )
 
 
 def test_check_sub_dir_ignore_file(tmp_dir, dvc, caplog):


### PR DESCRIPTION
fix #4555
1. Sub-repo pattern now would be considered in `check-ignore` command.
2. New outputs for sub-repo patterns in a `detail`
3. Related tests.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
