### PR TITLE
install: Potential fix for (non-fatal?) setup errors on Ubuntu 20.04.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ install_requires = [
     "shtab>=1.3.0,<2",
     "rich>=3.0.5",
     "dictdiffer>=0.8.1",
+    "wheel>=0.35.1",
 ]
 
 


### PR DESCRIPTION
Wheels fail to build on initial install. Install `wheel` to fix this.

Original error message:
```
Building wheel for pyyaml (setup.py) ... error
  ERROR: Command errored out with exit status 1:
   command: /home/david/Documents/job-hunting/dvc/.env/bin/python3 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-nhmea2xe/pyyaml/setup.py'"'"'; __file__='"'"'/tmp/pip-install-nhmea2xe/pyyaml/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-v2ewd51w
       cwd: /tmp/pip-install-nhmea2xe/pyyaml/
  Complete output (6 lines):
  usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: setup.py --help [cmd1 cmd2 ...]
     or: setup.py --help-commands
     or: setup.py cmd --help

  error: invalid command 'bdist_wheel'
  ----------------------------------------
  ERROR: Failed building wheel for pyyaml
  Running setup.py clean for pyyaml
```

Potential fix applied from:
	https://stackoverflow.com/questions/34819221/why-is-python-setup-py-saying-invalid-command-bdist-wheel-on-travis-ci

Fixes #4605.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.