### PR TITLE
Implement foreach ... in loop in dvc.yaml

### DIFF
--- a/dvc/schema.py
+++ b/dvc/schema.py
@@ -2,7 +2,7 @@ from voluptuous import Any, Optional, Required, Schema
 
 from dvc import dependency, output
 from dvc.output import CHECKSUMS_SCHEMA, BaseOutput
-from dvc.parsing import USE_KWD, VARS_KWD
+from dvc.parsing import FOREACH_KWD, IN_KWD, USE_KWD, VARS_KWD
 from dvc.stage.params import StageParams
 
 STAGES = "stages"
@@ -48,26 +48,28 @@ PLOT_PSTAGE_SCHEMA = {str: Any(PLOT_PROPS_SCHEMA, [PLOT_PROPS_SCHEMA])}
 
 PARAM_PSTAGE_NON_DEFAULT_SCHEMA = {str: [str]}
 
-SINGLE_PIPELINE_STAGE_SCHEMA = {
-    str: {
-        StageParams.PARAM_CMD: str,
-        Optional(StageParams.PARAM_WDIR): str,
-        Optional(StageParams.PARAM_DEPS): [str],
-        Optional(StageParams.PARAM_PARAMS): [
-            Any(str, PARAM_PSTAGE_NON_DEFAULT_SCHEMA)
-        ],
-        Optional(StageParams.PARAM_FROZEN): bool,
-        Optional(StageParams.PARAM_META): object,
-        Optional(StageParams.PARAM_ALWAYS_CHANGED): bool,
-        Optional(StageParams.PARAM_OUTS): [
-            Any(str, OUT_PSTAGE_DETAILED_SCHEMA)
-        ],
-        Optional(StageParams.PARAM_METRICS): [
-            Any(str, OUT_PSTAGE_DETAILED_SCHEMA)
-        ],
-        Optional(StageParams.PARAM_PLOTS): [Any(str, PLOT_PSTAGE_SCHEMA)],
-    }
+STAGE_DEFINITION = {
+    StageParams.PARAM_CMD: str,
+    Optional(StageParams.PARAM_WDIR): str,
+    Optional(StageParams.PARAM_DEPS): [str],
+    Optional(StageParams.PARAM_PARAMS): [
+        Any(str, PARAM_PSTAGE_NON_DEFAULT_SCHEMA)
+    ],
+    Optional(StageParams.PARAM_FROZEN): bool,
+    Optional(StageParams.PARAM_META): object,
+    Optional(StageParams.PARAM_ALWAYS_CHANGED): bool,
+    Optional(StageParams.PARAM_OUTS): [Any(str, OUT_PSTAGE_DETAILED_SCHEMA)],
+    Optional(StageParams.PARAM_METRICS): [
+        Any(str, OUT_PSTAGE_DETAILED_SCHEMA)
+    ],
+    Optional(StageParams.PARAM_PLOTS): [Any(str, PLOT_PSTAGE_SCHEMA)],
 }
+
+FOREACH_IN = {
+    Required(FOREACH_KWD): Any(dict, list, str),
+    Required(IN_KWD): STAGE_DEFINITION,
+}
+SINGLE_PIPELINE_STAGE_SCHEMA = {str: Any(STAGE_DEFINITION, FOREACH_IN)}
 MULTI_STAGE_SCHEMA = {
     STAGES: SINGLE_PIPELINE_STAGE_SCHEMA,
     USE_KWD: str,

--- a/tests/func/test_stage_resolver.py
+++ b/tests/func/test_stage_resolver.py
@@ -233,3 +233,72 @@ def test_with_templated_wdir(tmp_dir, dvc):
             }
         },
     )
+
+
+def test_simple_foreach_loop(tmp_dir, dvc):
+    iterable = ["foo", "bar", "baz"]
+    d = {
+        "stages": {
+            "build": {
+                "foreach": iterable,
+                "in": {"cmd": "python script.py ${item}"},
+            }
+        }
+    }
+
+    resolver = DataResolver(dvc, PathInfo(str(tmp_dir)), d)
+    assert resolver.resolve() == {
+        "stages": {
+            f"build-{item}": {"cmd": f"python script.py {item}"}
+            for item in iterable
+        }
+    }
+
+
+def test_foreach_loop_dict(tmp_dir, dvc):
+    iterable = {"models": {"us": {"thresh": 10}, "gb": {"thresh": 15}}}
+    d = {
+        "stages": {
+            "build": {
+                "foreach": iterable,
+                "in": {"cmd": "python script.py ${item}"},
+            }
+        }
+    }
+
+    resolver = DataResolver(dvc, PathInfo(str(tmp_dir)), d)
+    assert resolver.resolve() == {
+        "stages": {
+            f"build-{key}": {"cmd": f"python script.py {item}"}
+            for key, item in iterable.items()
+        }
+    }
+
+
+def test_foreach_loop_templatized(tmp_dir, dvc):
+    params = {"models": {"us": {"thresh": 10}}}
+    vars_ = {"models": {"gb": {"thresh": 15}}}
+    dump_yaml(tmp_dir / DEFAULT_PARAMS_FILE, params)
+    d = {
+        "vars": vars_,
+        "stages": {
+            "build": {
+                "foreach": "${models}",
+                "in": {"cmd": "python script.py --thresh ${item.thresh}"},
+            }
+        },
+    }
+
+    resolver = DataResolver(dvc, PathInfo(str(tmp_dir)), d)
+    assert_stage_equal(
+        resolver.resolve(),
+        {
+            "stages": {
+                "build-gb": {"cmd": "python script.py --thresh 15"},
+                "build-us": {
+                    "cmd": "python script.py --thresh 10",
+                    "params": ["models.us.thresh"],
+                },
+            }
+        },
+    )

--- a/tests/func/test_stage_resolver.py
+++ b/tests/func/test_stage_resolver.py
@@ -260,8 +260,8 @@ def test_foreach_loop_dict(tmp_dir, dvc):
     d = {
         "stages": {
             "build": {
-                "foreach": iterable,
-                "in": {"cmd": "python script.py ${item}"},
+                "foreach": iterable["models"],
+                "in": {"cmd": "python script.py ${item.thresh}"},
             }
         }
     }
@@ -269,8 +269,8 @@ def test_foreach_loop_dict(tmp_dir, dvc):
     resolver = DataResolver(dvc, PathInfo(str(tmp_dir)), d)
     assert resolver.resolve() == {
         "stages": {
-            f"build-{key}": {"cmd": f"python script.py {item}"}
-            for key, item in iterable.items()
+            f"build-{key}": {"cmd": f"python script.py {item['thresh']}"}
+            for key, item in iterable["models"].items()
         }
     }
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Here's a wiki documenting the feature: https://github.com/iterative/dvc/wiki/Parametrization#foreach--in.
And, following are the examples for the foreach:

1. Looping through a list
```yaml
stages:
  build:
    foreach:
    - foo
    - bar
    - baz
    in:
      cmd: python script.py ${item}
```

2. Looping through a dictionary
```yaml
stages:
  build:
    foreach:
      models:
        us:
          thresh: 10
        gb:
          thresh: 15
    in:
      cmd: python script.py ${item}
```

3. Looping throuhg values in [vars](https://github.com/iterative/dvc/wiki/Parametrization#vars-section) or params.yaml
```yaml
stages:
  build:
    foreach: ${models}
    in:
      cmd: python script.py --thresh ${item.thresh}
```

You might notice `set` in the wiki. That is currently not implemented.
