### PR TITLE
tests, packages: roll back environmental files change

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -20,11 +20,11 @@ jobs:
         ruby-version: 2.4
     - name: Build
       run: ./scripts/build_posix.sh
-    - name: set up github token
-      run: echo 'GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}' >> $GITHUB_ENV
     - name: Publish deb
       if: github.event_name == 'release'
       uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: dvc_${{ github.event.release.tag_name }}_amd64.deb
@@ -33,6 +33,8 @@ jobs:
     - name: Publish rpm
       if: github.event_name == 'release'
       uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: dvc-${{ github.event.release.tag_name }}-1.x86_64.rpm
@@ -52,11 +54,11 @@ jobs:
         ruby-version: 2.4
     - name: Build
       run: ./scripts/build_posix.sh
-    - name: set up github token
-      run: echo 'GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}' >> $GITHUB_ENV
     - name: Publish
       if: github.event_name == 'release'
       uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: dvc-${{ github.event.release.tag_name }}.pkg

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,6 +8,12 @@ on:
     branches:
       - master
 
+env:
+  DVC_TEST: "true"
+  HOMEBREW_NO_AUTO_UPDATE: 1
+  SHELL: /bin/bash
+  GDRIVE_CREDENTIALS_DATA: ${{ secrets.GDRIVE_CREDENTIALS_DATA }}
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -34,12 +40,6 @@ jobs:
           - os: windows-2019
             pyv: "3.9"
     steps:
-    - name: set up environment variables
-      run: |
-        echo 'DVC_TEST=true' >> $GITHUB_ENV
-        echo 'HOMEBREW_NO_AUTO_UPDATE=1' >> $GITHUB_ENV
-        echo 'SHELL=/bin/bash' >> $GITHUB_ENV
-        echo 'GDRIVE_CREDENTIALS_DATA=${{ secrets.GDRIVE_CREDENTIALS_DATA }}' >> $GITHUB_ENV
     - uses: actions/checkout@v2.3.2
     - name: Set up Python
       uses: actions/setup-python@v2.1.2


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Related to #4711 #4684 #4703

Turns out `env` is fine. I got confused due to lots of warning we have been receiving on our builds, and assumed that `env` is calling `set-env` somehow.

Context:
https://github.community/t/environmental-files-on-windows/137631