### PR TITLE
Run CI for Python3.9

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,8 +36,8 @@ jobs:
         with:
           python-version: ${{ matrix.pyv }}
       - name: Install libxml2 and libxslt
-        if: matrix.pyv == "3.9-dev" && matrix.os == "ubuntu-18.04"
-        # need to install for building lxml
+        if: matrix.pyv == '3.9-dev' && matrix.os == 'ubuntu-18.04'
+        # need to install for building
         run: |
           sudo apt install libxml2 libxslt
       - name: install

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,11 +35,11 @@ jobs:
         uses: actions/setup-python@v2.1.2
         with:
           python-version: ${{ matrix.pyv }}
-      - name: Install libxml2 and libxslt-dev
+      - name: Install libxml2 and libxslt
         if: matrix.pyv == '3.9-dev' && matrix.os == 'ubuntu-18.04'
         # need to install for building
         run: |
-          sudo apt install libxml2 libxslt
+          sudo apt install libxml2 libxslt-dev
       - name: install
         run: |
           pip install ".[all,tests]"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,47 +11,42 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
-    - name: Install requirements
-      run: pip install ".[all,tests]" Pygments collective.checkdocs pre-commit
-    - name: Check README
-      run: python setup.py checkdocs
-    - name: Check formatting
-      run: pre-commit run --all-files
+      - uses: actions/checkout@v1
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install requirements
+        run: pip install ".[all,tests]" Pygments collective.checkdocs pre-commit
+      - name: Check README
+        run: python setup.py checkdocs
+      - name: Check formatting
+        run: pre-commit run --all-files
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, windows-2019, macos-10.15]
-        pyv: [3.6, 3.7, 3.8]
-        exclude:
-          - os: windows-2019
-            pyv: 3.8
+        os: [ubuntu-18.04]
+        pyv: ["3.9-dev"]
     steps:
-    - uses: actions/checkout@v2.3.2
-    - name: Set up Python
-      uses: actions/setup-python@v2.1.2
-      with:
-        python-version: ${{ matrix.pyv }}
-    - name: install
-      run: |
-        pip install ".[all,tests]"
-    - name: setup git
-      run: |
-        git config --global user.email "dvctester@example.com"
-        git config --global user.name "DVC Tester"
-    - name: run tests
-      run: python -m tests --cov-report=xml
-    - name: upload coverage report
-      if: github.event.name == 'push'
-      uses: codecov/codecov-action@v1.0.13
-      with:
-        file: ./coverage.xml
-        fail_ci_if_error: true
-
-
+      - uses: actions/checkout@v2.3.2
+      - name: Set up Python
+        uses: actions/setup-python@v2.1.2
+        with:
+          python-version: ${{ matrix.pyv }}
+      - name: install
+        run: |
+          pip install ".[all,tests]"
+      - name: setup git
+        run: |
+          git config --global user.email "dvctester@example.com"
+          git config --global user.name "DVC Tester"
+      - name: run tests
+        run: python -m tests --cov-report=xml
+      - name: upload coverage report
+        if: github.event.name == 'push'
+        uses: codecov/codecov-action@v1.0.13
+        with:
+          file: ./coverage.xml
+          fail_ci_if_error: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/setup-python@v2.1.2
         with:
           python-version: ${{ matrix.pyv }}
-      - name: Install libxml2 and libxslt
+      - name: Install libxml2 and libxslt-dev
         if: matrix.pyv == '3.9-dev' && matrix.os == 'ubuntu-18.04'
         # need to install for building
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,6 +35,11 @@ jobs:
         uses: actions/setup-python@v2.1.2
         with:
           python-version: ${{ matrix.pyv }}
+      - name: Install libxml2 and libxslt
+        if: matrix.pyv == "3.9-dev" && matrix.os == "ubuntu-18.04"
+        # need to install for building lxml
+        run: |
+          sudo apt install libxml2 libxslt
       - name: install
         run: |
           pip install ".[all,tests]"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,7 +48,7 @@ jobs:
           git config --global user.email "dvctester@example.com"
           git config --global user.name "DVC Tester"
       - name: run tests
-        run: python -m tests --cov-report=xml
+        run: python -m tests -rs --cov-report=xml
       - name: upload coverage report
         if: github.event.name == 'push'
         uses: codecov/codecov-action@v1.0.13

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import importlib.util
 import os
-import sys
 
 from setuptools import find_packages, setup
 from setuptools.command.build_py import build_py as _build_py
@@ -93,7 +92,9 @@ s3 = ["boto3>=1.9.201"]
 azure = ["azure-storage-blob>=12.0", "knack"]
 oss = ["oss2==2.6.1"]
 ssh = ["paramiko[invoke]>=2.7.0"]
-hdfs = ["pyarrow>=0.17.0"]
+
+# Remove the env marker if/when pyarrow is available for Python3.9
+hdfs = ["pyarrow>=0.17.0;  python_version < '3.9'"]
 webdav = ["webdavclient3>=3.14.5"]
 # gssapi should not be included in all_remotes, because it doesn't have wheels
 # for linux and mac, so it will fail to compile if user doesn't have all the
@@ -138,10 +139,8 @@ tests_requirements = [
     "pylint-plugin-utils",
     "wget",
     "filelock",
+    "black==19.10b0",
 ]
-
-if (sys.version_info) >= (3, 6):
-    tests_requirements.append("black==19.10b0")
 
 setup(
     name="dvc",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,9 @@
 import os
+import sys
+
+PY39 = sys.version_info >= (3, 9, 0)
+HDFS_SKIP_REASON = "pyarrow not available yet for Python3.9"
+
 
 # Increasing fd ulimit for tests
 if os.name == "nt":

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,8 +1,9 @@
 import os
 import sys
 
+# FIXME: Search and replace these from the tests if pyarrow wheel is available
 PY39 = sys.version_info >= (3, 9, 0)
-HDFS_SKIP_REASON = "pyarrow not available yet for Python3.9"
+PYARROW_NOT_AVAILABLE = "pyarrow not available yet for Python3.9"
 
 
 # Increasing fd ulimit for tests

--- a/tests/func/test_output.py
+++ b/tests/func/test_output.py
@@ -2,6 +2,7 @@ import pytest
 
 from dvc.output import OUTS_MAP, _get
 from dvc.stage import Stage
+from tests import PY39
 
 TESTS = [
     ("s3://bucket/path", "s3"),
@@ -17,6 +18,10 @@ TESTS = [
     ("..\\file", "local"),
     ("unknown://path", "local"),
 ]
+
+
+if not PY39:
+    TESTS.append(("hdfs://example.com/dir/path", "hdfs"))
 
 
 def _get_out(dvc, path):

--- a/tests/func/test_output.py
+++ b/tests/func/test_output.py
@@ -2,13 +2,14 @@ import pytest
 
 from dvc.output import OUTS_MAP, _get
 from dvc.stage import Stage
-from tests import PY39
+from tests import PY39, PYARROW_NOT_AVAILABLE
+
+MARKERS = [pytest.mark.skipif(PY39, reason=PYARROW_NOT_AVAILABLE)]
 
 TESTS = [
     ("s3://bucket/path", "s3"),
     ("gs://bucket/path", "gs"),
     ("ssh://example.com:/dir/path", "ssh"),
-    ("hdfs://example.com/dir/path", "hdfs"),
     ("path/to/file", "local"),
     ("path\\to\\file", "local"),
     ("file", "local"),
@@ -17,11 +18,9 @@ TESTS = [
     ("../file", "local"),
     ("..\\file", "local"),
     ("unknown://path", "local"),
+    pytest.param("hdfs://example.com/dir/path", "hdfs", marks=MARKERS),
+    pytest.param("hdfs://example.com/dir/path", "hdfs", marks=MARKERS),
 ]
-
-
-if not PY39:
-    TESTS.append(("hdfs://example.com/dir/path", "hdfs"))
 
 
 def _get_out(dvc, path):

--- a/tests/func/test_version.py
+++ b/tests/func/test_version.py
@@ -1,13 +1,14 @@
 import re
 
 from dvc.main import main
+from tests.unit.test_info import PYTHON_VERSION_REGEX
 
 
 def test_(tmp_dir, dvc, scm, caplog):
     assert main(["version"]) == 0
 
     assert re.search(r"DVC version: \d+\.\d+\.\d+.*", caplog.text)
-    assert re.search(r"Platform: Python \d\.\d+\.\d+ on .*", caplog.text)
+    assert re.search(f"Platform: {PYTHON_VERSION_REGEX} on .*", caplog.text)
     assert re.search(r"Supports: .*", caplog.text)
     assert re.search(r"Cache types: .*", caplog.text)
     assert "Repo: dvc, git" in caplog.text

--- a/tests/remotes/hdfs.py
+++ b/tests/remotes/hdfs.py
@@ -1,13 +1,13 @@
 import locale
 import os
 import platform
-import sys
 import uuid
 from contextlib import contextmanager
 
 import pytest
 
 from dvc.path_info import URLInfo
+from tests import PY39, PYARROW_NOT_AVAILABLE
 
 from .base import Base
 
@@ -74,8 +74,8 @@ def hadoop():
     if platform.system() != "Linux":
         pytest.skip("only supported on Linux")
 
-    if sys.version_info >= (3, 9, 0):
-        pytest.skip("pyarrow not available yet for Python3.9")
+    if PY39:
+        pytest.skip(PYARROW_NOT_AVAILABLE)
 
     import wget
     from appdirs import user_cache_dir

--- a/tests/remotes/hdfs.py
+++ b/tests/remotes/hdfs.py
@@ -1,6 +1,7 @@
 import locale
 import os
 import platform
+import sys
 import uuid
 from contextlib import contextmanager
 
@@ -70,11 +71,14 @@ class HDFS(Base, URLInfo):  # pylint: disable=abstract-method
 
 @pytest.fixture(scope="session")
 def hadoop():
-    import wget
-    from appdirs import user_cache_dir
-
     if platform.system() != "Linux":
         pytest.skip("only supported on Linux")
+
+    if sys.version_info >= (3, 9, 0):
+        pytest.skip("pyarrow not available yet for Python3.9")
+
+    import wget
+    from appdirs import user_cache_dir
 
     hadoop_name = "hadoop-2.7.2.tar.gz"
     java_name = "openjdk-7u75-b13-linux-x64-18_dec_2014.tar.gz"

--- a/tests/unit/dependency/test_hdfs.py
+++ b/tests/unit/dependency/test_hdfs.py
@@ -1,11 +1,11 @@
 import pytest
 
 from dvc.dependency.hdfs import HDFSDependency
-from tests import HDFS_SKIP_REASON, PY39
+from tests import PY39, PYARROW_NOT_AVAILABLE
 from tests.unit.dependency.test_local import TestLocalDependency
 
 
-@pytest.mark.skipif(PY39, reason=HDFS_SKIP_REASON)
+@pytest.mark.skipif(PY39, reason=PYARROW_NOT_AVAILABLE)
 class TestHDFSDependency(TestLocalDependency):
     def _get_cls(self):
         return HDFSDependency

--- a/tests/unit/dependency/test_hdfs.py
+++ b/tests/unit/dependency/test_hdfs.py
@@ -1,7 +1,11 @@
+import pytest
+
 from dvc.dependency.hdfs import HDFSDependency
+from tests import HDFS_SKIP_REASON, PY39
 from tests.unit.dependency.test_local import TestLocalDependency
 
 
+@pytest.mark.skipif(PY39, reason=HDFS_SKIP_REASON)
 class TestHDFSDependency(TestLocalDependency):
     def _get_cls(self):
         return HDFSDependency

--- a/tests/unit/output/test_hdfs.py
+++ b/tests/unit/output/test_hdfs.py
@@ -1,7 +1,11 @@
+import pytest
+
 from dvc.output.hdfs import HDFSOutput
+from tests import HDFS_SKIP_REASON, PY39
 from tests.unit.output.test_local import TestLocalOutput
 
 
+@pytest.mark.skipif(PY39, reason=HDFS_SKIP_REASON)
 class TestHDFSOutput(TestLocalOutput):
     def _get_cls(self):
         return HDFSOutput

--- a/tests/unit/output/test_hdfs.py
+++ b/tests/unit/output/test_hdfs.py
@@ -1,11 +1,11 @@
 import pytest
 
 from dvc.output.hdfs import HDFSOutput
-from tests import HDFS_SKIP_REASON, PY39
+from tests import PY39, PYARROW_NOT_AVAILABLE
 from tests.unit.output.test_local import TestLocalOutput
 
 
-@pytest.mark.skipif(PY39, reason=HDFS_SKIP_REASON)
+@pytest.mark.skipif(PY39, reason=PYARROW_NOT_AVAILABLE)
 class TestHDFSOutput(TestLocalOutput):
     def _get_cls(self):
         return HDFSOutput

--- a/tests/unit/test_info.py
+++ b/tests/unit/test_info.py
@@ -6,6 +6,12 @@ import pytest
 
 from dvc.info import get_dvc_info, psutil
 
+# PYthon's version is in the shape of:
+# <major>.<minor>.<patch>[{a|b|rc}N][.postN][.devN]
+# `patch` is more than enough for the tests.
+# Refer PEP-0440 for complete regex just in-case.
+PYTHON_VERSION_REGEX = r"Python \d\.\d+\.\d+\S*"
+
 
 @pytest.mark.parametrize("scm_init", [True, False])
 def test_info_in_repo(scm_init, tmp_dir):
@@ -16,7 +22,7 @@ def test_info_in_repo(scm_init, tmp_dir):
     dvc_info = get_dvc_info()
 
     assert re.search(r"DVC version: \d+\.\d+\.\d+.*", dvc_info)
-    assert re.search(r"Platform: Python \d\.\d+\.\d+ on .*", dvc_info)
+    assert re.search(f"Platform: {PYTHON_VERSION_REGEX} on .*", dvc_info)
     assert re.search(r"Supports: .*", dvc_info)
     assert re.search(r"Cache types: .*", dvc_info)
 
@@ -60,7 +66,7 @@ def test_info_outside_of_repo(tmp_dir, caplog):
     dvc_info = get_dvc_info()
 
     assert re.search(r"DVC version: \d+\.\d+\.\d+.*", dvc_info)
-    assert re.search(r"Platform: Python \d\.\d+\.\d+ on .*", dvc_info)
+    assert re.search(f"Platform: {PYTHON_VERSION_REGEX} on .*", dvc_info)
     assert re.search(r"Supports: .*", dvc_info)
     assert not re.search(r"Cache types: .*", dvc_info)
     assert "Repo:" not in dvc_info
@@ -70,5 +76,5 @@ def test_info_outside_of_repo(tmp_dir, caplog):
 def test_fs_info_outside_of_repo(tmp_dir, caplog):
     dvc_info = get_dvc_info()
     assert re.search(r"DVC version: \d+\.\d+\.\d+.*", dvc_info)
-    assert re.search(r"Platform: Python \d\.\d+\.\d+ on .*", dvc_info)
+    assert re.search(f"Platform: {PYTHON_VERSION_REGEX} on .*", dvc_info)
     assert re.search(r"Supports: .*", dvc_info)


### PR DESCRIPTION
skips hdfs tests for 3.9

Also, `dvc[hdfs]` install will be a no-op until we have
a pyarrow wheel for 3.9.

Note that this does not add an entry to the classifier
claiming it supports 3.9, that will be added when 3.9
gets released (or, wait for pyarrow to be released).

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
