### PR TITLE
tests build: buil on push/pr to master

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,9 +1,16 @@
 name: Tests build
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
 
 jobs:
   lint:
+    if: ${{ github.repository }} == 'iteratie/dvc'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.3.2
@@ -18,6 +25,7 @@ jobs:
     - name: Check formatting
       run: pre-commit run --all-files
   tests:
+    if: ${{ github.repository }} == 'iteratie/dvc'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Currently each time anyone pushes anything to any fork of DVC, the test build is triggered. I think we should not allow that. Since the only builds that are interesting to us are the ones for master commits/pull requests. 