### PR TITLE
dvc: capitalize help message for all subcommands

### DIFF
--- a/dvc/cli.py
+++ b/dvc/cli.py
@@ -138,6 +138,16 @@ def get_parent_parser():
     """
     parent_parser = argparse.ArgumentParser(add_help=False)
 
+    # NOTE: We are doing this to capitalize help message.
+    # All subparsers that use this as parent should specify "add_help=False"
+    parent_parser.add_argument(
+        "-h",
+        "--help",
+        action="help",
+        default=argparse.SUPPRESS,
+        help="Show this help message and exit.",
+    )
+
     parent_parser.add_argument(
         "--cprofile",
         action="store_true",
@@ -168,18 +178,6 @@ def get_main_parser():
         parents=[parent_parser],
         formatter_class=argparse.RawTextHelpFormatter,
         add_help=False,
-    )
-
-    # NOTE: We are doing this to capitalize help message.
-    # Unfortunately, there is no easier and clearer way to do it,
-    # as adding this argument in get_parent_parser() either in
-    # log_level_group or on parent_parser itself will cause unexpected error.
-    parser.add_argument(
-        "-h",
-        "--help",
-        action="help",
-        default=argparse.SUPPRESS,
-        help="Show this help message and exit.",
     )
 
     # NOTE: On some python versions action='version' prints to stderr

--- a/dvc/command/add.py
+++ b/dvc/command/add.py
@@ -35,6 +35,7 @@ def add_parser(subparsers, parent_parser):
         "add",
         parents=[parent_parser],
         description=append_doc_link(ADD_HELP, "add"),
+        add_help=False,
         help=ADD_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/cache.py
+++ b/dvc/command/cache.py
@@ -27,6 +27,7 @@ def add_parser(subparsers, parent_parser):
         "cache",
         parents=[parent_parser],
         description=append_doc_link(CACHE_HELP, "cache"),
+        add_help=False,
         help=CACHE_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -47,6 +48,7 @@ def add_parser(subparsers, parent_parser):
         "dir",
         parents=[parent_parser, parent_cache_config_parser],
         description=append_doc_link(CACHE_HELP, "cache/dir"),
+        add_help=False,
         help=CACHE_DIR_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/check_ignore.py
+++ b/dvc/command/check_ignore.py
@@ -88,6 +88,7 @@ def add_parser(subparsers, parent_parser):
         "check-ignore",
         parents=[parent_parser],
         description=append_doc_link(ADD_HELP, "check-ignore"),
+        add_help=False,
         help=ADD_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/checkout.py
+++ b/dvc/command/checkout.py
@@ -73,6 +73,7 @@ def add_parser(subparsers, parent_parser):
         "checkout",
         parents=[parent_parser],
         description=append_doc_link(CHECKOUT_HELP, "checkout"),
+        add_help=False,
         help=CHECKOUT_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/commit.py
+++ b/dvc/command/commit.py
@@ -38,6 +38,7 @@ def add_parser(subparsers, parent_parser):
         "commit",
         parents=[parent_parser],
         description=append_doc_link(COMMIT_HELP, "commit"),
+        add_help=False,
         help=COMMIT_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/completion.py
+++ b/dvc/command/completion.py
@@ -44,6 +44,7 @@ def add_parser(subparsers, parent_parser):
         "completion",
         parents=[parent_parser],
         description=append_doc_link(COMPLETION_DESCRIPTION, "completion"),
+        add_help=False,
         help=COMPLETION_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/config.py
+++ b/dvc/command/config.py
@@ -82,6 +82,7 @@ def add_parser(subparsers, parent_parser):
         "config",
         parents=[parent_config_parser, parent_parser],
         description=append_doc_link(CONFIG_HELP, "config"),
+        add_help=False,
         help=CONFIG_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/daemon.py
+++ b/dvc/command/daemon.py
@@ -55,6 +55,7 @@ def add_parser(subparsers, parent_parser):
         "updater",
         parents=[parent_parser],
         description=DAEMON_UPDATER_HELP,
+        add_help=False,
         help=DAEMON_UPDATER_HELP,
     )
     daemon_updater_parser.set_defaults(func=CmdDaemonUpdater)
@@ -64,6 +65,7 @@ def add_parser(subparsers, parent_parser):
         "analytics",
         parents=[parent_parser],
         description=DAEMON_ANALYTICS_HELP,
+        add_help=False,
         help=DAEMON_ANALYTICS_HELP,
     )
     daemon_analytics_parser.add_argument(

--- a/dvc/command/dag.py
+++ b/dvc/command/dag.py
@@ -90,6 +90,7 @@ def add_parser(subparsers, parent_parser):
         "dag",
         parents=[parent_parser],
         description=append_doc_link(DAG_HELP, "dag"),
+        add_help=False,
         help=DAG_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/data_sync.py
+++ b/dvc/command/data_sync.py
@@ -126,6 +126,7 @@ def add_parser(subparsers, _parent_parser):
         "pull",
         parents=[shared_parent_parser()],
         description=append_doc_link(PULL_HELP, "pull"),
+        add_help=False,
         help=PULL_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -188,6 +189,7 @@ def add_parser(subparsers, _parent_parser):
         "push",
         parents=[shared_parent_parser()],
         description=append_doc_link(PUSH_HELP, "push"),
+        add_help=False,
         help=PUSH_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -246,6 +248,7 @@ def add_parser(subparsers, _parent_parser):
         "fetch",
         parents=[shared_parent_parser()],
         description=append_doc_link(FETCH_HELP, "fetch"),
+        add_help=False,
         help=FETCH_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -306,6 +309,7 @@ def add_parser(subparsers, _parent_parser):
         "status",
         parents=[shared_parent_parser()],
         description=append_doc_link(STATUS_HELP, "status"),
+        add_help=False,
         help=STATUS_HELP,
         conflict_handler="resolve",
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/dvc/command/destroy.py
+++ b/dvc/command/destroy.py
@@ -38,6 +38,7 @@ def add_parser(subparsers, parent_parser):
         "destroy",
         parents=[parent_parser],
         description=append_doc_link(DESTROY_HELP, "destroy"),
+        add_help=False,
         help=DESTROY_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/diff.py
+++ b/dvc/command/diff.py
@@ -164,6 +164,7 @@ def add_parser(subparsers, parent_parser):
         "diff",
         parents=[parent_parser],
         description=append_doc_link(DIFF_DESCRIPTION, "diff"),
+        add_help=False,
         help=DIFF_DESCRIPTION,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -486,6 +486,7 @@ def add_parser(subparsers, parent_parser):
         aliases=["exp"],
         description=append_doc_link(EXPERIMENTS_HELP, "experiments"),
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        add_help=False,
     )
 
     experiments_subparsers = experiments_parser.add_subparsers(
@@ -501,6 +502,7 @@ def add_parser(subparsers, parent_parser):
         "show",
         parents=[parent_parser],
         description=append_doc_link(EXPERIMENTS_SHOW_HELP, "experiments/show"),
+        add_help=False,
         help=EXPERIMENTS_SHOW_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -605,6 +607,7 @@ def add_parser(subparsers, parent_parser):
         description=append_doc_link(
             EXPERIMENTS_CHECKOUT_HELP, "experiments/checkout"
         ),
+        add_help=False,
         help=EXPERIMENTS_CHECKOUT_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -620,6 +623,7 @@ def add_parser(subparsers, parent_parser):
         "diff",
         parents=[parent_parser],
         description=append_doc_link(EXPERIMENTS_DIFF_HELP, "experiments/diff"),
+        add_help=False,
         help=EXPERIMENTS_DIFF_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -679,6 +683,7 @@ def add_parser(subparsers, parent_parser):
         "run",
         parents=[parent_parser],
         description=append_doc_link(EXPERIMENTS_RUN_HELP, "experiments/run"),
+        add_help=False,
         help=EXPERIMENTS_RUN_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/freeze.py
+++ b/dvc/command/freeze.py
@@ -36,6 +36,7 @@ def add_parser(subparsers, parent_parser):
         "freeze",
         parents=[parent_parser],
         description=append_doc_link(FREEZE_HELP, "freeze"),
+        add_help=False,
         help=FREEZE_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -49,6 +50,7 @@ def add_parser(subparsers, parent_parser):
         "unfreeze",
         parents=[parent_parser],
         description=append_doc_link(UNFREEZE_HELP, "unfreeze"),
+        add_help=False,
         help=UNFREEZE_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/gc.py
+++ b/dvc/command/gc.py
@@ -69,6 +69,7 @@ def add_parser(subparsers, parent_parser):
         "gc",
         parents=[parent_parser],
         description=append_doc_link(GC_DESCRIPTION, "gc"),
+        add_help=False,
         help=GC_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/get.py
+++ b/dvc/command/get.py
@@ -56,6 +56,7 @@ def add_parser(subparsers, parent_parser):
         "get",
         parents=[parent_parser],
         description=append_doc_link(GET_HELP, "get"),
+        add_help=False,
         help=GET_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/get_url.py
+++ b/dvc/command/get_url.py
@@ -27,6 +27,7 @@ def add_parser(subparsers, parent_parser):
         "get-url",
         parents=[parent_parser],
         description=append_doc_link(GET_HELP, "get-url"),
+        add_help=False,
         help=GET_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/git_hook.py
+++ b/dvc/command/git_hook.py
@@ -103,6 +103,7 @@ def add_parser(subparsers, parent_parser):
         "pre-commit",
         parents=[parent_parser],
         description=PRE_COMMIT_HELP,
+        add_help=False,
         help=PRE_COMMIT_HELP,
     )
     pre_commit_parser.add_argument(
@@ -115,6 +116,7 @@ def add_parser(subparsers, parent_parser):
         "post-checkout",
         parents=[parent_parser],
         description=POST_CHECKOUT_HELP,
+        add_help=False,
         help=POST_CHECKOUT_HELP,
     )
     post_checkout_parser.add_argument(
@@ -127,6 +129,7 @@ def add_parser(subparsers, parent_parser):
         "pre-push",
         parents=[parent_parser],
         description=PRE_PUSH_HELP,
+        add_help=False,
         help=PRE_PUSH_HELP,
     )
     pre_push_parser.add_argument(
@@ -139,6 +142,7 @@ def add_parser(subparsers, parent_parser):
         "merge-driver",
         parents=[parent_parser],
         description=MERGE_DRIVER_HELP,
+        add_help=False,
         help=MERGE_DRIVER_HELP,
     )
     merge_driver_parser.add_argument(

--- a/dvc/command/imp.py
+++ b/dvc/command/imp.py
@@ -38,6 +38,7 @@ def add_parser(subparsers, parent_parser):
         "import",
         parents=[parent_parser],
         description=append_doc_link(IMPORT_HELP, "import"),
+        add_help=False,
         help=IMPORT_HELP,
         formatter_class=argparse.RawTextHelpFormatter,
     )

--- a/dvc/command/imp_url.py
+++ b/dvc/command/imp_url.py
@@ -37,6 +37,7 @@ def add_parser(subparsers, parent_parser):
         "import-url",
         parents=[parent_parser],
         description=append_doc_link(IMPORT_HELP, "import-url"),
+        add_help=False,
         help=IMPORT_HELP,
         formatter_class=argparse.RawTextHelpFormatter,
     )

--- a/dvc/command/init.py
+++ b/dvc/command/init.py
@@ -65,6 +65,7 @@ def add_parser(subparsers, parent_parser):
         "init",
         parents=[parent_parser],
         description=append_doc_link(INIT_DESCRIPTION, "init"),
+        add_help=False,
         help=INIT_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/install.py
+++ b/dvc/command/install.py
@@ -23,6 +23,7 @@ def add_parser(subparsers, parent_parser):
         "install",
         parents=[parent_parser],
         description=append_doc_link(INSTALL_HELP, "install"),
+        add_help=False,
         help=INSTALL_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/ls/__init__.py
+++ b/dvc/command/ls/__init__.py
@@ -52,6 +52,7 @@ def add_parser(subparsers, parent_parser):
         "list",
         parents=[parent_parser],
         description=append_doc_link(LIST_HELP, "list"),
+        add_help=False,
         help=LIST_HELP,
         formatter_class=argparse.RawTextHelpFormatter,
     )

--- a/dvc/command/metrics.py
+++ b/dvc/command/metrics.py
@@ -148,6 +148,7 @@ def add_parser(subparsers, parent_parser):
         "metrics",
         parents=[parent_parser],
         description=append_doc_link(METRICS_HELP, "metrics"),
+        add_help=False,
         help=METRICS_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -164,6 +165,7 @@ def add_parser(subparsers, parent_parser):
         "show",
         parents=[parent_parser],
         description=append_doc_link(METRICS_SHOW_HELP, "metrics/show"),
+        add_help=False,
         help=METRICS_SHOW_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -221,6 +223,7 @@ def add_parser(subparsers, parent_parser):
         "diff",
         parents=[parent_parser],
         description=append_doc_link(METRICS_DIFF_HELP, "metrics/diff"),
+        add_help=False,
         help=METRICS_DIFF_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/move.py
+++ b/dvc/command/move.py
@@ -33,6 +33,7 @@ def add_parser(subparsers, parent_parser):
         "move",
         parents=[parent_parser],
         description=append_doc_link(MOVE_DESCRIPTION, "move"),
+        add_help=False,
         help=MOVE_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/params.py
+++ b/dvc/command/params.py
@@ -61,6 +61,7 @@ def add_parser(subparsers, parent_parser):
         "params",
         parents=[parent_parser],
         description=append_doc_link(PARAMS_HELP, "params"),
+        add_help=False,
         help=PARAMS_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -80,6 +81,7 @@ def add_parser(subparsers, parent_parser):
         "diff",
         parents=[parent_parser],
         description=append_doc_link(PARAMS_DIFF_HELP, "params/diff"),
+        add_help=False,
         help=PARAMS_DIFF_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/plots.py
+++ b/dvc/command/plots.py
@@ -116,6 +116,7 @@ def add_parser(subparsers, parent_parser):
         "plots",
         parents=[parent_parser],
         description=append_doc_link(PLOTS_HELP, "plots"),
+        add_help=False,
         help=PLOTS_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -131,6 +132,7 @@ def add_parser(subparsers, parent_parser):
         "show",
         parents=[parent_parser],
         description=append_doc_link(SHOW_HELP, "plots/show"),
+        add_help=False,
         help=SHOW_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -153,6 +155,7 @@ def add_parser(subparsers, parent_parser):
         "diff",
         parents=[parent_parser],
         description=append_doc_link(PLOTS_DIFF_HELP, "plots/diff"),
+        add_help=False,
         help=PLOTS_DIFF_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -183,6 +186,7 @@ def add_parser(subparsers, parent_parser):
         "modify",
         parents=[parent_parser],
         description=append_doc_link(PLOTS_MODIFY_HELP, "plots/modify"),
+        add_help=False,
         help=PLOTS_MODIFY_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/remote.py
+++ b/dvc/command/remote.py
@@ -150,6 +150,7 @@ def add_parser(subparsers, parent_parser):
         "remote",
         parents=[parent_parser],
         description=append_doc_link(REMOTE_HELP, "remote"),
+        add_help=False,
         help=REMOTE_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -166,6 +167,7 @@ def add_parser(subparsers, parent_parser):
         "add",
         parents=[parent_config_parser, parent_parser],
         description=append_doc_link(REMOTE_ADD_HELP, "remote/add"),
+        add_help=False,
         help=REMOTE_ADD_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -197,6 +199,7 @@ def add_parser(subparsers, parent_parser):
         "default",
         parents=[parent_config_parser, parent_parser],
         description=append_doc_link(REMOTE_DEFAULT_HELP, "remote/default"),
+        add_help=False,
         help=REMOTE_DEFAULT_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -217,6 +220,7 @@ def add_parser(subparsers, parent_parser):
         "modify",
         parents=[parent_config_parser, parent_parser],
         description=append_doc_link(REMOTE_MODIFY_HELP, "remote/modify"),
+        add_help=False,
         help=REMOTE_MODIFY_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -241,6 +245,7 @@ def add_parser(subparsers, parent_parser):
         "list",
         parents=[parent_config_parser, parent_parser],
         description=append_doc_link(REMOTE_LIST_HELP, "remote/list"),
+        add_help=False,
         help=REMOTE_LIST_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -251,6 +256,7 @@ def add_parser(subparsers, parent_parser):
         "remove",
         parents=[parent_config_parser, parent_parser],
         description=append_doc_link(REMOTE_REMOVE_HELP, "remote/remove"),
+        add_help=False,
         help=REMOTE_REMOVE_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -263,6 +269,7 @@ def add_parser(subparsers, parent_parser):
         "rename",
         parents=[parent_config_parser, parent_parser],
         description=append_doc_link(REMOTE_RENAME_HELP, "remote/rename"),
+        add_help=False,
         help=REMOTE_RENAME_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/remove.py
+++ b/dvc/command/remove.py
@@ -27,6 +27,7 @@ def add_parser(subparsers, parent_parser):
         "remove",
         parents=[parent_parser],
         description=append_doc_link(REMOVE_HELP, "remove"),
+        add_help=False,
         help=REMOVE_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -180,6 +180,7 @@ def add_parser(subparsers, parent_parser):
         "repro",
         parents=[parent_parser],
         description=append_doc_link(REPRO_HELP, "repro"),
+        add_help=False,
         help=REPRO_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/root.py
+++ b/dvc/command/root.py
@@ -21,6 +21,7 @@ def add_parser(subparsers, parent_parser):
         "root",
         parents=[parent_parser],
         description=append_doc_link(ROOT_HELP, "root"),
+        add_help=False,
         help=ROOT_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/run.py
+++ b/dvc/command/run.py
@@ -90,6 +90,7 @@ def add_parser(subparsers, parent_parser):
         "run",
         parents=[parent_parser],
         description=append_doc_link(RUN_HELP, "run"),
+        add_help=False,
         help=RUN_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/unprotect.py
+++ b/dvc/command/unprotect.py
@@ -29,6 +29,7 @@ def add_parser(subparsers, parent_parser):
         "unprotect",
         parents=[parent_parser],
         description=append_doc_link(UNPROTECT_HELP, "unprotect"),
+        add_help=False,
         help=UNPROTECT_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/update.py
+++ b/dvc/command/update.py
@@ -29,6 +29,7 @@ def add_parser(subparsers, parent_parser):
         "update",
         parents=[parent_parser],
         description=append_doc_link(UPDATE_HELP, "update"),
+        add_help=False,
         help=UPDATE_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/dvc/command/version.py
+++ b/dvc/command/version.py
@@ -22,6 +22,7 @@ def add_parser(subparsers, parent_parser):
         "version",
         parents=[parent_parser],
         description=append_doc_link(VERSION_HELP, "version"),
+        add_help=False,
         help=VERSION_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
         aliases=["doctor"],


### PR DESCRIPTION
When I was working on #4681 and #4695, I noticed that this small refactoring can improve consistency around `-h` message

Before this change:
```
$ dvc init -h
...
optional arguments:
  -h, --help     show this help message and exit
...
```
After this change:
```
$ dvc init -h         
...
optional arguments:
  -h, --help     Show this help message and exit.
...
```
I hope is not so controversial as my previous PRs :).

----

This refactoring is pretty safe as if you forget to add `add_help=False` for child subparsers you will get an error right away
```sh
# removing from one nested subparster
$ git df
diff --git a/dvc/command/plots.py b/dvc/command/plots.py
index f2b901b4..00354be1 100644
--- a/dvc/command/plots.py
+++ b/dvc/command/plots.py
@@ -132,7 +132,6 @@ def add_parser(subparsers, parent_parser):
         "show",
         parents=[parent_parser],
         description=append_doc_link(SHOW_HELP, "plots/show"),
-        add_help=False,
         help=SHOW_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

# getting an error right away
$ dvc -h         
ERROR: unexpected error - argument -h/--help: conflicting option strings: -h, --help

Having any troubles? Hit us up at https://dvc.org/support, we are always happy to help!
```

----
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
