### PR TITLE
bump shtab dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ install_requires = [
     "tabulate>=0.8.7",
     "pygtrie==2.3.2",
     "dpath>=2.0.1,<3",
-    "shtab>=1.3.0,<2",
+    "shtab>=1.3.2,<2",
     "rich>=3.0.5",
     "dictdiffer>=0.8.1",
 ]


### PR DESCRIPTION
Fixes bash>=4.4 completion (https://github.com/iterative/shtab/pull/23 <- https://github.com/iterative/shtab/issues/22)

- [ ] depends on https://github.com/conda-forge/shtab-feedstock/pull/16