### PR TITLE
experiments: add `--show-json` for `exp show`

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -3,7 +3,7 @@ import io
 import logging
 import os
 from collections import OrderedDict
-from datetime import date
+from datetime import date, datetime
 from itertools import groupby
 from typing import Iterable, Optional
 
@@ -255,6 +255,12 @@ def _show_experiments(all_experiments, console, **kwargs):
     console.print(table)
 
 
+def _format_json(item):
+    if isinstance(item, (date, datetime)):
+        return item.isoformat()
+    raise TypeError
+
+
 class CmdExperimentsShow(CmdBase):
     def run(self):
         from rich.console import Console
@@ -271,6 +277,12 @@ class CmdExperimentsShow(CmdBase):
                 all_commits=self.args.all_commits,
                 sha_only=self.args.sha,
             )
+
+            if self.args.show_json:
+                import json
+
+                logger.info(json.dumps(all_experiments, default=_format_json))
+                return 0
 
             if self.args.no_pager:
                 console = Console()
@@ -529,6 +541,12 @@ def add_parser(subparsers, parent_parser):
         action="store_true",
         default=False,
         help="Always show git commit SHAs instead of branch/tag names.",
+    )
+    experiments_show_parser.add_argument(
+        "--show-json",
+        action="store_true",
+        default=False,
+        help="Print output in JSON format instead of a human-readable table.",
     )
     experiments_show_parser.set_defaults(func=CmdExperimentsShow)
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will close #4688.

```console
$ dvc exp show --no-pager
┏━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ Experiment            ┃ Created      ┃     auc ┃ featurize.max_features ┃ featurize.ngrams ┃ prepare.seed ┃ prepare.split ┃ train.n_estimators ┃ train.seed ┃
┡━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
│ workspace             │ -            │ 0.57756 │ 2000                   │ 2                │ 20170428     │ 0.2           │ 50                 │ 20170428   │
│ 11-bigrams-experiment │ Jun 20, 2020 │ 0.61314 │ 1500                   │ 2                │ 20170428     │ 0.2           │ 50                 │ 20170428   │
│ ├── 1df77f7           │ 02:29 PM     │ 0.51676 │ 500                    │ 2                │ 20170428     │ 0.2           │ 50                 │ 20170428   │
│ ├── 1dad0d2           │ 02:29 PM     │ 0.57756 │ 2000                   │ 2                │ 20170428     │ 0.2           │ 50                 │ 20170428   │
│ └── *5a9d6dc          │ 02:29 PM     │       - │ 2000                   │ 2                │ 20170428     │ 0.2           │ 50                 │ 20170428   │
└───────────────────────┴──────────────┴─────────┴────────────────────────┴──────────────────┴──────────────┴───────────────┴────────────────────┴────────────┘
```

Indented output for `dvc exp show --show-json` in the same project:
```json
{
  "workspace":{
    "baseline":{
      "timestamp":null,
      "params":{
        "params.yaml":{
          "prepare":{
            "split":0.2,
            "seed":20170428
          },
          "featurize":{
            "max_features":2000,
            "ngrams":2
          },
          "train":{
            "seed":20170428,
            "n_estimators":50
          }
        }
      },
      "queued":false,
      "metrics":{
        "scores.json":{
          "auc":0.5775633054725381
        }
      }
    }
  },
  "9e0cd8a4f9eff4dd184470721da42ac4eb64fd2c":{
    "baseline":{
      "timestamp":"2020-06-20T06:45:46",
      "params":{
        "params.yaml":{
          "prepare":{
            "split":0.2,
            "seed":20170428
          },
          "featurize":{
            "max_features":1500,
            "ngrams":2
          },
          "train":{
            "seed":20170428,
            "n_estimators":50
          }
        }
      },
      "queued":false,
      "metrics":{
        "scores.json":{
          "auc":0.6131382960762474
        }
      },
      "name":"11-bigrams-experiment"
    },
    "1df77f701b1f73e79df68513676631db8bd59636":{
      "timestamp":"2020-10-09T14:29:23",
      "params":{
        "params.yaml":{
          "prepare":{
            "split":0.2,
            "seed":20170428
          },
          "featurize":{
            "max_features":500,
            "ngrams":2
          },
          "train":{
            "seed":20170428,
            "n_estimators":50
          }
        }
      },
      "queued":false,
      "metrics":{
        "scores.json":{
          "auc":0.5167645657589519
        }
      }
    },
    "1dad0d2bd1ee6dced3a676e5cb672522e9e6406a":{
      "timestamp":"2020-10-09T14:29:49",
      "params":{
        "params.yaml":{
          "prepare":{
            "split":0.2,
            "seed":20170428
          },
          "featurize":{
            "max_features":2000,
            "ngrams":2
          },
          "train":{
            "seed":20170428,
            "n_estimators":50
          }
        }
      },
      "queued":false,
      "metrics":{
        "scores.json":{
          "auc":0.5775633054725381
        }
      }
    },
    "5a9d6dc5056efa1310cd9afb61f437680f38b1af":{
      "timestamp":"2020-10-09T14:29:53",
      "params":{
        "params.yaml":{
          "prepare":{
            "split":0.2,
            "seed":20170428
          },
          "featurize":{
            "max_features":2000,
            "ngrams":2
          },
          "train":{
            "seed":20170428,
            "n_estimators":50
          }
        }
      },
      "queued":true
    }
  }
}
```