### PR TITLE
yaml: wrap ruamel's DuplicateKeyError

### DIFF
--- a/dvc/command/status.py
+++ b/dvc/command/status.py
@@ -72,6 +72,6 @@ class CmdDataStatus(CmdDataBase):
                 logger.info(self.UP_TO_DATE_MSG)
 
         except DvcException:
-            logger.exception("failed to obtain data status")
+            logger.exception("")
             return 1
         return 0

--- a/tests/unit/utils/serialize/test_yaml.py
+++ b/tests/unit/utils/serialize/test_yaml.py
@@ -1,0 +1,14 @@
+import pytest
+
+from dvc.utils.serialize._yaml import YAMLError, parse_yaml
+
+
+def test_parse_yaml_duplicate_key_error():
+    text = """\
+    mykey:
+    - foo
+    mykey:
+    - bar
+    """
+    with pytest.raises(YAMLError, match='found duplicate key "mykey"'):
+        parse_yaml(text, "mypath")


### PR DESCRIPTION
Unfortunately ruamel's exception doesn't contain much info that we could
reuse, so we can only reasonably extract the exc.problem and have       
something like:                                                         
                                                                        
```                                                                     
ERROR: unable to read: 'dvc.yaml', found duplicate key "metrics" with value "[]" (original value: "[]")          
```                                                                     

Fixes #4664

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
