### PR TITLE
Support for WebHDFS

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -265,7 +265,7 @@ contextmanager-decorators=contextlib.contextmanager
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
-generated-members=pytest.lazy_fixture,logging.TRACE,logger.trace,sys.getwindowsversion
+generated-members=hdfs.*,pytest.lazy_fixture,logging.TRACE,logger.trace,sys.getwindowsversion
 
 # Tells whether missing members accessed in mixin class should be ignored. A
 # mixin class is detected if its name ends with "mixin" (case insensitive).

--- a/dvc/cache/__init__.py
+++ b/dvc/cache/__init__.py
@@ -36,7 +36,13 @@ class Cache:
     """
 
     CACHE_DIR = "cache"
-    CLOUD_SCHEMES = [Schemes.S3, Schemes.GS, Schemes.SSH, Schemes.HDFS]
+    CLOUD_SCHEMES = [
+        Schemes.S3,
+        Schemes.GS,
+        Schemes.SSH,
+        Schemes.HDFS,
+        Schemes.WEBHDFS,
+    ]
 
     def __init__(self, repo):
         self.repo = repo

--- a/dvc/cache/__init__.py
+++ b/dvc/cache/__init__.py
@@ -73,7 +73,6 @@ class Cache:
     def by_scheme(self):
         yield from self._cache.items()
 
-
 class NamedCacheItem:
     def __init__(self):
         self.names = set()

--- a/dvc/cache/__init__.py
+++ b/dvc/cache/__init__.py
@@ -79,6 +79,7 @@ class Cache:
     def by_scheme(self):
         yield from self._cache.items()
 
+
 class NamedCacheItem:
     def __init__(self):
         self.names = set()

--- a/dvc/config.py
+++ b/dvc/config.py
@@ -149,6 +149,7 @@ SCHEMA = {
         "s3": str,
         "gs": str,
         "hdfs": str,
+        "webhdfs": str,
         "ssh": str,
         "azure": str,
         # This is for default local cache
@@ -195,6 +196,13 @@ SCHEMA = {
                     **REMOTE_COMMON,
                 },
                 "hdfs": {"user": str, **REMOTE_COMMON},
+                "webhdfs": {
+                    "hdfscli_config": str,
+                    "webhdfs_token": str,
+                    "user": str,
+                    "webhdfs_alias": str,
+                    **REMOTE_COMMON,
+                },
                 "azure": {"connection_string": str, **REMOTE_COMMON},
                 "oss": {
                     "oss_key_id": str,

--- a/dvc/dependency/__init__.py
+++ b/dvc/dependency/__init__.py
@@ -13,6 +13,7 @@ from dvc.dependency.s3 import S3Dependency
 from dvc.dependency.ssh import SSHDependency
 from dvc.dependency.webdav import WebDAVDependency
 from dvc.dependency.webdavs import WebDAVSDependency
+from dvc.dependency.webhdfs import WebHDFSDependency
 from dvc.output.base import BaseOutput
 from dvc.scheme import Schemes
 
@@ -28,7 +29,8 @@ DEPS = [
     S3Dependency,
     SSHDependency,
     WebDAVDependency,
-    WebDAVSDependency
+    WebDAVSDependency,
+    WebHDFSDependency,
     # NOTE: LocalDependency is the default choice
 ]
 
@@ -43,6 +45,7 @@ DEP_MAP = {
     Schemes.HTTPS: HTTPSDependency,
     Schemes.WEBDAV: WebDAVDependency,
     Schemes.WEBDAVS: WebDAVSDependency,
+    Schemes.WEBHDFS: WebHDFSDependency,
 }
 
 

--- a/dvc/dependency/webhdfs.py
+++ b/dvc/dependency/webhdfs.py
@@ -1,0 +1,6 @@
+from dvc.dependency.base import BaseDependency
+from dvc.output.webhdfs import WebHDFSOutput
+
+
+class WebHDFSDependency(BaseDependency, WebHDFSOutput):
+    pass

--- a/dvc/output/__init__.py
+++ b/dvc/output/__init__.py
@@ -11,18 +11,21 @@ from dvc.output.hdfs import HDFSOutput
 from dvc.output.local import LocalOutput
 from dvc.output.s3 import S3Output
 from dvc.output.ssh import SSHOutput
+from dvc.output.webhdfs import WebHDFSOutput
 from dvc.scheme import Schemes
 
 from ..tree import get_cloud_tree
 from ..tree.hdfs import HDFSTree
 from ..tree.local import LocalTree
 from ..tree.s3 import S3Tree
+from ..tree.webhdfs import WebHDFSTree
 
 OUTS = [
     HDFSOutput,
     S3Output,
     GSOutput,
     SSHOutput,
+    WebHDFSOutput,
     # NOTE: LocalOutput is the default choice
 ]
 
@@ -32,6 +35,7 @@ OUTS_MAP = {
     Schemes.GS: GSOutput,
     Schemes.SSH: SSHOutput,
     Schemes.LOCAL: LocalOutput,
+    Schemes.WEBHDFS: WebHDFSOutput,
 }
 
 CHECKSUM_SCHEMA = Any(
@@ -52,6 +56,7 @@ CHECKSUMS_SCHEMA = {
     LocalTree.PARAM_CHECKSUM: CHECKSUM_SCHEMA,
     S3Tree.PARAM_CHECKSUM: CHECKSUM_SCHEMA,
     HDFSTree.PARAM_CHECKSUM: CHECKSUM_SCHEMA,
+    WebHDFSTree.PARAM_CHECKSUM: CHECKSUM_SCHEMA,
 }
 
 SCHEMA = CHECKSUMS_SCHEMA.copy()

--- a/dvc/output/base.py
+++ b/dvc/output/base.py
@@ -254,7 +254,6 @@ class BaseOutput:
     # pylint: enable=no-member
 
     def save(self):
-        print(self)
         if not self.exists:
             raise self.DoesNotExistError(self)
 

--- a/dvc/output/base.py
+++ b/dvc/output/base.py
@@ -254,6 +254,7 @@ class BaseOutput:
     # pylint: enable=no-member
 
     def save(self):
+        print(self)
         if not self.exists:
             raise self.DoesNotExistError(self)
 

--- a/dvc/output/webhdfs.py
+++ b/dvc/output/webhdfs.py
@@ -1,0 +1,7 @@
+from dvc.output.base import BaseOutput
+
+from ..tree.webhdfs import WebHDFSTree
+
+
+class WebHDFSOutput(BaseOutput):
+    TREE_CLS = WebHDFSTree

--- a/dvc/scheme.py
+++ b/dvc/scheme.py
@@ -1,6 +1,7 @@
 class Schemes:
     SSH = "ssh"
     HDFS = "hdfs"
+    WEBHDFS = "webhdfs"
     S3 = "s3"
     AZURE = "azure"
     HTTP = "http"

--- a/dvc/tree/__init__.py
+++ b/dvc/tree/__init__.py
@@ -13,6 +13,7 @@ from .s3 import S3Tree
 from .ssh import SSHTree
 from .webdav import WebDAVTree
 from .webdavs import WebDAVSTree
+from .webhdfs import WebHDFSTree
 
 TREES = [
     AzureTree,
@@ -26,6 +27,7 @@ TREES = [
     OSSTree,
     WebDAVTree,
     WebDAVSTree,
+    WebHDFSTree
     # NOTE: LocalTree is the default
 ]
 

--- a/dvc/tree/webhdfs.py
+++ b/dvc/tree/webhdfs.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import threading
+from contextlib import contextmanager
 
 from funcy import cached_property, wrap_prop
 
@@ -57,6 +58,15 @@ class WebHDFSTree(BaseTree):
                 )
 
         return client
+
+    @contextmanager
+    def open(self, path_info, mode="r", encoding=None):
+        assert mode in {"r", "rt", "rb"}
+
+        with self.hdfs_client.read(
+            path_info.path, encoding=encoding
+        ) as reader:
+            yield reader.read()
 
     def walk_files(self, path_info, **kwargs):
         yield self.hdfs_client.walk(

--- a/dvc/tree/webhdfs.py
+++ b/dvc/tree/webhdfs.py
@@ -65,7 +65,7 @@ class WebHDFSTree(BaseTree):
         logger.debug("HDFSConfig: %s", self.hdfscli_config)
 
         try:
-            client = hdfs.config.Config(self.hdfscli_config).get_client(
+            return hdfs.config.Config(self.hdfscli_config).get_client(
                 self.alias
             )
         except hdfs.util.HdfsError as exc:

--- a/dvc/tree/webhdfs.py
+++ b/dvc/tree/webhdfs.py
@@ -134,6 +134,7 @@ class WebHDFSTree(BaseTree):
         self.hdfs_client.write(to_info.path, data=content)
 
     def move(self, from_info, to_info, mode=None):
+        self.hdfs_client.makedirs(to_info.parent.path)
         self.hdfs_client.rename(from_info.path, to_info.path)
 
     def _upload(

--- a/dvc/tree/webhdfs.py
+++ b/dvc/tree/webhdfs.py
@@ -1,6 +1,9 @@
 import logging
+import os
 import threading
+from collections import deque
 from contextlib import contextmanager
+from urllib.parse import urlparse
 
 from funcy import cached_property, wrap_prop
 
@@ -13,20 +16,44 @@ from .base import BaseTree
 logger = logging.getLogger(__name__)
 
 
+def update_pbar(pbar):
+    """Update pbar to accept the two arguments passed by hdfs"""
+
+    def update(_, bytes_transfered):  # No use for first argument (path)
+        if bytes_transfered == -1:
+            return
+        pbar.update(bytes_transfered)
+
+    return update
+
+
 class WebHDFSTree(BaseTree):
     scheme = Schemes.WEBHDFS
     PATH_CLS = CloudURLInfo
     REQUIRES = {"hdfs": "hdfs"}
+    REGEX = r"^webhdfs://((?P<user>.*)@)?.*$"
 
     def __init__(self, repo, config):
         super().__init__(repo, config)
 
+        self.path_info = None
         url = config.get("url")
-        self.path_info = self.PATH_CLS(url) if url else None
+        if not url:
+            return
+
+        parsed = urlparse(url)
+        user = parsed.username or config.get("user")
+
+        self.path_info = self.PATH_CLS.from_parts(
+            scheme="webhdfs",
+            host=parsed.hostname,
+            user=user,
+            port=parsed.port,
+            path=parsed.path,
+        )
 
         self.hdfscli_config = config.get("hdfscli_config")
         self.token = config.get("webhdfs_token")
-        self.user = config.get("user")
         self.alias = config.get("webhdfs_alias")
 
     @wrap_prop(threading.Lock())
@@ -40,15 +67,17 @@ class WebHDFSTree(BaseTree):
         try:
             client = hdfs.config.Config(  # pylint: disable=no-member
                 self.hdfscli_config
-            ).get(self.alias)
+            ).get_client(self.alias)
         except hdfs.util.HdfsError:  # pylint: disable=no-member
+            http_url = f"http://{self.path_info.host}:{self.path_info.port}"
+
             if self.token is not None:
                 client = hdfs.TokenClient(  # pylint: disable=no-member
-                    self.path_info.url, self.token
+                    http_url, self.token
                 )
             else:
                 client = hdfs.InsecureClient(  # pylint: disable=no-member
-                    self.path_info.url, self.user
+                    http_url, self.path_info.user
                 )
 
         return client
@@ -63,9 +92,22 @@ class WebHDFSTree(BaseTree):
             yield reader.read()
 
     def walk_files(self, path_info, **kwargs):
-        yield self.hdfs_client.walk(
-            path_info.path, depth=kwargs.get("depth", 0)
-        )
+        if not self.exists(path_info):
+            return
+
+        root = path_info.path
+        dir_queue = deque([root])
+
+        while dir_queue:
+            for path, dirs, files in self.hdfs_client.walk(
+                dir_queue.pop(), depth=kwargs.get("depth", 0)
+            ):
+                new_dirs = [os.path.join(path, dir_) for dir_ in dirs]
+                dir_queue.extend(new_dirs)
+
+                for file_ in files:
+                    path = os.path.join(path, file_)
+                    yield path_info.replace(path=path)
 
     def remove(self, path_info):
         if path_info.scheme != self.scheme:
@@ -84,10 +126,14 @@ class WebHDFSTree(BaseTree):
         self, from_file, to_info, name=None, no_progress_bar=False, **_kwargs
     ):
         with Tqdm(desc=name, disable=no_progress_bar, bytes=True) as pbar:
-            self.hdfs_client.upload(to_info.path, from_file, progress=pbar)
+            self.hdfs_client.upload(
+                to_info.path, from_file, progress=update_pbar(pbar)
+            )
 
     def _download(
         self, from_info, to_file, name=None, no_progress_bar=False, **_kwargs
     ):
         with Tqdm(desc=name, disable=no_progress_bar, bytes=True) as pbar:
-            self.hdfs_client.download(from_info.path, to_file, progress=pbar)
+            self.hdfs_client.download(
+                from_info.path, to_file, progress=update_pbar(pbar)
+            )

--- a/dvc/tree/webhdfs.py
+++ b/dvc/tree/webhdfs.py
@@ -32,7 +32,6 @@ class WebHDFSTree(BaseTree):
     scheme = Schemes.WEBHDFS
     PATH_CLS = CloudURLInfo
     REQUIRES = {"hdfs": "hdfs"}
-    REGEX = r"^webhdfs://((?P<user>.*)@)?.*$"
     PARAM_CHECKSUM = "checksum"
 
     def __init__(self, repo, config):

--- a/dvc/tree/webhdfs.py
+++ b/dvc/tree/webhdfs.py
@@ -1,8 +1,11 @@
 import logging
+import os
+import threading
 import shutil
 
 from funcy import cached_property, wrap_prop
 
+from dvc.path_info import CloudURLInfo
 from dvc.progress import Tqdm
 
 from .base import BaseTree
@@ -13,7 +16,7 @@ logger = logging.getLogger(__name__)
 class WebHDFSTree(BaseTree):
     PATH_CLS = CloudURLInfo
     REQUIRES = {"hdfs": "hdfs"}
-    
+
     def __init__(self, repo, config):
         super().__init__(repo, config)
 
@@ -25,7 +28,7 @@ class WebHDFSTree(BaseTree):
             or os.getenv("HDFSCLI_CONFIG")
             or "~/.hdfscli.cfg"
         )
-        
+
         self.token = (
             config.get("webhdfs_token")
         )
@@ -40,11 +43,10 @@ class WebHDFSTree(BaseTree):
     @cached_property
     def hdfs_client(self):
         import hdfs
-        
+
         logger.debug("URL: %s", self.path_info)
         logger.debug("HDFSConfig: %s", self.hdfscli_config)
 
-        
         try:
             client = hdfs.config.Config(self.hdfscli_config).get(self.alias)
         except hdfs.HdfsError:
@@ -58,7 +60,7 @@ class WebHDFSTree(BaseTree):
     def exists(self, path_info, use_dvcignore=True):
         status = self.hdfs_client.status(path_info.path, strict=False)
         return status is not None
-    
+
     def _upload(
         self, from_file, to_info, name=None, no_progress_bar=False, **_kwargs
     ):

--- a/dvc/tree/webhdfs.py
+++ b/dvc/tree/webhdfs.py
@@ -127,7 +127,10 @@ class WebHDFSTree(BaseTree):
     ):
         with Tqdm(desc=name, disable=no_progress_bar, bytes=True) as pbar:
             self.hdfs_client.upload(
-                to_info.path, from_file, progress=update_pbar(pbar)
+                to_info.path,
+                from_file,
+                overwrite=True,
+                progress=update_pbar(pbar),
             )
 
     def _download(

--- a/dvc/tree/webhdfs.py
+++ b/dvc/tree/webhdfs.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import threading
-from collections import deque
 from contextlib import contextmanager
 from urllib.parse import urlparse
 
@@ -97,13 +96,10 @@ class WebHDFSTree(BaseTree):
             return
 
         root = path_info.path
-        dir_queue = deque([root])
-
-        while dir_queue:
-            for path, _, files in self.hdfs_client.walk(dir_queue.pop()):
-                for file_ in files:
-                    path = os.path.join(path, file_)
-                    yield path_info.replace(path=path)
+        for path, _, files in self.hdfs_client.walk(root):
+            for file_ in files:
+                path = os.path.join(path, file_)
+                yield path_info.replace(path=path)
 
     def remove(self, path_info):
         if path_info.scheme != self.scheme:

--- a/dvc/tree/webhdfs.py
+++ b/dvc/tree/webhdfs.py
@@ -123,7 +123,10 @@ class WebHDFSTree(BaseTree):
 
     def get_file_hash(self, path_info):
         checksum = self.hdfs_client.checksum(path_info.path)
-        return HashInfo(self.PARAM_CHECKSUM, checksum["bytes"])
+        hash_info = HashInfo(self.PARAM_CHECKSUM, checksum["bytes"])
+
+        hash_info.size = self.hdfs_client.status(path_info.path)["length"]
+        return hash_info
 
     def copy(self, from_info, to_info, **_kwargs):
         with self.hdfs_client.read(from_info.path) as reader:

--- a/dvc/tree/webhdfs.py
+++ b/dvc/tree/webhdfs.py
@@ -133,6 +133,9 @@ class WebHDFSTree(BaseTree):
             content = reader.read()
         self.hdfs_client.write(to_info.path, data=content)
 
+    def move(self, from_info, to_info, mode=None):
+        self.hdfs_client.rename(from_info.path, to_info.path)
+
     def _upload(
         self, from_file, to_info, name=None, no_progress_bar=False, **_kwargs
     ):

--- a/dvc/tree/webhdfs.py
+++ b/dvc/tree/webhdfs.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import threading
 from contextlib import contextmanager
 
@@ -25,12 +24,7 @@ class WebHDFSTree(BaseTree):
         url = config.get("url")
         self.path_info = self.PATH_CLS(url) if url else None
 
-        self.hdfscli_config = (
-            config.get("hdfscli_config")
-            or os.getenv("HDFSCLI_CONFIG")
-            or "~/.hdfscli.cfg"
-        )
-
+        self.hdfscli_config = config.get("hdfscli_config")
         self.token = config.get("webhdfs_token")
         self.user = config.get("user")
         self.alias = config.get("webhdfs_alias")

--- a/dvc/tree/webhdfs.py
+++ b/dvc/tree/webhdfs.py
@@ -101,12 +101,7 @@ class WebHDFSTree(BaseTree):
         dir_queue = deque([root])
 
         while dir_queue:
-            for path, dirs, files in self.hdfs_client.walk(
-                dir_queue.pop(), depth=kwargs.get("depth", 0)
-            ):
-                new_dirs = [os.path.join(path, dir_) for dir_ in dirs]
-                dir_queue.extend(new_dirs)
-
+            for path, _, files in self.hdfs_client.walk(dir_queue.pop()):
                 for file_ in files:
                     path = os.path.join(path, file_)
                     yield path_info.replace(path=path)

--- a/dvc/tree/webhdfs.py
+++ b/dvc/tree/webhdfs.py
@@ -71,6 +71,8 @@ class WebHDFSTree(BaseTree):
                 self.alias
             )
         except hdfs.util.HdfsError:
+            # No hdfs config file was found, or parsing failed. Fallback to
+            # clients using Hadoop delegation token or username
             http_url = f"http://{self.path_info.host}:{self.path_info.port}"
 
             if self.token is not None:

--- a/dvc/tree/webhdfs.py
+++ b/dvc/tree/webhdfs.py
@@ -1,0 +1,74 @@
+import logging
+import shutil
+
+from funcy import cached_property, wrap_prop
+
+from dvc.progress import Tqdm
+
+from .base import BaseTree
+
+logger = logging.getLogger(__name__)
+
+
+class WebHDFSTree(BaseTree):
+    PATH_CLS = CloudURLInfo
+    REQUIRES = {"hdfs": "hdfs"}
+    
+    def __init__(self, repo, config):
+        super().__init__(repo, config)
+
+        url = config.get("url")
+        self.path_info = self.PATH_CLS(url) if url else None
+
+        self.hdfscli_config = (
+            config.get("hdfscli_config")
+            or os.getenv("HDFSCLI_CONFIG")
+            or "~/.hdfscli.cfg"
+        )
+        
+        self.token = (
+            config.get("webhdfs_token")
+        )
+        self.user = (
+            config.get("webhdfs_user")
+        )
+        self.alias = (
+            config.get("webhdfs_alias")
+        )
+
+    @wrap_prop(threading.Lock())
+    @cached_property
+    def hdfs_client(self):
+        import hdfs
+        
+        logger.debug("URL: %s", self.path_info)
+        logger.debug("HDFSConfig: %s", self.hdfscli_config)
+
+        
+        try:
+            client = hdfs.config.Config(self.hdfscli_config).get(self.alias)
+        except hdfs.HdfsError:
+            if self.token is not None:
+                client = hdfs.TokenClient(self.path_info.url, self.token)
+            else:
+                client = hdfs.InsecureClient(self.path_info.url, self.user)
+   
+        return client
+
+    def exists(self, path_info, use_dvcignore=True):
+        status = self.hdfs_client.status(path_info.path, strict=False)
+        return status is not None
+    
+    def _upload(
+        self, from_file, to_info, name=None, no_progress_bar=False, **_kwargs
+    ):
+        with Tqdm(desc=name, disable=no_progress_bar, bytes=True) as pbar:
+            with self.hdfs_client.write(to_info.path, encoding='utf-8') as writer:
+                shutil.copyfileobj(from_file, writer)
+
+    def _download(
+        self, from_info, to_file, name=None, no_progress_bar=False, **_kwargs
+    ):
+        with Tqdm(desc=name, disable=no_progress_bar, bytes=True) as pbar:
+            with self.hdfs_client.read(from_info.path, encoding='utf-8') as reader:
+                shutil.copyfileobj(reader, to_file)

--- a/dvc/tree/webhdfs.py
+++ b/dvc/tree/webhdfs.py
@@ -68,9 +68,16 @@ class WebHDFSTree(BaseTree):
             client = hdfs.config.Config(self.hdfscli_config).get_client(
                 self.alias
             )
-        except hdfs.util.HdfsError:
-            # No hdfs config file was found, or parsing failed. Fallback to
-            # clients using Hadoop delegation token or username
+        except hdfs.util.HdfsError as exc:
+            exc_msg = str(exc)
+            errors = (
+                "No alias specified",
+                "Invalid configuration file",
+                f"Alias {self.alias} not found",
+            )
+            if not any(err in exc_msg for err in errors):
+                raise
+
             http_url = f"http://{self.path_info.host}:{self.path_info.port}"
 
             if self.token is not None:

--- a/dvc/tree/webhdfs.py
+++ b/dvc/tree/webhdfs.py
@@ -67,18 +67,16 @@ class WebHDFSTree(BaseTree):
         logger.debug("HDFSConfig: %s", self.hdfscli_config)
 
         try:
-            client = hdfs.config.Config(  # pylint: disable=no-member
-                self.hdfscli_config
-            ).get_client(self.alias)
-        except hdfs.util.HdfsError:  # pylint: disable=no-member
+            client = hdfs.config.Config(self.hdfscli_config).get_client(
+                self.alias
+            )
+        except hdfs.util.HdfsError:
             http_url = f"http://{self.path_info.host}:{self.path_info.port}"
 
             if self.token is not None:
-                client = hdfs.TokenClient(  # pylint: disable=no-member
-                    http_url, token=self.token, root="/"
-                )
+                client = hdfs.TokenClient(http_url, token=self.token, root="/")
             else:
-                client = hdfs.InsecureClient(  # pylint: disable=no-member
+                client = hdfs.InsecureClient(
                     http_url, user=self.path_info.user, root="/"
                 )
 

--- a/dvc/tree/webhdfs.py
+++ b/dvc/tree/webhdfs.py
@@ -126,7 +126,6 @@ class WebHDFSTree(BaseTree):
 
     def get_file_hash(self, path_info):
         checksum = self.hdfs_client.checksum(path_info.path)
-        print(checksum)
         return HashInfo(self.PARAM_CHECKSUM, checksum["bytes"])
 
     def copy(self, from_info, to_info, **_kwargs):

--- a/setup.py
+++ b/setup.py
@@ -98,13 +98,14 @@ ssh = ["paramiko[invoke]>=2.7.0"]
 
 # Remove the env marker if/when pyarrow is available for Python3.9
 hdfs = ["pyarrow>=2.0.0;  python_version < '3.9'"]
+webhdfs = ["hdfs==2.5.8"]
 webdav = ["webdavclient3>=3.14.5"]
 # gssapi should not be included in all_remotes, because it doesn't have wheels
 # for linux and mac, so it will fail to compile if user doesn't have all the
 # requirements, including kerberos itself. Once all the wheels are available,
 # we can start shipping it by default.
 ssh_gssapi = ["paramiko[invoke,gssapi]>=2.7.0"]
-all_remotes = gs + s3 + azure + ssh + oss + gdrive + hdfs + webdav
+all_remotes = gs + s3 + azure + ssh + oss + gdrive + hdfs + webhdfs + webdav
 
 # Extra dependecies to run tests
 tests_requirements = [
@@ -173,6 +174,7 @@ setup(
         "ssh": ssh,
         "ssh_gssapi": ssh_gssapi,
         "hdfs": hdfs,
+        "webhdfs": webhdfs,
         "webdav": webdav,
         "tests": tests_requirements,
     },

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -17,3 +17,4 @@ services:
       # `dfs.datanode.address` in `hdfs-site.xml` and probably something
       # else, so using default one for now.
       - "50010:50010"
+      - "50070"

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -11,10 +11,12 @@ services:
       - "8880"
   hdfs:
     image: rkuprieiev/docker-hdfs
+    hostname: localhost
     ports:
       - "8020"
       # NOTE: having this port as dynamic one will require modifying
       # `dfs.datanode.address` in `hdfs-site.xml` and probably something
       # else, so using default one for now.
       - "50010:50010"
+      - "50075:50075"
       - "50070"

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -288,6 +288,11 @@ def test_add_filtered_files_in_dir(
             "checksum",
             "000002000000000000000000a86fe4d846edc1bf4c355cb6112f141e",
         ),
+        (
+            pytest.lazy_fixture("webhdfs"),
+            "checksum",
+            "000002000000000000000000a86fe4d846edc1bf4c355cb6112f141e00000000",
+        ),
     ],
     indirect=["workspace"],
 )

--- a/tests/func/test_api.py
+++ b/tests/func/test_api.py
@@ -20,6 +20,7 @@ cloud_names = [
     "http",
     "hdfs",
     "webdav",
+    "webhdfs",
 ]
 clouds = [pytest.lazy_fixture(cloud) for cloud in cloud_names]
 all_clouds = [pytest.lazy_fixture("local_cloud")] + clouds

--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -30,6 +30,7 @@ all_clouds = [
         "http",
         "hdfs",
         "webdav",
+        "webhdfs",
     ]
 ] + [
     pytest.param(

--- a/tests/func/test_gc.py
+++ b/tests/func/test_gc.py
@@ -356,6 +356,7 @@ def test_gc_not_collect_pipeline_tracked_files(tmp_dir, dvc, run_copy):
         pytest.lazy_fixture("s3"),
         pytest.lazy_fixture("gs"),
         pytest.lazy_fixture("hdfs"),
+        pytest.lazy_fixture("webhdfs"),
         pytest.param(
             pytest.lazy_fixture("ssh"),
             marks=pytest.mark.skipif(

--- a/tests/func/test_import_url.py
+++ b/tests/func/test_import_url.py
@@ -122,6 +122,7 @@ def test_import_url_with_no_exec(tmp_dir, dvc, erepo_dir):
         pytest.lazy_fixture("s3"),
         pytest.lazy_fixture("gs"),
         pytest.lazy_fixture("hdfs"),
+        pytest.lazy_fixture("webhdfs"),
         pytest.param(
             pytest.lazy_fixture("ssh"),
             marks=pytest.mark.skipif(

--- a/tests/func/test_update.py
+++ b/tests/func/test_update.py
@@ -164,6 +164,7 @@ def test_update_before_and_after_dvc_init(tmp_dir, dvc, git_dir):
         pytest.lazy_fixture("s3"),
         pytest.lazy_fixture("gs"),
         pytest.lazy_fixture("hdfs"),
+        pytest.lazy_fixture("webhdfs"),
         pytest.param(
             pytest.lazy_fixture("ssh"),
             marks=pytest.mark.skipif(

--- a/tests/remotes/__init__.py
+++ b/tests/remotes/__init__.py
@@ -3,7 +3,7 @@ import subprocess
 import pytest
 
 from .azure import Azure, azure, azure_server  # noqa: F401
-from .hdfs import HDFS, hadoop, hdfs, hdfs_server  # noqa: F401
+from .hdfs import HDFS, hadoop, hdfs, hdfs_server, webhdfs  # noqa: F401
 from .http import HTTP, http, http_server  # noqa: F401
 from .local import Local, local_cloud, local_remote  # noqa: F401
 from .oss import (  # noqa: F401

--- a/tests/remotes/hdfs.py
+++ b/tests/remotes/hdfs.py
@@ -153,17 +153,15 @@ class WebHDFS(Base, URLInfo):  # pylint: disable=abstract-method
 
         client = hdfs.InsecureClient(self.url, self.user)
         return client
-        
 
     def is_file(self):
         with self._webhdfs() as _hdfs:
             return _hdfs.status(self.path)["type"] == "FILE"
-            
 
     def is_dir(self):
         with self._webhdfs() as _hdfs:
             return _hdfs.status(self.path)["type"] == "DIRECTORY"
-            
+
     def exists(self):
         with self._webhdfs() as _hdfs:
             return _hdfs.status(self.path, strict=False) is not None

--- a/tests/remotes/hdfs.py
+++ b/tests/remotes/hdfs.py
@@ -119,6 +119,7 @@ def hdfs_server(hadoop, docker_compose, docker_services):
     import pyarrow
 
     port = docker_services.port_for("hdfs", 8020)
+    web_port = docker_services.port_for("hdfs", 50070)
 
     def _check():
         try:
@@ -136,12 +137,12 @@ def hdfs_server(hadoop, docker_compose, docker_services):
 
     docker_services.wait_until_responsive(timeout=30.0, pause=5, check=_check)
 
-    return port
+    return {"hdfs": port, "webhdfs": web_port}
 
 
 @pytest.fixture
 def hdfs(hdfs_server):
-    port = hdfs_server
+    port = hdfs_server["hdfs"]
     url = f"hdfs://127.0.0.1:{port}/{uuid.uuid4()}"
     yield HDFS(url)
 
@@ -200,6 +201,6 @@ class WebHDFS(Base, URLInfo):  # pylint: disable=abstract-method
 
 @pytest.fixture
 def webhdfs(hdfs_server):
-    port = hdfs_server
+    port = hdfs_server["webhdfs"]
     url = f"webhdfs://127.0.0.1:{port}/{uuid.uuid4()}"
     yield WebHDFS(url)

--- a/tests/remotes/hdfs.py
+++ b/tests/remotes/hdfs.py
@@ -200,6 +200,6 @@ class WebHDFS(Base, URLInfo):  # pylint: disable=abstract-method
 
 @pytest.fixture
 def webhdfs(hdfs_server):
-    port = "50070"
+    port = hdfs_server
     url = f"webhdfs://127.0.0.1:{port}/{uuid.uuid4()}"
     yield WebHDFS(url)

--- a/tests/remotes/hdfs.py
+++ b/tests/remotes/hdfs.py
@@ -144,3 +144,63 @@ def hdfs(hdfs_server):
     port = hdfs_server
     url = f"hdfs://127.0.0.1:{port}/{uuid.uuid4()}"
     yield HDFS(url)
+
+
+class WebHDFS(Base, URLInfo):  # pylint: disable=abstract-method
+    @contextmanager
+    def _webhdfs(self):
+        import hdfs
+
+        client = hdfs.InsecureClient(self.url, self.user)
+        return client
+        
+
+    def is_file(self):
+        with self._webhdfs() as _hdfs:
+            return _hdfs.status(self.path)["type"] == "FILE"
+            
+
+    def is_dir(self):
+        with self._webhdfs() as _hdfs:
+            return _hdfs.status(self.path)["type"] == "DIRECTORY"
+            
+    def exists(self):
+        with self._webhdfs() as _hdfs:
+            return _hdfs.status(self.path, strict=False) is not None
+
+    def mkdir(self, mode=0o777, parents=False, exist_ok=False):
+        assert mode == 0o777
+        assert parents
+        assert not exist_ok
+
+        with self._webhdfs() as _hdfs:
+            # NOTE: hdfs.makekdirs always creates parents
+            _hdfs.makedirs(self.path)
+
+    def write_bytes(self, contents):
+        with self._webhdfs() as _hdfs:
+            with _hdfs.write(self.path) as writer:
+                writer.write(contents)
+
+    def write_text(self, contents, encoding=None, errors=None):
+        if not encoding:
+            encoding = locale.getpreferredencoding(False)
+        assert errors is None
+        self.write_bytes(contents.encode(encoding))
+
+    def read_bytes(self):
+        with self._webhdfs().read(self.path) as reader:
+            return reader.read()
+
+    def read_text(self, encoding=None, errors=None):
+        if not encoding:
+            encoding = locale.getpreferredencoding(False)
+        assert errors is None
+        return self.read_bytes().decode(encoding)
+
+
+@pytest.fixture
+def webhdfs(hdfs_server):
+    port = "50070"
+    url = f"webhdfs://127.0.0.1:{port}/{uuid.uuid4()}"
+    yield WebHDFS(url)

--- a/tests/remotes/hdfs.py
+++ b/tests/remotes/hdfs.py
@@ -149,10 +149,10 @@ def hdfs(hdfs_server):
 class WebHDFS(Base, URLInfo):  # pylint: disable=abstract-method
     @contextmanager
     def _webhdfs(self):
-        import hdfs
+        from hdfs import InsecureClient
 
-        client = hdfs.InsecureClient(self.url, self.user)
-        return client
+        client = InsecureClient(self.url, self.user)
+        yield client
 
     def is_file(self):
         with self._webhdfs() as _hdfs:
@@ -187,8 +187,9 @@ class WebHDFS(Base, URLInfo):  # pylint: disable=abstract-method
         self.write_bytes(contents.encode(encoding))
 
     def read_bytes(self):
-        with self._webhdfs().read(self.path) as reader:
-            return reader.read()
+        with self._webhdfs() as _hdfs:
+            with _hdfs.read(self.path) as reader:
+                return reader.read()
 
     def read_text(self, encoding=None, errors=None):
         if not encoding:

--- a/tests/remotes/hdfs.py
+++ b/tests/remotes/hdfs.py
@@ -152,7 +152,7 @@ class WebHDFS(Base, URLInfo):  # pylint: disable=abstract-method
     def _webhdfs(self):
         from hdfs import InsecureClient
 
-        client = InsecureClient(self.url, self.user)
+        client = InsecureClient(f"http://{self.host}:{self.port}", self.user)
         yield client
 
     def is_file(self):
@@ -174,11 +174,11 @@ class WebHDFS(Base, URLInfo):  # pylint: disable=abstract-method
 
         with self._webhdfs() as _hdfs:
             # NOTE: hdfs.makekdirs always creates parents
-            _hdfs.makedirs(self.path)
+            _hdfs.makedirs(self.path, permission=mode)
 
     def write_bytes(self, contents):
         with self._webhdfs() as _hdfs:
-            with _hdfs.write(self.path) as writer:
+            with _hdfs.write(self.path, overwrite=True) as writer:
                 writer.write(contents)
 
     def write_text(self, contents, encoding=None, errors=None):

--- a/tests/unit/remote/test_webhdfs.py
+++ b/tests/unit/remote/test_webhdfs.py
@@ -1,0 +1,24 @@
+from dvc.tree.webhdfs import WebHDFSTree
+
+user = "test"
+webhdfs_token = "token"
+webhdfs_alias = "alias-name"
+hdfscli_config = "path/to/cli/config"
+
+
+def test_init(dvc):
+    url = "webhdfs://127.0.0.1:50070"
+    config = {
+        "url": url,
+        "webhdfs_token": webhdfs_token,
+        "webhdfs_alias": webhdfs_alias,
+        "hdfscli_config": hdfscli_config,
+        "user": user,
+    }
+
+    tree = WebHDFSTree(dvc, config)
+    assert tree.path_info == url
+    assert tree.token == webhdfs_token
+    assert tree.alias == webhdfs_alias
+    assert tree.user == user
+    assert tree.hdfscli_config == hdfscli_config

--- a/tests/unit/remote/test_webhdfs.py
+++ b/tests/unit/remote/test_webhdfs.py
@@ -7,7 +7,7 @@ hdfscli_config = "path/to/cli/config"
 
 
 def test_init(dvc):
-    url = "webhdfs://127.0.0.1:50070"
+    url = "webhdfs://test@127.0.0.1:50070"
     config = {
         "url": url,
         "webhdfs_token": webhdfs_token,
@@ -20,5 +20,5 @@ def test_init(dvc):
     assert tree.path_info == url
     assert tree.token == webhdfs_token
     assert tree.alias == webhdfs_alias
-    assert tree.user == user
+    assert tree.path_info.user == user
     assert tree.hdfscli_config == hdfscli_config


### PR DESCRIPTION
* [✅ ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [✔️] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

This is a draft PR to close #4687. Documentation is required ~but no issue or separate PR has been created yet~, is tracked by https://github.com/iterative/dvc.org/issues/1899, and being worked on in https://github.com/iterative/dvc.org/pull/1916.

As I work on the PR, I would like some input on:
* Choice of library: I went with [hdfs](https://pypi.org/project/hdfs/) as it seems to be the most stable.
* Scope: assuming consensus on library, there's some optional parameters that could be supported on connection (for example, a `timeout` or `proxy`), as well as different connection clients (an `InsecureClient` using `user` and a `TokenClient`). Should the connection parameters be limited? I have currently prioritized the use of a config file as it's the preferred method for `hdfs` (the library), and left `InsecureClient` and `TokenClient` as fallbacks if no config file exists.
* Whether I'm over-complicating functional testing by creating a `WebHDFS` class similar to `HDFS` (available [here](https://github.com/iterative/dvc/blob/master/tests/remotes/hdfs.py#L15)). It smells a bit to me as it's mostly passing calls to the underlying client, but I'm not too certain on how functional tests use `HDFS` 😃.

