### PR TITLE
api: enter state when trying to get a hash

### DIFF
--- a/dvc/api.py
+++ b/dvc/api.py
@@ -34,7 +34,8 @@ def get_url(path, repo=None, rev=None, remote=None):
             raise OutputNotFoundError(path, repo)
 
         cloud = metadata.repo.cloud
-        hash_info = _repo.repo_tree.get_hash(path_info)
+        with _repo.state:
+            hash_info = _repo.repo_tree.get_hash(path_info)
         return cloud.get_url_for(remote, checksum=hash_info.value)
 
 

--- a/tests/func/test_api.py
+++ b/tests/func/test_api.py
@@ -210,6 +210,9 @@ def test_get_url_granular(tmp_dir, dvc, s3):
         {"dir": {"foo": "foo", "bar": "bar", "nested": {"file": "file"}}}
     )
 
+    expected_url = URLInfo(s3.url) / "5f/c28ea78987408341668eba6525ebd1.dir"
+    assert api.get_url("dir") == expected_url
+
     expected_url = URLInfo(s3.url) / "ac/bd18db4cc2f85cedef654fccc4a4d8"
     assert api.get_url("dir/foo") == expected_url
 


### PR DESCRIPTION
`get_hash` is an internal api, so conventions should be respected.

We've been discussing automatically entering state instead, but that is out of scope for this particular bug.

Fixes #4575

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
