### PR TITLE
api.open: fix error if uncached file inside a dir is accessed

### DIFF
--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -611,7 +611,7 @@ class Repo:
         """Opens a specified resource as a file descriptor"""
 
         tree = RepoTree(self, stream=True, subrepos=True)
-        path = os.path.join(self.root_dir, path)
+        path = PathInfo(self.root_dir) / path
         try:
             with self.state:
                 with tree.open(

--- a/dvc/tree/repo.py
+++ b/dvc/tree/repo.py
@@ -150,13 +150,14 @@ class RepoTree(BaseTree):  # pylint:disable=abstract-method
             encoding = None
 
         tree, dvc_tree = self._get_tree_pair(path)
+        path_info = PathInfo(path)
         try:
-            return tree.open(path, mode=mode, encoding=encoding)
+            return tree.open(path_info, mode=mode, encoding=encoding)
         except FileNotFoundError:
             if not dvc_tree:
                 raise
 
-        return dvc_tree.open(path, mode=mode, encoding=encoding, **kwargs)
+        return dvc_tree.open(path_info, mode=mode, encoding=encoding, **kwargs)
 
     def exists(
         self, path, use_dvcignore=True


### PR DESCRIPTION
Wrap path in Repo.open_by_relpath() with PathInfo.
Closes #4650

@efiop @pared @pmrowla, How should we get rid of this class of bugs?

Should we test more or solve it with docstring + type-checking? I find a lot of our bugs is due to this kind of syntax error or assertion errors.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
