### PR TITLE
metrics/plots: initial support non-dvc repos

### DIFF
--- a/dvc/command/base.py
+++ b/dvc/command/base.py
@@ -29,13 +29,15 @@ def append_doc_link(help_message, path):
 
 
 class CmdBase(ABC):
+    UNINITIALIZED = False
+
     def __init__(self, args):
         from dvc.repo import Repo
         from dvc.updater import Updater
 
         os.chdir(args.cd)
 
-        self.repo = Repo()
+        self.repo = Repo(uninitialized=self.UNINITIALIZED)
         self.config = self.repo.config
         self.args = args
         hardlink_lock = self.config["core"].get("hardlink_lock", False)

--- a/dvc/command/metrics.py
+++ b/dvc/command/metrics.py
@@ -38,7 +38,11 @@ def show_metrics(
         raise BadMetricError(missing)
 
 
-class CmdMetricsShow(CmdBase):
+class CmdMetricsBase(CmdBase):
+    UNINITIALIZED = True
+
+
+class CmdMetricsShow(CmdMetricsBase):
     def run(self):
         try:
             metrics = self.repo.metrics.show(
@@ -104,7 +108,7 @@ def _show_diff(diff, markdown=False, no_path=False, old=False, precision=None):
     return table(header, rows, markdown)
 
 
-class CmdMetricsDiff(CmdBase):
+class CmdMetricsDiff(CmdMetricsBase):
     def run(self):
         try:
             diff = self.repo.metrics.diff(

--- a/dvc/command/plots.py
+++ b/dvc/command/plots.py
@@ -31,6 +31,8 @@ DIV_HTML = """<div id = "{id}"></div>
 
 
 class CmdPlots(CmdBase):
+    UNINITILIZED = True
+
     def _func(self, *args, **kwargs):
         raise NotImplementedError
 

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -80,7 +80,14 @@ class Repo:
     from dvc.repo.status import status
     from dvc.repo.update import update
 
-    def __init__(self, root_dir=None, scm=None, rev=None, subrepos=False):
+    def __init__(
+        self,
+        root_dir=None,
+        scm=None,
+        rev=None,
+        subrepos=False,
+        uninitialized=False,
+    ):
         from dvc.cache import Cache
         from dvc.data_cloud import DataCloud
         from dvc.lock import make_lock
@@ -103,7 +110,12 @@ class Repo:
             )
             self.state = StateNoop()
         else:
-            root_dir = self.find_root(root_dir)
+            try:
+                root_dir = self.find_root(root_dir)
+            except NotDvcRepoError:
+                if not uninitialized:
+                    raise
+                root_dir = SCM(root_dir or os.curdir).root_dir
             self.root_dir = os.path.abspath(os.path.realpath(root_dir))
             self.tree = LocalTree(
                 self,

--- a/tests/func/metrics/test_show.py
+++ b/tests/func/metrics/test_show.py
@@ -112,18 +112,30 @@ def test_missing_cache(tmp_dir, dvc, run_copy_metrics):
     assert dvc.metrics.show() == {"": {"metrics.yaml": 1.1}}
 
 
-def test_show_non_metric(tmp_dir, dvc):
+@pytest.mark.parametrize("use_dvc", [True, False])
+def test_show_non_metric(tmp_dir, scm, use_dvc):
     tmp_dir.gen("metrics.yaml", "foo: 1.1")
+
+    if use_dvc:
+        dvc = Repo.init()
+    else:
+        dvc = Repo(uninitialized=True)
 
     assert dvc.metrics.show(targets=["metrics.yaml"]) == {
         "": {"metrics.yaml": {"foo": 1.1}}
     }
 
 
-def test_show_non_metric_branch(tmp_dir, scm, dvc):
+@pytest.mark.parametrize("use_dvc", [True, False])
+def test_show_non_metric_branch(tmp_dir, scm, use_dvc):
     tmp_dir.scm_gen("metrics.yaml", "foo: 1.1", commit="init")
     with tmp_dir.branch("branch", new=True):
         tmp_dir.scm_gen("metrics.yaml", "foo: 2.2", commit="other")
+
+    if use_dvc:
+        dvc = Repo.init()
+    else:
+        dvc = Repo(uninitialized=True)
 
     assert dvc.metrics.show(targets=["metrics.yaml"], revs=["branch"]) == {
         "workspace": {"metrics.yaml": {"foo": 1.1}},

--- a/tests/func/plots/test_plots.py
+++ b/tests/func/plots/test_plots.py
@@ -8,6 +8,7 @@ from collections import OrderedDict
 import pytest
 from funcy import first
 
+from dvc.repo import Repo
 from dvc.repo.plots.data import (
     JSONPlotData,
     NoMetricInHistoryError,
@@ -604,12 +605,19 @@ def test_multiple_plots(tmp_dir, scm, dvc, run_copy_metrics):
     assert len(dvc.plots.show().keys()) == 2
 
 
-def test_show_non_plot(tmp_dir, scm, dvc):
+@pytest.mark.parametrize("use_dvc", [True, False])
+def test_show_non_plot(tmp_dir, scm, use_dvc):
     metric = [
         {"first_val": 100, "val": 2},
         {"first_val": 200, "val": 3},
     ]
     _write_json(tmp_dir, metric, "metric.json")
+
+    if use_dvc:
+        dvc = Repo.init()
+    else:
+        dvc = Repo(uninitialized=True)
+
     plot_string = dvc.plots.show(targets=["metric.json"])["metric.json"]
 
     plot_content = json.loads(plot_string)


### PR DESCRIPTION
Initial hacky support, that still tries to create `.dvc` directory as a side-effect. That side effect will be addressed in the upcoming 
PR. This feature in general makes us really rethink what a dvc repo is and whether having `.dvc` is really required.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
