### PR TITLE
status: Show friendly message for empty project.

### DIFF
--- a/dvc/command/status.py
+++ b/dvc/command/status.py
@@ -12,9 +12,9 @@ class CmdDataStatus(CmdDataBase):
     STATUS_INDENT = "\t"
     UP_TO_DATE_MSG = "Data and pipelines are up to date."
     EMPTY_PROJECT_MSG = (
-        "There is no data tracked in this project yet.\n"
+        "There are no data or pipelines tracked in this project yet.\n"
         "See {link} to get started!"
-    ).format(link=format_link("https://dvc.org/doc/start/data-versioning"))
+    ).format(link=format_link("https://dvc.org/doc/start"))
 
     def _normalize(self, s):
         s += ":"

--- a/dvc/command/status.py
+++ b/dvc/command/status.py
@@ -14,8 +14,8 @@ class CmdDataStatus(CmdDataBase):
     UP_TO_DATE_MSG = "Data and pipelines are up to date."
     EMPTY_PROJECT_MSG = (
         "There is no data tracked in this project yet.\n"
-        "See {blue}https://dvc.org/doc/start/data-versioning{nc} to get started!"
-    ).format(blue=colorama.Fore.BLUE, nc=colorama.Fore.RESET)
+        "See {bl}https://dvc.org/doc/start/data-versioning{nc} to get started!"
+    ).format(bl=colorama.Fore.BLUE, nc=colorama.Fore.RESET)
 
     def _normalize(self, s):
         s += ":"

--- a/dvc/command/status.py
+++ b/dvc/command/status.py
@@ -1,5 +1,7 @@
 import logging
 
+import colorama
+
 from dvc.command.data_sync import CmdDataBase
 from dvc.exceptions import DvcException
 
@@ -10,6 +12,10 @@ class CmdDataStatus(CmdDataBase):
     STATUS_LEN = 20
     STATUS_INDENT = "\t"
     UP_TO_DATE_MSG = "Data and pipelines are up to date."
+    EMPTY_PROJECT_MSG = (
+        "There is no data tracked in this project yet.\n"
+        "See {blue}https://dvc.org/doc/start/data-versioning{nc} to get started!"
+    ).format(blue=colorama.Fore.BLUE, nc=colorama.Fore.RESET)
 
     def _normalize(self, s):
         s += ":"
@@ -61,6 +67,8 @@ class CmdDataStatus(CmdDataBase):
                 logger.info(json.dumps(st))
             elif st:
                 self._show(st, indent)
+            elif not self.repo.stages:
+                logger.info(self.EMPTY_PROJECT_MSG)
             else:
                 logger.info(self.UP_TO_DATE_MSG)
 

--- a/dvc/command/status.py
+++ b/dvc/command/status.py
@@ -1,9 +1,8 @@
 import logging
 
-import colorama
-
 from dvc.command.data_sync import CmdDataBase
 from dvc.exceptions import DvcException
+from dvc.utils import format_link
 
 logger = logging.getLogger(__name__)
 
@@ -14,8 +13,8 @@ class CmdDataStatus(CmdDataBase):
     UP_TO_DATE_MSG = "Data and pipelines are up to date."
     EMPTY_PROJECT_MSG = (
         "There is no data tracked in this project yet.\n"
-        "See {bl}https://dvc.org/doc/start/data-versioning{nc} to get started!"
-    ).format(bl=colorama.Fore.BLUE, nc=colorama.Fore.RESET)
+        "See {link} to get started!"
+    ).format(link=format_link("https://dvc.org/doc/start/data-versioning"))
 
     def _normalize(self, s):
         s += ":"

--- a/dvc/repo/init.py
+++ b/dvc/repo/init.py
@@ -10,7 +10,9 @@ from dvc.ignore import init as init_dvcignore
 from dvc.repo import Repo
 from dvc.scm import SCM
 from dvc.scm.base import SCMError
-from dvc.utils import boxify, relpath
+from dvc.utils import boxify
+from dvc.utils import format_link as fmt_link
+from dvc.utils import relpath
 from dvc.utils.fs import remove
 
 logger = logging.getLogger(__name__)
@@ -22,9 +24,7 @@ def _welcome_message():
             boxify(
                 "DVC has enabled anonymous aggregate usage analytics.\n"
                 "Read the analytics documentation (and how to opt-out) here:\n"
-                "{blue}https://dvc.org/doc/user-guide/analytics{nc}".format(
-                    blue=colorama.Fore.BLUE, nc=colorama.Fore.RESET
-                ),
+                + fmt_link("https://dvc.org/doc/user-guide/analytics"),
                 border_color="red",
             )
         )
@@ -32,14 +32,10 @@ def _welcome_message():
     msg = (
         "{yellow}What's next?{nc}\n"
         "{yellow}------------{nc}\n"
-        "- Check out the documentation: {blue}https://dvc.org/doc{nc}\n"
-        "- Get help and share ideas: {blue}https://dvc.org/chat{nc}\n"
-        "- Star us on GitHub: {blue}https://github.com/iterative/dvc{nc}"
-    ).format(
-        yellow=colorama.Fore.YELLOW,
-        blue=colorama.Fore.BLUE,
-        nc=colorama.Fore.RESET,
-    )
+        f"- Check out the documentation: {fmt_link('https://dvc.org/doc')}\n"
+        f"- Get help and share ideas: {fmt_link('https://dvc.org/chat')}\n"
+        f"- Star us on GitHub: {fmt_link('https://github.com/iterative/dvc')}"
+    ).format(yellow=colorama.Fore.YELLOW, nc=colorama.Fore.RESET)
 
     logger.info(msg)
 


### PR DESCRIPTION
When there are no stages in the repo, show a friendly message to that effect and display a [getting-started](https://dvc.org/doc/start/data-versioning) URL.

Fixes #4395.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Note: This PR, as well as the incidental https://github.com/iterative/dvc/pull/4606, are part of the application process for a job with DVC.