### PR TITLE
github actions: migrate to envrionmental files

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -9,6 +9,8 @@ jobs:
   linux:
     runs-on: ubuntu-16.04
     steps:
+    - name: set up environment variables
+      run: echo 'GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}' >> $GITHUB_ENV
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
@@ -23,8 +25,6 @@ jobs:
     - name: Publish deb
       if: github.event_name == 'release'
       uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: dvc_${{ github.event.release.tag_name }}_amd64.deb
@@ -33,8 +33,6 @@ jobs:
     - name: Publish rpm
       if: github.event_name == 'release'
       uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: dvc-${{ github.event.release.tag_name }}-1.x86_64.rpm
@@ -57,8 +55,7 @@ jobs:
     - name: Publish
       if: github.event_name == 'release'
       uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: echo 'GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}' >> $GITHUB_ENV
       with:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: dvc-${{ github.event.release.tag_name }}.pkg
@@ -78,8 +75,7 @@ jobs:
     - name: Publish
       if: github.event_name == 'release'
       uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: echo 'GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}' >> $GITHUB_ENV
       with:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: dvc-${{ github.event.release.tag_name }}.exe

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,17 +2,11 @@ name: Tests build
 
 on: [push, pull_request]
 
-env:
-  DVC_TEST: "true"
-  HOMEBREW_NO_AUTO_UPDATE: 1
-  SHELL: /bin/bash
-  GDRIVE_CREDENTIALS_DATA: ${{ secrets.GDRIVE_CREDENTIALS_DATA }}
-
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2.3.2
     - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
@@ -34,6 +28,12 @@ jobs:
           - os: windows-2019
             pyv: "3.9-dev"
     steps:
+    - name: set up environment variables
+      run: |
+        echo 'DVC_TEST=true' >> $GITHUB_ENV
+        echo 'HOMEBREW_NO_AUTO_UPDATE=1' >> $GITHUB_ENV
+        echo 'SHELL=/bin/bash' >> $GITHUB_ENV
+        echo 'GDRIVE_CREDENTIALS_DATA=${{ secrets.GDRIVE_CREDENTIALS_DATA }}' >> $GITHUB_ENV
     - uses: actions/checkout@v2.3.2
     - name: Set up Python
       uses: actions/setup-python@v2.1.2


### PR DESCRIPTION
* [ ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
GitHub is deprecating `set-env` command, and we need to migrate to environmental files.
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/ 