### PR TITLE
ssh: don't use self.path_info for upload/download

### DIFF
--- a/dvc/tree/ssh/__init__.py
+++ b/dvc/tree/ssh/__init__.py
@@ -246,8 +246,7 @@ class SSHTree(BaseTree):
             return ssh.getsize(path_info.path)
 
     def _download(self, from_info, to_file, name=None, no_progress_bar=False):
-        assert from_info.isin(self.path_info)
-        with self.ssh(self.path_info) as ssh:
+        with self.ssh(from_info) as ssh:
             ssh.download(
                 from_info.path,
                 to_file,
@@ -256,8 +255,7 @@ class SSHTree(BaseTree):
             )
 
     def _upload(self, from_file, to_info, name=None, no_progress_bar=False):
-        assert to_info.isin(self.path_info)
-        with self.ssh(self.path_info) as ssh:
+        with self.ssh(to_info) as ssh:
             ssh.upload(
                 from_file,
                 to_info.path,


### PR DESCRIPTION
A leftover from an ancient code back when we didn't have connection pools.

Fixes #4618 

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
