### PR TITLE
Escape spaces in file paths when running commands on SSH remote

### DIFF
--- a/dvc/tree/ssh/connection.py
+++ b/dvc/tree/ssh/connection.py
@@ -2,6 +2,7 @@ import errno
 import logging
 import os
 import posixpath
+import shlex
 import stat
 from contextlib import suppress
 
@@ -291,6 +292,7 @@ class SSHConnection:
          Example:
               MD5 (foo.txt) = f3d220a856b52aabbf294351e8a24300
         """
+        path = shlex.quote(path)
         if self.uname == "Linux":
             md5 = self.execute("md5sum " + path).split()[0]
         elif self.uname == "Darwin":

--- a/dvc/tree/ssh/connection.py
+++ b/dvc/tree/ssh/connection.py
@@ -306,6 +306,8 @@ class SSHConnection:
         return md5
 
     def copy(self, src, dest):
+        dest = shlex.quote(dest)
+        src = shlex.quote(src)
         self.execute(f"cp {src} {dest}")
 
     def open_max_sftp_channels(self):
@@ -327,6 +329,8 @@ class SSHConnection:
         self.sftp.symlink(src, dest)
 
     def reflink(self, src, dest):
+        dest = shlex.quote(dest)
+        src = shlex.quote(src)
         if self.uname == "Linux":
             return self.execute(f"cp --reflink {src} {dest}")
 
@@ -336,4 +340,6 @@ class SSHConnection:
         raise DvcException(f"'{self.uname}' is not supported as a SSH remote")
 
     def hardlink(self, src, dest):
+        dest = shlex.quote(dest)
+        src = shlex.quote(src)
         self.execute(f"ln {src} {dest}")

--- a/tests/unit/remote/ssh/test_connection.py
+++ b/tests/unit/remote/ssh/test_connection.py
@@ -8,8 +8,17 @@ import pytest
 
 from dvc.info import get_fs_type
 from dvc.system import System
+from dvc.tree.ssh.connection import SSHConnection
 
 here = os.path.abspath(os.path.dirname(__file__))
+
+SRC_PATH_WITH_SPECIAL_CHARACTERS = "Escape me [' , ']"
+ESCAPED_SRC_PATH_WITH_SPECIAL_CHARACTERS = "'Escape me ['\"'\"' , '\"'\"']'"
+
+DEST_PATH_WITH_SPECIAL_CHARACTERS = "Escape me too [' , ']"
+ESCAPED_DEST_PATH_WITH_SPECIAL_CHARACTERS = (
+    "'Escape me too ['\"'\"' , '\"'\"']'"
+)
 
 
 def test_isdir(ssh_connection):
@@ -131,3 +140,60 @@ def test_move(tmp_dir, ssh_connection):
     ssh_connection.move("foo", "copy")
     assert os.path.exists("copy")
     assert not os.path.exists("foo")
+
+
+@pytest.mark.parametrize(
+    "uname,md5command", [("Linux", "md5sum"), ("Darwin", "md5")]
+)
+def test_escapes_filepaths_for_md5_calculation(
+    ssh_connection, uname, md5command, mocker
+):
+    fake_md5 = "x" * 32
+    uname_mock = mocker.PropertyMock(return_value=uname)
+    mocker.patch.object(SSHConnection, "uname", new_callable=uname_mock)
+    ssh_connection.execute = mocker.Mock(return_value=fake_md5)
+    ssh_connection.md5(SRC_PATH_WITH_SPECIAL_CHARACTERS)
+    ssh_connection.execute.assert_called_with(
+        f"{md5command} {ESCAPED_SRC_PATH_WITH_SPECIAL_CHARACTERS}"
+    )
+
+
+def test_escapes_filepaths_for_copy(ssh_connection, mocker):
+    ssh_connection.execute = mocker.Mock()
+    ssh_connection.copy(
+        SRC_PATH_WITH_SPECIAL_CHARACTERS, DEST_PATH_WITH_SPECIAL_CHARACTERS
+    )
+    ssh_connection.execute.assert_called_with(
+        f"cp {ESCAPED_SRC_PATH_WITH_SPECIAL_CHARACTERS} "
+        + f"{ESCAPED_DEST_PATH_WITH_SPECIAL_CHARACTERS}"
+    )
+
+
+@pytest.mark.parametrize(
+    "uname,cp_command", [("Linux", "cp --reflink"), ("Darwin", "cp -c")]
+)
+def test_escapes_filepaths_for_reflink(
+    ssh_connection, uname, cp_command, mocker
+):
+    uname_mock = mocker.PropertyMock(return_value=uname)
+    mocker.patch.object(SSHConnection, "uname", new_callable=uname_mock)
+    ssh_connection.execute = mocker.Mock()
+    ssh_connection.reflink(
+        SRC_PATH_WITH_SPECIAL_CHARACTERS, DEST_PATH_WITH_SPECIAL_CHARACTERS
+    )
+    ssh_connection.execute.assert_called_with(
+        f"{cp_command} "
+        + f"{ESCAPED_SRC_PATH_WITH_SPECIAL_CHARACTERS} "
+        + f"{ESCAPED_DEST_PATH_WITH_SPECIAL_CHARACTERS}"
+    )
+
+
+def test_escapes_filepaths_for_hardlink(ssh_connection, mocker):
+    ssh_connection.execute = mocker.Mock()
+    ssh_connection.hardlink(
+        SRC_PATH_WITH_SPECIAL_CHARACTERS, DEST_PATH_WITH_SPECIAL_CHARACTERS
+    )
+    ssh_connection.execute.assert_called_with(
+        f"ln {ESCAPED_SRC_PATH_WITH_SPECIAL_CHARACTERS} "
+        + f"{ESCAPED_DEST_PATH_WITH_SPECIAL_CHARACTERS}"
+    )

--- a/tests/unit/remote/ssh/test_pool.py
+++ b/tests/unit/remote/ssh/test_pool.py
@@ -5,11 +5,12 @@ from dvc.tree.ssh.connection import SSHConnection
 from tests.remotes.ssh import TEST_SSH_KEY_PATH, TEST_SSH_USER
 
 SRC_PATH_WITH_SPECIAL_CHARACTERS = "Escape me [' , ']"
-ESCAPED_SRC_PATH_WITH_SPECIAL_CHARACTERS = '\'Escape me [\'"\'"\' , \'"\'"\']\''
+ESCAPED_SRC_PATH_WITH_SPECIAL_CHARACTERS = "'Escape me ['\"'\"' , '\"'\"']'"
 
 DEST_PATH_WITH_SPECIAL_CHARACTERS = "Escape me too [' , ']"
-ESCAPED_DEST_PATH_WITH_SPECIAL_CHARACTERS = '\'Escape me too [\'"\'"\' ,' \
-                                            ' \'"\'"\']\''
+ESCAPED_DEST_PATH_WITH_SPECIAL_CHARACTERS = (
+    "'Escape me too ['\"'\"' , '\"'\"']'"
+)
 
 
 def test_doesnt_swallow_errors(ssh_server):
@@ -27,10 +28,12 @@ def test_doesnt_swallow_errors(ssh_server):
             raise MyError
 
 
-@pytest.mark.parametrize("uname,md5command",
-                         [("Linux", "md5sum"), ("Darwin", "md5")])
-def test_escapes_filepaths_for_md5_calculation(ssh_server, uname, md5command,
-                                               mocker):
+@pytest.mark.parametrize(
+    "uname,md5command", [("Linux", "md5sum"), ("Darwin", "md5")]
+)
+def test_escapes_filepaths_for_md5_calculation(
+    ssh_server, uname, md5command, mocker
+):
     fake_md5 = "x" * 32
 
     with get_connection(
@@ -45,7 +48,8 @@ def test_escapes_filepaths_for_md5_calculation(ssh_server, uname, md5command,
         connection.execute = mocker.Mock(return_value=fake_md5)
         connection.md5(SRC_PATH_WITH_SPECIAL_CHARACTERS)
         connection.execute.assert_called_with(
-            f"{md5command} {ESCAPED_SRC_PATH_WITH_SPECIAL_CHARACTERS}")
+            f"{md5command} {ESCAPED_SRC_PATH_WITH_SPECIAL_CHARACTERS}"
+        )
 
 
 def test_escapes_filepaths_for_copy(ssh_server, mocker):
@@ -57,15 +61,18 @@ def test_escapes_filepaths_for_copy(ssh_server, mocker):
         key_filename=TEST_SSH_KEY_PATH,
     ) as connection:
         connection.execute = mocker.Mock()
-        connection.copy(SRC_PATH_WITH_SPECIAL_CHARACTERS,
-                        DEST_PATH_WITH_SPECIAL_CHARACTERS)
+        connection.copy(
+            SRC_PATH_WITH_SPECIAL_CHARACTERS, DEST_PATH_WITH_SPECIAL_CHARACTERS
+        )
         connection.execute.assert_called_with(
             f"cp {ESCAPED_SRC_PATH_WITH_SPECIAL_CHARACTERS} "
-            f"{ESCAPED_DEST_PATH_WITH_SPECIAL_CHARACTERS}")
+            + f"{ESCAPED_DEST_PATH_WITH_SPECIAL_CHARACTERS}"
+        )
 
 
-@pytest.mark.parametrize("uname,cp_command",
-                         [("Linux", "cp --reflink"), ("Darwin", "cp -c")])
+@pytest.mark.parametrize(
+    "uname,cp_command", [("Linux", "cp --reflink"), ("Darwin", "cp -c")]
+)
 def test_escapes_filepaths_for_reflink(ssh_server, uname, cp_command, mocker):
     with get_connection(
         SSHConnection,
@@ -77,12 +84,14 @@ def test_escapes_filepaths_for_reflink(ssh_server, uname, cp_command, mocker):
         uname_mock = mocker.PropertyMock(return_value=uname)
         mocker.patch.object(SSHConnection, "uname", new_callable=uname_mock)
         connection.execute = mocker.Mock()
-        connection.reflink(SRC_PATH_WITH_SPECIAL_CHARACTERS,
-                           DEST_PATH_WITH_SPECIAL_CHARACTERS)
+        connection.reflink(
+            SRC_PATH_WITH_SPECIAL_CHARACTERS, DEST_PATH_WITH_SPECIAL_CHARACTERS
+        )
         connection.execute.assert_called_with(
             f"{cp_command} "
-            f"{ESCAPED_SRC_PATH_WITH_SPECIAL_CHARACTERS} "
-            f"{ESCAPED_DEST_PATH_WITH_SPECIAL_CHARACTERS}")
+            + f"{ESCAPED_SRC_PATH_WITH_SPECIAL_CHARACTERS} "
+            + f"{ESCAPED_DEST_PATH_WITH_SPECIAL_CHARACTERS}"
+        )
 
 
 def test_escapes_filepaths_for_hardlink(ssh_server, mocker):
@@ -94,8 +103,10 @@ def test_escapes_filepaths_for_hardlink(ssh_server, mocker):
         key_filename=TEST_SSH_KEY_PATH,
     ) as connection:
         connection.execute = mocker.Mock()
-        connection.hardlink(SRC_PATH_WITH_SPECIAL_CHARACTERS,
-                            DEST_PATH_WITH_SPECIAL_CHARACTERS)
+        connection.hardlink(
+            SRC_PATH_WITH_SPECIAL_CHARACTERS, DEST_PATH_WITH_SPECIAL_CHARACTERS
+        )
         connection.execute.assert_called_with(
             f"ln {ESCAPED_SRC_PATH_WITH_SPECIAL_CHARACTERS} "
-            f"{ESCAPED_DEST_PATH_WITH_SPECIAL_CHARACTERS}")
+            + f"{ESCAPED_DEST_PATH_WITH_SPECIAL_CHARACTERS}"
+        )

--- a/tests/unit/remote/ssh/test_pool.py
+++ b/tests/unit/remote/ssh/test_pool.py
@@ -18,3 +18,30 @@ def test_doesnt_swallow_errors(ssh_server):
             key_filename=TEST_SSH_KEY_PATH,
         ):
             raise MyError
+
+
+@pytest.mark.parametrize("uname,md5command", [("Linux", "md5sum"), ("Darwin", "md5")])
+def test_escapes_filepaths_for_md5_calculation(ssh_server, uname, md5command, mocker):
+    path_with_spaces = "Some Path With Spaces"
+    escaped_path_with_spaces = "\'Some Path With Spaces\'"
+    fake_md5 = "x" * 32
+    return_values = {
+        "uname": uname,
+        f"{md5command} {path_with_spaces}": fake_md5,
+        f"{md5command} {escaped_path_with_spaces}": fake_md5,
+    }
+
+    def mock_execute(arg):
+        return return_values[arg]
+
+    with get_connection(
+        SSHConnection,
+        host=ssh_server.host,
+        port=ssh_server.port,
+        username=TEST_SSH_USER,
+        key_filename=TEST_SSH_KEY_PATH,
+    ) as connection:
+        connection.execute = mocker.Mock(side_effect=mock_execute)
+        connection.md5(path_with_spaces)
+        connection.execute.assert_called_with(f"{md5command} {escaped_path_with_spaces}")
+

--- a/tests/unit/remote/ssh/test_pool.py
+++ b/tests/unit/remote/ssh/test_pool.py
@@ -4,14 +4,6 @@ from dvc.tree.pool import get_connection
 from dvc.tree.ssh.connection import SSHConnection
 from tests.remotes.ssh import TEST_SSH_KEY_PATH, TEST_SSH_USER
 
-SRC_PATH_WITH_SPECIAL_CHARACTERS = "Escape me [' , ']"
-ESCAPED_SRC_PATH_WITH_SPECIAL_CHARACTERS = "'Escape me ['\"'\"' , '\"'\"']'"
-
-DEST_PATH_WITH_SPECIAL_CHARACTERS = "Escape me too [' , ']"
-ESCAPED_DEST_PATH_WITH_SPECIAL_CHARACTERS = (
-    "'Escape me too ['\"'\"' , '\"'\"']'"
-)
-
 
 def test_doesnt_swallow_errors(ssh_server):
     class MyError(Exception):
@@ -26,87 +18,3 @@ def test_doesnt_swallow_errors(ssh_server):
             key_filename=TEST_SSH_KEY_PATH,
         ):
             raise MyError
-
-
-@pytest.mark.parametrize(
-    "uname,md5command", [("Linux", "md5sum"), ("Darwin", "md5")]
-)
-def test_escapes_filepaths_for_md5_calculation(
-    ssh_server, uname, md5command, mocker
-):
-    fake_md5 = "x" * 32
-
-    with get_connection(
-        SSHConnection,
-        host=ssh_server.host,
-        port=ssh_server.port,
-        username=TEST_SSH_USER,
-        key_filename=TEST_SSH_KEY_PATH,
-    ) as connection:
-        uname_mock = mocker.PropertyMock(return_value=uname)
-        mocker.patch.object(SSHConnection, "uname", new_callable=uname_mock)
-        connection.execute = mocker.Mock(return_value=fake_md5)
-        connection.md5(SRC_PATH_WITH_SPECIAL_CHARACTERS)
-        connection.execute.assert_called_with(
-            f"{md5command} {ESCAPED_SRC_PATH_WITH_SPECIAL_CHARACTERS}"
-        )
-
-
-def test_escapes_filepaths_for_copy(ssh_server, mocker):
-    with get_connection(
-        SSHConnection,
-        host=ssh_server.host,
-        port=ssh_server.port,
-        username=TEST_SSH_USER,
-        key_filename=TEST_SSH_KEY_PATH,
-    ) as connection:
-        connection.execute = mocker.Mock()
-        connection.copy(
-            SRC_PATH_WITH_SPECIAL_CHARACTERS, DEST_PATH_WITH_SPECIAL_CHARACTERS
-        )
-        connection.execute.assert_called_with(
-            f"cp {ESCAPED_SRC_PATH_WITH_SPECIAL_CHARACTERS} "
-            + f"{ESCAPED_DEST_PATH_WITH_SPECIAL_CHARACTERS}"
-        )
-
-
-@pytest.mark.parametrize(
-    "uname,cp_command", [("Linux", "cp --reflink"), ("Darwin", "cp -c")]
-)
-def test_escapes_filepaths_for_reflink(ssh_server, uname, cp_command, mocker):
-    with get_connection(
-        SSHConnection,
-        host=ssh_server.host,
-        port=ssh_server.port,
-        username=TEST_SSH_USER,
-        key_filename=TEST_SSH_KEY_PATH,
-    ) as connection:
-        uname_mock = mocker.PropertyMock(return_value=uname)
-        mocker.patch.object(SSHConnection, "uname", new_callable=uname_mock)
-        connection.execute = mocker.Mock()
-        connection.reflink(
-            SRC_PATH_WITH_SPECIAL_CHARACTERS, DEST_PATH_WITH_SPECIAL_CHARACTERS
-        )
-        connection.execute.assert_called_with(
-            f"{cp_command} "
-            + f"{ESCAPED_SRC_PATH_WITH_SPECIAL_CHARACTERS} "
-            + f"{ESCAPED_DEST_PATH_WITH_SPECIAL_CHARACTERS}"
-        )
-
-
-def test_escapes_filepaths_for_hardlink(ssh_server, mocker):
-    with get_connection(
-        SSHConnection,
-        host=ssh_server.host,
-        port=ssh_server.port,
-        username=TEST_SSH_USER,
-        key_filename=TEST_SSH_KEY_PATH,
-    ) as connection:
-        connection.execute = mocker.Mock()
-        connection.hardlink(
-            SRC_PATH_WITH_SPECIAL_CHARACTERS, DEST_PATH_WITH_SPECIAL_CHARACTERS
-        )
-        connection.execute.assert_called_with(
-            f"ln {ESCAPED_SRC_PATH_WITH_SPECIAL_CHARACTERS} "
-            + f"{ESCAPED_DEST_PATH_WITH_SPECIAL_CHARACTERS}"
-        )


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Fixes #4766
Fixes #4628