### PR TITLE
experiments: migrate `dvc repro -e` to `dvc exp run`

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -7,11 +7,10 @@ from datetime import date
 from itertools import groupby
 from typing import Iterable, Optional
 
-from dvc.command import completion
 from dvc.command.base import CmdBase, append_doc_link, fix_subparsers
-from dvc.command.metrics import DEFAULT_PRECISION, _show_metrics
-from dvc.command.status import CmdDataStatus
-from dvc.dvcfile import PIPELINE_FILE
+from dvc.command.metrics import DEFAULT_PRECISION
+from dvc.command.repro import CmdRepro
+from dvc.command.repro import add_arguments as add_repro_arguments
 from dvc.exceptions import DvcException, InvalidArgumentError
 from dvc.utils.flatten import flatten
 
@@ -388,7 +387,7 @@ class CmdExperimentsDiff(CmdBase):
         return 0
 
 
-class CmdExperimentsRun(CmdBase):
+class CmdExperimentsRun(CmdRepro):
     def run(self):
         if not self.repo.experiments:
             return 0
@@ -405,20 +404,8 @@ class CmdExperimentsRun(CmdBase):
         ret = 0
         for target in self.args.targets:
             try:
-                stages = self.repo.reproduce(
+                self.repo.experiments.run(
                     target,
-                    single_item=self.args.single_item,
-                    force=self.args.force,
-                    dry=self.args.dry,
-                    interactive=self.args.interactive,
-                    pipeline=self.args.pipeline,
-                    all_pipelines=self.args.all_pipelines,
-                    run_cache=not self.args.no_run_cache,
-                    no_commit=self.args.no_commit,
-                    downstream=self.args.downstream,
-                    recursive=self.args.recursive,
-                    force_downstream=self.args.force_downstream,
-                    experiment=True,
                     queue=self.args.queue,
                     run_all=self.args.run_all,
                     jobs=self.args.jobs,
@@ -428,15 +415,8 @@ class CmdExperimentsRun(CmdBase):
                         or self.args.checkpoint_continue is not None
                     ),
                     checkpoint_continue=self.args.checkpoint_continue,
+                    **self._repro_kwargs,
                 )
-
-                if len(stages) == 0:
-                    logger.info(CmdDataStatus.UP_TO_DATE_MSG)
-
-                if self.args.metrics:
-                    metrics = self.repo.metrics.show()
-                    logger.info(_show_metrics(metrics))
-
             except DvcException:
                 logger.exception("")
                 ret = 1
@@ -636,105 +616,8 @@ def add_parser(subparsers, parent_parser):
         help=EXPERIMENTS_RUN_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    experiments_run_parser.add_argument(
-        "targets",
-        nargs="*",
-        help=f"Stages to reproduce. '{PIPELINE_FILE}' by default.",
-    ).complete = completion.DVC_FILE
-    experiments_run_parser.add_argument(
-        "-f",
-        "--force",
-        action="store_true",
-        default=False,
-        help="Reproduce even if dependencies were not changed.",
-    )
-    experiments_run_parser.add_argument(
-        "-s",
-        "--single-item",
-        action="store_true",
-        default=False,
-        help="Reproduce only single data item without recursive dependencies "
-        "check.",
-    )
-    experiments_run_parser.add_argument(
-        "-c",
-        "--cwd",
-        default=os.path.curdir,
-        help="Directory within your repo to reproduce from. Note: deprecated "
-        "by `dvc --cd <path>`.",
-        metavar="<path>",
-    )
-    experiments_run_parser.add_argument(
-        "-m",
-        "--metrics",
-        action="store_true",
-        default=False,
-        help="Show metrics after reproduction.",
-    )
-    experiments_run_parser.add_argument(
-        "--dry",
-        action="store_true",
-        default=False,
-        help="Only print the commands that would be executed without "
-        "actually executing.",
-    )
-    experiments_run_parser.add_argument(
-        "-i",
-        "--interactive",
-        action="store_true",
-        default=False,
-        help="Ask for confirmation before reproducing each stage.",
-    )
-    experiments_run_parser.add_argument(
-        "-p",
-        "--pipeline",
-        action="store_true",
-        default=False,
-        help="Reproduce the whole pipeline that the specified stage file "
-        "belongs to.",
-    )
-    experiments_run_parser.add_argument(
-        "-P",
-        "--all-pipelines",
-        action="store_true",
-        default=False,
-        help="Reproduce all pipelines in the repo.",
-    )
-    experiments_run_parser.add_argument(
-        "-R",
-        "--recursive",
-        action="store_true",
-        default=False,
-        help="Reproduce all stages in the specified directory.",
-    )
-    experiments_run_parser.add_argument(
-        "--no-run-cache",
-        action="store_true",
-        default=False,
-        help=(
-            "Execute stage commands even if they have already been run with "
-            "the same command/dependencies/outputs/etc before."
-        ),
-    )
-    experiments_run_parser.add_argument(
-        "--force-downstream",
-        action="store_true",
-        default=False,
-        help="Reproduce all descendants of a changed stage even if their "
-        "direct dependencies didn't change.",
-    )
-    experiments_run_parser.add_argument(
-        "--no-commit",
-        action="store_true",
-        default=False,
-        help="Don't put files/directories into cache.",
-    )
-    experiments_run_parser.add_argument(
-        "--downstream",
-        action="store_true",
-        default=False,
-        help="Start from the specified stages when reproducing pipelines.",
-    )
+    # inherit arguments from `dvc repro`
+    add_repro_arguments(experiments_run_parser)
     experiments_run_parser.add_argument(
         "--params",
         action="append",

--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -26,26 +26,7 @@ class CmdRepro(CmdBase):
         ret = 0
         for target in self.args.targets:
             try:
-                stages = self.repo.reproduce(
-                    target,
-                    single_item=self.args.single_item,
-                    force=self.args.force,
-                    dry=self.args.dry,
-                    interactive=self.args.interactive,
-                    pipeline=self.args.pipeline,
-                    all_pipelines=self.args.all_pipelines,
-                    run_cache=not self.args.no_run_cache,
-                    no_commit=self.args.no_commit,
-                    downstream=self.args.downstream,
-                    recursive=self.args.recursive,
-                    force_downstream=self.args.force_downstream,
-                    experiment=self.args.experiment,
-                    queue=self.args.queue,
-                    run_all=self.args.run_all,
-                    jobs=self.args.jobs,
-                    params=self.args.params,
-                    pull=self.args.pull,
-                )
+                stages = self.repo.reproduce(target, **self._repro_kwargs)
 
                 if len(stages) == 0:
                     logger.info(CmdDataStatus.UP_TO_DATE_MSG)
@@ -62,18 +43,25 @@ class CmdRepro(CmdBase):
         os.chdir(saved_dir)
         return ret
 
+    @property
+    def _repro_kwargs(self):
+        return {
+            "single_item": self.args.single_item,
+            "force": self.args.force,
+            "dry": self.args.dry,
+            "interactive": self.args.interactive,
+            "pipeline": self.args.pipeline,
+            "all_pipelines": self.args.all_pipelines,
+            "run_cache": not self.args.no_run_cache,
+            "no_commit": self.args.no_commit,
+            "downstream": self.args.downstream,
+            "recursive": self.args.recursive,
+            "force_downstream": self.args.force_downstream,
+            "pull": self.args.pull,
+        }
 
-def add_parser(subparsers, parent_parser):
-    REPRO_HELP = (
-        "Reproduce complete or partial pipelines by executing their stages."
-    )
-    repro_parser = subparsers.add_parser(
-        "repro",
-        parents=[parent_parser],
-        description=append_doc_link(REPRO_HELP, "repro"),
-        help=REPRO_HELP,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
+
+def add_arguments(repro_parser):
     repro_parser.add_argument(
         "targets",
         nargs="*",
@@ -174,32 +162,6 @@ def add_parser(subparsers, parent_parser):
         help="Start from the specified stages when reproducing pipelines.",
     )
     repro_parser.add_argument(
-        "-e",
-        "--experiment",
-        action="store_true",
-        default=False,
-        help=argparse.SUPPRESS,
-    )
-    repro_parser.add_argument(
-        "--params",
-        action="append",
-        default=[],
-        help=argparse.SUPPRESS,
-        metavar="[<filename>:]<params_list>",
-    )
-    repro_parser.add_argument(
-        "--queue", action="store_true", default=False, help=argparse.SUPPRESS
-    )
-    repro_parser.add_argument(
-        "--run-all",
-        action="store_true",
-        default=False,
-        help=argparse.SUPPRESS,
-    )
-    repro_parser.add_argument(
-        "-j", "--jobs", type=int, help=argparse.SUPPRESS, metavar="<number>"
-    )
-    repro_parser.add_argument(
         "--pull",
         action="store_true",
         default=False,
@@ -208,4 +170,18 @@ def add_parser(subparsers, parent_parser):
             "from the run-cache."
         ),
     )
+
+
+def add_parser(subparsers, parent_parser):
+    REPRO_HELP = (
+        "Reproduce complete or partial pipelines by executing their stages."
+    )
+    repro_parser = subparsers.add_parser(
+        "repro",
+        parents=[parent_parser],
+        description=append_doc_link(REPRO_HELP, "repro"),
+        help=REPRO_HELP,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    add_arguments(repro_parser)
     repro_parser.set_defaults(func=CmdRepro)

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -777,3 +777,8 @@ class Experiments:
         from dvc.repo.experiments.show import show
 
         return show(self.repo, *args, **kwargs)
+
+    def run(self, *args, **kwargs):
+        from dvc.repo.experiments.run import run
+
+        return run(self.repo, *args, **kwargs)

--- a/dvc/repo/experiments/run.py
+++ b/dvc/repo/experiments/run.py
@@ -1,0 +1,67 @@
+import logging
+from typing import Iterable, Optional
+
+from dvc.exceptions import InvalidArgumentError
+from dvc.repo import locked
+from dvc.repo.experiments import UnchangedExperimentError
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_params(path_params: Iterable):
+    from ruamel.yaml import YAMLError
+
+    from dvc.dependency.param import ParamsDependency
+    from dvc.utils.flatten import unflatten
+    from dvc.utils.serialize import loads_yaml
+
+    ret = {}
+    for path_param in path_params:
+        path, _, params_str = path_param.rpartition(":")
+        # remove empty strings from params, on condition such as `-p "file1:"`
+        params = {}
+        for param_str in filter(bool, params_str.split(",")):
+            try:
+                # interpret value strings using YAML rules
+                key, value = param_str.split("=")
+                params[key] = loads_yaml(value)
+            except (ValueError, YAMLError):
+                raise InvalidArgumentError(
+                    f"Invalid param/value pair '{param_str}'"
+                )
+        if not path:
+            path = ParamsDependency.DEFAULT_PARAMS_FILE
+        ret[path] = unflatten(params)
+    return ret
+
+
+@locked
+def run(
+    repo,
+    target: Optional[str] = None,
+    params: Optional[Iterable] = None,
+    run_all: Optional[bool] = False,
+    jobs: Optional[int] = 1,
+    **kwargs,
+) -> dict:
+    """Reproduce the specified target as an experiment.
+
+    Accepts the same additional kwargs as Repo.reproduce.
+
+    Returns a dict mapping new experiment SHAs to the results
+    of `repro` for that experiment.
+    """
+    if run_all:
+        return repo.experiments.reproduce_queued(jobs=jobs)
+
+    if params:
+        params = _parse_params(params)
+    else:
+        params = []
+    try:
+        return repo.experiments.reproduce_one(
+            target=target, params=params, **kwargs
+        )
+    except UnchangedExperimentError:
+        # If experiment contains no changes, just run regular repro
+        return {None: repo.reproduce(target=target, **kwargs)}

--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -40,7 +40,7 @@ def test_show_experiment(tmp_dir, scm, dvc):
         scm.repo.rev_parse(baseline_rev).committed_date
     )
 
-    dvc.reproduce(PIPELINE_FILE, experiment=True, params=["foo=2"])
+    dvc.experiments.run(PIPELINE_FILE, params=["foo=2"])
     results = dvc.experiments.show()
 
     expected_baseline = {
@@ -76,9 +76,7 @@ def test_show_queued(tmp_dir, scm, dvc):
     scm.commit("baseline")
     baseline_rev = scm.get_rev()
 
-    dvc.reproduce(
-        stage.addressing, experiment=True, params=["foo=2"], queue=True
-    )
+    dvc.experiments.run(stage.addressing, params=["foo=2"], queue=True)
     exp_rev = dvc.experiments.scm.resolve_rev("stash@{0}")
 
     results = dvc.experiments.show()[baseline_rev]
@@ -93,9 +91,7 @@ def test_show_queued(tmp_dir, scm, dvc):
     scm.commit("new commit")
     new_rev = scm.get_rev()
 
-    dvc.reproduce(
-        stage.addressing, experiment=True, params=["foo=3"], queue=True
-    )
+    dvc.experiments.run(stage.addressing, params=["foo=3"], queue=True)
     exp_rev = dvc.experiments.scm.resolve_rev("stash@{0}")
 
     results = dvc.experiments.show()[new_rev]

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -6,6 +6,8 @@ from dvc.command.experiments import (
 )
 from dvc.dvcfile import PIPELINE_FILE
 
+from .test_repro import default_arguments as repro_arguments
+
 
 def test_experiments_diff(dvc, mocker):
     cli_args = parse_args(
@@ -61,32 +63,22 @@ def test_experiments_show(dvc, mocker):
     )
 
 
-default_run_arguments = {
-    "all_pipelines": False,
-    "downstream": False,
-    "dry": False,
-    "force": False,
-    "run_cache": True,
-    "interactive": False,
-    "no_commit": False,
-    "pipeline": False,
-    "single_item": False,
-    "recursive": False,
-    "force_downstream": False,
-    "params": [],
-    "queue": False,
-    "run_all": False,
-    "jobs": None,
-    "checkpoint": False,
-    "checkpoint_continue": None,
-    "experiment": True,
-}
-
-
 def test_experiments_run(dvc, mocker):
+    default_arguments = {
+        "params": [],
+        "queue": False,
+        "run_all": False,
+        "jobs": None,
+        "checkpoint": False,
+        "checkpoint_continue": None,
+    }
+
+    default_arguments.update(repro_arguments)
+
     cmd = CmdExperimentsRun(parse_args(["exp", "run"]))
     mocker.patch.object(cmd.repo, "reproduce")
+    mocker.patch.object(cmd.repo.experiments, "run")
     cmd.run()
-    cmd.repo.reproduce.assert_called_with(
-        PIPELINE_FILE, **default_run_arguments
+    cmd.repo.experiments.run.assert_called_with(
+        PIPELINE_FILE, **default_arguments
     )

--- a/tests/unit/command/test_repro.py
+++ b/tests/unit/command/test_repro.py
@@ -14,11 +14,6 @@ default_arguments = {
     "single_item": False,
     "recursive": False,
     "force_downstream": False,
-    "experiment": False,
-    "params": [],
-    "queue": False,
-    "run_all": False,
-    "jobs": None,
     "pull": False,
 }
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

* Finishes separating the experiments specific behavior from repro