### PR TITLE
metrics show: allow falsey values

### DIFF
--- a/dvc/command/metrics.py
+++ b/dvc/command/metrics.py
@@ -67,8 +67,8 @@ class CmdMetricsShow(CmdMetricsBase):
                     self.args.all_tags,
                     self.args.all_commits,
                 )
-                for _line in lines:
-                    logger.info(lines)
+                for line in lines:
+                    logger.info(line)
         except DvcException:
             logger.exception("failed to show metrics")
             return 1

--- a/dvc/command/metrics.py
+++ b/dvc/command/metrics.py
@@ -38,7 +38,7 @@ def _show_metrics(
     if missing:
         raise BadMetricError(missing)
 
-    return lines
+    return "\n".join(lines)
 
 
 class CmdMetricsBase(CmdBase):
@@ -61,14 +61,14 @@ class CmdMetricsShow(CmdMetricsBase):
 
                 logger.info(json.dumps(metrics))
             else:
-                lines = _show_metrics(
+                table = _show_metrics(
                     metrics,
                     self.args.all_branches,
                     self.args.all_tags,
                     self.args.all_commits,
                 )
-                for line in lines:
-                    logger.info(line)
+                if table:
+                    logger.info(table)
         except DvcException:
             logger.exception("failed to show metrics")
             return 1

--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -4,7 +4,7 @@ import os
 
 from dvc.command import completion
 from dvc.command.base import CmdBase, append_doc_link
-from dvc.command.metrics import show_metrics
+from dvc.command.metrics import CmdMetricsShow
 from dvc.command.status import CmdDataStatus
 from dvc.dvcfile import PIPELINE_FILE
 from dvc.exceptions import DvcException
@@ -51,7 +51,7 @@ class CmdRepro(CmdBase):
 
                 if self.args.metrics:
                     metrics = self.repo.metrics.show()
-                    show_metrics(metrics)
+                    CmdMetricsShow(metrics)
             except DvcException:
                 logger.exception("")
                 ret = 1

--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -51,9 +51,7 @@ class CmdRepro(CmdBase):
 
                 if self.args.metrics:
                     metrics = self.repo.metrics.show()
-                    lines = _show_metrics(metrics)
-                    for line in lines:
-                        logger.info(line)
+                    logger.info(_show_metrics(metrics))
 
             except DvcException:
                 logger.exception("")

--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -4,7 +4,7 @@ import os
 
 from dvc.command import completion
 from dvc.command.base import CmdBase, append_doc_link
-from dvc.command.metrics import CmdMetricsShow
+from dvc.command.metrics import _show_metrics
 from dvc.command.status import CmdDataStatus
 from dvc.dvcfile import PIPELINE_FILE
 from dvc.exceptions import DvcException
@@ -51,7 +51,10 @@ class CmdRepro(CmdBase):
 
                 if self.args.metrics:
                     metrics = self.repo.metrics.show()
-                    CmdMetricsShow(metrics)
+                    lines = _show_metrics(metrics)
+                    for line in lines:
+                        logger.info(line)
+
             except DvcException:
                 logger.exception("")
                 ret = 1

--- a/dvc/repo/metrics/show.py
+++ b/dvc/repo/metrics/show.py
@@ -48,7 +48,7 @@ def _extract_metrics(metrics, path, rev):
     ret = {}
     for key, val in metrics.items():
         m = _extract_metrics(val, path, rev)
-        if m:
+        if m not in (None, {}):
             ret[key] = m
         else:
             logger.debug(
@@ -80,7 +80,7 @@ def _read_metrics(repo, metrics, rev):
             continue
 
         val = _extract_metrics(val, metric, rev)
-        if val:
+        if val not in (None, {}):
             res[str(metric)] = val
 
     return res

--- a/tests/func/metrics/test_show.py
+++ b/tests/func/metrics/test_show.py
@@ -160,3 +160,10 @@ def test_non_metric_and_recurisve_show(tmp_dir, dvc, run_copy_metrics):
             "metrics_t.yaml": {"foo": 1.1},
         }
     }
+
+
+def test_show_falsey(tmp_dir, dvc):
+    tmp_dir.gen("metrics.json", '{"foo": 0, "bar": 0.0, "baz": {}}')
+    assert dvc.metrics.show(targets=["metrics.json"]) == {
+        "": {"metrics.json": {"foo": 0, "bar": 0.0}}
+    }

--- a/tests/unit/command/test_metrics.py
+++ b/tests/unit/command/test_metrics.py
@@ -1,7 +1,12 @@
 import textwrap
 
 from dvc.cli import parse_args
-from dvc.command.metrics import CmdMetricsDiff, CmdMetricsShow, _show_diff
+from dvc.command.metrics import (
+    CmdMetricsDiff,
+    CmdMetricsShow,
+    _show_diff,
+    _show_metrics,
+)
 
 
 def test_metrics_diff(dvc, mocker):
@@ -233,3 +238,16 @@ def test_metrics_diff_with_old():
         metrics.yaml  a.d.e     3      4      1
         metrics.yaml  x.b       5      6      1"""
     )
+
+
+def test_metrics_show_with_valid_falsey_values():
+    assert _show_metrics(
+        {"branch_1": {"metrics.json": {"a": 0, "b": {"ad": 0.0, "bc": 0.0}}}},
+        all_branches=True,
+    ) == [
+        "branch_1:",
+        "\tmetrics.json:",
+        "\t\ta: 0",
+        "\t\tb.ad: 0.0",
+        "\t\tb.bc: 0.0",
+    ]

--- a/tests/unit/command/test_metrics.py
+++ b/tests/unit/command/test_metrics.py
@@ -244,10 +244,11 @@ def test_metrics_show_with_valid_falsey_values():
     assert _show_metrics(
         {"branch_1": {"metrics.json": {"a": 0, "b": {"ad": 0.0, "bc": 0.0}}}},
         all_branches=True,
-    ) == [
-        "branch_1:",
-        "\tmetrics.json:",
-        "\t\ta: 0",
-        "\t\tb.ad: 0.0",
-        "\t\tb.bc: 0.0",
-    ]
+    ) == textwrap.dedent(
+        """\
+        branch_1:
+        \tmetrics.json:
+        \t\ta: 0
+        \t\tb.ad: 0.0
+        \t\tb.bc: 0.0"""
+    )


### PR DESCRIPTION
Fixes #4630. 

Refactors `CmdMetricsShow` to use a hidden `_show_metrics` function that is more easily testable, similar to `_show_diff` for `CmdMetricsDiff`

Fixed a now broken import & implementation in `dvc/command/repro.py` caused by the change.

Added a simple test case which passes.

