### PR TITLE
add: warn on cache link errors instead of failing

### DIFF
--- a/dvc/cache/base.py
+++ b/dvc/cache/base.py
@@ -8,6 +8,7 @@ from shortuuid import uuid
 
 import dvc.prompt as prompt
 from dvc.exceptions import (
+    CacheLinkError,
     CheckoutError,
     ConfirmRemoveError,
     DvcException,
@@ -192,7 +193,7 @@ class CloudCache:
                 )
                 del link_types[0]
 
-        raise DvcException("no possible cache types left to try out.")
+        raise CacheLinkError([to_info])
 
     def _do_link(self, from_info, to_info, link_method):
         if self.tree.exists(to_info):

--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -343,7 +343,7 @@ class MergeError(DvcException):
 class CacheLinkError(DvcException):
     SUPPORT_LINK = "See {} for more information.".format(
         format_link(
-            "https://dvc.org/doc/user-guide/" "troubleshooting#cache-types"
+            "https://dvc.org/doc/user-guide/troubleshooting#cache-types"
         )
     )
 

--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -338,3 +338,18 @@ class NoOutputOrStageError(DvcException):
 
 class MergeError(DvcException):
     pass
+
+
+class CacheLinkError(DvcException):
+    SUPPORT_LINK = "See {} for more information.".format(
+        format_link(
+            "https://dvc.org/doc/user-guide/" "troubleshooting#cache-types"
+        )
+    )
+
+    def __init__(self, path_infos):
+        msg = "No possible cache link types for '{}'. {}".format(
+            ", ".join([str(path) for path in path_infos]), self.SUPPORT_LINK,
+        )
+        super().__init__(msg)
+        self.path_infos = path_infos


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will fix #4797.
Docs PR https://github.com/iterative/dvc.org/pull/1892

* `output.commit()` no longer fails if file cannot be linked during `cache.save()` (as long as the file was still moved to cache successfully)
* `dvc add` will succesfully create .dvc file if the link step fails, and will warn user about the link failure and suggest re-running `dvc checkout`

Link failure during add now looks like:

```
$ dvc add foo
100% Add|██████████████████████████████████████████████████████████████████████████████████████████████████████████████|1/1 [00:00,  3.35file/s]
WARNING: Some targets could not be linked from cache to workspace.
See <https://dvc.org/doc/user-guide/troubleshooting#cache-types> for more information.
To re-link these targets, reconfigure cache types and run:

        dvc checkout foo.dvc

To track the changes with git, run:

        git add foo.dvc

$ ls -l
total 4.0K
-rw-r--r-- 1 pmrowla staff 58 Oct 29 12:07 foo.dvc
```

Link failure during `dvc checkout` fails like before, but will include the paths which failed and the troubleshooting link.

```
$ dvc checkout foo.dvc
ERROR: No possible cache types for 'foo'. See <https://dvc.org/doc/user-guide/troubleshooting#cache-types> for more information.
```