### PR TITLE
http: raise error on unsuccessful http statuses on `exists`

### DIFF
--- a/dvc/tree/http.py
+++ b/dvc/tree/http.py
@@ -141,7 +141,13 @@ class HTTPTree(BaseTree):  # pylint:disable=abstract-method
         return response
 
     def exists(self, path_info, use_dvcignore=True):
-        return bool(self._head(path_info.url))
+        res = self._head(path_info.url)
+        if res.status_code == 404:
+            return False
+        if bool(res):
+            return True
+        res.raise_for_status()
+        return False
 
     def get_file_hash(self, path_info):
         url = path_info.url

--- a/dvc/tree/http.py
+++ b/dvc/tree/http.py
@@ -146,8 +146,7 @@ class HTTPTree(BaseTree):  # pylint:disable=abstract-method
             return False
         if bool(res):
             return True
-        res.raise_for_status()
-        return False
+        raise HTTPError(res.status_code, res.reason)
 
     def get_file_hash(self, path_info):
         url = path_info.url

--- a/tests/unit/remote/test_http.py
+++ b/tests/unit/remote/test_http.py
@@ -127,23 +127,27 @@ def test_http_method(dvc):
     assert isinstance(tree._auth_method(), HTTPBasicAuth)
 
 
-def test_exists(dvc, http, mocker):
+def test_exists(mocker):
     import io
 
     import requests
 
+    from dvc.path_info import URLInfo
+
     res = requests.Response()
     res.raw = io.StringIO("foo")
-    tree = HTTPTree(dvc, http.config)
+    tree = HTTPTree(None, {})
 
     mocker.patch.object(tree, "request", return_value=res)
 
+    url = URLInfo("https://example.org/file.txt")
+
     res.status_code = 200
-    assert tree.exists(http / "file.txt") is True
+    assert tree.exists(url) is True
 
     res.status_code = 404
-    assert tree.exists(http / "file.txt") is False
+    assert tree.exists(url) is False
 
     res.status_code = 403
     with pytest.raises(HTTPError):
-        tree.exists(http / "file.txt")
+        tree.exists(url)

--- a/tests/unit/remote/test_http.py
+++ b/tests/unit/remote/test_http.py
@@ -125,3 +125,25 @@ def test_http_method(dvc):
     assert tree._auth_method() == auth
     assert tree.method == "PUT"
     assert isinstance(tree._auth_method(), HTTPBasicAuth)
+
+
+def test_exists(dvc, http, mocker):
+    import io
+
+    import requests
+
+    res = requests.Response()
+    res.raw = io.StringIO("foo")
+    tree = HTTPTree(dvc, http.config)
+
+    mocker.patch.object(tree, "request", return_value=res)
+
+    res.status_code = 200
+    assert tree.exists(http / "file.txt") is True
+
+    res.status_code = 404
+    assert tree.exists(http / "file.txt") is False
+
+    res.status_code = 403
+    with pytest.raises(HTTPError):
+        tree.exists(http / "file.txt")

--- a/tests/unit/remote/test_http.py
+++ b/tests/unit/remote/test_http.py
@@ -135,9 +135,11 @@ def test_exists(mocker):
     from dvc.path_info import URLInfo
 
     res = requests.Response()
+    # need to add `raw`, as `exists()` fallbacks to a streaming GET requests
+    # on HEAD request failure.
     res.raw = io.StringIO("foo")
-    tree = HTTPTree(None, {})
 
+    tree = HTTPTree(None, {})
     mocker.patch.object(tree, "request", return_value=res)
 
     url = URLInfo("https://example.org/file.txt")


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

This PR is to fix #4288 . It is still a work in progress as I haven't written any tests for the changes I have implemented, and I need some guidance on where/how to write tests for the project. Do I add to the unit test script in `dvc/tests/unit/remote/test_http.py`? 

I'm not sure if this requires documentation, but I'll create a PR for it if needed.