### PR TITLE
checkpoints: allow missing outputs on checkout and stage.run

### DIFF
--- a/dvc/output/base.py
+++ b/dvc/output/base.py
@@ -282,6 +282,9 @@ class BaseOutput:
         self.hash_info = self.get_hash()
 
     def commit(self):
+        if not self.exists:
+            raise self.DoesNotExistError(self)
+
         assert self.hash_info
         if self.use_cache:
             self.cache.save(self.path_info, self.cache.tree, self.hash_info)
@@ -326,7 +329,7 @@ class BaseOutput:
         progress_callback=None,
         relink=False,
         filter_info=None,
-        allow_persist_missing=False,
+        allow_missing=False,
     ):
         if not self.use_cache:
             if progress_callback:
@@ -345,7 +348,7 @@ class BaseOutput:
                 filter_info=filter_info,
             )
         except CheckoutError:
-            if self.persist and allow_persist_missing:
+            if allow_missing:
                 return None
             raise
 

--- a/dvc/repo/checkout.py
+++ b/dvc/repo/checkout.py
@@ -46,7 +46,7 @@ def checkout(
     force=False,
     relink=False,
     recursive=False,
-    allow_persist_missing=False,
+    allow_missing=False,
 ):
     from dvc.stage.exceptions import (
         StageFileBadNameError,
@@ -97,7 +97,7 @@ def checkout(
                 progress_callback=pbar.update_msg,
                 relink=relink,
                 filter_info=filter_info,
-                allow_persist_missing=allow_persist_missing,
+                allow_missing=allow_missing,
             )
             for key, items in result.items():
                 stats[key].extend(_fspath_dir(path) for path in items)

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -395,7 +395,7 @@ class Experiments:
         )
         exp_rev = first(results)
         if exp_rev is not None:
-            self.checkout_exp(exp_rev)
+            self.checkout_exp(exp_rev, allow_missing=checkpoint)
         return results
 
     def reproduce_queued(self, **kwargs):
@@ -727,7 +727,7 @@ class Experiments:
             raise UploadError(fails)
 
     @scm_locked
-    def checkout_exp(self, rev):
+    def checkout_exp(self, rev, allow_missing=False):
         """Checkout an experiment to the user's workspace."""
         from git.exc import GitCommandError
 
@@ -761,7 +761,7 @@ class Experiments:
                 self._unstash_workspace()
 
         if need_checkout:
-            dvc_checkout(self.repo)
+            dvc_checkout(self.repo, allow_missing=allow_missing)
 
     def _check_baseline(self, exp_rev):
         baseline_sha = self.repo.scm.get_rev()

--- a/dvc/repo/experiments/executor.py
+++ b/dvc/repo/experiments/executor.py
@@ -168,8 +168,12 @@ class LocalExecutor(ExperimentExecutor):
             #   is not polluted with the (persistent) out from an unrelated
             #   experiment run
             checkpoint = kwargs.pop("checkpoint", False)
-            dvc.checkout(allow_persist_missing=checkpoint, force=checkpoint)
-            stages = dvc.reproduce(on_unchanged=filter_pipeline, **kwargs)
+            dvc.checkout(allow_missing=checkpoint, force=checkpoint)
+            stages = dvc.reproduce(
+                on_unchanged=filter_pipeline,
+                allow_missing=checkpoint,
+                **kwargs,
+            )
         finally:
             if old_cwd is not None:
                 os.chdir(old_cwd)

--- a/dvc/stage/run.py
+++ b/dvc/stage/run.py
@@ -169,7 +169,7 @@ def _checkpoint_run(stage, callback_func, done_cond, proc):
 
 @relock_repo
 def _run_callback(stage, callback_func):
-    stage.save()
+    stage.save(allow_missing=True)
     # TODO: do we need commit() (and check for --no-commit) here
     logger.debug("Running checkpoint callback for stage '%s'", stage)
     callback_func()


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will close #4707, may also be related to #4746.

* Adds support for allowing missing outputs in `repo.checkout` and `stage.run` (previously we supported missing `persist` outs for checkpoints, but we actually need this for regular outs as well).

For checkpoint experiments, we want to support the potential use case where a stage may contain both intermediate outputs (that persist) and regular (non-persist) outputs. Depending on when the checkpoint run is interrupted, the regular outputs may not have been created yet, but this should not be considered a failure state for checkpoint experiments.