### PR TITLE
experiments: checkpoints proof of concept

### DIFF
--- a/dvc/api.py
+++ b/dvc/api.py
@@ -109,3 +109,24 @@ def _make_repo(repo_url=None, rev=None):
             pass  # fallthrough to external_repo
     with external_repo(url=repo_url, rev=rev) as repo:
         yield repo
+
+
+def make_checkpoint():
+    """
+    Signal DVC to create a checkpoint experiment.
+
+    If the current process is being run from DVC, this function will block
+    until DVC has finished creating the checkpoint. Otherwise, this function
+    will return immediately.
+    """
+    import builtins
+    from time import sleep
+
+    from dvc.stage.run import CHECKPOINT_SIGNAL_FILE
+
+    if os.getenv("DVC_CHECKPOINT") is None:
+        return
+
+    builtins.open(CHECKPOINT_SIGNAL_FILE, "w")
+    while os.path.exists(CHECKPOINT_SIGNAL_FILE):
+        sleep(5)

--- a/dvc/api.py
+++ b/dvc/api.py
@@ -127,6 +127,16 @@ def make_checkpoint():
     if os.getenv("DVC_CHECKPOINT") is None:
         return
 
-    builtins.open(CHECKPOINT_SIGNAL_FILE, "w")
-    while os.path.exists(CHECKPOINT_SIGNAL_FILE):
+    root_dir = Repo.find_root()
+    signal_file = os.path.join(
+        root_dir, Repo.DVC_DIR, "tmp", CHECKPOINT_SIGNAL_FILE
+    )
+
+    with builtins.open(signal_file, "w") as fobj:
+        # NOTE: force flushing/writing empty file to disk, otherwise when
+        # run in certain contexts (pytest) file may not actually be written
+        fobj.write("")
+        fobj.flush()
+        os.fsync(fobj.fileno())
+    while os.path.exists(signal_file):
         sleep(1)

--- a/dvc/api.py
+++ b/dvc/api.py
@@ -129,4 +129,4 @@ def make_checkpoint():
 
     builtins.open(CHECKPOINT_SIGNAL_FILE, "w")
     while os.path.exists(CHECKPOINT_SIGNAL_FILE):
-        sleep(5)
+        sleep(1)

--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -1,13 +1,17 @@
 import argparse
 import io
 import logging
+import os
 from collections import OrderedDict
 from datetime import date
 from itertools import groupby
 from typing import Iterable, Optional
 
+from dvc.command import completion
 from dvc.command.base import CmdBase, append_doc_link, fix_subparsers
-from dvc.command.metrics import DEFAULT_PRECISION
+from dvc.command.metrics import DEFAULT_PRECISION, _show_metrics
+from dvc.command.status import CmdDataStatus
+from dvc.dvcfile import PIPELINE_FILE
 from dvc.exceptions import DvcException, InvalidArgumentError
 from dvc.utils.flatten import flatten
 
@@ -373,6 +377,63 @@ class CmdExperimentsDiff(CmdBase):
         return 0
 
 
+class CmdExperimentsRun(CmdBase):
+    def run(self):
+        if not self.repo.experiments:
+            return 0
+
+        saved_dir = os.path.realpath(os.curdir)
+        os.chdir(self.args.cwd)
+
+        # Dirty hack so the for loop below can at least enter once
+        if self.args.all_pipelines:
+            self.args.targets = [None]
+        elif not self.args.targets:
+            self.args.targets = self.default_targets
+
+        ret = 0
+        for target in self.args.targets:
+            try:
+                stages = self.repo.reproduce(
+                    target,
+                    single_item=self.args.single_item,
+                    force=self.args.force,
+                    dry=self.args.dry,
+                    interactive=self.args.interactive,
+                    pipeline=self.args.pipeline,
+                    all_pipelines=self.args.all_pipelines,
+                    run_cache=not self.args.no_run_cache,
+                    no_commit=self.args.no_commit,
+                    downstream=self.args.downstream,
+                    recursive=self.args.recursive,
+                    force_downstream=self.args.force_downstream,
+                    experiment=True,
+                    queue=self.args.queue,
+                    run_all=self.args.run_all,
+                    jobs=self.args.jobs,
+                    params=self.args.params,
+                    checkpoint=(
+                        self.args.checkpoint or self.args.checkpoint_continue
+                    ),
+                    checkpoint_continue=self.args.checkpoint_continue,
+                )
+
+                if len(stages) == 0:
+                    logger.info(CmdDataStatus.UP_TO_DATE_MSG)
+
+                if self.args.metrics:
+                    metrics = self.repo.metrics.show()
+                    logger.info(_show_metrics(metrics))
+
+            except DvcException:
+                logger.exception("")
+                ret = 1
+                break
+
+        os.chdir(saved_dir)
+        return ret
+
+
 def add_parser(subparsers, parent_parser):
     EXPERIMENTS_HELP = "Commands to display and compare experiments."
 
@@ -552,3 +613,156 @@ def add_parser(subparsers, parent_parser):
         metavar="<n>",
     )
     experiments_diff_parser.set_defaults(func=CmdExperimentsDiff)
+
+    EXPERIMENTS_RUN_HELP = (
+        "Reproduce complete or partial experiment pipelines."
+    )
+    experiments_run_parser = experiments_subparsers.add_parser(
+        "run",
+        parents=[parent_parser],
+        description=append_doc_link(EXPERIMENTS_RUN_HELP, "experiments/run"),
+        help=EXPERIMENTS_RUN_HELP,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    experiments_run_parser.add_argument(
+        "targets",
+        nargs="*",
+        help=f"Stages to reproduce. '{PIPELINE_FILE}' by default.",
+    ).complete = completion.DVC_FILE
+    experiments_run_parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        default=False,
+        help="Reproduce even if dependencies were not changed.",
+    )
+    experiments_run_parser.add_argument(
+        "-s",
+        "--single-item",
+        action="store_true",
+        default=False,
+        help="Reproduce only single data item without recursive dependencies "
+        "check.",
+    )
+    experiments_run_parser.add_argument(
+        "-c",
+        "--cwd",
+        default=os.path.curdir,
+        help="Directory within your repo to reproduce from. Note: deprecated "
+        "by `dvc --cd <path>`.",
+        metavar="<path>",
+    )
+    experiments_run_parser.add_argument(
+        "-m",
+        "--metrics",
+        action="store_true",
+        default=False,
+        help="Show metrics after reproduction.",
+    )
+    experiments_run_parser.add_argument(
+        "--dry",
+        action="store_true",
+        default=False,
+        help="Only print the commands that would be executed without "
+        "actually executing.",
+    )
+    experiments_run_parser.add_argument(
+        "-i",
+        "--interactive",
+        action="store_true",
+        default=False,
+        help="Ask for confirmation before reproducing each stage.",
+    )
+    experiments_run_parser.add_argument(
+        "-p",
+        "--pipeline",
+        action="store_true",
+        default=False,
+        help="Reproduce the whole pipeline that the specified stage file "
+        "belongs to.",
+    )
+    experiments_run_parser.add_argument(
+        "-P",
+        "--all-pipelines",
+        action="store_true",
+        default=False,
+        help="Reproduce all pipelines in the repo.",
+    )
+    experiments_run_parser.add_argument(
+        "-R",
+        "--recursive",
+        action="store_true",
+        default=False,
+        help="Reproduce all stages in the specified directory.",
+    )
+    experiments_run_parser.add_argument(
+        "--no-run-cache",
+        action="store_true",
+        default=False,
+        help=(
+            "Execute stage commands even if they have already been run with "
+            "the same command/dependencies/outputs/etc before."
+        ),
+    )
+    experiments_run_parser.add_argument(
+        "--force-downstream",
+        action="store_true",
+        default=False,
+        help="Reproduce all descendants of a changed stage even if their "
+        "direct dependencies didn't change.",
+    )
+    experiments_run_parser.add_argument(
+        "--no-commit",
+        action="store_true",
+        default=False,
+        help="Don't put files/directories into cache.",
+    )
+    experiments_run_parser.add_argument(
+        "--downstream",
+        action="store_true",
+        default=False,
+        help="Start from the specified stages when reproducing pipelines.",
+    )
+    experiments_run_parser.add_argument(
+        "--params",
+        action="append",
+        default=[],
+        help="Use the specified param values when reproducing pipelines.",
+        metavar="[<filename>:]<params_list>",
+    )
+    experiments_run_parser.add_argument(
+        "--queue",
+        action="store_true",
+        default=False,
+        help="Stage this experiment in the run queue for future execution.",
+    )
+    experiments_run_parser.add_argument(
+        "--run-all",
+        action="store_true",
+        default=False,
+        help="Execute all experiments in the run queue.",
+    )
+    experiments_run_parser.add_argument(
+        "-j",
+        "--jobs",
+        type=int,
+        help="Run the specified number of experiments at a time in parallel.",
+        metavar="<number>",
+    )
+    experiments_run_parser.add_argument(
+        "--checkpoint",
+        action="store_true",
+        default=False,
+        help="Reproduce pipelines as a checkpoint experiment.",
+    )
+    experiments_run_parser.add_argument(
+        "--continue",
+        nargs=1,
+        default=None,
+        dest="checkpoint_continue",
+        help=(
+            "Continue from the specified checkpoint experiment"
+            "(implies --checkpoint)."
+        ),
+    )
+    experiments_run_parser.set_defaults(func=CmdExperimentsRun)

--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -113,19 +113,30 @@ def _collect_rows(
         reverse = sort_order == "desc"
         experiments = _sort_exp(experiments, sort_by, sort_type, reverse)
 
+    last_tip = None
     for i, (rev, exp) in enumerate(experiments.items()):
         row = []
         style = None
         queued = "*" if exp.get("queued", False) else ""
 
+        tip = exp.get("checkpoint_tip")
         if rev == "baseline":
             name = exp.get("name", base_rev)
             row.append(f"{name}")
             style = "bold"
-        elif i < len(experiments) - 1:
-            row.append(f"├── {queued}{rev[:7]}")
         else:
-            row.append(f"└── {queued}{rev[:7]}")
+            if tip and tip == last_tip:
+                tree = "│ ╟"
+            else:
+                if i < len(experiments) - 1:
+                    if tip:
+                        tree = "├─╥"
+                    else:
+                        tree = "├──"
+                else:
+                    tree = "└──"
+            row.append(f"{tree} {queued}{rev[:7]}")
+        last_tip = tip
 
         if not no_timestamp:
             row.append(_format_time(exp.get("timestamp")))

--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -424,7 +424,8 @@ class CmdExperimentsRun(CmdBase):
                     jobs=self.args.jobs,
                     params=self.args.params,
                     checkpoint=(
-                        self.args.checkpoint or self.args.checkpoint_continue
+                        self.args.checkpoint
+                        or self.args.checkpoint_continue is not None
                     ),
                     checkpoint_continue=self.args.checkpoint_continue,
                 )

--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -45,6 +45,7 @@ class CmdRepro(CmdBase):
                     jobs=self.args.jobs,
                     params=self.args.params,
                     pull=self.args.pull,
+                    checkpoint=self.args.checkpoint,
                 )
 
                 if len(stages) == 0:
@@ -207,5 +208,11 @@ def add_parser(subparsers, parent_parser):
             "Try automatically pulling missing cache for outputs restored "
             "from the run-cache."
         ),
+    )
+    repro_parser.add_argument(
+        "--checkpoint",
+        action="store_true",
+        default=False,
+        help=argparse.SUPPRESS,
     )
     repro_parser.set_defaults(func=CmdRepro)

--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -45,7 +45,6 @@ class CmdRepro(CmdBase):
                     jobs=self.args.jobs,
                     params=self.args.params,
                     pull=self.args.pull,
-                    checkpoint=self.args.checkpoint,
                 )
 
                 if len(stages) == 0:
@@ -208,11 +207,5 @@ def add_parser(subparsers, parent_parser):
             "Try automatically pulling missing cache for outputs restored "
             "from the run-cache."
         ),
-    )
-    repro_parser.add_argument(
-        "--checkpoint",
-        action="store_true",
-        default=False,
-        help=argparse.SUPPRESS,
     )
     repro_parser.set_defaults(func=CmdRepro)

--- a/dvc/repo/checkout.py
+++ b/dvc/repo/checkout.py
@@ -46,6 +46,7 @@ def checkout(
     force=False,
     relink=False,
     recursive=False,
+    allow_persist_missing=False,
 ):
     from dvc.stage.exceptions import (
         StageFileBadNameError,
@@ -96,6 +97,7 @@ def checkout(
                 progress_callback=pbar.update_msg,
                 relink=relink,
                 filter_info=filter_info,
+                allow_persist_missing=allow_persist_missing,
             )
             for key, items in result.items():
                 stats[key].extend(_fspath_dir(path) for path in items)

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -528,6 +528,7 @@ class Experiments:
             executor.reproduce(
                 executor.dvc_dir,
                 cwd=executor.dvc.root_dir,
+                checkpoint=True,
                 checkpoint_func=checkpoint_func,
                 **executor.repro_kwargs,
             )

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -556,6 +556,11 @@ class Experiments:
             # checkpoint commit after repro is killed, or if we should only do
             # it on explicit make_checkpoint() signals.
 
+        # NOTE: our cached GitPython Repo instance cannot be re-used if the
+        # checkpoint run was interrupted via SIGINT, so we need this hack
+        # to create a new git repo instance after checkpoint runs.
+        del self.scm
+
         return result
 
     def _collect_and_commit(self, rev, executor, exp_hash):
@@ -744,6 +749,8 @@ class Experiments:
             self._checkout_default_branch()
         try:
             name = self.scm.repo.git.branch(contains=rev)
+            if name.startswith("*"):
+                name = name[1:]
             return name.rsplit("/")[-1].strip()
         except GitCommandError:
             pass

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -323,7 +323,7 @@ class Experiments:
 
     def reproduce_one(self, queue=False, **kwargs):
         """Reproduce and checkout a single experiment."""
-        checkpoint = kwargs.pop("checkpoint", False)
+        checkpoint = kwargs.get("checkpoint", False)
         stash_rev = self.new(**kwargs)
         if queue:
             logger.info(
@@ -367,7 +367,10 @@ class Experiments:
             rev = self.repo.scm.get_rev()
         self._scm_checkout(rev)
         try:
-            stash_rev = self._stash_exp(*args, **kwargs)
+            checkpoint = kwargs.pop("checkpoint")
+            stash_rev = self._stash_exp(
+                *args, allow_unchanged=checkpoint, **kwargs
+            )
         except UnchangedExperimentError as exc:
             logger.info("Reproducing existing experiment '%s'.", rev[:7])
             raise exc

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -323,13 +323,16 @@ class Experiments:
 
     def reproduce_one(self, queue=False, **kwargs):
         """Reproduce and checkout a single experiment."""
+        checkpoint = kwargs.pop("checkpoint", False)
         stash_rev = self.new(**kwargs)
         if queue:
             logger.info(
                 "Queued experiment '%s' for future execution.", stash_rev[:7]
             )
             return [stash_rev]
-        results = self.reproduce([stash_rev], keep_stash=False)
+        results = self.reproduce(
+            [stash_rev], keep_stash=False, checkpoint=checkpoint
+        )
         exp_rev = first(results)
         if exp_rev is not None:
             self.checkout_exp(exp_rev)
@@ -499,6 +502,8 @@ class Experiments:
     def _reproduce_checkpoint(self, executors):
         result = {}
         for rev, executor in executors.items():
+            logger.debug("Reproducing checkpoint experiment '%s'")
+
             if executor.branch:
                 self._scm_checkout(executor.branch)
             else:

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -378,6 +378,8 @@ class Experiments:
             logger.debug(
                 "Continuing checkpoint experiment '%s'", checkpoint_continue
             )
+            kwargs["apply_workspace"] = False
+
         if branch:
             rev = self.scm.resolve_rev(branch)
             logger.debug(
@@ -386,13 +388,10 @@ class Experiments:
         else:
             rev = self.repo.scm.get_rev()
         self._scm_checkout(rev)
+
         try:
             stash_rev = self._stash_exp(
-                *args,
-                branch=branch,
-                allow_unchanged=checkpoint,
-                apply_workspace=not checkpoint_continue,
-                **kwargs,
+                *args, branch=branch, allow_unchanged=checkpoint, **kwargs
             )
         except UnchangedExperimentError as exc:
             logger.info("Reproducing existing experiment '%s'.", rev[:7])

--- a/dvc/repo/experiments/executor.py
+++ b/dvc/repo/experiments/executor.py
@@ -149,8 +149,20 @@ class LocalExecutor(ExperimentExecutor):
         try:
             logger.debug("Running repro in '%s'", cwd)
             dvc = Repo(dvc_dir)
+
+            # NOTE: for checkpoint experiments we handle persist outs slightly
+            # differently than normal:
+            #
+            # - checkpoint out may not yet exist if this is the first time this
+            #   experiment has been run, this is not an error condition for
+            #   experiments
+            # - at the start of a repro run, we need to remove the persist out
+            #   and restore it to its last known (committed) state (which may
+            #   be removed/does not yet exist) so that our executor workspace
+            #   is not polluted with the (persistent) out from an unrelated
+            #   experiment run
             checkpoint = kwargs.pop("checkpoint", False)
-            dvc.checkout(allow_persist_missing=checkpoint)
+            dvc.checkout(allow_persist_missing=checkpoint, force=checkpoint)
             stages = dvc.reproduce(on_unchanged=filter_pipeline, **kwargs)
         finally:
             if old_cwd is not None:

--- a/dvc/repo/experiments/executor.py
+++ b/dvc/repo/experiments/executor.py
@@ -134,9 +134,10 @@ class LocalExecutor(ExperimentExecutor):
 
         unchanged = []
 
-        def filter_pipeline(stage):
-            if isinstance(stage, PipelineStage):
-                unchanged.append(stage)
+        def filter_pipeline(stages):
+            unchanged.extend(
+                [stage for stage in stages if isinstance(stage, PipelineStage)]
+            )
 
         if cwd:
             old_cwd = os.getcwd()

--- a/dvc/repo/experiments/executor.py
+++ b/dvc/repo/experiments/executor.py
@@ -149,7 +149,8 @@ class LocalExecutor(ExperimentExecutor):
         try:
             logger.debug("Running repro in '%s'", cwd)
             dvc = Repo(dvc_dir)
-            dvc.checkout()
+            checkpoint = kwargs.pop("checkpoint", False)
+            dvc.checkout(allow_persist_missing=checkpoint)
             stages = dvc.reproduce(on_unchanged=filter_pipeline, **kwargs)
         finally:
             if old_cwd is not None:

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -1,4 +1,5 @@
 import logging
+from functools import partial
 
 from dvc.exceptions import InvalidArgumentError, ReproductionError
 from dvc.repo.experiments import UnchangedExperimentError
@@ -11,6 +12,14 @@ logger = logging.getLogger(__name__)
 
 
 def _reproduce_stage(stage, **kwargs):
+    def _run_callback(repro_callback):
+        _dump_stage(stage)
+        repro_callback([stage])
+
+    checkpoint_func = kwargs.pop("checkpoint_func")
+    if checkpoint_func:
+        kwargs["checkpoint_func"] = partial(_run_callback, checkpoint_func)
+
     if stage.frozen and not stage.is_import:
         logger.warning(
             "{} is frozen. Its dependencies are"
@@ -22,12 +31,16 @@ def _reproduce_stage(stage, **kwargs):
         return []
 
     if not kwargs.get("dry", False):
-        from ..dvcfile import Dvcfile
-
-        dvcfile = Dvcfile(stage.repo, stage.path)
-        dvcfile.dump(stage, update_pipeline=False)
+        _dump_stage(stage)
 
     return [stage]
+
+
+def _dump_stage(stage):
+    from ..dvcfile import Dvcfile
+
+    dvcfile = Dvcfile(stage.repo, stage.path)
+    dvcfile.dump(stage, update_pipeline=False)
 
 
 def _get_active_graph(G):
@@ -75,6 +88,7 @@ def reproduce(
     queue = kwargs.pop("queue", False)
     run_all = kwargs.pop("run_all", False)
     jobs = kwargs.pop("jobs", 1)
+    checkpoint = kwargs.pop("checkpoint", False)
     if (experiment or run_all) and self.experiments:
         try:
             return _reproduce_experiments(
@@ -86,6 +100,7 @@ def reproduce(
                 queue=queue,
                 run_all=run_all,
                 jobs=jobs,
+                checkpoint=checkpoint,
                 **kwargs,
             )
         except UnchangedExperimentError:
@@ -219,16 +234,25 @@ def _reproduce_stages(
 
     force_downstream = kwargs.pop("force_downstream", False)
     result = []
+    unchanged = []
     # `ret` is used to add a cosmetic newline.
     ret = []
     for stage in pipeline:
         if ret:
             logger.info("")
 
+        checkpoint_func = kwargs.pop("checkpoint_func")
+        if checkpoint_func:
+            kwargs["checkpoint_func"] = partial(
+                _repro_callback, checkpoint_func, unchanged
+            )
+
         try:
             ret = _reproduce_stage(stage, **kwargs)
 
-            if len(ret) != 0 and force_downstream:
+            if len(ret) == 0:
+                unchanged.extend([stage])
+            elif force_downstream:
                 # NOTE: we are walking our pipeline from the top to the
                 # bottom. If one stage is changed, it will be reproduced,
                 # which tells us that we should force reproducing all of
@@ -238,9 +262,13 @@ def _reproduce_stages(
 
             if ret:
                 result.extend(ret)
-            elif on_unchanged is not None:
-                on_unchanged(stage)
         except Exception as exc:
             raise ReproductionError(stage.relpath) from exc
 
+    if on_unchanged is not None:
+        on_unchanged(unchanged)
     return result
+
+
+def _repro_callback(experiments_callback, unchanged, stages):
+    experiments_callback(unchanged, stages)

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -16,7 +16,7 @@ def _reproduce_stage(stage, **kwargs):
         _dump_stage(stage)
         repro_callback([stage])
 
-    checkpoint_func = kwargs.pop("checkpoint_func")
+    checkpoint_func = kwargs.pop("checkpoint_func", None)
     if checkpoint_func:
         kwargs["checkpoint_func"] = partial(_run_callback, checkpoint_func)
 
@@ -241,7 +241,7 @@ def _reproduce_stages(
         if ret:
             logger.info("")
 
-        checkpoint_func = kwargs.pop("checkpoint_func")
+        checkpoint_func = kwargs.pop("checkpoint_func", None)
         if checkpoint_func:
             kwargs["checkpoint_func"] = partial(
                 _repro_callback, checkpoint_func, unchanged

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -89,6 +89,7 @@ def reproduce(
     run_all = kwargs.pop("run_all", False)
     jobs = kwargs.pop("jobs", 1)
     checkpoint = kwargs.pop("checkpoint", False)
+    checkpoint_continue = kwargs.pop("checkpoint_continue", None)
     if (experiment or run_all) and self.experiments:
         try:
             return _reproduce_experiments(
@@ -101,6 +102,7 @@ def reproduce(
                 run_all=run_all,
                 jobs=jobs,
                 checkpoint=checkpoint,
+                checkpoint_continue=checkpoint_continue,
                 **kwargs,
             )
         except UnchangedExperimentError:

--- a/dvc/stage/decorators.py
+++ b/dvc/stage/decorators.py
@@ -50,3 +50,19 @@ def unlocked_repo(f):
         return ret
 
     return wrapper
+
+
+def relock_repo(f):
+    @wraps(f)
+    def wrapper(stage, *args, **kwargs):
+        stage.repo.lock.lock()
+        stage.repo.state.load()
+        try:
+            ret = f(stage, *args, **kwargs)
+        finally:
+            stage.repo.state.dump()
+            stage.repo.lock.unlock()
+            stage.repo._reset()  # pylint: disable=protected-access
+        return ret
+
+    return wrapper

--- a/dvc/stage/run.py
+++ b/dvc/stage/run.py
@@ -13,7 +13,7 @@ from .exceptions import StageCmdFailedError
 logger = logging.getLogger(__name__)
 
 
-CHECKPOINT_SIGNAL_FILE = os.path.join(".dvc", "tmp", "DVC_CHECKPOINT")
+CHECKPOINT_SIGNAL_FILE = "DVC_CHECKPOINT"
 
 
 def _nix_cmd(executable, cmd):
@@ -136,7 +136,7 @@ def checkpoint_monitor(stage, callback_func):
 
 def _checkpoint_run(stage, callback_func, done, done_cond):
     """Run callback_func whenever checkpoint signal file is present."""
-    signal_path = os.path.join(CHECKPOINT_SIGNAL_FILE)
+    signal_path = os.path.join(stage.repo.tmp_dir, CHECKPOINT_SIGNAL_FILE)
     while True:
         if os.path.exists(signal_path):
             _run_callback(stage, callback_func)

--- a/dvc/stage/run.py
+++ b/dvc/stage/run.py
@@ -143,7 +143,7 @@ def _checkpoint_run(stage, callback_func, done, done_cond):
             logger.debug("Remove checkpoint signal file")
             os.remove(signal_path)
         with done_cond:
-            if done or done_cond.wait(5):
+            if done or done_cond.wait(1):
                 return
 
 

--- a/dvc/stage/run.py
+++ b/dvc/stage/run.py
@@ -88,9 +88,7 @@ def cmd_run(stage, *args, checkpoint=False, **kwargs):
         raise StageCmdFailedError(stage.cmd, retcode)
 
 
-def run_stage(
-    stage, dry=False, force=False, checkpoint_func=None, **kwargs
-):
+def run_stage(stage, dry=False, force=False, checkpoint_func=None, **kwargs):
     if not (dry or force or checkpoint_func):
         from .cache import RunCacheNotFoundError
 

--- a/dvc/stage/run.py
+++ b/dvc/stage/run.py
@@ -13,7 +13,7 @@ from .exceptions import StageCmdFailedError
 logger = logging.getLogger(__name__)
 
 
-CHECKPOINT_SIGNAL_FILE = "DVC_CHECKPOINT"
+CHECKPOINT_SIGNAL_FILE = os.path.join(".dvc", "tmp", "DVC_CHECKPOINT")
 
 
 def _nix_cmd(executable, cmd):
@@ -136,7 +136,7 @@ def checkpoint_monitor(stage, callback_func):
 
 def _checkpoint_run(stage, callback_func, done, done_cond):
     """Run callback_func whenever checkpoint signal file is present."""
-    signal_path = os.path.join(stage.wdir, CHECKPOINT_SIGNAL_FILE)
+    signal_path = os.path.join(CHECKPOINT_SIGNAL_FILE)
     while True:
         if os.path.exists(signal_path):
             _run_callback(stage, callback_func)

--- a/tests/func/test_repro.py
+++ b/tests/func/test_repro.py
@@ -1302,4 +1302,4 @@ def test_repro_when_cmd_changes(tmp_dir, dvc, run_copy, mocker):
         stage.addressing: ["changed checksum"]
     }
     assert dvc.reproduce(stage.addressing)[0] == stage
-    m.assert_called_once_with(stage)
+    m.assert_called_once_with(stage, checkpoint=False)

--- a/tests/func/test_repro_multistage.py
+++ b/tests/func/test_repro_multistage.py
@@ -286,7 +286,7 @@ def test_repro_when_cmd_changes(tmp_dir, dvc, run_copy, mocker):
 
     assert dvc.status([target]) == {target: ["changed command"]}
     assert dvc.reproduce(target)[0] == stage
-    m.assert_called_once_with(stage)
+    m.assert_called_once_with(stage, checkpoint=False)
 
 
 def test_repro_when_new_deps_is_added_in_dvcfile(tmp_dir, dvc, run_copy):

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -1,5 +1,10 @@
 from dvc.cli import parse_args
-from dvc.command.experiments import CmdExperimentsDiff, CmdExperimentsShow
+from dvc.command.experiments import (
+    CmdExperimentsDiff,
+    CmdExperimentsRun,
+    CmdExperimentsShow,
+)
+from dvc.dvcfile import PIPELINE_FILE
 
 
 def test_experiments_diff(dvc, mocker):
@@ -53,4 +58,35 @@ def test_experiments_show(dvc, mocker):
         all_branches=True,
         all_commits=True,
         sha_only=True,
+    )
+
+
+default_run_arguments = {
+    "all_pipelines": False,
+    "downstream": False,
+    "dry": False,
+    "force": False,
+    "run_cache": True,
+    "interactive": False,
+    "no_commit": False,
+    "pipeline": False,
+    "single_item": False,
+    "recursive": False,
+    "force_downstream": False,
+    "params": [],
+    "queue": False,
+    "run_all": False,
+    "jobs": None,
+    "checkpoint": False,
+    "checkpoint_continue": None,
+    "experiment": True,
+}
+
+
+def test_experiments_run(dvc, mocker):
+    cmd = CmdExperimentsRun(parse_args(["exp", "run"]))
+    mocker.patch.object(cmd.repo, "reproduce")
+    cmd.run()
+    cmd.repo.reproduce.assert_called_with(
+        PIPELINE_FILE, **default_run_arguments
     )


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.
* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will close #4498.

* `dvc exp run --checkpoint` can be used to reproduce a checkpoint experiment
    * Checkpoint stages should be generated using `--always-changed` and with `--outs-persist` for the intermediate checkpoint outputs
    * When running a checkpoint experiment, a new commit in the experiment branch will be generated each time the running stage calls `dvc.api.make_checkpoint()` (or generates the appropriate `.dvc/tmp/DVC_CHECKPOINT`) signal file
    * Reproduction and checkpoint generation will run forever until the user code exits or is killed via Ctrl+C
* `dvc exp run --continue <checkpoint_exp_rev>` can be used to resume a prior checkpoint experiment. Execution will be resumed from the tip of the checkpoint branch.
* Checkpoint experiments can be viewed as normal in `dvc exp show`

Known issues (needs further investigation after this PR):
* Git-python sometimes throws broken pipe errors when checkpoint runs are killed via Ctrl-C
* Reproducing a baseline commit does not work properly, for a checkpoint experiment to be generated properly, there needs to be some change versus the baseline/parent commit (either in the workspace or via the `repro --params` option)
* Sorting in `dvc exp show` will not work properly if the table contains checkpoint experiments, but filtering should work as expected

Features that will need follow up PR:
* Branching from some commit in the middle of a checkpoint experiment and then resuming a "new" branch with potentially modified code/params is not yet supported