### PR TITLE
Make codecov push results on every run

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,1 +1,1 @@
-
+comment: false

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -52,7 +52,6 @@ jobs:
     - name: run tests
       run: python -m tests -ra --cov-report=xml --tap-combined
     - name: upload coverage report
-      if: github.event.name == 'push'
       uses: codecov/codecov-action@v1.0.13
       with:
         file: ./coverage.xml


### PR DESCRIPTION
Most likely because of this `if` conditional, coverage results were never pushed in the last two months. This conditional is unnecessary. 

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
