### PR TITLE
Job application: build_package/build_posix/pypi_upload.sh : single to double bracket ifs

### DIFF
--- a/scripts/build_package.sh
+++ b/scripts/build_package.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-if [ ! -d "dvc" ]; then
+if [[ ! -d "dvc" ]]; then
   echo "Please run this script from repository root" >&2
   exit 1
 fi

--- a/scripts/build_posix.sh
+++ b/scripts/build_posix.sh
@@ -31,7 +31,7 @@ print_error() {
   echo -e "\e[31m$1\e[0m" >&2
 }
 
-if [ ! -d "dvc" ]; then
+if [[ ! -d "dvc" ]]; then
   print_error "Please run this script from repository root"
   exit 1
 fi

--- a/scripts/pypi_upload.sh
+++ b/scripts/pypi_upload.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ ! -d "dvc" ]; then
+if [[ ! -d "dvc" ]]; then
   echo "Please run this script from repository root"
   exit 1
 fi


### PR DESCRIPTION
* [ x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

P.S. On my system the tests are flaky. When running the full suite (prior to any modiffications I made), some tests are failing. When I run the tests again with the pytest `--lf` argument (last failed), they pass. Different tests keep failing for different reasons (TLS handshake timeouts, date formats).

On top of this, running all the tests takes 30-45 minutes on my machine.

For these reasons, it's not easy for me to tell whether the changes I made might have affected the tests or not, but the likelihood seems very low.

Flaky test example:
```
__________________________________________________ test_download_dir[s3] __________________________________________________
[gw1] linux -- Python 3.7.6 /home/shefuto/personal/clones/dvc/.env/bin/python3

value = 'Lu, 19 oct 2020 11:04:35 GMT', tzinfo = <class 'dateutil.tz.tz.tzlocal'>

    def _parse_timestamp_with_tzinfo(value, tzinfo):
        """Parse timestamp with pluggable tzinfo options."""
        if isinstance(value, (int, float)):
            # Possibly an epoch time.
            return datetime.datetime.fromtimestamp(value, tzinfo())
        else:
            try:
                return datetime.datetime.fromtimestamp(float(value), tzinfo())
            except (TypeError, ValueError):
                pass
        try:
            # In certain cases, a timestamp marked with GMT can be parsed into a
            # different time zone, so here we provide a context which will
            # enforce that GMT == UTC.
>           return dateutil.parser.parse(value, tzinfos={'GMT': tzutc()})

/home/shefuto/personal/clones/dvc/.env/lib/python3.7/site-packages/botocore/utils.py:613: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

timestr = 'Lu, 19 oct 2020 11:04:35 GMT', parserinfo = None, kwargs = {'tzinfos': {'GMT': tzutc()}}

    def parse(timestr, parserinfo=None, **kwargs):
        """
    
        Parse a string in one of the supported formats, using the
        ``parserinfo`` parameters.
    
        :param timestr:
            A string containing a date/time stamp.
    
        :param parserinfo:
            A :class:`parserinfo` object containing parameters for the parser.
            If ``None``, the default arguments to the :class:`parserinfo`
            constructor are used.
    
        The ``**kwargs`` parameter takes the following keyword arguments:
    
        :param default:
            The default datetime object, if this is a datetime object and not
            ``None``, elements specified in ``timestr`` replace elements in the
            default object.
    
        :param ignoretz:
            If set ``True``, time zones in parsed strings are ignored and a naive
            :class:`datetime` object is returned.
    
        :param tzinfos:
            Additional time zone names / aliases which may be present in the
            string. This argument maps time zone names (and optionally offsets
            from those time zones) to time zones. This parameter can be a
            dictionary with timezone aliases mapping time zone names to time
            zones or a function taking two parameters (``tzname`` and
            ``tzoffset``) and returning a time zone.
    
            The timezones to which the names are mapped can be an integer
            offset from UTC in seconds or a :class:`tzinfo` object.
    
            .. doctest::
               :options: +NORMALIZE_WHITESPACE
    
                >>> from dateutil.parser import parse
                >>> from dateutil.tz import gettz
                >>> tzinfos = {"BRST": -7200, "CST": gettz("America/Chicago")}
                >>> parse("2012-01-19 17:21:00 BRST", tzinfos=tzinfos)
                datetime.datetime(2012, 1, 19, 17, 21, tzinfo=tzoffset(u'BRST', -7200))
                >>> parse("2012-01-19 17:21:00 CST", tzinfos=tzinfos)
                datetime.datetime(2012, 1, 19, 17, 21,
                                  tzinfo=tzfile('/usr/share/zoneinfo/America/Chicago'))
    
            This parameter is ignored if ``ignoretz`` is set.
    
        :param dayfirst:
            Whether to interpret the first value in an ambiguous 3-integer date
            (e.g. 01/05/09) as the day (``True``) or month (``False``). If
            ``yearfirst`` is set to ``True``, this distinguishes between YDM and
            YMD. If set to ``None``, this value is retrieved from the current
            :class:`parserinfo` object (which itself defaults to ``False``).
    
        :param yearfirst:
            Whether to interpret the first value in an ambiguous 3-integer date
            (e.g. 01/05/09) as the year. If ``True``, the first number is taken to
            be the year, otherwise the last number is taken to be the year. If
            this is set to ``None``, the value is retrieved from the current
            :class:`parserinfo` object (which itself defaults to ``False``).
    
        :param fuzzy:
            Whether to allow fuzzy parsing, allowing for string like "Today is
            January 1, 2047 at 8:21:00AM".
    
        :param fuzzy_with_tokens:
            If ``True``, ``fuzzy`` is automatically set to True, and the parser
            will return a tuple where the first element is the parsed
            :class:`datetime.datetime` datetimestamp and the second element is
            a tuple containing the portions of the string which were ignored:
    
            .. doctest::
    
                >>> from dateutil.parser import parse
                >>> parse("Today is January 1, 2047 at 8:21:00AM", fuzzy_with_tokens=True)
                (datetime.datetime(2047, 1, 1, 8, 21), (u'Today is ', u' ', u'at '))
    
        :return:
            Returns a :class:`datetime.datetime` object or, if the
            ``fuzzy_with_tokens`` option is ``True``, returns a tuple, the
            first element being a :class:`datetime.datetime` object, the second
            a tuple containing the fuzzy tokens.
    
        :raises ValueError:
            Raised for invalid or unknown string format, if the provided
            :class:`tzinfo` is not in a valid format, or if an invalid date
            would be created.
    
        :raises OverflowError:
            Raised if the parsed date exceeds the largest valid C integer on
            your system.
        """
        if parserinfo:
            return parser(parserinfo).parse(timestr, **kwargs)
        else:
>           return DEFAULTPARSER.parse(timestr, **kwargs)

/home/shefuto/personal/clones/dvc/.env/lib/python3.7/site-packages/dateutil/parser/_parser.py:1374: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <dateutil.parser._parser.parser object at 0x7fea0138b590>, timestr = 'Lu, 19 oct 2020 11:04:35 GMT'
default = datetime.datetime(2020, 10, 19, 0, 0), ignoretz = False, tzinfos = {'GMT': tzutc()}, kwargs = {}, res = None
skipped_tokens = None

    def parse(self, timestr, default=None,
              ignoretz=False, tzinfos=None, **kwargs):
        """
        Parse the date/time string into a :class:`datetime.datetime` object.
    
        :param timestr:
            Any date/time string using the supported formats.
    
        :param default:
            The default datetime object, if this is a datetime object and not
            ``None``, elements specified in ``timestr`` replace elements in the
            default object.
    
        :param ignoretz:
            If set ``True``, time zones in parsed strings are ignored and a
            naive :class:`datetime.datetime` object is returned.
    
        :param tzinfos:
            Additional time zone names / aliases which may be present in the
            string. This argument maps time zone names (and optionally offsets
            from those time zones) to time zones. This parameter can be a
            dictionary with timezone aliases mapping time zone names to time
            zones or a function taking two parameters (``tzname`` and
            ``tzoffset``) and returning a time zone.
    
            The timezones to which the names are mapped can be an integer
            offset from UTC in seconds or a :class:`tzinfo` object.
    
            .. doctest::
               :options: +NORMALIZE_WHITESPACE
    
                >>> from dateutil.parser import parse
                >>> from dateutil.tz import gettz
                >>> tzinfos = {"BRST": -7200, "CST": gettz("America/Chicago")}
                >>> parse("2012-01-19 17:21:00 BRST", tzinfos=tzinfos)
                datetime.datetime(2012, 1, 19, 17, 21, tzinfo=tzoffset(u'BRST', -7200))
                >>> parse("2012-01-19 17:21:00 CST", tzinfos=tzinfos)
                datetime.datetime(2012, 1, 19, 17, 21,
                                  tzinfo=tzfile('/usr/share/zoneinfo/America/Chicago'))
    
            This parameter is ignored if ``ignoretz`` is set.
    
        :param \\*\\*kwargs:
            Keyword arguments as passed to ``_parse()``.
    
        :return:
            Returns a :class:`datetime.datetime` object or, if the
            ``fuzzy_with_tokens`` option is ``True``, returns a tuple, the
            first element being a :class:`datetime.datetime` object, the second
            a tuple containing the fuzzy tokens.
    
        :raises ParserError:
            Raised for invalid or unknown string format, if the provided
            :class:`tzinfo` is not in a valid format, or if an invalid date
            would be created.
    
        :raises TypeError:
            Raised for non-string or character stream input.
    
        :raises OverflowError:
            Raised if the parsed date exceeds the largest valid C integer on
            your system.
        """
    
        if default is None:
            default = datetime.datetime.now().replace(hour=0, minute=0,
                                                      second=0, microsecond=0)
    
        res, skipped_tokens = self._parse(timestr, **kwargs)
    
        if res is None:
>           raise ParserError("Unknown string format: %s", timestr)
E           dateutil.parser._parser.ParserError: Unknown string format: Lu, 19 oct 2020 11:04:35 GMT

/home/shefuto/personal/clones/dvc/.env/lib/python3.7/site-packages/dateutil/parser/_parser.py:649: ParserError

During handling of the above exception, another exception occurred:

remote = Remote: 's3://dvc-temp/63637c55-241a-4a69-8a1b-d307824f3f11'
tmpdir = local('/tmp/pytest-of-shefuto/pytest-2/popen-gw1/test_download_dir_s3_0')

    @pytest.mark.parametrize("remote", remotes, indirect=True)
    def test_download_dir(remote, tmpdir):
        path = str(tmpdir / "data")
        to_info = PathInfo(path)
>       remote.tree.download(remote.tree.path_info / "data", to_info)

/home/shefuto/personal/clones/dvc/tests/unit/remote/test_remote_tree.py:144: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/home/shefuto/personal/clones/dvc/dvc/tree/base.py:387: in download
    from_info, to_info, name, no_progress_bar, file_mode, dir_mode
/home/shefuto/personal/clones/dvc/dvc/tree/base.py:435: in _download_dir
    raise exc
/home/shefuto/.pyenv/versions/3.7.6/lib/python3.7/concurrent/futures/thread.py:57: in run
    result = self.fn(*self.args, **self.kwargs)
/home/shefuto/personal/clones/dvc/dvc/progress.py:126: in wrapped
    res = fn(*args, **kwargs)
/home/shefuto/personal/clones/dvc/dvc/tree/base.py:448: in _download_file
    from_info, tmp_file, name=name, no_progress_bar=no_progress_bar
/home/shefuto/personal/clones/dvc/dvc/tree/s3.py:352: in _download
    total=obj.content_length,
/home/shefuto/personal/clones/dvc/.env/lib/python3.7/site-packages/boto3/resources/factory.py:339: in property_loader
    self.load()
/home/shefuto/personal/clones/dvc/.env/lib/python3.7/site-packages/boto3/resources/factory.py:505: in do_action
    response = action(self, *args, **kwargs)
/home/shefuto/personal/clones/dvc/.env/lib/python3.7/site-packages/boto3/resources/action.py:83: in __call__
    response = getattr(parent.meta.client, operation_name)(*args, **params)
/home/shefuto/personal/clones/dvc/.env/lib/python3.7/site-packages/botocore/client.py:357: in _api_call
    return self._make_api_call(operation_name, kwargs)
/home/shefuto/personal/clones/dvc/.env/lib/python3.7/site-packages/botocore/client.py:663: in _make_api_call
    operation_model, request_dict, request_context)
/home/shefuto/personal/clones/dvc/.env/lib/python3.7/site-packages/botocore/client.py:682: in _make_request
    return self._endpoint.make_request(operation_model, request_dict)
/home/shefuto/personal/clones/dvc/.env/lib/python3.7/site-packages/botocore/endpoint.py:102: in make_request
    return self._send_request(request_dict, operation_model)
/home/shefuto/personal/clones/dvc/.env/lib/python3.7/site-packages/botocore/endpoint.py:135: in _send_request
    request, operation_model, context)
/home/shefuto/personal/clones/dvc/.env/lib/python3.7/site-packages/botocore/endpoint.py:167: in _get_response
    request, operation_model)
/home/shefuto/personal/clones/dvc/.env/lib/python3.7/site-packages/botocore/endpoint.py:218: in _do_get_response
    response_dict, operation_model.output_shape)
/home/shefuto/personal/clones/dvc/.env/lib/python3.7/site-packages/botocore/parsers.py:245: in parse
    parsed = self._do_parse(response, shape)
/home/shefuto/personal/clones/dvc/.env/lib/python3.7/site-packages/botocore/parsers.py:809: in _do_parse
    self._add_modeled_parse(response, shape, final_parsed)
/home/shefuto/personal/clones/dvc/.env/lib/python3.7/site-packages/botocore/parsers.py:817: in _add_modeled_parse
    member_shapes, final_parsed)
/home/shefuto/personal/clones/dvc/.env/lib/python3.7/site-packages/botocore/parsers.py:880: in _parse_non_payload_attrs
    member_shape, headers[header_name])
/home/shefuto/personal/clones/dvc/.env/lib/python3.7/site-packages/botocore/parsers.py:312: in _parse_shape
    return handler(shape, node)
/home/shefuto/personal/clones/dvc/.env/lib/python3.7/site-packages/botocore/parsers.py:174: in _get_text_content
    return func(self, shape, text)
/home/shefuto/personal/clones/dvc/.env/lib/python3.7/site-packages/botocore/parsers.py:482: in _handle_timestamp
    return self._timestamp_parser(text)
/home/shefuto/personal/clones/dvc/.env/lib/python3.7/site-packages/botocore/utils.py:632: in parse_timestamp
    return _parse_timestamp_with_tzinfo(value, tzinfo)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

value = 'Lu, 19 oct 2020 11:04:35 GMT', tzinfo = <class 'dateutil.tz.tz.tzlocal'>

    def _parse_timestamp_with_tzinfo(value, tzinfo):
        """Parse timestamp with pluggable tzinfo options."""
        if isinstance(value, (int, float)):
            # Possibly an epoch time.
            return datetime.datetime.fromtimestamp(value, tzinfo())
        else:
            try:
                return datetime.datetime.fromtimestamp(float(value), tzinfo())
            except (TypeError, ValueError):
                pass
        try:
            # In certain cases, a timestamp marked with GMT can be parsed into a
            # different time zone, so here we provide a context which will
            # enforce that GMT == UTC.
            return dateutil.parser.parse(value, tzinfos={'GMT': tzutc()})
        except (TypeError, ValueError) as e:
>           raise ValueError('Invalid timestamp "%s": %s' % (value, e))
E           ValueError: Invalid timestamp "Lu, 19 oct 2020 11:04:35 GMT": Unknown string format: Lu, 19 oct 2020 11:04:35 GMT

/home/shefuto/personal/clones/dvc/.env/lib/python3.7/site-packages/botocore/utils.py:615: ValueError
```