### PR TITLE
Simpler param updates with python-benedict

### DIFF
--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -312,31 +312,18 @@ class Experiments:
 
     def _update_params(self, params: dict):
         """Update experiment params files with the specified values."""
+        from benedict import benedict
+
         from dvc.utils.serialize import MODIFIERS
 
         logger.debug("Using experiment params '%s'", params)
-
-        # recursive dict update
-        def _update(dict_, other):
-            for key, value in other.items():
-                if isinstance(dict_, list) and key.isdigit():
-                    key = int(key)
-                if isinstance(value, Mapping):
-                    if isinstance(dict_, list):
-                        fallback_value = dict_[key]
-                    else:
-                        fallback_value = dict_.get(key, {})
-                    dict_[key] = _update(fallback_value, value)
-                else:
-                    dict_[key] = value
-            return dict_
 
         for params_fname in params:
             path = PathInfo(self.exp_dvc.root_dir) / params_fname
             suffix = path.suffix.lower()
             modify_data = MODIFIERS[suffix]
             with modify_data(path, tree=self.exp_dvc.tree) as data:
-                _update(data, params[params_fname])
+                benedict(data).merge(params[params_fname], overwrite=True)
 
         # Force params file changes to be staged in git
         # Otherwise in certain situations the changes to params file may be

--- a/dvc/repo/experiments/run.py
+++ b/dvc/repo/experiments/run.py
@@ -12,7 +12,6 @@ def _parse_params(path_params: Iterable):
     from ruamel.yaml import YAMLError
 
     from dvc.dependency.param import ParamsDependency
-    from dvc.utils.flatten import unflatten
     from dvc.utils.serialize import loads_yaml
 
     ret = {}
@@ -31,7 +30,7 @@ def _parse_params(path_params: Iterable):
                 )
         if not path:
             path = ParamsDependency.DEFAULT_PARAMS_FILE
-        ret[path] = unflatten(params)
+        ret[path] = params
     return ret
 
 

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ install_requires = [
     "shtab>=1.3.2,<2",
     "rich>=3.0.5",
     "dictdiffer>=0.8.1",
+    "python-benedict>=0.21.1",
 ]
 
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

## Description of Changes
Following up on my last [comment](https://github.com/iterative/dvc/pull/4769#issuecomment-714869426) on #4769 

So I did some testing and my idea to use [benedict](https://github.com/fabiocaccamo/python-benedict) to simplify the code actually works great... ~almost~. (**Update:** figured it out) As you can see in the changes here, you can replace a lot of code with a single built-in function call. This also has the benefit of using more standard `[0]` syntax for list accessing.

~I added more tests to make sure that everything was working, then I ran into this strange behavior on a single test case:~
![image](https://user-images.githubusercontent.com/5074378/97004288-790dd680-1502-11eb-980c-f2218295debe.png)

~The params are being correctly updated and written, but for some reason the experiment doesn't seem to actually run the copy step. It's strange, and I would appreciate any help chasing this down...~

I just needed to add `goo` to the list of stage params :facepalm: 

Linting is failing on changes I didn't make.

## TODO
- [x] What's up with that weird behavior?!
- [x] Run the full test suite to make sure I didn't break anything elsewhere :smile: 