### PR TITLE
command: print the current cache directory when no cmd flags are provided

### DIFF
--- a/dvc/command/cache.py
+++ b/dvc/command/cache.py
@@ -7,6 +7,9 @@ from dvc.command.config import CmdConfig
 
 class CmdCacheDir(CmdConfig):
     def run(self):
+        if not self.args.value:
+            print(self.config["cache"]["dir"])
+            return 0
         with self.config.edit(level=self.args.level) as edit:
             edit["cache"]["dir"] = self.args.value
         return 0
@@ -55,6 +58,8 @@ def add_parser(subparsers, parent_parser):
         "value",
         help="Path to cache directory. Relative paths are resolved relative "
         "to the current directory and saved to config relative to the "
-        "config file location.",
+        "config file location. If no path is provided, it returns the "
+        "current cache directory.",
+        nargs="?",
     ).complete = completion.DIR
     cache_dir_parser.set_defaults(func=CmdCacheDir)

--- a/dvc/command/cache.py
+++ b/dvc/command/cache.py
@@ -7,7 +7,7 @@ from dvc.command.config import CmdConfig
 
 class CmdCacheDir(CmdConfig):
     def run(self):
-        if not self.args.value:
+        if self.args.value is None and not self.args.unset:
             print(self.config["cache"]["dir"])
             return 0
         with self.config.edit(level=self.args.level) as edit:

--- a/dvc/command/cache.py
+++ b/dvc/command/cache.py
@@ -8,7 +8,7 @@ from dvc.command.config import CmdConfig
 class CmdCacheDir(CmdConfig):
     def run(self):
         if self.args.value is None and not self.args.unset:
-            print(self.config["cache"]["dir"])
+            logger.info(self.config["cache"]["dir"])
             return 0
         with self.config.edit(level=self.args.level) as edit:
             edit["cache"]["dir"] = self.args.value

--- a/dvc/command/cache.py
+++ b/dvc/command/cache.py
@@ -1,8 +1,11 @@
 import argparse
+import logging
 
 from dvc.command import completion
 from dvc.command.base import append_doc_link, fix_subparsers
 from dvc.command.config import CmdConfig
+
+logger = logging.getLogger(__name__)
 
 
 class CmdCacheDir(CmdConfig):

--- a/tests/func/test_cache.py
+++ b/tests/func/test_cache.py
@@ -154,7 +154,7 @@ class TestCacheLinkType(TestDvc):
 class TestCmdCacheDir(TestDvc):
     def test(self):
         ret = main(["cache", "dir"])
-        self.assertEqual(ret, 254)
+        self.assertEqual(ret, 0)
 
     def test_abs_path(self):
         dname = os.path.join(os.path.dirname(self._root_dir), "dir")


### PR DESCRIPTION
comamnd 'dvc cache dir' now prints the current cache dir
when no cmd flags are provided.

Fixes #1998

Signed-off-by: Girish Joshi <girish946@gmail.com>