### PR TITLE
Do not require account-level permissions for Azure tree

### DIFF
--- a/dvc/tree/azure.py
+++ b/dvc/tree/azure.py
@@ -95,7 +95,7 @@ class AzureTree(BaseTree):
             container_client.create_container()
         except HttpResponseError as e:
             # client may not have account-level privileges
-            if e.status_code != 403:
+            if exc.status_code != 403:
                 raise
 
         return blob_service

--- a/dvc/tree/azure.py
+++ b/dvc/tree/azure.py
@@ -93,8 +93,11 @@ class AzureTree(BaseTree):
             container_client.get_container_properties()
         except ResourceNotFoundError:
             container_client.create_container()
-        except HttpResponseError:
-            pass  # Client may not have account-level privileges
+        except HttpResponseError as e:
+            if e.status_code == 403:
+                pass  # client may not have account-level privileges
+            else:
+                raise
 
         return blob_service
 

--- a/dvc/tree/azure.py
+++ b/dvc/tree/azure.py
@@ -94,9 +94,8 @@ class AzureTree(BaseTree):
         except ResourceNotFoundError:
             container_client.create_container()
         except HttpResponseError as e:
-            if e.status_code == 403:
-                pass  # client may not have account-level privileges
-            else:
+            # client may not have account-level privileges
+            if e.status_code != 403:
                 raise
 
         return blob_service

--- a/dvc/tree/azure.py
+++ b/dvc/tree/azure.py
@@ -69,6 +69,7 @@ class AzureTree(BaseTree):
         # pylint: disable=no-name-in-module
         from azure.core.exceptions import ResourceNotFoundError
         from azure.storage.blob import BlobServiceClient
+        from azure.core.exceptions import HttpResponseError
 
         logger.debug(f"URL {self.path_info}")
 
@@ -92,6 +93,8 @@ class AzureTree(BaseTree):
             container_client.get_container_properties()
         except ResourceNotFoundError:
             container_client.create_container()
+        except HttpResponseError:
+            pass  # Client may not have account-level privileges
 
         return blob_service
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Background: We only issue container-level, user-delegated SAS tokens to our developers for the Azure blob store. That is a hard requirement due to some HIPAA security needs. To be very specific, I generate the SAS like so:

```
az storage container generate-sas --account-name my-account --name my-container --permissions acdlrw --expiry 2020-09-23 --auth-mode login --as-user
```

As long as I construct the connection string correctly, everything works fine except for this check:

https://github.com/iterative/dvc/blob/15488ebefd5d1bcaad80526472b04b46f89a71cb/dvc/tree/azure.py#L91-L94

This pull request gives a pass if that check fails for authentication error purposes. I believe this should be backwards compatible, since:

a) If they were using container-level SAS tokens this wouldn't have worked for them in the first place
b) If the get_container_properties() function fails with the ResourceNotFoundError, it will revert to the old behavior

I think requiring people to make their own containers is an acceptable solution too, but the goal here was to maintain backwards compability.

With this fix, I'm able to use the Container-level SAS's described above. 


