### PR TITLE
Use lxml wheel instead of legacy setup.py builds

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,20 +36,12 @@ jobs:
       matrix:
         os: [ubuntu-18.04, windows-2019, macos-10.15]
         pyv: ["3.6", "3.7", "3.8", "3.9"]
-        exclude:
-          - os: windows-2019
-            pyv: "3.9"
     steps:
     - uses: actions/checkout@v2.3.2
     - name: Set up Python
       uses: actions/setup-python@v2.1.2
       with:
         python-version: ${{ matrix.pyv }}
-    - name: Install libxml2 and libxslt
-      if: matrix.pyv == '3.9' && matrix.os == 'ubuntu-18.04'
-      # need to install for building lxml, a dependency of webdavclient3
-      run: |
-        sudo apt install libxml2 libxslt-dev
     - name: install
       run: |
         pip install ".[all,tests]"


### PR DESCRIPTION
`lxml` now provides wheel for Python3.9. 

Also, enable windows test for Python3.9

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
