### PR TITLE
gha: get rid of unnecessary if

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   lint:
-    if: ${{ github.repository }} == 'iteratie/dvc'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.3.2
@@ -25,7 +24,6 @@ jobs:
     - name: Check formatting
       run: pre-commit run --all-files
   tests:
-    if: ${{ github.repository }} == 'iteratie/dvc'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

As @skshetry noted under https://github.com/iterative/dvc/pull/4680 - the repository name is wrong. Since the introduction of this change, there has been at least few builds, none of which should actually execute (and they did). Seems like job-level `if` is not working as intended. Removing it for now.