### PR TITLE
gha: fix github token providing for assets upload

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -9,8 +9,6 @@ jobs:
   linux:
     runs-on: ubuntu-16.04
     steps:
-    - name: set up environment variables
-      run: echo 'GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}' >> $GITHUB_ENV
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
@@ -22,6 +20,8 @@ jobs:
         ruby-version: 2.4
     - name: Build
       run: ./scripts/build_posix.sh
+    - name: set up github token
+      run: echo 'GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}' >> $GITHUB_ENV
     - name: Publish deb
       if: github.event_name == 'release'
       uses: actions/upload-release-asset@v1.0.1
@@ -52,10 +52,11 @@ jobs:
         ruby-version: 2.4
     - name: Build
       run: ./scripts/build_posix.sh
+    - name: set up github token
+      run: echo 'GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}' >> $GITHUB_ENV
     - name: Publish
       if: github.event_name == 'release'
       uses: actions/upload-release-asset@v1.0.1
-      run: echo 'GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}' >> $GITHUB_ENV
       with:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: dvc-${{ github.event.release.tag_name }}.pkg
@@ -72,10 +73,11 @@ jobs:
     - name: Build
       run: scripts\build_windows.cmd
       shell: cmd
+    - name: set up github token
+      run: echo 'GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}' >> $GITHUB_ENV
     - name: Publish
       if: github.event_name == 'release'
       uses: actions/upload-release-asset@v1.0.1
-      run: echo 'GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}' >> $GITHUB_ENV
       with:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: dvc-${{ github.event.release.tag_name }}.exe


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Provide `GITHUB_TOKEN` for publishing actions.

Github Actions does not allow to use both `run` and `uses` in one step.

https://github.com/iterative/dvc/actions/runs/301977911 - example.