### PR TITLE
Plots: Better confusion matrix, and normalized version to

### DIFF
--- a/dvc/repo/plots/template.py
+++ b/dvc/repo/plots/template.py
@@ -145,6 +145,18 @@ class DefaultConfusionTemplate(Template):
                     "groupby": [Template.anchor("y"), Template.anchor("x")],
                 },
                 {
+                    "impute": "xy_count",
+                    "groupby": ["rev", Template.anchor("y")],
+                    "key": Template.anchor("x"),
+                    "value": 0,
+                },
+                {
+                    "impute": "xy_count",
+                    "groupby": ["rev", Template.anchor("x")],
+                    "key": Template.anchor("y"),
+                    "value": 0,
+                },
+                {
                     "joinaggregate": [
                         {"op": "max", "field": "xy_count", "as": "max_count"}
                     ],
@@ -213,6 +225,18 @@ class NormalizedConfusionTemplate(Template):
                 {
                     "aggregate": [{"op": "count", "as": "xy_count"}],
                     "groupby": [Template.anchor("y"), Template.anchor("x")],
+                },
+                {
+                    "impute": "xy_count",
+                    "groupby": ["rev", Template.anchor("y")],
+                    "key": Template.anchor("x"),
+                    "value": 0,
+                },
+                {
+                    "impute": "xy_count",
+                    "groupby": ["rev", Template.anchor("x")],
+                    "key": Template.anchor("y"),
+                    "value": 0,
                 },
                 {
                     "joinaggregate": [

--- a/dvc/repo/plots/template.py
+++ b/dvc/repo/plots/template.py
@@ -137,22 +137,140 @@ class DefaultConfusionTemplate(Template):
         "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
         "data": {"values": Template.anchor("data")},
         "title": Template.anchor("title"),
-        "mark": "rect",
-        "encoding": {
-            "x": {
-                "field": Template.anchor("x"),
-                "type": "nominal",
-                "sort": "ascending",
-                "title": Template.anchor("x_label"),
+        "facet": {"field": "rev", "type": "nominal"},
+        "spec": {
+            "transform": [
+                {
+                    "aggregate": [{"op": "count", "as": "xy_count"}],
+                    "groupby": [Template.anchor("y"), Template.anchor("x")],
+                },
+                {
+                    "joinaggregate": [
+                        {"op": "max", "field": "xy_count", "as": "max_count"}
+                    ],
+                    "groupby": [],
+                },
+                {
+                    "calculate": "datum.xy_count / datum.max_count",
+                    "as": "percent_of_max",
+                },
+            ],
+            "encoding": {
+                "x": {
+                    "field": Template.anchor("x"),
+                    "type": "nominal",
+                    "sort": "ascending",
+                    "title": Template.anchor("x_label"),
+                },
+                "y": {
+                    "field": Template.anchor("y"),
+                    "type": "nominal",
+                    "sort": "ascending",
+                    "title": Template.anchor("y_label"),
+                },
             },
-            "y": {
-                "field": Template.anchor("y"),
-                "type": "nominal",
-                "sort": "ascending",
-                "title": Template.anchor("y_label"),
+            "layer": [
+                {
+                    "mark": "rect",
+                    "width": 300,
+                    "height": 300,
+                    "encoding": {
+                        "color": {
+                            "field": "xy_count",
+                            "type": "quantitative",
+                            "title": "",
+                            "scale": {"domainMin": 0, "nice": True},
+                        }
+                    },
+                },
+                {
+                    "mark": "text",
+                    "encoding": {
+                        "text": {"field": "xy_count", "type": "quantitative"},
+                        "color": {
+                            "condition": {
+                                "test": "datum.percent_of_max > 0.5",
+                                "value": "white",
+                            },
+                            "value": "black",
+                        },
+                    },
+                },
+            ],
+        },
+    }
+
+
+class NormalizedConfusionTemplate(Template):
+    DEFAULT_NAME = "confusion_normalized"
+    DEFAULT_CONTENT = {
+        "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+        "data": {"values": Template.anchor("data")},
+        "title": Template.anchor("title"),
+        "facet": {"field": "rev", "type": "nominal"},
+        "spec": {
+            "transform": [
+                {
+                    "aggregate": [{"op": "count", "as": "xy_count"}],
+                    "groupby": [Template.anchor("y"), Template.anchor("x")],
+                },
+                {
+                    "joinaggregate": [
+                        {"op": "sum", "field": "xy_count", "as": "sum_y"}
+                    ],
+                    "groupby": [Template.anchor("y")],
+                },
+                {
+                    "calculate": "datum.xy_count / datum.sum_y",
+                    "as": "percent_of_y",
+                },
+            ],
+            "encoding": {
+                "x": {
+                    "field": Template.anchor("x"),
+                    "type": "nominal",
+                    "sort": "ascending",
+                    "title": Template.anchor("x_label"),
+                },
+                "y": {
+                    "field": Template.anchor("y"),
+                    "type": "nominal",
+                    "sort": "ascending",
+                    "title": Template.anchor("y_label"),
+                },
             },
-            "color": {"aggregate": "count", "type": "quantitative"},
-            "facet": {"field": "rev", "type": "nominal"},
+            "layer": [
+                {
+                    "mark": "rect",
+                    "width": 300,
+                    "height": 300,
+                    "encoding": {
+                        "color": {
+                            "field": "percent_of_y",
+                            "type": "quantitative",
+                            "title": "",
+                            "scale": {"domain": [0, 1]},
+                        }
+                    },
+                },
+                {
+                    "mark": "text",
+                    "encoding": {
+                        "text": {
+                            "field": "percent_of_y",
+                            "type": "quantitative",
+                            "format": ".2f",
+                        },
+                        "color": {
+                            "condition": {
+                                "test": "datum.percent_of_y > 0.5",
+                                "value": "white",
+                            },
+                            "value": "black",
+                        },
+                    },
+                },
+            ],
         },
     }
 
@@ -219,6 +337,7 @@ class PlotTemplates:
     TEMPLATES = [
         DefaultLinearTemplate,
         DefaultConfusionTemplate,
+        NormalizedConfusionTemplate,
         DefaultScatterTemplate,
         SmoothLinearTemplate,
     ]

--- a/tests/func/metrics/plots/test_show.py
+++ b/tests/func/metrics/plots/test_show.py
@@ -230,7 +230,7 @@ def test_plot_confusion_normalized(tmp_dir, dvc, run_copy_metrics):
         "actual",
         "predicted",
     ]
-    assert plot_content["spec"]["transform"][1]["groupby"] == ["actual"]
+    assert plot_content["spec"]["transform"][1]["groupby"] == ["rev", "actual"]
     assert plot_content["spec"]["encoding"]["x"]["field"] == "predicted"
     assert plot_content["spec"]["encoding"]["y"]["field"] == "actual"
 

--- a/tests/func/metrics/plots/test_show.py
+++ b/tests/func/metrics/plots/test_show.py
@@ -193,8 +193,46 @@ def test_plot_confusion(tmp_dir, dvc, run_copy_metrics):
         {"predicted": "B", "actual": "A", "rev": "workspace"},
         {"predicted": "A", "actual": "A", "rev": "workspace"},
     ]
-    assert plot_content["encoding"]["x"]["field"] == "predicted"
-    assert plot_content["encoding"]["y"]["field"] == "actual"
+    assert plot_content["spec"]["transform"][0]["groupby"] == [
+        "actual",
+        "predicted",
+    ]
+    assert plot_content["spec"]["encoding"]["x"]["field"] == "predicted"
+    assert plot_content["spec"]["encoding"]["y"]["field"] == "actual"
+
+
+def test_plot_confusion_normalized(tmp_dir, dvc, run_copy_metrics):
+    confusion_matrix = [
+        {"predicted": "B", "actual": "A"},
+        {"predicted": "A", "actual": "A"},
+    ]
+    _write_json(tmp_dir, confusion_matrix, "metric_t.json")
+    run_copy_metrics(
+        "metric_t.json",
+        "metric.json",
+        plots_no_cache=["metric.json"],
+        commit="first run",
+    )
+
+    props = {
+        "template": "confusion_normalized",
+        "x": "predicted",
+        "y": "actual",
+    }
+    plot_string = dvc.plots.show(props=props)["metric.json"]
+
+    plot_content = json.loads(plot_string)
+    assert plot_content["data"]["values"] == [
+        {"predicted": "B", "actual": "A", "rev": "workspace"},
+        {"predicted": "A", "actual": "A", "rev": "workspace"},
+    ]
+    assert plot_content["spec"]["transform"][0]["groupby"] == [
+        "actual",
+        "predicted",
+    ]
+    assert plot_content["spec"]["transform"][1]["groupby"] == ["actual"]
+    assert plot_content["spec"]["encoding"]["x"]["field"] == "predicted"
+    assert plot_content["spec"]["encoding"]["y"]["field"] == "actual"
 
 
 def test_plot_multiple_revs_default(tmp_dir, scm, dvc, run_copy_metrics):


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

## Description of Changes
Relates to #3801 

I really wasn't happy with the default confusion matrix provided in DVC, so I dove into Vega-Lite and figured out how to add a few features:
* Text labels on each cell showing record counts
* Added new confusion_normalized template to show counts normalized by actual label
   * I thought about adding a new anchor to control the normalization direction (groupby actual vs. predicted), but this can also easily be achieved by simply switching x and y :smile: 

## Screenshots
**New `confusion` template**
![visualization](https://user-images.githubusercontent.com/5074378/97109695-3da61000-169a-11eb-9e4d-4dfc5d87f2ee.png)

**Results of `dvc plots diff` with new `confusion_normalized` template**
![visualization](https://user-images.githubusercontent.com/5074378/97109666-20714180-169a-11eb-928d-7253990e8496.png)

## Feedback Wanted
Here are some stylistic decisions I made that I'm open to reverting in interest of genericness:
- Made the plot much bigger (can't reasonably overlay text on the current tiny size)
- Hid the title next to the color bar
- In the normalized plot, the scale is clamped from 0 to 1
- In the unnormalized plot, the scale minimum is clamped to 0 and the max is set to `nice: true`

~Also, cells that are zero are empty. This is because of how the grouping works, and I couldn't find a way to "fill in" the missing values. If someone more expert in Vega syntax can help me figure that out, that would be awesome.~ Fixed!