### PR TITLE
command: add dvc push instruction after dvc repro

### DIFF
--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -30,14 +30,15 @@ class CmdRepro(CmdBase):
 
                 if len(stages) == 0:
                     logger.info(CmdDataStatus.UP_TO_DATE_MSG)
+                else:
+                    logger.info(
+                        "Use `dvc push` to send your updates to "
+                        "remote storage."
+                    )
 
                 if self.args.metrics:
                     metrics = self.repo.metrics.show()
                     logger.info(_show_metrics(metrics))
-
-                logger.info(
-                    "Use 'dvc push' to send your updates to remote storage."
-                )
 
             except DvcException:
                 logger.exception("")

--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -35,6 +35,10 @@ class CmdRepro(CmdBase):
                     metrics = self.repo.metrics.show()
                     logger.info(_show_metrics(metrics))
 
+                logger.info(
+                    "To save your updates to remote storage, run 'dvc push'."
+                )
+
             except DvcException:
                 logger.exception("")
                 ret = 1

--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -36,7 +36,7 @@ class CmdRepro(CmdBase):
                     logger.info(_show_metrics(metrics))
 
                 logger.info(
-                    "To save your updates to remote storage, run 'dvc push'."
+                    "Use 'dvc push' to send your updates to remote storage."
                 )
 
             except DvcException:


### PR DESCRIPTION
Adds a logger.info() statement to remind the user to run dvc push after
running dvc repro.

Closes #2359

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
