### PR TITLE
Display coverage report on the GHA log and measure branch coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+source = dvc
 omit =
     *__main__.py
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,10 +1,13 @@
 [run]
+branch = True
 omit =
     *__main__.py
 
 [report]
 exclude_lines =
     if __name__ == .__main__.:
+    if typing.TYPE_CHECKING:
+    if TYPE_CHECKING:
     pass
     raise NotImplementedError
     # pragma: no cover

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,7 +50,7 @@ jobs:
         git config --global user.email "dvctester@example.com"
         git config --global user.name "DVC Tester"
     - name: run tests
-      run: python -m tests -ra --cov-report=xml
+      run: python -m tests -ra --cov-report=xml --cov-report=term
     - name: upload coverage report
       if: github.event.name == 'push'
       uses: codecov/codecov-action@v1.0.13

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,7 +44,8 @@ jobs:
         python-version: ${{ matrix.pyv }}
     - name: install
       run: |
-        pip install ".[all,tests]"
+        pip install wheel
+        pip install -e ".[all,tests]"
     - name: setup git
       run: |
         git config --global user.email "dvctester@example.com"


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

This prints coverage report on Github Actions log, and also enables measuring of branch coverage (eg: `if` conditionals).
Our coverage may decrease, but it will provide us better sense of our coverage.
