### PR TITLE
gdrive: revert back to the hack for uploading empty files

### DIFF
--- a/dvc/tree/gdrive.py
+++ b/dvc/tree/gdrive.py
@@ -366,7 +366,10 @@ class GDriveTree(BaseTree):
                 total=total,
                 disable=no_progress_bar,
             ) as wrapped:
-                item.content = wrapped
+                # PyDrive doesn't like content property setting for empty files
+                # https://github.com/gsuitedevs/PyDrive/issues/121
+                if total:
+                    item.content = wrapped
                 item.Upload()
         return item
 

--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -19,7 +19,17 @@ from dvc.tree.local import LocalTree
 from dvc.utils.fs import move, remove
 from dvc.utils.serialize import dump_yaml, load_yaml
 
-from .test_api import all_clouds
+all_clouds = [
+    pytest.lazy_fixture(cloud)
+    for cloud in ["s3", "gs", "azure", "gdrive", "ssh", "http"]
+] + [
+    pytest.param(
+        pytest.lazy_fixture("oss"),
+        marks=pytest.mark.xfail(
+            reason="https://github.com/iterative/dvc/issues/4633",
+        ),
+    )
+]
 
 
 @pytest.mark.parametrize("remote", all_clouds, indirect=True)
@@ -35,6 +45,7 @@ def test_cloud(tmp_dir, dvc, remote):  # pylint:disable=unused-argument
             "data_dir": {
                 "data_sub_dir": {"data_sub": "data_sub"},
                 "data": "data",
+                "empty": "",
             }
         }
     )
@@ -128,6 +139,7 @@ def test_cloud_cli(tmp_dir, dvc, remote):
             "data_dir": {
                 "data_sub_dir": {"data_sub": "data_sub"},
                 "data": "data",
+                "empty": "",
             }
         }
     )


### PR DESCRIPTION
We still need this hack, as `Upload` doesn't support callbacks yet and wrapping an empty content into our own progress bar results in errors.

Fixes #4593 

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
