### PR TITLE
[WIP] Run pytype type checker as part of CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,6 +50,10 @@ jobs:
       run: |
         git config --global user.email "dvctester@example.com"
         git config --global user.name "DVC Tester"
+    - name: run type checker
+      if: contains(matrix.os, 'ubuntu')
+      run: |
+        pytype -V${{ matrix.pyv }}
     - name: run tests
       run: python -m tests -ra --cov-report=xml
     - name: upload coverage report

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,3 +18,8 @@ count=true
 profile=black
 known_first_party=dvc,tests
 line_length=79
+
+[pytype]
+inputs =
+    dvc
+    tests

--- a/setup.py
+++ b/setup.py
@@ -137,6 +137,7 @@ tests_requirements = [
     "pylint==2.5.3",
     "pylint-pytest>=0.3.0",
     "pylint-plugin-utils",
+    "pytype",
     "wget",
     "filelock",
     "black==19.10b0",


### PR DESCRIPTION
* Run pytype as part of tests on Ubuntu

Pytype is currently not supported at all on Windows.  Since pytype's results
_should_ be completely platform-agnostic and Linux is its primary target OS,
it's not worth slowing down macOS builds to re-run it there.

It _is_ worth running pytype as a test (as opposed to lint) to make sure the
types are valid in all of the supported versions of Python since later versions
introduced additional types to the stdlib.

Addresses #4697.

* [X] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org).

   *Question*: No user-facing documentation should be required.  Do develop docs need to be addressed here?