### PR TITLE
diff/dvctree: optimize dir cache access

### DIFF
--- a/dvc/cache/base.py
+++ b/dvc/cache/base.py
@@ -263,6 +263,8 @@ class CloudCache:
         from dvc.utils import tmp_fname
 
         # Sorting the list by path to ensure reproducibility
+        if isinstance(dir_info, dict):
+            dir_info = self._from_dict(dir_info)
         dir_info = sorted(dir_info, key=itemgetter(self.tree.PARAM_RELPATH))
 
         tmp = tempfile.NamedTemporaryFile(delete=False).name
@@ -275,7 +277,7 @@ class CloudCache:
 
         hash_info = self.tree.get_file_hash(to_info)
         hash_info.value += self.tree.CHECKSUM_DIR_SUFFIX
-        hash_info.dir_info = dir_info
+        hash_info.dir_info = self._to_dict(dir_info)
 
         return hash_info, to_info
 
@@ -299,15 +301,14 @@ class CloudCache:
 
     def _save_dir(self, path_info, tree, hash_info, save_link=True, **kwargs):
         if not hash_info.dir_info:
-            hash_info.dir_info = tree.cache.get_dir_cache(hash_info)
-        hi = self.save_dir_info(hash_info.dir_info, hash_info)
-        for entry in Tqdm(
-            hi.dir_info, desc="Saving " + path_info.name, unit="file"
-        ):
-            entry_info = path_info / entry[self.tree.PARAM_RELPATH]
-            entry_hash = HashInfo(
-                self.tree.PARAM_CHECKSUM, entry[self.tree.PARAM_CHECKSUM]
+            hash_info.dir_info = self._to_dict(
+                tree.cache.get_dir_cache(hash_info)
             )
+        hi = self.save_dir_info(hash_info.dir_info, hash_info)
+        for relpath, entry_hash in Tqdm(
+            hi.dir_info.items(), desc="Saving " + path_info.name, unit="file"
+        ):
+            entry_info = path_info / relpath
             self._save_file(
                 entry_info, tree, entry_hash, save_link=False, **kwargs
             )
@@ -615,7 +616,9 @@ class CloudCache:
 
     def _to_dict(self, dir_info):
         return {
-            entry[self.tree.PARAM_RELPATH]: entry[self.tree.PARAM_CHECKSUM]
+            entry[self.tree.PARAM_RELPATH]: HashInfo(
+                self.tree.PARAM_CHECKSUM, entry[self.tree.PARAM_CHECKSUM]
+            )
             for entry in dir_info
         }
 
@@ -623,9 +626,9 @@ class CloudCache:
         return [
             {
                 self.tree.PARAM_RELPATH: relpath,
-                self.tree.PARAM_CHECKSUM: checksum,
+                hash_info.name: hash_info.value,
             }
-            for relpath, checksum in dir_dict.items()
+            for relpath, hash_info in dir_dict.items()
         ]
 
     @staticmethod
@@ -692,3 +695,8 @@ class CloudCache:
             return hash_info
 
         return self.save_dir_info(hash_info.dir_info, hash_info)
+
+    def set_dir_info(self, hash_info):
+        assert hash_info.isdir
+
+        hash_info.dir_info = self._to_dict(self.get_dir_cache(hash_info))

--- a/dvc/cache/base.py
+++ b/dvc/cache/base.py
@@ -615,12 +615,17 @@ class CloudCache:
         )
 
     def _to_dict(self, dir_info):
-        return {
-            entry[self.tree.PARAM_RELPATH]: HashInfo(
-                self.tree.PARAM_CHECKSUM, entry[self.tree.PARAM_CHECKSUM]
-            )
-            for entry in dir_info
-        }
+        info = {}
+        for entry in dir_info:
+            relpath = None
+            hash_info = None
+            for key, value in entry.items():
+                if key == self.tree.PARAM_RELPATH:
+                    relpath = value
+                else:
+                    hash_info = HashInfo(key, value)
+            info[relpath] = hash_info
+        return info
 
     def _from_dict(self, dir_dict):
         return [

--- a/dvc/hash_info.py
+++ b/dvc/hash_info.py
@@ -7,7 +7,7 @@ HASH_DIR_SUFFIX = ".dir"
 class HashInfo:
     name: str
     value: str
-    dir_info: list = field(default=None, compare=False)
+    dir_info: dict = field(default=None, compare=False)
 
     def __bool__(self):
         return bool(self.value)

--- a/dvc/output/base.py
+++ b/dvc/output/base.py
@@ -385,6 +385,9 @@ class BaseOutput:
                 show_checksums=False,
                 **kwargs,
             )
+            self.hash_info.dir_info = None
+        if not self.hash_info.dir_info:
+            self.cache.set_dir_info(self.hash_info)
         return self.dir_cache
 
     def collect_used_dir_cache(

--- a/dvc/repo/diff.py
+++ b/dvc/repo/diff.py
@@ -111,7 +111,7 @@ def _dir_output_paths(repo_tree, output):
 
     try:
         for fname in repo_tree.walk_files(output.path_info):
-            yield str(fname), repo_tree.get_hash(fname).value
+            yield str(fname), repo_tree.get_file_hash(fname).value
     except NoRemoteError:
         logger.warning("dir cache entry for '%s' is missing", output)
 

--- a/dvc/tree/base.py
+++ b/dvc/tree/base.py
@@ -256,7 +256,7 @@ class BaseTree:
         if hash_:
             hash_info = HashInfo(self.PARAM_CHECKSUM, hash_)
             if hash_info.isdir:
-                hash_info.dir_info = self.cache.get_dir_cache(hash_info)
+                self.cache.set_dir_info(hash_info)
             return hash_info
 
         if self.isdir(path_info):

--- a/dvc/tree/dvc.py
+++ b/dvc/tree/dvc.py
@@ -56,12 +56,16 @@ class DvcTree(BaseTree):  # pylint:disable=abstract-method
         assert isinstance(path_info, PathInfo)
         if not self.fetch and not self.stream:
             raise FileNotFoundError
+
+        # NOTE: use string paths here for performance reasons
+        path_str = path_info.as_posix()
+        out_path_str = out.path_info.as_posix()
         dir_cache = out.get_dir_cache(remote=remote)
         for entry in dir_cache:
             entry_relpath = entry[out.tree.PARAM_RELPATH]
             if os.name == "nt":
                 entry_relpath = entry_relpath.replace("/", os.sep)
-            if path_info == out.path_info / entry_relpath:
+            if path_str == "/".join([out_path_str, entry_relpath]):
                 return entry[out.tree.PARAM_CHECKSUM]
         raise FileNotFoundError
 

--- a/dvc/tree/dvc.py
+++ b/dvc/tree/dvc.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import typing
-from functools import lru_cache
 
 from dvc.exceptions import OutputNotFoundError
 from dvc.hash_info import HashInfo
@@ -15,23 +14,6 @@ if typing.TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
-
-
-# cache metadata for sequential exists/isdir/isfile/etc calls
-@lru_cache(maxsize=1)
-def _get_metadata(tree, path_info):
-    path_info = PathInfo(os.path.abspath(path_info))
-
-    try:
-        outs = tree._find_outs(  # pylint:disable=protected-access
-            path_info, strict=False, recursive=True
-        )
-    except OutputNotFoundError as exc:
-        raise FileNotFoundError from exc
-
-    meta = Metadata(path_info=path_info, outs=outs, repo=tree.repo)
-    meta.isdir = meta.isdir or tree.check_isdir(meta.path_info, meta.outs)
-    return meta
 
 
 class DvcTree(BaseTree):  # pylint:disable=abstract-method
@@ -303,4 +285,13 @@ class DvcTree(BaseTree):  # pylint:disable=abstract-method
         return out.hash_info
 
     def metadata(self, path_info):
-        return _get_metadata(self, path_info)
+        path_info = PathInfo(os.path.abspath(path_info))
+
+        try:
+            outs = self._find_outs(path_info, strict=False, recursive=True)
+        except OutputNotFoundError as exc:
+            raise FileNotFoundError from exc
+
+        meta = Metadata(path_info=path_info, outs=outs, repo=self.repo)
+        meta.isdir = meta.isdir or self.check_isdir(meta.path_info, meta.outs)
+        return meta

--- a/dvc/tree/dvc.py
+++ b/dvc/tree/dvc.py
@@ -4,6 +4,7 @@ import typing
 
 from dvc.exceptions import OutputNotFoundError
 from dvc.path_info import PathInfo
+from dvc.utils import relpath
 
 from ._metadata import Metadata
 from .base import BaseTree, RemoteActionNotImplemented
@@ -59,7 +60,7 @@ class DvcTree(BaseTree):  # pylint:disable=abstract-method
             raise FileNotFoundError
 
         # NOTE: use string paths here for performance reasons
-        path_str = str(path_info.relative_to(out.path_info))
+        path_str = relpath(path_info, out.path_info)
         out.get_dir_cache(remote=remote)
         file_hash = out.hash_info.dir_info.get(path_str)
         if file_hash:

--- a/dvc/tree/dvc.py
+++ b/dvc/tree/dvc.py
@@ -61,6 +61,8 @@ class DvcTree(BaseTree):  # pylint:disable=abstract-method
 
         # NOTE: use string paths here for performance reasons
         path_str = relpath(path_info, out.path_info)
+        if os.name == "nt":
+            path_str = path_str.replace(os.sep, "/")
         out.get_dir_cache(remote=remote)
         file_hash = out.hash_info.dir_info.get(path_str)
         if file_hash:

--- a/dvc/tree/dvc.py
+++ b/dvc/tree/dvc.py
@@ -61,7 +61,7 @@ class DvcTree(BaseTree):  # pylint:disable=abstract-method
 
         # NOTE: use string paths here for performance reasons
         self._update_dir_entry_hashes(out, remote)
-        path_str = path_info.as_posix()
+        path_str = str(path_info)
         hash_info = self._dir_entry_hashes.get(path_str)
         if hash_info:
             return hash_info
@@ -76,12 +76,12 @@ class DvcTree(BaseTree):  # pylint:disable=abstract-method
 
         self._cached_dir_cache = dir_cache
         self._dir_entry_hashes.clear()
-        out_path_str = out.path_info.as_posix()
+        out_path_str = str(out.path_info)
         for entry in dir_cache:
             entry_relpath = entry[out.tree.PARAM_RELPATH]
             if os.name == "nt":
                 entry_relpath = entry_relpath.replace("/", os.sep)
-            entry_path_str = "/".join([out_path_str, entry_relpath])
+            entry_path_str = os.sep.join([out_path_str, entry_relpath])
             hash_info = HashInfo(
                 out.tree.PARAM_CHECKSUM, entry[out.tree.PARAM_CHECKSUM]
             )


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will fix #4580.

* `HashInfo.dir_info` is now stored as a dict instead of list, dir cache is still kept in the list format everywhere else
* `DvcTree._get_granular_checksum` now uses `out.hash_info.dir_info` to lookup file hashes