### PR TITLE
Experiments: allow setting of list parameters

### DIFF
--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -318,12 +318,13 @@ class Experiments:
         # recursive dict update
         def _update(dict_, other):
             for key, value in other.items():
+                if isinstance(dict_, list) and key.isdigit():
+                    key = int(key)
                 if isinstance(value, Mapping):
-                    if isinstance(dict_, Mapping):
-                        fallback_value = dict_.get(key, {})
-                    elif isinstance(dict_, list) and key.isdigit():
-                        key = int(key)
+                    if isinstance(dict_, list):
                         fallback_value = dict_[key]
+                    else:
+                        fallback_value = dict_.get(key, {})
                     dict_[key] = _update(fallback_value, value)
                 else:
                     dict_[key] = value

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -319,7 +319,12 @@ class Experiments:
         def _update(dict_, other):
             for key, value in other.items():
                 if isinstance(value, Mapping):
-                    dict_[key] = _update(dict_.get(key, {}), value)
+                    if isinstance(dict_, Mapping):
+                        fallback_value = dict_.get(key, {})
+                    elif isinstance(dict_, list) and key.isdigit():
+                        key = int(key)
+                        fallback_value = dict_[key]
+                    dict_[key] = _update(fallback_value, value)
                 else:
                     dict_[key] = value
             return dict_


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏


Will close #4768

As stated in the issue, I'm sure more work will be needed, but this little tweak was enough to at least allow the experiment to run. Some more work would be required to get parameter diffs to show up nicely in `dvc exp show` (screenshot of current display is included below, see the change in activation function), but that might be out of scope for this issue.

![image](https://user-images.githubusercontent.com/5074378/96757109-9cb60d00-139a-11eb-8566-d58d105bc5ce.png)

If there are no major objections, I can go ahead and write up some tests and finish this PR off proper-like.