### PR TITLE
checkpoints: `--continue` from last run experiment by default

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -710,12 +710,16 @@ def add_parser(subparsers, parent_parser):
     experiments_run_parser.add_argument(
         "--continue",
         type=str,
+        nargs="?",
         default=None,
+        const=":last",
         dest="checkpoint_continue",
         help=(
             "Continue from the specified checkpoint experiment "
-            "(implies --checkpoint)."
+            "(implies --checkpoint). If no experiment revision is provided, "
+            "the most recently run checkpoint experiment will be used."
         ),
+        metavar="<experiment_rev>",
     )
     experiments_run_parser.add_argument(
         "--reset",

--- a/tests/func/experiments/test_experiments.py
+++ b/tests/func/experiments/test_experiments.py
@@ -301,7 +301,8 @@ def test_new_checkpoint(tmp_dir, scm, dvc, mocker):
     ).read_text().strip() == "foo: 2"
 
 
-def test_continue_checkpoint(tmp_dir, scm, dvc, mocker):
+@pytest.mark.parametrize("last", [True, False])
+def test_continue_checkpoint(tmp_dir, scm, dvc, mocker, last):
     tmp_dir.gen("checkpoint.py", CHECKPOINT_SCRIPT)
     tmp_dir.gen("params.yaml", "foo: 1")
     stage = dvc.run(
@@ -326,7 +327,10 @@ def test_continue_checkpoint(tmp_dir, scm, dvc, mocker):
     results = dvc.experiments.run(
         stage.addressing, checkpoint=True, params=["foo=2"]
     )
-    exp_rev = first(results)
+    if last:
+        exp_rev = ":last"
+    else:
+        exp_rev = first(results)
 
     dvc.experiments.run(
         stage.addressing, checkpoint=True, checkpoint_continue=exp_rev,


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will close #4756