### PR TITLE
dvc: update order of -q -v -h args

### DIFF
--- a/dvc/cli.py
+++ b/dvc/cli.py
@@ -129,8 +129,11 @@ class VersionAction(argparse.Action):  # pragma: no cover
         sys.exit(0)
 
 
-def add_common_args(parser):
+def add_common_args(parser, *, func=None):
     """Add common arguments shared among all the commands."""
+    if func:
+        parser.set_defaults(func=func)
+
     parser.add_argument(
         "--cprofile",
         action="store_true",

--- a/dvc/cli.py
+++ b/dvc/cli.py
@@ -129,19 +129,7 @@ class VersionAction(argparse.Action):  # pragma: no cover
         sys.exit(0)
 
 
-def get_parent_parser():
-    """Create instances of a parser containing common arguments shared among
-    all the commands.
-
-    When overwriting `-q` or `-v`, you need to instantiate a new object
-    in order to prevent some weird behavior.
-    """
-    parent_parser = argparse.ArgumentParser(add_help=False)
-    add_common_args(parent_parser)
-    return parent_parser
-
-
-def add_common_args(parser, add_help=False):
+def add_common_args(parser):
     """Add common arguments shared among all the commands."""
     parser.add_argument(
         "--cprofile",
@@ -159,15 +147,15 @@ def add_common_args(parser, add_help=False):
         "-v", "--verbose", action="count", default=0, help="Be verbose."
     )
 
-    if add_help:
-        # NOTE: We are doing this to capitalize help message.
-        parser.add_argument(
-            "-h",
-            "--help",
-            action="help",
-            default=argparse.SUPPRESS,
-            help="Show this help message and exit.",
-        )
+    # NOTE: We are doing this to capitalize help message and move it to the
+    # bottom of all agruments.
+    parser.add_argument(
+        "-h",
+        "--help",
+        action="help",
+        default=argparse.SUPPRESS,
+        help="Show this help message and exit.",
+    )
 
 
 def get_main_parser():
@@ -198,7 +186,7 @@ def get_main_parser():
         type=str,
     )
 
-    add_common_args(parser, add_help=True)
+    add_common_args(parser)
 
     # Sub commands
     subparsers = parser.add_subparsers(
@@ -210,12 +198,8 @@ def get_main_parser():
 
     fix_subparsers(subparsers)
 
-    parent_parser = get_parent_parser()
     for cmd in COMMANDS:
-        subparser = cmd.add_parser(subparsers, parent_parser)
-        if isinstance(subparser, argparse.ArgumentParser):
-            add_common_args(subparser, add_help=True)
-
+        cmd.add_parser(subparsers, add_common_args)
     return parser
 
 

--- a/dvc/command/add.py
+++ b/dvc/command/add.py
@@ -65,5 +65,4 @@ def add_parser(subparsers, add_common_args):
     parser.add_argument(
         "targets", nargs="+", help="Input files/directories to add.",
     ).complete = completion.FILE
-    parser.set_defaults(func=CmdAdd)
-    add_common_args(parser)
+    add_common_args(parser, func=CmdAdd)

--- a/dvc/command/add.py
+++ b/dvc/command/add.py
@@ -28,13 +28,13 @@ class CmdAdd(CmdBase):
         return 0
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     ADD_HELP = "Track data files or directories with DVC."
 
     parser = subparsers.add_parser(
         "add",
-        parents=[parent_parser],
         description=append_doc_link(ADD_HELP, "add"),
+        add_help=False,
         help=ADD_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -66,3 +66,4 @@ def add_parser(subparsers, parent_parser):
         "targets", nargs="+", help="Input files/directories to add.",
     ).complete = completion.FILE
     parser.set_defaults(func=CmdAdd)
+    add_common_args(parser)

--- a/dvc/command/cache.py
+++ b/dvc/command/cache.py
@@ -12,18 +12,19 @@ class CmdCacheDir(CmdConfig):
         return 0
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     from dvc.command.config import parent_config_parser
 
     CACHE_HELP = "Manage cache settings."
 
     cache_parser = subparsers.add_parser(
         "cache",
-        parents=[parent_parser],
         description=append_doc_link(CACHE_HELP, "cache"),
+        add_help=False,
         help=CACHE_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    add_common_args(cache_parser)
 
     cache_subparsers = cache_parser.add_subparsers(
         dest="cmd",
@@ -39,8 +40,9 @@ def add_parser(subparsers, parent_parser):
 
     cache_dir_parser = cache_subparsers.add_parser(
         "dir",
-        parents=[parent_parser, parent_cache_config_parser],
+        parents=[parent_cache_config_parser],
         description=append_doc_link(CACHE_HELP, "cache/dir"),
+        add_help=False,
         help=CACHE_DIR_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -58,3 +60,4 @@ def add_parser(subparsers, parent_parser):
         "config file location.",
     ).complete = completion.DIR
     cache_dir_parser.set_defaults(func=CmdCacheDir)
+    add_common_args(cache_dir_parser)

--- a/dvc/command/cache.py
+++ b/dvc/command/cache.py
@@ -59,5 +59,4 @@ def add_parser(subparsers, add_common_args):
         "to the current directory and saved to config relative to the "
         "config file location.",
     ).complete = completion.DIR
-    cache_dir_parser.set_defaults(func=CmdCacheDir)
-    add_common_args(cache_dir_parser)
+    add_common_args(cache_dir_parser, func=CmdCacheDir)

--- a/dvc/command/check_ignore.py
+++ b/dvc/command/check_ignore.py
@@ -79,15 +79,15 @@ class CmdCheckIgnore(CmdBase):
         return self._normal_mode()
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     ADD_HELP = (
         "Check whether files or directories are excluded due to `.dvcignore`."
     )
 
     parser = subparsers.add_parser(
         "check-ignore",
-        parents=[parent_parser],
         description=append_doc_link(ADD_HELP, "check-ignore"),
+        add_help=False,
         help=ADD_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -124,3 +124,4 @@ def add_parser(subparsers, parent_parser):
         "targets", nargs="*", help="File or directory paths to check",
     ).complete = completion.FILE
     parser.set_defaults(func=CmdCheckIgnore)
+    add_common_args(parser)

--- a/dvc/command/check_ignore.py
+++ b/dvc/command/check_ignore.py
@@ -123,5 +123,4 @@ def add_parser(subparsers, add_common_args):
     parser.add_argument(
         "targets", nargs="*", help="File or directory paths to check",
     ).complete = completion.FILE
-    parser.set_defaults(func=CmdCheckIgnore)
-    add_common_args(parser)
+    add_common_args(parser, func=CmdCheckIgnore)

--- a/dvc/command/checkout.py
+++ b/dvc/command/checkout.py
@@ -66,13 +66,13 @@ class CmdCheckout(CmdBase):
         return 0
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     CHECKOUT_HELP = "Checkout data files from cache."
 
     checkout_parser = subparsers.add_parser(
         "checkout",
-        parents=[parent_parser],
         description=append_doc_link(CHECKOUT_HELP, "checkout"),
+        add_help=False,
         help=CHECKOUT_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -118,3 +118,4 @@ def add_parser(subparsers, parent_parser):
         ),
     ).complete = completion.DVC_FILE
     checkout_parser.set_defaults(func=CmdCheckout)
+    add_common_args(checkout_parser)

--- a/dvc/command/checkout.py
+++ b/dvc/command/checkout.py
@@ -117,5 +117,4 @@ def add_parser(subparsers, add_common_args):
             ".dvc files, or stage names."
         ),
     ).complete = completion.DVC_FILE
-    checkout_parser.set_defaults(func=CmdCheckout)
-    add_common_args(checkout_parser)
+    add_common_args(checkout_parser, func=CmdCheckout)

--- a/dvc/command/commit.py
+++ b/dvc/command/commit.py
@@ -68,5 +68,4 @@ def add_parser(subparsers, add_common_args):
         help="DVC-files to commit. Optional. "
         "(Finds all DVC-files in the workspace by default.)",
     ).complete = completion.DVC_FILE
-    commit_parser.set_defaults(func=CmdCommit)
-    add_common_args(commit_parser)
+    add_common_args(commit_parser, func=CmdCommit)

--- a/dvc/command/commit.py
+++ b/dvc/command/commit.py
@@ -31,7 +31,7 @@ class CmdCommit(CmdBase):
         return 0
 
 
-def add_parser(subparsers, *args):
+def add_parser(subparsers, add_common_args):
     COMMIT_HELP = "Save changed data to cache and update DVC-files."
 
     commit_parser = subparsers.add_parser(
@@ -69,4 +69,4 @@ def add_parser(subparsers, *args):
         "(Finds all DVC-files in the workspace by default.)",
     ).complete = completion.DVC_FILE
     commit_parser.set_defaults(func=CmdCommit)
-    return commit_parser
+    add_common_args(commit_parser)

--- a/dvc/command/commit.py
+++ b/dvc/command/commit.py
@@ -31,13 +31,13 @@ class CmdCommit(CmdBase):
         return 0
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, *args):
     COMMIT_HELP = "Save changed data to cache and update DVC-files."
 
     commit_parser = subparsers.add_parser(
         "commit",
-        parents=[parent_parser],
         description=append_doc_link(COMMIT_HELP, "commit"),
+        add_help=False,
         help=COMMIT_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -69,3 +69,4 @@ def add_parser(subparsers, parent_parser):
         "(Finds all DVC-files in the workspace by default.)",
     ).complete = completion.DVC_FILE
     commit_parser.set_defaults(func=CmdCommit)
+    return commit_parser

--- a/dvc/command/completion.py
+++ b/dvc/command/completion.py
@@ -37,13 +37,13 @@ class CmdCompletion(CmdBaseNoRepo):
         return 0
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     COMPLETION_HELP = "Generate shell tab completion."
     COMPLETION_DESCRIPTION = "Prints out shell tab completion scripts."
     completion_parser = subparsers.add_parser(
         "completion",
-        parents=[parent_parser],
         description=append_doc_link(COMPLETION_DESCRIPTION, "completion"),
+        add_help=False,
         help=COMPLETION_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -55,3 +55,4 @@ def add_parser(subparsers, parent_parser):
         choices=["bash", "zsh"],
     )
     completion_parser.set_defaults(func=CmdCompletion)
+    add_common_args(completion_parser)

--- a/dvc/command/completion.py
+++ b/dvc/command/completion.py
@@ -54,5 +54,4 @@ def add_parser(subparsers, add_common_args):
         default="bash",
         choices=["bash", "zsh"],
     )
-    completion_parser.set_defaults(func=CmdCompletion)
-    add_common_args(completion_parser)
+    add_common_args(completion_parser, func=CmdCompletion)

--- a/dvc/command/config.py
+++ b/dvc/command/config.py
@@ -95,5 +95,4 @@ def add_parser(subparsers, add_common_args):
     )
     config_parser.add_argument("name", help="Option name.")
     config_parser.add_argument("value", nargs="?", help="Option value.")
-    config_parser.set_defaults(func=CmdConfig)
-    add_common_args(config_parser)
+    add_common_args(config_parser, func=CmdConfig)

--- a/dvc/command/config.py
+++ b/dvc/command/config.py
@@ -75,13 +75,14 @@ level_group.add_argument(
 parent_config_parser.set_defaults(level="repo")
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     CONFIG_HELP = "Get or set config options."
 
     config_parser = subparsers.add_parser(
         "config",
-        parents=[parent_config_parser, parent_parser],
+        parents=[parent_config_parser],
         description=append_doc_link(CONFIG_HELP, "config"),
+        add_help=False,
         help=CONFIG_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -95,3 +96,4 @@ def add_parser(subparsers, parent_parser):
     config_parser.add_argument("name", help="Option name.")
     config_parser.add_argument("value", nargs="?", help="Option value.")
     config_parser.set_defaults(func=CmdConfig)
+    add_common_args(config_parser)

--- a/dvc/command/daemon.py
+++ b/dvc/command/daemon.py
@@ -55,8 +55,7 @@ def add_parser(subparsers, add_common_args):
         add_help=False,
         help=DAEMON_UPDATER_HELP,
     )
-    daemon_updater_parser.set_defaults(func=CmdDaemonUpdater)
-    add_common_args(daemon_updater_parser)
+    add_common_args(daemon_updater_parser, func=CmdDaemonUpdater)
 
     DAEMON_ANALYTICS_HELP = "Send dvc usage analytics."
     daemon_analytics_parser = daemon_subparsers.add_parser(
@@ -68,5 +67,4 @@ def add_parser(subparsers, add_common_args):
     daemon_analytics_parser.add_argument(
         "target", help="Analytics file.",
     ).complete = completion.FILE
-    daemon_analytics_parser.set_defaults(func=CmdDaemonAnalytics)
-    add_common_args(daemon_analytics_parser)
+    add_common_args(daemon_analytics_parser, func=CmdDaemonAnalytics)

--- a/dvc/command/daemon.py
+++ b/dvc/command/daemon.py
@@ -34,14 +34,12 @@ class CmdDaemonAnalytics(CmdDaemonBase):
         return 0
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     DAEMON_HELP = "Service daemon."
     daemon_parser = subparsers.add_parser(
-        "daemon",
-        parents=[parent_parser],
-        description=DAEMON_HELP,
-        add_help=False,
+        "daemon", description=DAEMON_HELP, add_help=False,
     )
+    add_common_args(daemon_parser)
 
     daemon_subparsers = daemon_parser.add_subparsers(
         dest="cmd",
@@ -53,20 +51,22 @@ def add_parser(subparsers, parent_parser):
     DAEMON_UPDATER_HELP = "Fetch latest available version."
     daemon_updater_parser = daemon_subparsers.add_parser(
         "updater",
-        parents=[parent_parser],
         description=DAEMON_UPDATER_HELP,
+        add_help=False,
         help=DAEMON_UPDATER_HELP,
     )
     daemon_updater_parser.set_defaults(func=CmdDaemonUpdater)
+    add_common_args(daemon_updater_parser)
 
     DAEMON_ANALYTICS_HELP = "Send dvc usage analytics."
     daemon_analytics_parser = daemon_subparsers.add_parser(
         "analytics",
-        parents=[parent_parser],
         description=DAEMON_ANALYTICS_HELP,
+        add_help=False,
         help=DAEMON_ANALYTICS_HELP,
     )
     daemon_analytics_parser.add_argument(
         "target", help="Analytics file.",
     ).complete = completion.FILE
     daemon_analytics_parser.set_defaults(func=CmdDaemonAnalytics)
+    add_common_args(daemon_analytics_parser)

--- a/dvc/command/dag.py
+++ b/dvc/command/dag.py
@@ -84,12 +84,12 @@ class CmdDAG(CmdBase):
             return 1
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     DAG_HELP = "Visualize DVC project DAG."
     dag_parser = subparsers.add_parser(
         "dag",
-        parents=[parent_parser],
         description=append_doc_link(DAG_HELP, "dag"),
+        add_help=False,
         help=DAG_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -115,3 +115,4 @@ def add_parser(subparsers, parent_parser):
         "Finds all stages in the workspace by default.",
     )
     dag_parser.set_defaults(func=CmdDAG)
+    add_common_args(dag_parser)

--- a/dvc/command/dag.py
+++ b/dvc/command/dag.py
@@ -114,5 +114,4 @@ def add_parser(subparsers, add_common_args):
         help="Stage or output to show pipeline for (optional). "
         "Finds all stages in the workspace by default.",
     )
-    dag_parser.set_defaults(func=CmdDAG)
-    add_common_args(dag_parser)
+    add_common_args(dag_parser, func=CmdDAG)

--- a/dvc/command/data_sync.py
+++ b/dvc/command/data_sync.py
@@ -86,14 +86,11 @@ class CmdDataFetch(CmdDataBase):
         return 0
 
 
-def shared_parent_parser():
-    from dvc.cli import get_parent_parser
+def add_shared_args(parser):
+    from dvc.cli import add_common_args
 
     # Parent parser used in pull/push/status
-    parent_parser = argparse.ArgumentParser(
-        add_help=False, parents=[get_parent_parser()]
-    )
-    parent_parser.add_argument(
+    parser.add_argument(
         "-j",
         "--jobs",
         type=int,
@@ -104,7 +101,7 @@ def shared_parent_parser():
         ),
         metavar="<number>",
     )
-    parent_parser.add_argument(
+    parser.add_argument(
         "targets",
         nargs="*",
         help=(
@@ -113,10 +110,10 @@ def shared_parent_parser():
         ),
     ).complete = completion.DVC_FILE
 
-    return parent_parser
+    add_common_args(parser)
 
 
-def add_parser(subparsers, _parent_parser):
+def add_parser(subparsers, _add_common_args):
     from dvc.command.status import CmdDataStatus
 
     # Pull
@@ -124,11 +121,12 @@ def add_parser(subparsers, _parent_parser):
 
     pull_parser = subparsers.add_parser(
         "pull",
-        parents=[shared_parent_parser()],
         description=append_doc_link(PULL_HELP, "pull"),
+        add_help=False,
         help=PULL_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    add_shared_args(pull_parser)
     pull_parser.add_argument(
         "-r", "--remote", help="Remote storage to pull from", metavar="<name>",
     )
@@ -186,11 +184,12 @@ def add_parser(subparsers, _parent_parser):
 
     push_parser = subparsers.add_parser(
         "push",
-        parents=[shared_parent_parser()],
         description=append_doc_link(PUSH_HELP, "push"),
+        add_help=False,
         help=PUSH_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    add_shared_args(push_parser)
     push_parser.add_argument(
         "-r", "--remote", help="Remote storage to push to", metavar="<name>",
     )
@@ -244,11 +243,12 @@ def add_parser(subparsers, _parent_parser):
 
     fetch_parser = subparsers.add_parser(
         "fetch",
-        parents=[shared_parent_parser()],
         description=append_doc_link(FETCH_HELP, "fetch"),
+        add_help=False,
         help=FETCH_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    add_shared_args(fetch_parser)
     fetch_parser.add_argument(
         "-r",
         "--remote",
@@ -304,12 +304,13 @@ def add_parser(subparsers, _parent_parser):
 
     status_parser = subparsers.add_parser(
         "status",
-        parents=[shared_parent_parser()],
         description=append_doc_link(STATUS_HELP, "status"),
+        add_help=False,
         help=STATUS_HELP,
         conflict_handler="resolve",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    add_shared_args(status_parser)
     status_parser.add_argument(
         "-q",
         "--quiet",

--- a/dvc/command/destroy.py
+++ b/dvc/command/destroy.py
@@ -48,5 +48,4 @@ def add_parser(subparsers, add_common_args):
         default=False,
         help="Force destruction.",
     )
-    destroy_parser.set_defaults(func=CmdDestroy)
-    add_common_args(destroy_parser)
+    add_common_args(destroy_parser, func=CmdDestroy)

--- a/dvc/command/destroy.py
+++ b/dvc/command/destroy.py
@@ -31,13 +31,13 @@ class CmdDestroy(CmdBase):
         return 0
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     DESTROY_HELP = "Remove DVC-files, local DVC config and data cache."
 
     destroy_parser = subparsers.add_parser(
         "destroy",
-        parents=[parent_parser],
         description=append_doc_link(DESTROY_HELP, "destroy"),
+        add_help=False,
         help=DESTROY_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -49,3 +49,4 @@ def add_parser(subparsers, parent_parser):
         help="Force destruction.",
     )
     destroy_parser.set_defaults(func=CmdDestroy)
+    add_common_args(destroy_parser)

--- a/dvc/command/diff.py
+++ b/dvc/command/diff.py
@@ -155,15 +155,15 @@ class CmdDiff(CmdBase):
         return 0
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     DIFF_DESCRIPTION = (
         "Show added, modified, or deleted data between commits in the DVC"
         " repository, or between a commit and the workspace."
     )
     diff_parser = subparsers.add_parser(
         "diff",
-        parents=[parent_parser],
         description=append_doc_link(DIFF_DESCRIPTION, "diff"),
+        add_help=False,
         help=DIFF_DESCRIPTION,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -202,3 +202,4 @@ def add_parser(subparsers, parent_parser):
         action="store_true",
     )
     diff_parser.set_defaults(func=CmdDiff)
+    add_common_args(diff_parser)

--- a/dvc/command/diff.py
+++ b/dvc/command/diff.py
@@ -201,5 +201,4 @@ def add_parser(subparsers, add_common_args):
         help="Hide missing cache file status.",
         action="store_true",
     )
-    diff_parser.set_defaults(func=CmdDiff)
-    add_common_args(diff_parser)
+    add_common_args(diff_parser, func=CmdDiff)

--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -438,16 +438,17 @@ class CmdExperimentsRun(CmdRepro):
         return ret
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     EXPERIMENTS_HELP = "Commands to display and compare experiments."
 
     experiments_parser = subparsers.add_parser(
         "experiments",
-        parents=[parent_parser],
         aliases=["exp"],
         description=append_doc_link(EXPERIMENTS_HELP, "experiments"),
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        add_help=False,
     )
+    add_common_args(experiments_parser)
 
     experiments_subparsers = experiments_parser.add_subparsers(
         dest="cmd",
@@ -460,8 +461,8 @@ def add_parser(subparsers, parent_parser):
     EXPERIMENTS_SHOW_HELP = "Print experiments."
     experiments_show_parser = experiments_subparsers.add_parser(
         "show",
-        parents=[parent_parser],
         description=append_doc_link(EXPERIMENTS_SHOW_HELP, "experiments/show"),
+        add_help=False,
         help=EXPERIMENTS_SHOW_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -549,14 +550,15 @@ def add_parser(subparsers, parent_parser):
         help="Print output in JSON format instead of a human-readable table.",
     )
     experiments_show_parser.set_defaults(func=CmdExperimentsShow)
+    add_common_args(experiments_show_parser)
 
     EXPERIMENTS_CHECKOUT_HELP = "Checkout experiments."
     experiments_checkout_parser = experiments_subparsers.add_parser(
         "checkout",
-        parents=[parent_parser],
         description=append_doc_link(
             EXPERIMENTS_CHECKOUT_HELP, "experiments/checkout"
         ),
+        add_help=False,
         help=EXPERIMENTS_CHECKOUT_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -564,14 +566,15 @@ def add_parser(subparsers, parent_parser):
         "experiment", help="Checkout this experiment.",
     )
     experiments_checkout_parser.set_defaults(func=CmdExperimentsCheckout)
+    add_common_args(experiments_checkout_parser)
 
     EXPERIMENTS_DIFF_HELP = (
         "Show changes between experiments in the DVC repository."
     )
     experiments_diff_parser = experiments_subparsers.add_parser(
         "diff",
-        parents=[parent_parser],
         description=append_doc_link(EXPERIMENTS_DIFF_HELP, "experiments/diff"),
+        add_help=False,
         help=EXPERIMENTS_DIFF_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -623,14 +626,15 @@ def add_parser(subparsers, parent_parser):
         metavar="<n>",
     )
     experiments_diff_parser.set_defaults(func=CmdExperimentsDiff)
+    add_common_args(experiments_diff_parser)
 
     EXPERIMENTS_RUN_HELP = (
         "Reproduce complete or partial experiment pipelines."
     )
     experiments_run_parser = experiments_subparsers.add_parser(
         "run",
-        parents=[parent_parser],
         description=append_doc_link(EXPERIMENTS_RUN_HELP, "experiments/run"),
+        add_help=False,
         help=EXPERIMENTS_RUN_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -679,3 +683,4 @@ def add_parser(subparsers, parent_parser):
         ),
     )
     experiments_run_parser.set_defaults(func=CmdExperimentsRun)
+    add_common_args(experiments_run_parser)

--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -549,8 +549,7 @@ def add_parser(subparsers, add_common_args):
         default=False,
         help="Print output in JSON format instead of a human-readable table.",
     )
-    experiments_show_parser.set_defaults(func=CmdExperimentsShow)
-    add_common_args(experiments_show_parser)
+    add_common_args(experiments_show_parser, func=CmdExperimentsShow)
 
     EXPERIMENTS_CHECKOUT_HELP = "Checkout experiments."
     experiments_checkout_parser = experiments_subparsers.add_parser(
@@ -565,8 +564,7 @@ def add_parser(subparsers, add_common_args):
     experiments_checkout_parser.add_argument(
         "experiment", help="Checkout this experiment.",
     )
-    experiments_checkout_parser.set_defaults(func=CmdExperimentsCheckout)
-    add_common_args(experiments_checkout_parser)
+    add_common_args(experiments_checkout_parser, func=CmdExperimentsCheckout)
 
     EXPERIMENTS_DIFF_HELP = (
         "Show changes between experiments in the DVC repository."
@@ -625,8 +623,7 @@ def add_parser(subparsers, add_common_args):
         ),
         metavar="<n>",
     )
-    experiments_diff_parser.set_defaults(func=CmdExperimentsDiff)
-    add_common_args(experiments_diff_parser)
+    add_common_args(experiments_diff_parser, func=CmdExperimentsDiff)
 
     EXPERIMENTS_RUN_HELP = (
         "Reproduce complete or partial experiment pipelines."
@@ -682,5 +679,4 @@ def add_parser(subparsers, add_common_args):
             "(implies --checkpoint)."
         ),
     )
-    experiments_run_parser.set_defaults(func=CmdExperimentsRun)
-    add_common_args(experiments_run_parser)
+    add_common_args(experiments_run_parser, func=CmdExperimentsRun)

--- a/dvc/command/freeze.py
+++ b/dvc/command/freeze.py
@@ -30,12 +30,12 @@ class CmdUnfreeze(CmdFreezeBase):
         return self._run(self.repo.unfreeze, "unfreeze")
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     FREEZE_HELP = "Freeze stages or .dvc files."
     freeze_parser = subparsers.add_parser(
         "freeze",
-        parents=[parent_parser],
         description=append_doc_link(FREEZE_HELP, "freeze"),
+        add_help=False,
         help=FREEZE_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -43,12 +43,13 @@ def add_parser(subparsers, parent_parser):
         "targets", nargs="+", help="Stages or .dvc files to freeze",
     ).complete = completion.DVC_FILE
     freeze_parser.set_defaults(func=CmdFreeze)
+    add_common_args(freeze_parser)
 
     UNFREEZE_HELP = "Unfreeze stages or .dvc files."
     unfreeze_parser = subparsers.add_parser(
         "unfreeze",
-        parents=[parent_parser],
         description=append_doc_link(UNFREEZE_HELP, "unfreeze"),
+        add_help=False,
         help=UNFREEZE_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -56,3 +57,4 @@ def add_parser(subparsers, parent_parser):
         "targets", nargs="+", help="Stages or .dvc files to unfreeze",
     ).complete = completion.DVC_FILE
     unfreeze_parser.set_defaults(func=CmdUnfreeze)
+    add_common_args(unfreeze_parser)

--- a/dvc/command/freeze.py
+++ b/dvc/command/freeze.py
@@ -42,8 +42,7 @@ def add_parser(subparsers, add_common_args):
     freeze_parser.add_argument(
         "targets", nargs="+", help="Stages or .dvc files to freeze",
     ).complete = completion.DVC_FILE
-    freeze_parser.set_defaults(func=CmdFreeze)
-    add_common_args(freeze_parser)
+    add_common_args(freeze_parser, func=CmdFreeze)
 
     UNFREEZE_HELP = "Unfreeze stages or .dvc files."
     unfreeze_parser = subparsers.add_parser(
@@ -56,5 +55,4 @@ def add_parser(subparsers, add_common_args):
     unfreeze_parser.add_argument(
         "targets", nargs="+", help="Stages or .dvc files to unfreeze",
     ).complete = completion.DVC_FILE
-    unfreeze_parser.set_defaults(func=CmdUnfreeze)
-    add_common_args(unfreeze_parser)
+    add_common_args(unfreeze_parser, func=CmdUnfreeze)

--- a/dvc/command/gc.py
+++ b/dvc/command/gc.py
@@ -59,7 +59,7 @@ class CmdGC(CmdBase):
         return 0
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     GC_HELP = "Garbage collect unused objects from cache or remote storage."
     GC_DESCRIPTION = (
         "Removes all files in the cache or a remote which are not in\n"
@@ -67,8 +67,8 @@ def add_parser(subparsers, parent_parser):
     )
     gc_parser = subparsers.add_parser(
         "gc",
-        parents=[parent_parser],
         description=append_doc_link(GC_DESCRIPTION, "gc"),
+        add_help=False,
         help=GC_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -142,3 +142,4 @@ def add_parser(subparsers, parent_parser):
         metavar="<paths>",
     )
     gc_parser.set_defaults(func=CmdGC)
+    add_common_args(gc_parser)

--- a/dvc/command/gc.py
+++ b/dvc/command/gc.py
@@ -141,5 +141,4 @@ def add_parser(subparsers, add_common_args):
         "Useful if you share a single cache across repos.",
         metavar="<paths>",
     )
-    gc_parser.set_defaults(func=CmdGC)
-    add_common_args(gc_parser)
+    add_common_args(gc_parser, func=CmdGC)

--- a/dvc/command/get.py
+++ b/dvc/command/get.py
@@ -84,5 +84,4 @@ def add_parser(subparsers, add_common_args):
         help="Print the storage location (URL) the target data would be "
         "downloaded from, and exit.",
     )
-    get_parser.set_defaults(func=CmdGet)
-    add_common_args(get_parser)
+    add_common_args(get_parser, func=CmdGet)

--- a/dvc/command/get.py
+++ b/dvc/command/get.py
@@ -50,12 +50,12 @@ class CmdGet(CmdBaseNoRepo):
             return 1
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     GET_HELP = "Download file or directory tracked by DVC or by Git."
     get_parser = subparsers.add_parser(
         "get",
-        parents=[parent_parser],
         description=append_doc_link(GET_HELP, "get"),
+        add_help=False,
         help=GET_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -85,3 +85,4 @@ def add_parser(subparsers, parent_parser):
         "downloaded from, and exit.",
     )
     get_parser.set_defaults(func=CmdGet)
+    add_common_args(get_parser)

--- a/dvc/command/get_url.py
+++ b/dvc/command/get_url.py
@@ -36,5 +36,4 @@ def add_parser(subparsers, add_common_args):
     parser.add_argument(
         "out", nargs="?", help="Destination path to put data to.",
     ).complete = completion.DIR
-    parser.set_defaults(func=CmdGetUrl)
-    add_common_args(parser)
+    add_common_args(parser, func=CmdGetUrl)

--- a/dvc/command/get_url.py
+++ b/dvc/command/get_url.py
@@ -21,19 +21,20 @@ class CmdGetUrl(CmdBaseNoRepo):
             return 1
 
 
-def add_parser(subparsers, parent_parser):
-    GET_HELP = "Download or copy files from URL."
-    get_parser = subparsers.add_parser(
+def add_parser(subparsers, add_common_args):
+    HELP = "Download or copy files from URL."
+    parser = subparsers.add_parser(
         "get-url",
-        parents=[parent_parser],
-        description=append_doc_link(GET_HELP, "get-url"),
-        help=GET_HELP,
+        description=append_doc_link(HELP, "get-url"),
+        add_help=False,
+        help=HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    get_parser.add_argument(
+    parser.add_argument(
         "url", help="See `dvc import-url -h` for full list of supported URLs."
     )
-    get_parser.add_argument(
+    parser.add_argument(
         "out", nargs="?", help="Destination path to put data to.",
     ).complete = completion.DIR
-    get_parser.set_defaults(func=CmdGetUrl)
+    parser.set_defaults(func=CmdGetUrl)
+    add_common_args(parser)

--- a/dvc/command/git_hook.py
+++ b/dvc/command/git_hook.py
@@ -81,15 +81,13 @@ class CmdMergeDriver(CmdHookBase):
             dvc.close()
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     GIT_HOOK_HELP = "Run GIT hook."
 
     git_hook_parser = subparsers.add_parser(
-        "git-hook",
-        parents=[parent_parser],
-        description=GIT_HOOK_HELP,
-        add_help=False,
+        "git-hook", description=GIT_HOOK_HELP, add_help=False,
     )
+    add_common_args(git_hook_parser)
 
     git_hook_subparsers = git_hook_parser.add_subparsers(
         dest="cmd",
@@ -101,20 +99,21 @@ def add_parser(subparsers, parent_parser):
     PRE_COMMIT_HELP = "Run pre-commit GIT hook."
     pre_commit_parser = git_hook_subparsers.add_parser(
         "pre-commit",
-        parents=[parent_parser],
         description=PRE_COMMIT_HELP,
+        add_help=False,
         help=PRE_COMMIT_HELP,
     )
     pre_commit_parser.add_argument(
         "args", nargs="*", help="Arguments passed by GIT or pre-commit tool.",
     )
     pre_commit_parser.set_defaults(func=CmdPreCommit)
+    add_common_args(pre_commit_parser)
 
     POST_CHECKOUT_HELP = "Run post-checkout GIT hook."
     post_checkout_parser = git_hook_subparsers.add_parser(
         "post-checkout",
-        parents=[parent_parser],
         description=POST_CHECKOUT_HELP,
+        add_help=False,
         help=POST_CHECKOUT_HELP,
     )
     post_checkout_parser.add_argument(
@@ -125,20 +124,21 @@ def add_parser(subparsers, parent_parser):
     PRE_PUSH_HELP = "Run pre-push GIT hook."
     pre_push_parser = git_hook_subparsers.add_parser(
         "pre-push",
-        parents=[parent_parser],
         description=PRE_PUSH_HELP,
+        add_help=False,
         help=PRE_PUSH_HELP,
     )
     pre_push_parser.add_argument(
         "args", nargs="*", help="Arguments passed by GIT or pre-commit tool.",
     )
     pre_push_parser.set_defaults(func=CmdPrePush)
+    add_common_args(pre_push_parser)
 
     MERGE_DRIVER_HELP = "Run GIT merge driver."
     merge_driver_parser = git_hook_subparsers.add_parser(
         "merge-driver",
-        parents=[parent_parser],
         description=MERGE_DRIVER_HELP,
+        add_help=False,
         help=MERGE_DRIVER_HELP,
     )
     merge_driver_parser.add_argument(
@@ -157,3 +157,4 @@ def add_parser(subparsers, parent_parser):
         help="Other branch's version of the conflicting file.",
     )
     merge_driver_parser.set_defaults(func=CmdMergeDriver)
+    add_common_args(merge_driver_parser)

--- a/dvc/command/git_hook.py
+++ b/dvc/command/git_hook.py
@@ -106,8 +106,7 @@ def add_parser(subparsers, add_common_args):
     pre_commit_parser.add_argument(
         "args", nargs="*", help="Arguments passed by GIT or pre-commit tool.",
     )
-    pre_commit_parser.set_defaults(func=CmdPreCommit)
-    add_common_args(pre_commit_parser)
+    add_common_args(pre_commit_parser, func=CmdPreCommit)
 
     POST_CHECKOUT_HELP = "Run post-checkout GIT hook."
     post_checkout_parser = git_hook_subparsers.add_parser(
@@ -119,7 +118,7 @@ def add_parser(subparsers, add_common_args):
     post_checkout_parser.add_argument(
         "args", nargs="*", help="Arguments passed by GIT or pre-commit tool.",
     )
-    post_checkout_parser.set_defaults(func=CmdPostCheckout)
+    add_common_args(post_checkout_parser, func=CmdPostCheckout)
 
     PRE_PUSH_HELP = "Run pre-push GIT hook."
     pre_push_parser = git_hook_subparsers.add_parser(
@@ -131,8 +130,7 @@ def add_parser(subparsers, add_common_args):
     pre_push_parser.add_argument(
         "args", nargs="*", help="Arguments passed by GIT or pre-commit tool.",
     )
-    pre_push_parser.set_defaults(func=CmdPrePush)
-    add_common_args(pre_push_parser)
+    add_common_args(pre_push_parser, func=CmdPrePush)
 
     MERGE_DRIVER_HELP = "Run GIT merge driver."
     merge_driver_parser = git_hook_subparsers.add_parser(
@@ -156,5 +154,4 @@ def add_parser(subparsers, add_common_args):
         required=True,
         help="Other branch's version of the conflicting file.",
     )
-    merge_driver_parser.set_defaults(func=CmdMergeDriver)
-    add_common_args(merge_driver_parser)
+    add_common_args(merge_driver_parser, func=CmdMergeDriver)

--- a/dvc/command/imp.py
+++ b/dvc/command/imp.py
@@ -65,5 +65,4 @@ def add_parser(subparsers, add_common_args):
         help="Specify name of the DVC-file this command will generate.",
         metavar="<filename>",
     )
-    import_parser.set_defaults(func=CmdImport)
-    add_common_args(import_parser)
+    add_common_args(import_parser, func=CmdImport)

--- a/dvc/command/imp.py
+++ b/dvc/command/imp.py
@@ -28,7 +28,7 @@ class CmdImport(CmdBase):
         return 0
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     IMPORT_HELP = (
         "Download file or directory tracked by DVC or by Git "
         "into the workspace, and track it."
@@ -36,8 +36,8 @@ def add_parser(subparsers, parent_parser):
 
     import_parser = subparsers.add_parser(
         "import",
-        parents=[parent_parser],
         description=append_doc_link(IMPORT_HELP, "import"),
+        add_help=False,
         help=IMPORT_HELP,
         formatter_class=argparse.RawTextHelpFormatter,
     )
@@ -66,3 +66,4 @@ def add_parser(subparsers, parent_parser):
         metavar="<filename>",
     )
     import_parser.set_defaults(func=CmdImport)
+    add_common_args(import_parser)

--- a/dvc/command/imp_url.py
+++ b/dvc/command/imp_url.py
@@ -28,15 +28,15 @@ class CmdImportUrl(CmdBase):
         return 0
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     IMPORT_HELP = (
         "Download or copy file from URL and take it under DVC control."
     )
 
     import_parser = subparsers.add_parser(
         "import-url",
-        parents=[parent_parser],
         description=append_doc_link(IMPORT_HELP, "import-url"),
+        add_help=False,
         help=IMPORT_HELP,
         formatter_class=argparse.RawTextHelpFormatter,
     )
@@ -68,3 +68,4 @@ def add_parser(subparsers, parent_parser):
         help="Only create DVC-file without actually downloading it.",
     )
     import_parser.set_defaults(func=CmdImportUrl)
+    add_common_args(import_parser)

--- a/dvc/command/imp_url.py
+++ b/dvc/command/imp_url.py
@@ -67,5 +67,4 @@ def add_parser(subparsers, add_common_args):
         default=False,
         help="Only create DVC-file without actually downloading it.",
     )
-    import_parser.set_defaults(func=CmdImportUrl)
-    add_common_args(import_parser)
+    add_common_args(import_parser, func=CmdImportUrl)

--- a/dvc/command/init.py
+++ b/dvc/command/init.py
@@ -25,7 +25,7 @@ class CmdInit(CmdBaseNoRepo):
         return 0
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, *args):
     """Setup parser for `dvc init`."""
     INIT_HELP = "Initialize DVC in the current directory."
     INIT_DESCRIPTION = (
@@ -35,9 +35,9 @@ def add_parser(subparsers, parent_parser):
 
     init_parser = subparsers.add_parser(
         "init",
-        parents=[parent_parser],
         description=append_doc_link(INIT_DESCRIPTION, "init"),
         help=INIT_HELP,
+        add_help=False,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     init_parser.add_argument(
@@ -67,3 +67,4 @@ def add_parser(subparsers, parent_parser):
         ),
     )
     init_parser.set_defaults(func=CmdInit)
+    return init_parser

--- a/dvc/command/init.py
+++ b/dvc/command/init.py
@@ -66,5 +66,4 @@ def add_parser(subparsers, add_common_args):
             "parent SCM repository."
         ),
     )
-    init_parser.set_defaults(func=CmdInit)
-    add_common_args(init_parser)
+    add_common_args(init_parser, func=CmdInit)

--- a/dvc/command/init.py
+++ b/dvc/command/init.py
@@ -25,7 +25,7 @@ class CmdInit(CmdBaseNoRepo):
         return 0
 
 
-def add_parser(subparsers, *args):
+def add_parser(subparsers, add_common_args):
     """Setup parser for `dvc init`."""
     INIT_HELP = "Initialize DVC in the current directory."
     INIT_DESCRIPTION = (
@@ -67,4 +67,4 @@ def add_parser(subparsers, *args):
         ),
     )
     init_parser.set_defaults(func=CmdInit)
-    return init_parser
+    add_common_args(init_parser)

--- a/dvc/command/install.py
+++ b/dvc/command/install.py
@@ -33,5 +33,4 @@ def add_parser(subparsers, add_common_args):
         help="Install DVC hooks using pre-commit "
         "(https://pre-commit.com) if it is installed.",
     )
-    install_parser.set_defaults(func=CmdInstall)
-    add_common_args(install_parser)
+    add_common_args(install_parser, func=CmdInstall)

--- a/dvc/command/install.py
+++ b/dvc/command/install.py
@@ -17,12 +17,12 @@ class CmdInstall(CmdBase):
         return 0
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     INSTALL_HELP = "Install DVC git hooks into the repository."
     install_parser = subparsers.add_parser(
         "install",
-        parents=[parent_parser],
         description=append_doc_link(INSTALL_HELP, "install"),
+        add_help=False,
         help=INSTALL_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -34,3 +34,4 @@ def add_parser(subparsers, parent_parser):
         "(https://pre-commit.com) if it is installed.",
     )
     install_parser.set_defaults(func=CmdInstall)
+    add_common_args(install_parser)

--- a/dvc/command/ls/__init__.py
+++ b/dvc/command/ls/__init__.py
@@ -43,15 +43,15 @@ class CmdList(CmdBaseNoRepo):
             return 1
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     LIST_HELP = (
         "List repository contents, including files"
         " and directories tracked by DVC and by Git."
     )
     list_parser = subparsers.add_parser(
         "list",
-        parents=[parent_parser],
         description=append_doc_link(LIST_HELP, "list"),
+        add_help=False,
         help=LIST_HELP,
         formatter_class=argparse.RawTextHelpFormatter,
     )
@@ -77,3 +77,4 @@ def add_parser(subparsers, parent_parser):
         help="Path to directory within the repository to list outputs for",
     ).complete = completion.DIR
     list_parser.set_defaults(func=CmdList)
+    add_common_args(list_parser)

--- a/dvc/command/ls/__init__.py
+++ b/dvc/command/ls/__init__.py
@@ -76,5 +76,4 @@ def add_parser(subparsers, add_common_args):
         nargs="?",
         help="Path to directory within the repository to list outputs for",
     ).complete = completion.DIR
-    list_parser.set_defaults(func=CmdList)
-    add_common_args(list_parser)
+    add_common_args(list_parser, func=CmdList)

--- a/dvc/command/metrics.py
+++ b/dvc/command/metrics.py
@@ -141,16 +141,17 @@ class CmdMetricsDiff(CmdMetricsBase):
         return 0
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     METRICS_HELP = "Commands to display and compare metrics."
 
     metrics_parser = subparsers.add_parser(
         "metrics",
-        parents=[parent_parser],
         description=append_doc_link(METRICS_HELP, "metrics"),
+        add_help=False,
         help=METRICS_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    add_common_args(metrics_parser)
 
     metrics_subparsers = metrics_parser.add_subparsers(
         dest="cmd",
@@ -162,8 +163,8 @@ def add_parser(subparsers, parent_parser):
     METRICS_SHOW_HELP = "Print metrics, with optional formatting."
     metrics_show_parser = metrics_subparsers.add_parser(
         "show",
-        parents=[parent_parser],
         description=append_doc_link(METRICS_SHOW_HELP, "metrics/show"),
+        add_help=False,
         help=METRICS_SHOW_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -213,6 +214,7 @@ def add_parser(subparsers, parent_parser):
         ),
     )
     metrics_show_parser.set_defaults(func=CmdMetricsShow)
+    add_common_args(metrics_show_parser)
 
     METRICS_DIFF_HELP = (
         "Show changes in metrics between commits in the DVC repository, or "
@@ -220,8 +222,8 @@ def add_parser(subparsers, parent_parser):
     )
     metrics_diff_parser = metrics_subparsers.add_parser(
         "diff",
-        parents=[parent_parser],
         description=append_doc_link(METRICS_DIFF_HELP, "metrics/diff"),
+        add_help=False,
         help=METRICS_DIFF_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -286,3 +288,4 @@ def add_parser(subparsers, parent_parser):
         metavar="<n>",
     )
     metrics_diff_parser.set_defaults(func=CmdMetricsDiff)
+    add_common_args(metrics_diff_parser)

--- a/dvc/command/metrics.py
+++ b/dvc/command/metrics.py
@@ -213,8 +213,7 @@ def add_parser(subparsers, add_common_args):
             "metric files."
         ),
     )
-    metrics_show_parser.set_defaults(func=CmdMetricsShow)
-    add_common_args(metrics_show_parser)
+    add_common_args(metrics_show_parser, func=CmdMetricsShow)
 
     METRICS_DIFF_HELP = (
         "Show changes in metrics between commits in the DVC repository, or "
@@ -287,5 +286,4 @@ def add_parser(subparsers, add_common_args):
         ),
         metavar="<n>",
     )
-    metrics_diff_parser.set_defaults(func=CmdMetricsDiff)
-    add_common_args(metrics_diff_parser)
+    add_common_args(metrics_diff_parser, func=CmdMetricsDiff)

--- a/dvc/command/move.py
+++ b/dvc/command/move.py
@@ -21,7 +21,7 @@ class CmdMove(CmdBase):
         return 0
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     MOVE_HELP = "Rename or move a DVC controlled data file or a directory."
     MOVE_DESCRIPTION = (
         "Rename or move a DVC controlled data file or a directory.\n"
@@ -31,8 +31,8 @@ def add_parser(subparsers, parent_parser):
 
     move_parser = subparsers.add_parser(
         "move",
-        parents=[parent_parser],
         description=append_doc_link(MOVE_DESCRIPTION, "move"),
+        add_help=False,
         help=MOVE_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -43,3 +43,4 @@ def add_parser(subparsers, parent_parser):
         "dst", help="Destination path.",
     ).complete = completion.FILE
     move_parser.set_defaults(func=CmdMove)
+    add_common_args(move_parser)

--- a/dvc/command/move.py
+++ b/dvc/command/move.py
@@ -42,5 +42,4 @@ def add_parser(subparsers, add_common_args):
     move_parser.add_argument(
         "dst", help="Destination path.",
     ).complete = completion.FILE
-    move_parser.set_defaults(func=CmdMove)
-    add_common_args(move_parser)
+    add_common_args(move_parser, func=CmdMove)

--- a/dvc/command/params.py
+++ b/dvc/command/params.py
@@ -54,16 +54,17 @@ class CmdParamsDiff(CmdBase):
         return 0
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     PARAMS_HELP = "Commands to display params."
 
     params_parser = subparsers.add_parser(
         "params",
-        parents=[parent_parser],
         description=append_doc_link(PARAMS_HELP, "params"),
+        add_help=False,
         help=PARAMS_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    add_common_args(params_parser)
 
     params_subparsers = params_parser.add_subparsers(
         dest="cmd",
@@ -78,8 +79,8 @@ def add_parser(subparsers, parent_parser):
     )
     params_diff_parser = params_subparsers.add_parser(
         "diff",
-        parents=[parent_parser],
         description=append_doc_link(PARAMS_DIFF_HELP, "params/diff"),
+        add_help=False,
         help=PARAMS_DIFF_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -116,3 +117,4 @@ def add_parser(subparsers, parent_parser):
         help="Don't show params path.",
     )
     params_diff_parser.set_defaults(func=CmdParamsDiff)
+    add_common_args(params_diff_parser)

--- a/dvc/command/params.py
+++ b/dvc/command/params.py
@@ -116,5 +116,4 @@ def add_parser(subparsers, add_common_args):
         default=False,
         help="Don't show params path.",
     )
-    params_diff_parser.set_defaults(func=CmdParamsDiff)
-    add_common_args(params_diff_parser)
+    add_common_args(params_diff_parser, func=CmdParamsDiff)

--- a/dvc/command/plots.py
+++ b/dvc/command/plots.py
@@ -142,8 +142,7 @@ def add_parser(subparsers, add_common_args):
     ).complete = completion.FILE
     _add_props_arguments(plots_show_parser)
     _add_output_arguments(plots_show_parser)
-    plots_show_parser.set_defaults(func=CmdPlotsShow)
-    add_common_args(plots_show_parser)
+    add_common_args(plots_show_parser, func=CmdPlotsShow)
 
     PLOTS_DIFF_HELP = (
         "Show multiple versions of plot metrics "
@@ -176,8 +175,7 @@ def add_parser(subparsers, add_common_args):
     )
     _add_props_arguments(plots_diff_parser)
     _add_output_arguments(plots_diff_parser)
-    plots_diff_parser.set_defaults(func=CmdPlotsDiff)
-    add_common_args(plots_diff_parser)
+    add_common_args(plots_diff_parser, func=CmdPlotsDiff)
 
     PLOTS_MODIFY_HELP = "Modify display properties of plot metric files."
     plots_modify_parser = plots_subparsers.add_parser(
@@ -197,8 +195,7 @@ def add_parser(subparsers, add_common_args):
         metavar="<property>",
         help="Unset one or more display properties.",
     )
-    plots_modify_parser.set_defaults(func=CmdPlotsModify)
-    add_common_args(plots_modify_parser)
+    add_common_args(plots_modify_parser, func=CmdPlotsModify)
 
 
 def _add_props_arguments(parser):

--- a/dvc/command/plots.py
+++ b/dvc/command/plots.py
@@ -104,7 +104,7 @@ class CmdPlotsModify(CmdPlots):
         return 0
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     PLOTS_HELP = (
         "Commands to visualize and compare plot metrics in structured files "
         "(JSON, YAML, CSV, TSV)"
@@ -112,11 +112,12 @@ def add_parser(subparsers, parent_parser):
 
     plots_parser = subparsers.add_parser(
         "plots",
-        parents=[parent_parser],
         description=append_doc_link(PLOTS_HELP, "plots"),
+        add_help=False,
         help=PLOTS_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    add_common_args(plots_parser)
     plots_subparsers = plots_parser.add_subparsers(
         dest="cmd",
         help="Use `dvc plots CMD --help` to display command-specific help.",
@@ -127,8 +128,8 @@ def add_parser(subparsers, parent_parser):
     SHOW_HELP = "Generate plots from metric files."
     plots_show_parser = plots_subparsers.add_parser(
         "show",
-        parents=[parent_parser],
         description=append_doc_link(SHOW_HELP, "plots/show"),
+        add_help=False,
         help=SHOW_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -142,6 +143,7 @@ def add_parser(subparsers, parent_parser):
     _add_props_arguments(plots_show_parser)
     _add_output_arguments(plots_show_parser)
     plots_show_parser.set_defaults(func=CmdPlotsShow)
+    add_common_args(plots_show_parser)
 
     PLOTS_DIFF_HELP = (
         "Show multiple versions of plot metrics "
@@ -149,8 +151,8 @@ def add_parser(subparsers, parent_parser):
     )
     plots_diff_parser = plots_subparsers.add_parser(
         "diff",
-        parents=[parent_parser],
         description=append_doc_link(PLOTS_DIFF_HELP, "plots/diff"),
+        add_help=False,
         help=PLOTS_DIFF_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -175,12 +177,13 @@ def add_parser(subparsers, parent_parser):
     _add_props_arguments(plots_diff_parser)
     _add_output_arguments(plots_diff_parser)
     plots_diff_parser.set_defaults(func=CmdPlotsDiff)
+    add_common_args(plots_diff_parser)
 
     PLOTS_MODIFY_HELP = "Modify display properties of plot metric files."
     plots_modify_parser = plots_subparsers.add_parser(
         "modify",
-        parents=[parent_parser],
         description=append_doc_link(PLOTS_MODIFY_HELP, "plots/modify"),
+        add_help=False,
         help=PLOTS_MODIFY_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -195,6 +198,7 @@ def add_parser(subparsers, parent_parser):
         help="Unset one or more display properties.",
     )
     plots_modify_parser.set_defaults(func=CmdPlotsModify)
+    add_common_args(plots_modify_parser)
 
 
 def _add_props_arguments(parser):

--- a/dvc/command/remote.py
+++ b/dvc/command/remote.py
@@ -142,17 +142,18 @@ class CmdRemoteRename(CmdRemote):
         return 0
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     from dvc.command.config import parent_config_parser
 
     REMOTE_HELP = "Set up and manage data remotes."
     remote_parser = subparsers.add_parser(
         "remote",
-        parents=[parent_parser],
         description=append_doc_link(REMOTE_HELP, "remote"),
+        add_help=False,
         help=REMOTE_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    add_common_args(remote_parser)
 
     remote_subparsers = remote_parser.add_subparsers(
         dest="cmd",
@@ -164,8 +165,9 @@ def add_parser(subparsers, parent_parser):
     REMOTE_ADD_HELP = "Add a new data remote."
     remote_add_parser = remote_subparsers.add_parser(
         "add",
-        parents=[parent_config_parser, parent_parser],
+        parents=[parent_config_parser],
         description=append_doc_link(REMOTE_ADD_HELP, "remote/add"),
+        add_help=False,
         help=REMOTE_ADD_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -191,12 +193,14 @@ def add_parser(subparsers, parent_parser):
         help="Force overwriting existing configs",
     )
     remote_add_parser.set_defaults(func=CmdRemoteAdd)
+    add_common_args(remote_add_parser)
 
     REMOTE_DEFAULT_HELP = "Set/unset the default data remote."
     remote_default_parser = remote_subparsers.add_parser(
         "default",
-        parents=[parent_config_parser, parent_parser],
+        parents=[parent_config_parser],
         description=append_doc_link(REMOTE_DEFAULT_HELP, "remote/default"),
+        add_help=False,
         help=REMOTE_DEFAULT_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -211,12 +215,14 @@ def add_parser(subparsers, parent_parser):
         help="Unset default remote.",
     )
     remote_default_parser.set_defaults(func=CmdRemoteDefault)
+    add_common_args(remote_default_parser)
 
     REMOTE_MODIFY_HELP = "Modify the configuration of a data remote."
     remote_modify_parser = remote_subparsers.add_parser(
         "modify",
-        parents=[parent_config_parser, parent_parser],
+        parents=[parent_config_parser],
         description=append_doc_link(REMOTE_MODIFY_HELP, "remote/modify"),
+        add_help=False,
         help=REMOTE_MODIFY_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -235,22 +241,26 @@ def add_parser(subparsers, parent_parser):
         help="Unset option.",
     )
     remote_modify_parser.set_defaults(func=CmdRemoteModify)
+    add_common_args(remote_modify_parser)
 
     REMOTE_LIST_HELP = "List all available data remotes."
     remote_list_parser = remote_subparsers.add_parser(
         "list",
-        parents=[parent_config_parser, parent_parser],
+        parents=[parent_config_parser],
         description=append_doc_link(REMOTE_LIST_HELP, "remote/list"),
+        add_help=False,
         help=REMOTE_LIST_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     remote_list_parser.set_defaults(func=CmdRemoteList)
+    add_common_args(remote_list_parser)
 
     REMOTE_REMOVE_HELP = "Remove a data remote."
     remote_remove_parser = remote_subparsers.add_parser(
         "remove",
-        parents=[parent_config_parser, parent_parser],
+        parents=[parent_config_parser],
         description=append_doc_link(REMOTE_REMOVE_HELP, "remote/remove"),
+        add_help=False,
         help=REMOTE_REMOVE_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -258,14 +268,18 @@ def add_parser(subparsers, parent_parser):
         "name", help="Name of the remote to remove."
     )
     remote_remove_parser.set_defaults(func=CmdRemoteRemove)
+    add_common_args(remote_remove_parser)
+
     REMOTE_RENAME_HELP = "Rename a DVC remote"
     remote_rename_parser = remote_subparsers.add_parser(
         "rename",
-        parents=[parent_config_parser, parent_parser],
+        parents=[parent_config_parser],
         description=append_doc_link(REMOTE_RENAME_HELP, "remote/rename"),
+        add_help=False,
         help=REMOTE_RENAME_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     remote_rename_parser.add_argument("name", help="Remote to be renamed")
     remote_rename_parser.add_argument("new", help="New name of the remote")
     remote_rename_parser.set_defaults(func=CmdRemoteRename)
+    add_common_args(remote_rename_parser)

--- a/dvc/command/remote.py
+++ b/dvc/command/remote.py
@@ -192,8 +192,7 @@ def add_parser(subparsers, add_common_args):
         default=False,
         help="Force overwriting existing configs",
     )
-    remote_add_parser.set_defaults(func=CmdRemoteAdd)
-    add_common_args(remote_add_parser)
+    add_common_args(remote_add_parser, func=CmdRemoteAdd)
 
     REMOTE_DEFAULT_HELP = "Set/unset the default data remote."
     remote_default_parser = remote_subparsers.add_parser(
@@ -214,8 +213,7 @@ def add_parser(subparsers, add_common_args):
         default=False,
         help="Unset default remote.",
     )
-    remote_default_parser.set_defaults(func=CmdRemoteDefault)
-    add_common_args(remote_default_parser)
+    add_common_args(remote_default_parser, func=CmdRemoteDefault)
 
     REMOTE_MODIFY_HELP = "Modify the configuration of a data remote."
     remote_modify_parser = remote_subparsers.add_parser(
@@ -240,8 +238,7 @@ def add_parser(subparsers, add_common_args):
         action="store_true",
         help="Unset option.",
     )
-    remote_modify_parser.set_defaults(func=CmdRemoteModify)
-    add_common_args(remote_modify_parser)
+    add_common_args(remote_modify_parser, func=CmdRemoteModify)
 
     REMOTE_LIST_HELP = "List all available data remotes."
     remote_list_parser = remote_subparsers.add_parser(
@@ -252,8 +249,7 @@ def add_parser(subparsers, add_common_args):
         help=REMOTE_LIST_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    remote_list_parser.set_defaults(func=CmdRemoteList)
-    add_common_args(remote_list_parser)
+    add_common_args(remote_list_parser, func=CmdRemoteList)
 
     REMOTE_REMOVE_HELP = "Remove a data remote."
     remote_remove_parser = remote_subparsers.add_parser(
@@ -267,8 +263,7 @@ def add_parser(subparsers, add_common_args):
     remote_remove_parser.add_argument(
         "name", help="Name of the remote to remove."
     )
-    remote_remove_parser.set_defaults(func=CmdRemoteRemove)
-    add_common_args(remote_remove_parser)
+    add_common_args(remote_remove_parser, func=CmdRemoteRemove)
 
     REMOTE_RENAME_HELP = "Rename a DVC remote"
     remote_rename_parser = remote_subparsers.add_parser(
@@ -281,5 +276,4 @@ def add_parser(subparsers, add_common_args):
     )
     remote_rename_parser.add_argument("name", help="Remote to be renamed")
     remote_rename_parser.add_argument("new", help="New name of the remote")
-    remote_rename_parser.set_defaults(func=CmdRemoteRename)
-    add_common_args(remote_rename_parser)
+    add_common_args(remote_rename_parser, func=CmdRemoteRename)

--- a/dvc/command/remove.py
+++ b/dvc/command/remove.py
@@ -39,5 +39,4 @@ def add_parser(subparsers, add_common_args):
     remove_parser.add_argument(
         "targets", nargs="+", help="DVC-files to remove.",
     ).complete = completion.DVC_FILE
-    remove_parser.set_defaults(func=CmdRemove)
-    add_common_args(remove_parser)
+    add_common_args(remove_parser, func=CmdRemove)

--- a/dvc/command/remove.py
+++ b/dvc/command/remove.py
@@ -19,14 +19,14 @@ class CmdRemove(CmdBase):
         return 0
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     REMOVE_HELP = (
         "Remove stage entry, remove .gitignore entry and unprotect outputs"
     )
     remove_parser = subparsers.add_parser(
         "remove",
-        parents=[parent_parser],
         description=append_doc_link(REMOVE_HELP, "remove"),
+        add_help=False,
         help=REMOVE_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -40,3 +40,4 @@ def add_parser(subparsers, parent_parser):
         "targets", nargs="+", help="DVC-files to remove.",
     ).complete = completion.DVC_FILE
     remove_parser.set_defaults(func=CmdRemove)
+    add_common_args(remove_parser)

--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -172,16 +172,16 @@ def add_arguments(repro_parser):
     )
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     REPRO_HELP = (
         "Reproduce complete or partial pipelines by executing their stages."
     )
     repro_parser = subparsers.add_parser(
         "repro",
-        parents=[parent_parser],
         description=append_doc_link(REPRO_HELP, "repro"),
+        add_help=False,
         help=REPRO_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     add_arguments(repro_parser)
-    repro_parser.set_defaults(func=CmdRepro)
+    add_common_args(repro_parser, func=CmdRepro)

--- a/dvc/command/root.py
+++ b/dvc/command/root.py
@@ -15,13 +15,14 @@ class CmdRoot(CmdBaseNoRepo):
         return 0
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     ROOT_HELP = "Return the relative path to the root of the DVC project."
     root_parser = subparsers.add_parser(
         "root",
-        parents=[parent_parser],
         description=append_doc_link(ROOT_HELP, "root"),
+        add_help=False,
         help=ROOT_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     root_parser.set_defaults(func=CmdRoot)
+    add_common_args(root_parser)

--- a/dvc/command/root.py
+++ b/dvc/command/root.py
@@ -24,5 +24,4 @@ def add_parser(subparsers, add_common_args):
         help=ROOT_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    root_parser.set_defaults(func=CmdRoot)
-    add_common_args(root_parser)
+    add_common_args(root_parser, func=CmdRoot)

--- a/dvc/command/run.py
+++ b/dvc/command/run.py
@@ -84,12 +84,12 @@ class CmdRun(CmdBase):
         return f'"{argument}"'
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     RUN_HELP = "Generate a stage file from a command and execute the command."
     run_parser = subparsers.add_parser(
         "run",
-        parents=[parent_parser],
         description=append_doc_link(RUN_HELP, "run"),
+        add_help=False,
         help=RUN_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -234,3 +234,4 @@ def add_parser(subparsers, parent_parser):
         "command", nargs=argparse.REMAINDER, help="Command to execute."
     )
     run_parser.set_defaults(func=CmdRun)
+    add_common_args(run_parser)

--- a/dvc/command/run.py
+++ b/dvc/command/run.py
@@ -233,5 +233,4 @@ def add_parser(subparsers, add_common_args):
     run_parser.add_argument(
         "command", nargs=argparse.REMAINDER, help="Command to execute."
     )
-    run_parser.set_defaults(func=CmdRun)
-    add_common_args(run_parser)
+    add_common_args(run_parser, func=CmdRun)

--- a/dvc/command/unprotect.py
+++ b/dvc/command/unprotect.py
@@ -20,15 +20,15 @@ class CmdUnprotect(CmdBase):
         return 0
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     UNPROTECT_HELP = (
         "Unprotect tracked files or directories (when hardlinks or symlinks "
         "have been enabled with `dvc config cache.type`)"
     )
     unprotect_parser = subparsers.add_parser(
         "unprotect",
-        parents=[parent_parser],
         description=append_doc_link(UNPROTECT_HELP, "unprotect"),
+        add_help=False,
         help=UNPROTECT_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -36,3 +36,4 @@ def add_parser(subparsers, parent_parser):
         "targets", nargs="+", help="Data files/directories to unprotect.",
     ).complete = completion.FILE
     unprotect_parser.set_defaults(func=CmdUnprotect)
+    add_common_args(unprotect_parser)

--- a/dvc/command/unprotect.py
+++ b/dvc/command/unprotect.py
@@ -35,5 +35,4 @@ def add_parser(subparsers, add_common_args):
     unprotect_parser.add_argument(
         "targets", nargs="+", help="Data files/directories to unprotect.",
     ).complete = completion.FILE
-    unprotect_parser.set_defaults(func=CmdUnprotect)
-    add_common_args(unprotect_parser)
+    add_common_args(unprotect_parser, func=CmdUnprotect)

--- a/dvc/command/update.py
+++ b/dvc/command/update.py
@@ -23,12 +23,12 @@ class CmdUpdate(CmdBase):
         return ret
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     UPDATE_HELP = "Update data artifacts imported from other DVC repositories."
     update_parser = subparsers.add_parser(
         "update",
-        parents=[parent_parser],
         description=append_doc_link(UPDATE_HELP, "update"),
+        add_help=False,
         help=UPDATE_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -49,3 +49,4 @@ def add_parser(subparsers, parent_parser):
         help="Update all stages in the specified directory.",
     )
     update_parser.set_defaults(func=CmdUpdate)
+    add_common_args(update_parser)

--- a/dvc/command/update.py
+++ b/dvc/command/update.py
@@ -48,5 +48,4 @@ def add_parser(subparsers, add_common_args):
         default=False,
         help="Update all stages in the specified directory.",
     )
-    update_parser.set_defaults(func=CmdUpdate)
-    add_common_args(update_parser)
+    add_common_args(update_parser, func=CmdUpdate)

--- a/dvc/command/version.py
+++ b/dvc/command/version.py
@@ -14,15 +14,16 @@ class CmdVersion(CmdBaseNoRepo):
         return 0
 
 
-def add_parser(subparsers, parent_parser):
+def add_parser(subparsers, add_common_args):
     VERSION_HELP = (
         "Display the DVC version and system/environment information."
     )
     version_parser = subparsers.add_parser(
         "version",
-        parents=[parent_parser],
         description=append_doc_link(VERSION_HELP, "version"),
+        add_help=False,
         help=VERSION_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     version_parser.set_defaults(func=CmdVersion)
+    add_common_args(version_parser)

--- a/dvc/command/version.py
+++ b/dvc/command/version.py
@@ -25,5 +25,4 @@ def add_parser(subparsers, add_common_args):
         help=VERSION_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    version_parser.set_defaults(func=CmdVersion)
-    add_common_args(version_parser)
+    add_common_args(version_parser, func=CmdVersion)


### PR DESCRIPTION
Related to #3642

This is one possible solution for ordering these arguments. If this solution is acceptable, then other subcommands should be updated in a similar way.

### See `-q` `-v` and `-h` at the end:
```
$ dvc commit -h   
usage: dvc commit [-f] [-d] [-R] [-q | -v] [-h] [targets [targets ...]]

Save changed data to cache and update DVC-files.
Documentation: <https://man.dvc.org/commit>

positional arguments:
  targets          DVC-files to commit. Optional. (Finds all DVC-files in the workspace by default.)

optional arguments:
  -f, --force      Commit even if hash value for dependencies/outputs changed.
  -d, --with-deps  Commit all dependencies of the specified target.
  -R, --recursive  Commit cache for subdirectories of the specified directory.
  -q, --quiet      Be quiet.
  -v, --verbose    Be verbose.
  -h, --help       Show this help message and exit.

$ dvc init -h  
usage: dvc init [--no-scm] [-f] [--subdir] [-q | -v] [-h]

Initialize DVC in the current directory. Expects directory
to be a Git repository unless --no-scm option is specified.
Documentation: <https://man.dvc.org/init>

optional arguments:
  --no-scm       Initiate DVC in directory that is not tracked by any SCM tool (e.g. Git).
  -f, --force    Overwrite existing '.dvc/' directory. This operation removes local cache.
  --subdir       Necessary for running this command inside a subdirectory of a parent SCM repository.
  -q, --quiet    Be quiet.
  -v, --verbose  Be verbose.
  -h, --help     Show this help message and exit.

$ dvc -h       
usage: dvc [-V] [--cd <path>] [-q | -v] [-h] COMMAND ...

Data Version Control

optional arguments:
  -V, --version  Show program's version.
  --cd <path>    Change to directory before executing.
  -q, --quiet    Be quiet.
  -v, --verbose  Be verbose.
  -h, --help     Show this help message and exit.
...
```

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
