### PR TITLE
dvc.yaml: introduce set keyword

### DIFF
--- a/dvc/parsing/context.py
+++ b/dvc/parsing/context.py
@@ -56,6 +56,9 @@ class Value:
     def __repr__(self):
         return repr(self.value)
 
+    def __str__(self) -> str:
+        return str(self.value)
+
     def get_sources(self):
         return {self.meta.source: self.meta.path()}
 
@@ -103,7 +106,10 @@ class Container:
         return iter(self.data)
 
     def __eq__(self, o):
-        return o.data == self.data
+        container = type(self)
+        if isinstance(o, container):
+            return o.data == self.data
+        return container(o) == self
 
     def select(self, key: str):
         index, *rems = key.split(sep=".", maxsplit=1)

--- a/dvc/schema.py
+++ b/dvc/schema.py
@@ -2,7 +2,7 @@ from voluptuous import Any, Optional, Required, Schema
 
 from dvc import dependency, output
 from dvc.output import CHECKSUMS_SCHEMA, BaseOutput
-from dvc.parsing import FOREACH_KWD, IN_KWD, USE_KWD, VARS_KWD
+from dvc.parsing import FOREACH_KWD, IN_KWD, SET_KWD, USE_KWD, VARS_KWD
 from dvc.stage.params import StageParams
 
 STAGES = "stages"
@@ -50,6 +50,7 @@ PARAM_PSTAGE_NON_DEFAULT_SCHEMA = {str: [str]}
 
 STAGE_DEFINITION = {
     StageParams.PARAM_CMD: str,
+    Optional(SET_KWD): dict,
     Optional(StageParams.PARAM_WDIR): str,
     Optional(StageParams.PARAM_DEPS): [str],
     Optional(StageParams.PARAM_PARAMS): [
@@ -66,6 +67,7 @@ STAGE_DEFINITION = {
 }
 
 FOREACH_IN = {
+    Optional(SET_KWD): dict,
     Required(FOREACH_KWD): Any(dict, list, str),
     Required(IN_KWD): STAGE_DEFINITION,
 }

--- a/tests/func/test_stage_resolver.py
+++ b/tests/func/test_stage_resolver.py
@@ -1,5 +1,6 @@
 import os
 from copy import deepcopy
+from math import pi
 
 import pytest
 
@@ -302,3 +303,100 @@ def test_foreach_loop_templatized(tmp_dir, dvc):
             }
         },
     )
+
+
+@pytest.mark.parametrize(
+    "value", ["value", "To set or not to set", 3, pi, True, False, None]
+)
+def test_set(tmp_dir, dvc, value):
+    d = {
+        "stages": {
+            "build": {
+                "set": {"item": value},
+                "cmd": "python script.py --thresh ${item}",
+                "always_changed": "${item}",
+            }
+        }
+    }
+    resolver = DataResolver(dvc, PathInfo(str(tmp_dir)), d)
+    assert resolver.resolve() == {
+        "stages": {
+            "build": {
+                "cmd": f"python script.py --thresh {value}",
+                "always_changed": value,
+            }
+        }
+    }
+
+
+@pytest.mark.parametrize(
+    "coll", [["foo", "bar", "baz"], {"foo": "foo", "bar": "bar"}]
+)
+def test_coll(tmp_dir, dvc, coll):
+    d = {
+        "stages": {
+            "build": {
+                "set": {"item": coll, "thresh": 10},
+                "cmd": "python script.py --thresh ${thresh}",
+                "outs": "${item}",
+            }
+        }
+    }
+    resolver = DataResolver(dvc, PathInfo(str(tmp_dir)), d)
+    assert resolver.resolve() == {
+        "stages": {
+            "build": {"cmd": "python script.py --thresh 10", "outs": coll}
+        }
+    }
+
+
+def test_set_with_foreach(tmp_dir, dvc):
+    items = ["foo", "bar", "baz"]
+    d = {
+        "stages": {
+            "build": {
+                "set": {"items": items},
+                "foreach": "${items}",
+                "in": {"cmd": "command --value ${item}"},
+            }
+        }
+    }
+    resolver = DataResolver(dvc, PathInfo(str(tmp_dir)), d)
+    assert resolver.resolve() == {
+        "stages": {
+            f"build-{item}": {"cmd": f"command --value {item}"}
+            for item in items
+        }
+    }
+
+
+def test_set_with_foreach_and_on_stage_definition(tmp_dir, dvc):
+    iterable = {"models": {"us": {"thresh": 10}, "gb": {"thresh": 15}}}
+    dump_json(tmp_dir / "params.json", iterable)
+
+    d = {
+        "use": "params.json",
+        "stages": {
+            "build": {
+                "set": {"data": "${models}"},
+                "foreach": "${data}",
+                "in": {
+                    "set": {"thresh": "${item.thresh}"},
+                    "cmd": "command --value ${thresh}",
+                },
+            }
+        },
+    }
+    resolver = DataResolver(dvc, PathInfo(str(tmp_dir)), d)
+    assert resolver.resolve() == {
+        "stages": {
+            "build-us": {
+                "cmd": "command --value 10",
+                "params": [{"params.json": ["models.us.thresh"]}],
+            },
+            "build-gb": {
+                "cmd": "command --value 15",
+                "params": [{"params.json": ["models.gb.thresh"]}],
+            },
+        }
+    }

--- a/tests/unit/test_stage_resolver.py
+++ b/tests/unit/test_stage_resolver.py
@@ -1,5 +1,9 @@
+from math import pi
+
+import pytest
+
 from dvc.parsing import DataResolver
-from dvc.parsing.context import Context
+from dvc.parsing.context import Context, Value
 
 TEMPLATED_DVC_YAML_DATA = {
     "stages": {
@@ -38,3 +42,134 @@ def test_resolver(tmp_dir, dvc):
     resolver = DataResolver(dvc, tmp_dir, TEMPLATED_DVC_YAML_DATA)
     resolver.global_ctx = Context(CONTEXT_DATA)
     assert resolver.resolve() == RESOLVED_DVC_YAML_DATA
+
+
+def test_set():
+    context = Context(CONTEXT_DATA)
+    to_set = {
+        "foo": "foo",
+        "bar": "bar",
+        "pi": pi,
+        "true": True,
+        "false": False,
+        "none": "None",
+        "int": 1,
+        "lst2": [1, 2, 3],
+        "dct2": {"foo": "bar", "foobar": "foobar"},
+    }
+    DataResolver.set_context_from(context, to_set)
+
+    for key, value in to_set.items():
+        # FIXME: using for convenience, figure out better way to do it
+        assert context[key] == context._convert(key, value)
+
+
+@pytest.mark.parametrize(
+    "coll",
+    [
+        ["foo", "bar", ["foo", "bar"]],
+        ["foo", "bar", {"foo": "foo", "bar": "bar"}],
+        {"foo": "foo", "bar": ["foo", "bar"]},
+        {"foo": "foo", "bar": {"foo": "foo", "bar": "bar"}},
+    ],
+)
+def test_set_nested_coll(coll):
+    context = Context(CONTEXT_DATA)
+    with pytest.raises(ValueError, match="Cannot set 'item', has nested"):
+        DataResolver.set_context_from(context, {"thresh": 10, "item": coll})
+
+
+def test_set_already_exists():
+    context = Context({"item": "foo"})
+    with pytest.raises(
+        ValueError, match="Cannot set 'item', key already exists"
+    ):
+        DataResolver.set_context_from(context, {"item": "bar"})
+
+    assert context["item"] == Value("foo")
+
+
+@pytest.mark.parametrize(
+    "coll", [["foo", "${bar}"], {"foo": "${foo}", "bar": "bar"}],
+)
+def test_set_collection_interpolation(coll):
+    context = Context(CONTEXT_DATA)
+    with pytest.raises(
+        ValueError, match="Cannot set 'item', having interpolation inside"
+    ):
+        DataResolver.set_context_from(context, {"thresh": 10, "item": coll})
+
+
+def test_set_interpolated_string():
+    context = Context(CONTEXT_DATA)
+    DataResolver.set_context_from(
+        context,
+        {
+            "foo": "${dict.foo}",
+            "bar": "${dict.bar}",
+            "param1": "${list.0}",
+            "param2": "${list.1}",
+            "frozen": "${freeze}",
+            "dict2": "${dict}",
+            "list2": "${list}",
+        },
+    )
+
+    assert context["foo"] == Value("foo")
+    assert context["bar"] == Value("bar")
+    assert context["param1"] == Value("param1")
+    assert context["param2"] == Value("param2")
+    assert context["frozen"] == context["freeze"] == Value(True)
+    assert context["dict2"] == context["dict"] == CONTEXT_DATA["dict"]
+    assert context["list2"] == context["list"] == CONTEXT_DATA["list"]
+
+
+def test_set_ladder():
+    context = Context(CONTEXT_DATA)
+    DataResolver.set_context_from(
+        context,
+        {
+            "item": 5,
+            "foo": "${dict.foo}",
+            "bar": "${dict.bar}",
+            "bar2": "${bar}",
+            "dict2": "${dict}",
+            "list2": "${list}",
+            "dict3": "${dict2}",
+            "list3": "${list2}",
+        },
+    )
+
+    assert context["item"] == Value(5)
+    assert context["foo"] == context["dict"]["foo"] == Value("foo")
+    assert (
+        context["bar"]
+        == context["bar2"]
+        == context["dict"]["bar"]
+        == Value("bar")
+    )
+    assert (
+        context["dict"]
+        == context["dict2"]
+        == context["dict3"]
+        == CONTEXT_DATA["dict"]
+    )
+    assert (
+        context["list"]
+        == context["list2"]
+        == context["list3"]
+        == CONTEXT_DATA["list"]
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["param ${dict.foo}", "${dict.bar}${dict.foo}", "${dict.foo}-${dict.bar}"],
+)
+def test_set_multiple_interpolations(value):
+    context = Context(CONTEXT_DATA)
+    with pytest.raises(
+        ValueError,
+        match=r"Cannot set 'item', joining string with interpolated string",
+    ):
+        DataResolver.set_context_from(context, {"thresh": 10, "item": value})


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

On top of #4734 
Here's a wiki documenting the feature: https://github.com/iterative/dvc/wiki/Parametrization

This PR introduces set keyword, which can be used to alias a variable.
Some examples:
1. Setting variable inside for a stage to be DRY
```yaml
stages:
  build:
    set:
      item: "value"
    cmd: python script.py --thresh ${item}
    always_changed: ${item}
```

2. `set` can _set_ list to a variable. But, it is not allowed to contain nested list or nested dictionary inside of it.
```yaml
stages:
  build:
    set:
      item:
      - foo
      - bar
      - baz
      thresh: 10
    cmd: python script.py --thresh ${thresh}
    # note: DVC does not allow to change schema like this right now
    # just an example of how you could potentially use this
    outs: ${item}
```

3. `set` can _set_ dict to a variable. But, it is not allowed to contain nested list or nested dictionary inside of it.
```yaml
stages:
  build:
    set:
      item:
        foo: foo
        bar: bar
      thresh: 10
    cmd: python script.py --thresh ${thresh}
    outs: ${item}
```

4. `set` to  create an alias
```yaml
use: params.json
stages:
  build:
    set:  # optional, loop-wide effect
      data: ${models}
    foreach: ${data}
    in:
      set:  # optional, affects only one instance/iteration
        thresh: ${item.thresh}
      cmd: command --value ${thresh}
```
> NOTE: `set` is always evaluated first, before `foreach`, so it's available for iteration on foreach. Similarly, `cmd` and friends are also evaluated later after `set` and `foreach`( if it exists).

Also, note that joining strings is not supported with "set":
eg:
```yaml
set: 
  # not supported
   url: ${base_url}/${filename}
   # also, not supported
   name: My name is ${name}
```

