### PR TITLE
Fix error during external outputs checkout

### DIFF
--- a/dvc/cache/base.py
+++ b/dvc/cache/base.py
@@ -414,7 +414,7 @@ class CloudCache:
         return self.changed_cache_file(hash_info)
 
     def already_cached(self, path_info):
-        _, current = self.tree.get_hash(path_info)
+        current = self.tree.get_hash(path_info)
 
         if not current:
             return False

--- a/dvc/cache/local.py
+++ b/dvc/cache/local.py
@@ -94,11 +94,7 @@ class LocalCache(CloudCache):
     def already_cached(self, path_info):
         assert path_info.scheme in ["", "local"]
 
-        current = self.tree.get_hash(path_info)
-        if not current:
-            return False
-
-        return not self.changed_cache(current)
+        return super().already_cached(path_info)
 
     def _verify_link(self, path_info, link_type):
         if link_type == "hardlink" and self.tree.getsize(path_info) == 0:

--- a/tests/func/test_checkout.py
+++ b/tests/func/test_checkout.py
@@ -852,7 +852,9 @@ def test_checkouts_for_pipeline_tracked_outs(tmp_dir, dvc, scm, run_copy):
     assert set(dvc.checkout()["added"]) == {"bar", "ipsum"}
 
 
-@pytest.mark.parametrize("workspace", [pytest.lazy_fixture("s3")], indirect=True)
+@pytest.mark.parametrize(
+    "workspace", [pytest.lazy_fixture("s3")], indirect=True
+)
 def test_checkout_external_modified_file(tmp_dir, dvc, scm, mocker, workspace):
     # regression: happened when file in external output changed and checkout
     # was attempted without force, dvc checks if it's present in its cache


### PR DESCRIPTION
A user in discord complained that external outputs' checkout
was failing. Looks like, during refactor of `HashInfo`,
this was forgotten, and as no tests existed before, we had
a regression from 1.6.5 onwards.

This might have been avoided with Static Typings. :sparkles:

Discord context: https://discord.com/channels/485586884165107732/485596304961962003/755067231339020358
 
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
