### PR TITLE
WIP: Custom parametrization/imports

### DIFF
--- a/dvc/dvcfile.py
+++ b/dvc/dvcfile.py
@@ -105,7 +105,7 @@ class FileMixin:
         with self.repo.tree.open(self.path) as fd:
             stage_text = fd.read()
         d = parse_yaml(stage_text, self.path)
-        self.validate(d, self.relpath)
+        # self.validate(d, self.relpath)
         return d, stage_text
 
     @classmethod
@@ -225,9 +225,13 @@ class PipelineFile(FileMixin):
 
     @property
     def stages(self):
+        from dvc.parsing import DataLoader
+
         data, _ = self._load()
+        spec = DataLoader(data)
+        resolved = spec.resolve()
         lockfile_data = self._lockfile.load()
-        return StageLoader(self, data.get("stages", {}), lockfile_data)
+        return StageLoader(self, resolved.get("stages", {}), lockfile_data)
 
     def remove(self, force=False):
         if not force:

--- a/dvc/dvcfile.py
+++ b/dvc/dvcfile.py
@@ -3,6 +3,7 @@ import contextlib
 import logging
 import os
 
+from funcy import print_durations
 from voluptuous import MultipleInvalid
 
 from dvc.exceptions import DvcException
@@ -228,8 +229,10 @@ class PipelineFile(FileMixin):
         from dvc.parsing import DataLoader
 
         data, _ = self._load()
-        spec = DataLoader(data)
-        resolved = spec.resolve()
+
+        with print_durations("Resolving values"):
+            spec = DataLoader(data)
+            resolved = spec.resolve()
         lockfile_data = self._lockfile.load()
         return StageLoader(self, resolved.get("stages", {}), lockfile_data)
 

--- a/dvc/parsing/__init__.py
+++ b/dvc/parsing/__init__.py
@@ -42,7 +42,7 @@ def _resolve_str(src, context, tracker=None):
 
     # regex already backtracks and avoids any `${` starting with
     # backslashes(`\--`). We just need to replace those by `${`.
-    return src.replace(r"\${", "${")
+    return src.replace(r"\${", "${") if isinstance(src, str) else src
 
 
 def _resolve(src, context, tracker=None):

--- a/dvc/parsing/__init__.py
+++ b/dvc/parsing/__init__.py
@@ -37,9 +37,12 @@ def _resolve_str(src, context, tracker=None):
             # value rather than it's string counterparts.
             if num_matches == 1 and src == matches[0].group(0):
                 return list(to_replace.values())[0]
-            # but not "{num} days"
-            return str_interpolate(src, to_replace)
-    return src
+            # but not "${num} days"
+            src = str_interpolate(src, to_replace)
+
+    # regex already backtracks and avoids any `${` starting with
+    # backslashes(`\--`). We just need to replace those by `${`.
+    return src.replace(r"\${", "${")
 
 
 def _resolve(src, context, tracker=None):

--- a/dvc/parsing/__init__.py
+++ b/dvc/parsing/__init__.py
@@ -26,7 +26,7 @@ class DataLoader:
         args = d.get(ARGS, {})
 
         imports = args.get(IMPORTS, [])
-        constants = args.get(CONSTANTS, [])
+        constants = args.get(CONSTANTS, {})
         self.file_ctx = Context.load_variables(imports, constants)
 
     def _resolve_entry(self, name, definition):

--- a/dvc/parsing/__init__.py
+++ b/dvc/parsing/__init__.py
@@ -1,0 +1,108 @@
+import logging
+from collections.abc import Mapping
+from itertools import starmap
+
+from funcy import join, lmap, rpartial
+
+from dvc.parsing.context import Context
+from dvc.parsing.interpolate import find_match, get_value, str_interpolate
+
+logger = logging.getLogger(__name__)
+
+ARGS = "args"
+IMPORTS = "imports"
+CONSTANTS = "constants"
+STAGES = "stages"
+COLON = ":"
+PARAMS = "params"
+
+
+def _resolve_str(src, context, tracker=None):
+    if isinstance(src, str):
+        matches = find_match(src)
+        num_matches = len(matches)
+        if num_matches:
+            to_replace = {}
+            for match in matches:
+                expr = match.group()
+                expand_and_track, _, inner = match.groups()
+                track = expand_and_track
+                if expr not in to_replace:
+                    to_replace[expr] = get_value(context, inner)
+                if track and tracker is not None:
+                    # TODO: does not work with files other than `params.yaml`
+                    tracker.append(inner)
+
+            # replace "${enabled}", if `enabled` is a boolean, with it's actual
+            # value rather than it's string counterparts.
+            if num_matches == 1 and src == matches[0].group(0):
+                return list(to_replace.values())[0]
+            # but not "{num} days"
+            return str_interpolate(src, to_replace)
+    return src
+
+
+def _resolve(src, context, tracker=None):
+    # TODO: can we do this better?
+    Seq = (list, tuple, set)
+
+    apply_value = rpartial(_resolve, context, tracker)
+    if isinstance(src, Mapping):
+        return {key: apply_value(value) for key, value in src.items()}
+    elif isinstance(src, Seq):
+        return src.__class__(apply_value(value) for value in src)
+    return _resolve_str(src, context, tracker)
+
+
+class DataLoader:
+    def __init__(self, d, context=None):
+        """
+        Args:
+            d: data loaded from dvc.yaml or .dvc files
+            context: Global context, eg: those passed from
+                     `dvc repro --vars params.foo 3` (TODO)
+        """
+        self.d = d
+        args = d.get(ARGS, {})
+
+        self._imports = imports = args.get(IMPORTS, [])
+        assert len(imports) < 2, "Do not allow multiple imports for now."
+
+        contexts = lmap(self._load_imports, imports)
+        constant_ctx = Context(args.get(CONSTANTS, {}))
+        global_ctx = context or Context()
+
+        # this applies to all of the stages in this "dvc.yaml"
+        self.file_ctx = Context.merge(*contexts, constant_ctx, global_ctx)
+
+    @staticmethod
+    def _load_imports(spec: str):
+        return Context.load_and_select(*spec.rsplit(COLON, maxsplit=1))
+
+    def _resolve_entry(self, name, definition):
+        # TODO: we might need to create a context out of stage's definition
+        #  (think of `build-matrix` or `foreach`), empty dict for now.
+        local_ctx = Context({})
+        ctx = Context.merge(self.file_ctx, local_ctx)
+
+        logger.debug("Context for stage %s: %s", name, ctx)
+
+        tracker = []
+        stage_d = _resolve(definition, ctx, tracker)
+
+        logger.debug("Resolved data: %s", stage_d)
+
+        if tracker:
+            logger.debug("Tracking params: %s", tracker)
+
+            stage_d[PARAMS] = stage_d.get(PARAMS, [])
+            # TODO: resolve where that specific value came from
+            # TODO: does not support `:<var>` based imports
+            stage_d[PARAMS].extend(tracker)
+
+        return {name: stage_d}
+
+    def resolve(self):
+        stages = self.d.get(STAGES, {})
+        data = join(starmap(self._resolve_entry, stages.items()))
+        return {**self.d, STAGES: data}

--- a/dvc/parsing/context.py
+++ b/dvc/parsing/context.py
@@ -1,47 +1,217 @@
 import os
+from collections import defaultdict
+from collections.abc import Mapping, MutableMapping, MutableSequence
+from copy import deepcopy
+from dataclasses import dataclass, field, replace
+from typing import Any, List, Optional, Union
 
-from funcy import get_in
-
-from dvc.config import merge as _merge
 from dvc.utils.serialize import LOADERS
 
 
-def _key_parts(key):
-    return key.split(sep=".")
+def _merge(into, update, overwrite):
+    for key, val in update.items():
+        if isinstance(into.get(key), Mapping) and isinstance(val, Mapping):
+            _merge(into[key], val, overwrite)
+        else:
+            if key in into and not overwrite:
+                raise ValueError(
+                    f"Cannot overwrite as key {key} already exists in {into}"
+                )
+            into[key] = val
 
 
-class Context(dict):
-    @classmethod
-    def load(cls, file: str):
-        # supports yaml1.2, toml and json
-        d = LOADERS[os.path.splitext(file)[1]](file)
-        # TODO: what to do for the scalar values?
-        return cls(d or {})
+@dataclass
+class Meta:
+    # this value is useless for Containers, it's only used to drill down to
+    # `Value` for the first time on initialization.
+    # Rethink how this should be handled.
+    source: Optional[str]
+    import_dpath: Optional[str] = None
+    imported_as: Optional[str] = None
 
-    @classmethod
-    def load_and_select(cls, file, key=None):
-        ctx = cls.load(file)
-        return ctx.select(key) if key else ctx
+    dpaths: List[str] = field(default_factory=list)
+    aliased: Optional[str] = None
 
     @staticmethod
-    def merge(*args):
-        assert len(args) >= 2
-        m_dct, *rems = args
-        for d in rems:
-            _merge(m_dct, d)
-        return m_dct
+    def update_path(meta: "Meta", path):
+        if meta.aliased:
+            return meta
+        dpaths = meta.dpaths[:] + [path]
+        return replace(meta, dpaths=dpaths)
 
-    def update(self, key, value):
-        *parts, to_replace = _key_parts(key)
-        d = self
-        for part in parts:
-            d = d[part]
+    def __str__(self):
+        string = self.source or "<local>:"
+        if self.import_dpath:
+            string += ":"
+        string += self.path()
+        return string
 
-        d[to_replace] = value
-        return self
+    def path(self):
+        dpath = list(self.dpaths or [])
+        if self.import_dpath:
+            dpath = [self.import_dpath] + dpath
+        return ".".join(dpath)
+
+
+@dataclass
+class Value:
+    value: Any
+    meta: Optional[Meta] = field(compare=False, default=None, repr=False)
+
+    def __str__(self):
+        return str(self.value)
+
+
+class Container:
+    _meta: Meta
+    data: Union[list, dict]
+    _key_transform = staticmethod(lambda x: x)
+
+    def _convert(self, index, value):
+        meta = Meta.update_path(self._meta, index)
+        if value is None or isinstance(value, (int, float, str, bytes, bool)):
+            return Value(value, meta=meta)
+        elif isinstance(value, (CtxList, CtxDict, Value)):
+            return value
+        elif isinstance(value, (list, dict)):
+            container = CtxDict if isinstance(value, dict) else CtxList
+            return container(value, meta=meta)
+        else:
+            msg = "Unsupported value of type '{value}' in '{meta}'"
+            raise TypeError(msg)
+
+    def __setitem__(self, index, value):
+        self.data[index] = self._convert(index, value)
+
+    def __repr__(self):
+        return "".join(["<", self.__class__.__name__, ": ", str(self), ">"])
+
+    def __str__(self):
+        return str(self.data)
+
+    def __eq__(self, o):
+        return o.data == self.data
+
+    def __getitem__(self, k):
+        return self.data[k]
+
+    def __delitem__(self, v):
+        del self.data[v]
+
+    def __iter__(self):
+        return iter(self.data)
+
+    def __len__(self):
+        return len(self.data)
 
     def select(self, key: str):
-        d = get_in(self, _key_parts(key))
-        # TODO: what to do for the scalar values?
-        assert isinstance(d, (Context, dict))
-        return Context(d) if isinstance(d, dict) else d
+        index, *rems = key.split(sep=".", maxsplit=1)
+        index = self._key_transform(index)
+        try:
+            d = self.data[index]
+        except LookupError as exc:
+            raise ValueError(
+                f"Could not find '{index}' in {self.data}"
+            ) from exc
+
+        return d.select(rems[0]) if rems else d
+
+
+class CtxList(Container, MutableSequence):
+
+    _key_transform = staticmethod(int)
+
+    def __init__(self, values, meta, **kwargs):
+        self._meta = meta
+        self.data: list = []
+        self.extend(values)
+
+    def insert(self, index: int, value):
+        self.data.insert(index, self._convert(index, value))
+
+
+class CtxDict(Container, MutableMapping):
+    def __init__(self, mapping, meta, **kwargs):
+        self._meta = meta
+        mapping = mapping or {}
+        mapping.update(**kwargs)
+        self.data: dict = {}
+        self.update(mapping)
+
+    def __setitem__(self, key, value):
+        if not isinstance(key, str):
+            # limitations for the interpolation ignore other kinds of keys
+            return
+        return super().__setitem__(key, value)
+
+    def merge_update(self, *args, overwrite=True):
+        for d in args:
+            _merge(self.data, d, overwrite=overwrite)
+
+
+class Context(Container):
+    def __init__(self, data: Union[CtxDict, CtxList]):
+        self.data: Union[CtxDict, CtxList] = data
+        self._meta = Meta(source=None)
+        self._tracked_data = defaultdict(list)
+
+    @classmethod
+    def create(cls, d, source):
+        return cls(cls._make_context(d, Meta(source=source)))
+
+    @classmethod
+    def _make_context(cls, data, meta):
+        if isinstance(data, (CtxDict, CtxList)):
+            return data
+
+        if not isinstance(data, (list, dict)):
+            raise ValueError(
+                "Does not support loading types other than list or dict"
+            )
+        container = CtxDict if isinstance(data, dict) else CtxList
+        return container(data, meta=meta)
+
+    @classmethod
+    def load_variables(cls, imports: List[str], constants):
+        d = map(cls._load_and_select, imports)
+        m = cls._make_context(constants, Meta(source=None))
+        m.merge_update(*d)
+        return cls(m)
+
+    @classmethod
+    def clone(cls, ctx):
+        """Clones given context."""
+        return cls(deepcopy(ctx.data))
+
+    @classmethod
+    def _load(cls, file: str):
+        return LOADERS[os.path.splitext(file)[1]](file)
+
+    @classmethod
+    def _load_and_select(cls, imp: str):
+        file, *dpath = imp.rsplit(":", maxsplit=1)
+        key = dpath[0] if dpath else None
+        # TODO: normalize file path before passing it to the Meta
+        # Note that `source` should be relative to the path of the
+        # dvc.yaml file rather than the pwd.
+        meta = Meta(source=file, imported_as=imp, import_dpath=key)
+        d = cls._make_context(cls._load(file), meta=meta)
+        return d.select(dpath[0]) if dpath else d
+
+    def select(
+        self, key: str, track=False
+    ):  # pylint: disable=arguments-differ
+        node = self.data.select(key)
+        if isinstance(node, Value):
+            meta = node.meta
+            if meta and meta.source and track:
+                self._tracked_data[meta.source].append(meta.path())
+        return node
+
+    @property
+    def tracked(self):
+        return [{file: keys} for file, keys in self._tracked_data.items()]
+
+    def merge_update(self, *args, overwrite=False):
+        for ctx in args:
+            _merge(self.data, ctx.data, overwrite=overwrite)

--- a/dvc/parsing/context.py
+++ b/dvc/parsing/context.py
@@ -1,0 +1,47 @@
+import os
+
+from funcy import get_in
+
+from dvc.config import merge as _merge
+from dvc.utils.serialize import LOADERS
+
+
+def _key_parts(key):
+    return key.split(sep=".")
+
+
+class Context(dict):
+    @classmethod
+    def load(cls, file: str):
+        # supports yaml1.2, toml and json
+        d = LOADERS[os.path.splitext(file)[1]](file)
+        # TODO: what to do for the scalar values?
+        return cls(d or {})
+
+    @classmethod
+    def load_and_select(cls, file, key=None):
+        ctx = cls.load(file)
+        return ctx.select(key) if key else ctx
+
+    @staticmethod
+    def merge(*args):
+        assert len(args) >= 2
+        m_dct, *rems = args
+        for d in rems:
+            _merge(m_dct, d)
+        return m_dct
+
+    def update(self, key, value):
+        *parts, to_replace = _key_parts(key)
+        d = self
+        for part in parts:
+            d = d[part]
+
+        d[to_replace] = value
+        return self
+
+    def select(self, key: str):
+        d = get_in(self, _key_parts(key))
+        # TODO: what to do for the scalar values?
+        assert isinstance(d, (Context, dict))
+        return Context(d) if isinstance(d, dict) else d

--- a/dvc/parsing/interpolate.py
+++ b/dvc/parsing/interpolate.py
@@ -1,0 +1,61 @@
+import re
+
+KEYCRE = re.compile(
+    r"""
+    (?<!\\)                   # escape \${} or ${{}}
+    \$                        # starts with $
+    (?:({{)|({))              # either starts with double braces or single
+    ([\w._ \\/-]*?)           # match every char, attr access through "."
+    (?(1)}})(?(2)})           # end with same kinds of braces it opened with
+""",
+    re.VERBOSE,
+)
+
+
+def _maybe_int(s):
+    try:
+        return int(s)
+    except ValueError:
+        return s
+
+
+def _get_item(val, attr):
+    try:
+        return val[attr]
+    except KeyError:
+        # for dict, index could be str or int, from `maybe_int()`
+        # parsing above: i.e. {"2": "two"} vs {2: "two"}
+        if not (isinstance(val, dict) and isinstance(attr, int)):
+            raise
+        return val[str(attr)]
+
+
+def get_value(val, key):
+    obj_and_attrs = map(_maybe_int, key.strip().split("."))
+    value = val
+    for attr in obj_and_attrs:
+        if attr == "":
+            raise ValueError("Syntax error!")
+
+        try:
+            value = _get_item(value, attr)
+        except KeyError:
+            msg = (
+                f"Could not find '{attr}' "
+                "while substituting "
+                f"'{key}'.\n"
+                f"Interpolating with: {val}"
+            )
+            raise ValueError(msg)
+    return value
+
+
+def find_match(template):
+    return list(KEYCRE.finditer(template))
+
+
+def str_interpolate(template, replace_strings):
+    buf = str(template)
+    for replace_string, value in replace_strings.items():
+        buf = buf.replace(replace_string, str(value))
+    return buf

--- a/dvc/parsing/interpolate.py
+++ b/dvc/parsing/interpolate.py
@@ -1,4 +1,9 @@
 import re
+from collections.abc import Mapping
+
+from funcy import lmap, rpartial
+
+from dvc.parsing.context import Value
 
 KEYCRE = re.compile(
     r"""
@@ -12,50 +17,57 @@ KEYCRE = re.compile(
 )
 
 
-def _maybe_int(s):
-    try:
-        return int(s)
-    except ValueError:
-        return s
-
-
-def _get_item(val, attr):
-    try:
-        return val[attr]
-    except KeyError:
-        # for dict, index could be str or int, from `maybe_int()`
-        # parsing above: i.e. {"2": "two"} vs {2: "two"}
-        if not (isinstance(val, dict) and isinstance(attr, int)):
-            raise
-        return val[str(attr)]
-
-
-def get_value(val, key):
-    obj_and_attrs = map(_maybe_int, key.strip().split("."))
-    value = val
-    for attr in obj_and_attrs:
-        if attr == "":
-            raise ValueError("Syntax error!")
-
-        try:
-            value = _get_item(value, attr)
-        except KeyError:
-            msg = (
-                f"Could not find '{attr}' "
-                "while substituting "
-                f"'{key}'.\n"
-                f"Interpolating with: {val}"
-            )
-            raise ValueError(msg)
-    return value
-
-
-def find_match(template):
+def _find_match(template):
     return list(KEYCRE.finditer(template))
 
 
-def str_interpolate(template, replace_strings):
+def _str_interpolate(template, replace_strings):
     buf = str(template)
     for replace_string, value in replace_strings.items():
+        if not isinstance(value, Value):
+            raise TypeError(
+                "Cannot interpolate to string that's not a primitive",
+                "received: ",
+                type(value),
+            )
         buf = buf.replace(replace_string, str(value))
     return buf
+
+
+def _resolve_str(src, context):
+    if isinstance(src, str):
+        matches = _find_match(src)
+        num_matches = len(matches)
+        if num_matches:
+            to_replace = {}
+            for match in matches:
+                expr = match.group()
+                expand_and_track, _, inner = match.groups()
+                track = expand_and_track
+                if expr not in to_replace:
+                    to_replace[expr] = context.select(inner, track=track)
+            # replace "${enabled}", if `enabled` is a boolean, with it's actual
+            # value rather than it's string counterparts.
+            if num_matches == 1 and src == matches[0].group(0):
+                values = list(to_replace.values())
+                assert len(values) == 1
+                return values[0].value
+            # but not "${num} days"
+            src = _str_interpolate(src, to_replace)
+
+    # regex already backtracks and avoids any `${` starting with
+    # backslashes(`\`). We just need to replace those by `${`.
+    # FIXME: how to fix "\${abc} ${abc}"? right now, both will be replaced
+    return src.replace(r"\${", "${")
+
+
+def resolve(src, context):
+    # TODO: can we do this better?
+    Seq = (list, tuple, set)
+
+    apply_value = rpartial(resolve, context)
+    if isinstance(src, Mapping):
+        return {key: apply_value(value) for key, value in src.items()}
+    elif isinstance(src, Seq):
+        return lmap(apply_value, src)
+    return _resolve_str(src, context)


### PR DESCRIPTION
Expansion is based on `${var}` syntax, whereas `${{ var }}` can be
used for auto-tracking + expansion.

It needs the strucuture for `dvc.yaml` to be:
```yaml
args:
  imports:
    - params.yaml
  constants:
    a: 3

stages:
  ...
```

Auto-tracking is limited to imports from `params.yaml`.

I don't intend to merge this, this is just a simple-prototype to see how it feels. Looking to ask @dmpetrov for feedback later, this only works on happy-path cases and will report very bad error messages.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
