### PR TITLE
Replace dict calls for literals

### DIFF
--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -31,9 +31,12 @@ class Tqdm(tqdm):
     BAR_FMT_NOTOTAL = (
         "{desc}{bar:b}|{postfix[info]}{n_fmt} [{elapsed}, {rate_fmt:>11}]"
     )
-    BYTES_DEFAULTS = dict(
-        unit="B", unit_scale=True, unit_divisor=1024, miniters=1
-    )
+    BYTES_DEFAULTS = {
+        "unit": "B",
+        "unit_scale": True,
+        "unit_divisor": 1024,
+        "miniters": 1,
+    }
 
     def __init__(
         self,

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -114,7 +114,7 @@ class Repo:
             self.dvc_dir = None
             self.tmp_dir = None
 
-        tree_kwargs = dict(use_dvcignore=True, dvcignore_root=self.root_dir)
+        tree_kwargs = {"use_dvcignore": True, "dvcignore_root": self.root_dir}
         if scm:
             self.tree = scm.get_tree(rev, **tree_kwargs)
         else:

--- a/dvc/tree/s3.py
+++ b/dvc/tree/s3.py
@@ -64,7 +64,10 @@ class S3Tree(BaseTree):
     def s3(self):
         import boto3
 
-        session_opts = dict(profile_name=self.profile, region_name=self.region)
+        session_opts = {
+            "profile_name": self.profile,
+            "region_name": self.region,
+        }
 
         if self.access_key_id:
             session_opts["aws_access_key_id"] = self.access_key_id

--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ tests_requirements = [
     "rangehttpserver==1.2.0",
     "beautifulsoup4==4.4.0",
     "flake8-bugbear",
-    "flake8-comprehensions",
+    "flake8-comprehensions==3.3.0",
     "flake8-string-format",
     "pylint==2.5.3",
     "pylint-pytest>=0.3.0",

--- a/tests/func/test_tree.py
+++ b/tests/func/test_tree.py
@@ -271,6 +271,6 @@ def test_walk_dont_ignore_subrepos(tmp_dir, scm, dvc):
     assert get_dirs(next(dvc_tree.walk(path))) == []
     assert get_dirs(next(scm_tree.walk(path))) == []
 
-    kw = dict(ignore_subrepos=False)
+    kw = {"ignore_subrepos": False}
     assert get_dirs(next(dvc_tree.walk(path, **kw))) == ["subdir"]
     assert get_dirs(next(scm_tree.walk(path, **kw))) == ["subdir"]

--- a/tests/unit/command/test_diff.py
+++ b/tests/unit/command/test_diff.py
@@ -13,7 +13,7 @@ from dvc.command.diff import _digest, _show_md
     "checksum, expected",
     [
         ("wxyz1234pq", "wxyz1234"),
-        (dict(old="1234567890", new="0987654321"), "12345678..09876543"),
+        ({"old": "1234567890", "new": "0987654321"}, "12345678..09876543"),
     ],
     ids=["str", "dict"],
 )


### PR DESCRIPTION
* [✔️] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [❌] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.
Note: I don't think this requires documentation changes.

Closes #4783 

This PR changes a few `dict` calls to literals to make them compliant with `flake-comprehensions` recent changes. Literals should be faster as recommended by `flake-comprehensions`:
> It's slower to call e.g. ``dict()`` than using the empty literal, because the
name ``dict`` must be looked up in the global scope in case it has been
rebound. Same for the other two basic types here.
