### PR TITLE
checkpoints: cleanup --continue usage

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -670,7 +670,7 @@ def add_parser(subparsers, parent_parser):
     )
     experiments_run_parser.add_argument(
         "--continue",
-        nargs=1,
+        type=str,
         default=None,
         dest="checkpoint_continue",
         help=(


### PR DESCRIPTION
* warn if rev provided with `--continue` is ambiguous
* always provide tip of branch when suggesting to use `--continue`

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
