### PR TITLE
add: fix issue when adding already tracked symlinked files

### DIFF
--- a/dvc/output/local.py
+++ b/dvc/output/local.py
@@ -5,7 +5,6 @@ from urllib.parse import urlparse
 from dvc.exceptions import DvcException
 from dvc.istextfile import istextfile
 from dvc.output.base import BaseOutput
-from dvc.scm.base import FileNotInRepoError
 from dvc.utils import relpath
 from dvc.utils.fs import path_isin
 
@@ -66,18 +65,6 @@ class LocalOutput(BaseOutput):
     def is_in_repo(self):
         def_scheme = urlparse(self.def_path).scheme
         return def_scheme != "remote" and not os.path.isabs(self.def_path)
-
-    def ignore(self):
-        try:
-            super().ignore()
-        except FileNotInRepoError:
-            # relpath outputs that are symlinked to a path outside the git repo
-            # cannot be .gitignore'd
-            if path_isin(
-                os.path.realpath(self.fspath),
-                os.path.realpath(self.repo.root_dir),
-            ):
-                raise
 
     def dumpd(self):
         ret = super().dumpd()

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -372,9 +372,15 @@ def resolve_paths(repo, out):
     elif contains_symlink_up_to(dirname, repo.root_dir) or (
         os.path.isdir(abspath) and System.is_symlink(abspath)
     ):
-        raise DvcException(
-            "Cannot add files inside symlinked directories to DVC."
+        msg = (
+            "Cannot add files inside symlinked directories to DVC. "
+            "See {} for more information."
+        ).format(
+            format_link(
+                "https://dvc.org/doc/user-guide/troubleshooting#add-symlink"
+            )
         )
+        raise DvcException(msg)
     else:
         wdir = dirname
         out = base

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -353,7 +353,9 @@ def resolve_paths(repo, out):
     from urllib.parse import urlparse
 
     from ..dvcfile import DVC_FILE_SUFFIX
+    from ..exceptions import DvcException
     from ..path_info import PathInfo
+    from ..system import System
     from .fs import contains_symlink_up_to
 
     abspath = PathInfo(os.path.abspath(out))
@@ -364,15 +366,18 @@ def resolve_paths(repo, out):
     if os.name == "nt" and scheme == abspath.drive[0].lower():
         # urlparse interprets windows drive letters as URL scheme
         scheme = ""
-    if (
-        not scheme
-        and abspath.isin_or_eq(repo.root_dir)
-        and not contains_symlink_up_to(dirname, repo.root_dir)
+
+    if scheme or not abspath.isin_or_eq(repo.root_dir):
+        wdir = os.getcwd()
+    elif contains_symlink_up_to(dirname, repo.root_dir) or (
+        os.path.isdir(abspath) and System.is_symlink(abspath)
     ):
+        raise DvcException(
+            "Cannot add files inside symlinked directories to DVC."
+        )
+    else:
         wdir = dirname
         out = base
-    else:
-        wdir = os.getcwd()
 
     path = os.path.join(wdir, base + DVC_FILE_SUFFIX)
 

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -367,7 +367,7 @@ def resolve_paths(repo, out):
     if (
         not scheme
         and abspath.isin_or_eq(repo.root_dir)
-        and not contains_symlink_up_to(abspath, repo.root_dir)
+        and not contains_symlink_up_to(dirname, repo.root_dir)
     ):
         wdir = dirname
         out = base

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -1,7 +1,6 @@
 import filecmp
 import logging
 import os
-import posixpath
 import shutil
 import time
 
@@ -422,52 +421,6 @@ def test_should_collect_dir_cache_only_once(mocker, tmp_dir, dvc):
     assert get_dir_hash_counter.mock.call_count == 1
 
 
-class SymlinkAddTestBase(TestDvc):
-    def _get_data_dir(self):
-        raise NotImplementedError
-
-    def _prepare_external_data(self):
-        data_dir = self._get_data_dir()
-
-        data_file_name = "data_file"
-        external_data_path = os.path.join(data_dir, data_file_name)
-        with open(external_data_path, "w+") as f:
-            f.write("data")
-
-        link_name = "data_link"
-        System.symlink(data_dir, link_name)
-        return data_file_name, link_name
-
-    def _test(self):
-        data_file_name, link_name = self._prepare_external_data()
-
-        ret = main(["add", os.path.join(link_name, data_file_name)])
-        self.assertEqual(0, ret)
-
-        stage_file = data_file_name + DVC_FILE_SUFFIX
-        self.assertTrue(os.path.exists(stage_file))
-
-        d = load_yaml(stage_file)
-        relative_data_path = posixpath.join(link_name, data_file_name)
-        self.assertEqual(relative_data_path, d["outs"][0]["path"])
-
-
-class TestShouldAddDataFromExternalSymlink(SymlinkAddTestBase):
-    def _get_data_dir(self):
-        return self.mkdtemp()
-
-    def test(self):
-        self._test()
-
-
-class TestShouldAddDataFromInternalSymlink(SymlinkAddTestBase):
-    def _get_data_dir(self):
-        return self.DATA_DIR
-
-    def test(self):
-        self._test()
-
-
 class TestShouldPlaceStageInDataDirIfRepositoryBelowSymlink(TestDvc):
     def test(self):
         def is_symlink_true_below_dvc_root(path):
@@ -809,7 +762,7 @@ def test_add_pipeline_file(tmp_dir, dvc, run_copy):
         dvc.add(PIPELINE_FILE)
 
 
-def test_add_symlink(tmp_dir, dvc):
+def test_add_symlink_file(tmp_dir, dvc):
     tmp_dir.gen({"dir": {"bar": "bar"}})
 
     (tmp_dir / "dir" / "foo").symlink_to(os.path.join(".", "bar"))
@@ -835,20 +788,35 @@ def test_add_symlink(tmp_dir, dvc):
     dvc.add(os.path.join("dir", "foo"))
 
 
-def test_add_file_in_symlink_dir(make_tmp_dir, tmp_dir, dvc):
-    data_dir = make_tmp_dir("data")
-    data_dir.gen({"dir": {"foo": "foo"}})
+@pytest.mark.parametrize("external", [True, False])
+def test_add_symlink_dir(make_tmp_dir, tmp_dir, dvc, external):
+    if external:
+        data_dir = make_tmp_dir("data")
+        data_dir.gen({"foo": "foo"})
+        target = os.fspath(data_dir)
+    else:
+        tmp_dir.gen({"data": {"foo": "foo"}})
+        target = os.path.join(".", "data")
 
-    (tmp_dir / "dir").symlink_to(os.fspath(data_dir / "dir"))
+    tmp_dir.gen({"data": {"foo": "foo"}})
 
-    dvc.add(os.path.join("dir", "foo"))
+    (tmp_dir / "dir").symlink_to(target)
 
-    assert (tmp_dir / "foo.dvc").exists()
-    assert not (tmp_dir / "dir" / "foo.dvc").exists()
-    assert (tmp_dir / "dir" / "foo").read_text() == "foo"
-    assert (tmp_dir / ".dvc" / "cache").read_text() == {
-        "ac": {"bd18db4cc2f85cedef654fccc4a4d8": "foo"}
-    }
+    with pytest.raises(DvcException):
+        dvc.add("dir")
 
-    # Test that subsequent add succeeds
-    dvc.add(os.path.join("dir", "foo"))
+
+@pytest.mark.parametrize("external", [True, False])
+def test_add_file_in_symlink_dir(make_tmp_dir, tmp_dir, dvc, external):
+    if external:
+        data_dir = make_tmp_dir("data")
+        data_dir.gen({"dir": {"foo": "foo"}})
+        target = os.fspath(data_dir / "dir")
+    else:
+        tmp_dir.gen({"data": {"foo": "foo"}})
+        target = os.path.join(".", "data")
+
+    (tmp_dir / "dir").symlink_to(target)
+
+    with pytest.raises(DvcException):
+        dvc.add(os.path.join("dir", "foo"))


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will fix #4654.

* `dvc add <symlinked_file>` now works as expected. The DVC file will be placed in the same directory as the original symlink
* `dvc add`'ing symlinked a directory or a file inside a symlinked directory is now forbidden.

Docs PR: https://github.com/iterative/dvc.org/pull/1890