### PR TITLE
dvc: update order of -q -v -h args [v2]

### DIFF
--- a/dvc/cli.py
+++ b/dvc/cli.py
@@ -117,6 +117,37 @@ class DvcParser(argparse.ArgumentParser):
             self.error(msg % " ".join(argv), getattr(args, "func", None))
         return args
 
+    def parse_known_args(self, args=None, namespace=None):
+        self.add_common_args()
+
+        # TODO: temp, all subparser should be called with add_help=False
+        if self.prog in ("dvc", "dvc add", "dvc init"):
+            self.add_argument(
+                "-h",
+                "--help",
+                action="help",
+                default=argparse.SUPPRESS,
+                help="Show this help message and exit.",
+            )
+        return super().parse_known_args(args, namespace)
+
+    def add_common_args(self):
+        self.add_argument(
+            "--cprofile",
+            action="store_true",
+            default=False,
+            help=argparse.SUPPRESS,
+        )
+        self.add_argument("--cprofile-dump", help=argparse.SUPPRESS)
+
+        log_level_group = self.add_mutually_exclusive_group()
+        log_level_group.add_argument(
+            "-q", "--quiet", action="count", default=0, help="Be quiet."
+        )
+        log_level_group.add_argument(
+            "-v", "--verbose", action="count", default=0, help="Be verbose."
+        )
+
 
 class VersionAction(argparse.Action):  # pragma: no cover
     # pylint: disable=too-few-public-methods
@@ -138,21 +169,21 @@ def get_parent_parser():
     """
     parent_parser = argparse.ArgumentParser(add_help=False)
 
-    parent_parser.add_argument(
-        "--cprofile",
-        action="store_true",
-        default=False,
-        help=argparse.SUPPRESS,
-    )
-    parent_parser.add_argument("--cprofile-dump", help=argparse.SUPPRESS)
+    # parent_parser.add_argument(
+    #     "--cprofile",
+    #     action="store_true",
+    #     default=False,
+    #     help=argparse.SUPPRESS,
+    # )
+    # parent_parser.add_argument("--cprofile-dump", help=argparse.SUPPRESS)
 
-    log_level_group = parent_parser.add_mutually_exclusive_group()
-    log_level_group.add_argument(
-        "-q", "--quiet", action="count", default=0, help="Be quiet."
-    )
-    log_level_group.add_argument(
-        "-v", "--verbose", action="count", default=0, help="Be verbose."
-    )
+    # log_level_group = parent_parser.add_mutually_exclusive_group()
+    # log_level_group.add_argument(
+    #     "-q", "--quiet", action="count", default=0, help="Be quiet."
+    # )
+    # log_level_group.add_argument(
+    #     "-v", "--verbose", action="count", default=0, help="Be verbose."
+    # )
 
     return parent_parser
 
@@ -168,18 +199,6 @@ def get_main_parser():
         parents=[parent_parser],
         formatter_class=argparse.RawTextHelpFormatter,
         add_help=False,
-    )
-
-    # NOTE: We are doing this to capitalize help message.
-    # Unfortunately, there is no easier and clearer way to do it,
-    # as adding this argument in get_parent_parser() either in
-    # log_level_group or on parent_parser itself will cause unexpected error.
-    parser.add_argument(
-        "-h",
-        "--help",
-        action="help",
-        default=argparse.SUPPRESS,
-        help="Show this help message and exit.",
     )
 
     # NOTE: On some python versions action='version' prints to stderr

--- a/dvc/command/add.py
+++ b/dvc/command/add.py
@@ -35,6 +35,7 @@ def add_parser(subparsers, parent_parser):
         "add",
         parents=[parent_parser],
         description=append_doc_link(ADD_HELP, "add"),
+        add_help=False,
         help=ADD_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/init.py
+++ b/dvc/command/init.py
@@ -37,6 +37,7 @@ def add_parser(subparsers, parent_parser):
         "init",
         parents=[parent_parser],
         description=append_doc_link(INIT_DESCRIPTION, "init"),
+        add_help=False,
         help=INIT_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )


### PR DESCRIPTION
An alternative solution for #4681

I highlighted the idea here, if it's more suitable then I need to finalize it, adding `add_help=False` and cleaning `parent_parser` everywhere.

It works as previous PR:
```
$ dvc add -h        
usage: dvc add [-R] [--no-commit] [--external] [--file <filename>] [-q | -v] [-h] targets [targets ...]

Track data files or directories with DVC.
Documentation: <https://man.dvc.org/add>

positional arguments:
  targets            Input files/directories to add.

optional arguments:
  -R, --recursive    Recursively add files under directory targets.
  --no-commit        Don't put files/directories into cache.
  --external         Allow targets that are outside of the DVC repository.
  --file <filename>  Specify name of the DVC-file this command will generate.
  -q, --quiet        Be quiet.
  -v, --verbose      Be verbose.
  -h, --help         Show this help message and exit.

$ dvc init -h       
usage: dvc init [--no-scm] [-f] [--subdir] [-q | -v] [-h]

Initialize DVC in the current directory. Expects directory
to be a Git repository unless --no-scm option is specified.
Documentation: <https://man.dvc.org/init>

optional arguments:
  --no-scm       Initiate DVC in directory that is not tracked by any SCM tool (e.g. Git).
  -f, --force    Overwrite existing '.dvc/' directory. This operation removes local cache.
  --subdir       Necessary for running this command inside a subdirectory of a parent SCM repository.
  -q, --quiet    Be quiet.
  -v, --verbose  Be verbose.
  -h, --help     Show this help message and exit.

$ dvc -h            
usage: dvc [-V] [--cd <path>] [-q | -v] [-h] COMMAND ...

Data Version Control

optional arguments:
  -V, --version  Show program's version.
  --cd <path>    Change to directory before executing.
  -q, --quiet    Be quiet.
  -v, --verbose  Be verbose.
  -h, --help     Show this help message and exit.
```