### PR TITLE
cli: add --cd flag to change directories before executing commands

### DIFF
--- a/dvc/cli.py
+++ b/dvc/cli.py
@@ -1,6 +1,7 @@
 """DVC command line interface"""
 import argparse
 import logging
+import os
 import sys
 
 from .command import (
@@ -189,6 +190,14 @@ def get_main_parser():
         action=VersionAction,
         nargs=0,
         help="Show program's version.",
+    )
+
+    parser.add_argument(
+        "--cd",
+        default=os.path.curdir,
+        metavar="<path>",
+        help="Change to directory before executing.",
+        type=str,
     )
 
     # Sub commands

--- a/dvc/command/base.py
+++ b/dvc/command/base.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from abc import ABC, abstractmethod
 
 logger = logging.getLogger(__name__)
@@ -32,6 +33,8 @@ class CmdBase(ABC):
         from dvc.repo import Repo
         from dvc.updater import Updater
 
+        os.chdir(args.cd)
+
         self.repo = Repo()
         self.config = self.repo.config
         self.args = args
@@ -55,3 +58,5 @@ class CmdBase(ABC):
 class CmdBaseNoRepo(CmdBase):
     def __init__(self, args):  # pylint: disable=super-init-not-called
         self.args = args
+
+        os.chdir(args.cd)

--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -96,7 +96,8 @@ def add_parser(subparsers, parent_parser):
         "-c",
         "--cwd",
         default=os.path.curdir,
-        help="Directory within your repo to reproduce from.",
+        help="Directory within your repo to reproduce from. Note: deprecated "
+        "by `dvc --cd <path>`.",
         metavar="<path>",
     )
     repro_parser.add_argument(

--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -15,8 +15,7 @@ logger = logging.getLogger(__name__)
 class CmdRepro(CmdBase):
     def run(self):
         saved_dir = os.path.realpath(os.curdir)
-        if self.args.cwd:
-            os.chdir(self.args.cwd)
+        os.chdir(self.args.cwd)
 
         # Dirty hack so the for loop below can at least enter once
         if self.args.all_pipelines:

--- a/tests/func/test_cli.py
+++ b/tests/func/test_cli.py
@@ -160,8 +160,6 @@ class TestCheckout(TestDvc):
 
 class TestFindRoot(TestDvc):
     def test(self):
-        os.chdir("..")
-
         class Cmd(CmdBase):
             def run(self):
                 pass
@@ -169,10 +167,30 @@ class TestFindRoot(TestDvc):
         class A:
             quiet = False
             verbose = True
+            cd = os.path.pardir
 
         args = A()
         with self.assertRaises(DvcException):
             Cmd(args)
+
+
+class TestCd(TestDvc):
+    def test(self):
+        class Cmd(CmdBase):
+            def run(self):
+                pass
+
+        class A:
+            quiet = False
+            verbose = True
+            cd = os.path.pardir
+
+        parent_dir = os.path.realpath(os.path.pardir)
+        args = A()
+        with self.assertRaises(DvcException):
+            Cmd(args)
+        current_dir = os.path.realpath(os.path.curdir)
+        self.assertEqual(parent_dir, current_dir)
 
 
 def test_unknown_command_help(capsys):


### PR DESCRIPTION
Fixes #4025

I was initally going to use `--cwd` and remove `--cwd` from `repro`, but that left `repro` with the very strange `args.c` value. So I turned to the tar manpage for inspiratoin and found the long form of `-C` is `--cd`. Tar is good enough for me.

I actually ran into this problem yesterday trying to launch dvc from ssh for a dumb reason.

I also added a docs PR:
https://github.com/iterative/dvc.org/pull/1780

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
