### PR TITLE
remote: add WebDAV dependency

### DIFF
--- a/dvc/dependency/__init__.py
+++ b/dvc/dependency/__init__.py
@@ -11,6 +11,8 @@ from dvc.dependency.local import LocalDependency
 from dvc.dependency.param import ParamsDependency
 from dvc.dependency.s3 import S3Dependency
 from dvc.dependency.ssh import SSHDependency
+from dvc.dependency.webdav import WebDAVDependency
+from dvc.dependency.webdavs import WebDAVSDependency
 from dvc.output.base import BaseOutput
 from dvc.scheme import Schemes
 
@@ -25,6 +27,8 @@ DEPS = [
     HTTPSDependency,
     S3Dependency,
     SSHDependency,
+    WebDAVDependency,
+    WebDAVSDependency
     # NOTE: LocalDependency is the default choice
 ]
 
@@ -37,6 +41,8 @@ DEP_MAP = {
     Schemes.HDFS: HDFSDependency,
     Schemes.HTTP: HTTPDependency,
     Schemes.HTTPS: HTTPSDependency,
+    Schemes.WEBDAV: WebDAVDependency,
+    Schemes.WEBDAVS: WebDAVSDependency,
 }
 
 

--- a/dvc/dependency/webdav.py
+++ b/dvc/dependency/webdav.py
@@ -1,0 +1,8 @@
+from dvc.dependency.base import BaseDependency
+from dvc.output.base import BaseOutput
+
+from ..tree.webdav import WebDAVTree
+
+
+class WebDAVDependency(BaseDependency, BaseOutput):
+    TREE_CLS = WebDAVTree

--- a/dvc/dependency/webdavs.py
+++ b/dvc/dependency/webdavs.py
@@ -1,0 +1,6 @@
+from ..tree.webdavs import WebDAVSTree
+from .webdav import WebDAVDependency
+
+
+class WebDAVSDependency(WebDAVDependency):
+    TREE_CLS = WebDAVSTree

--- a/tests/unit/dependency/test_webdav.py
+++ b/tests/unit/dependency/test_webdav.py
@@ -1,0 +1,7 @@
+from dvc.dependency.webdav import WebDAVDependency
+from tests.unit.dependency.test_local import TestLocalDependency
+
+
+class TestWebDAVDependency(TestLocalDependency):
+    def _get_cls(self):
+        return WebDAVDependency


### PR DESCRIPTION
This adds the dependency for WebDAV and enables calls like `import-url
remote://some-webdav/data`

Related to #4374

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
