### PR TITLE
experiments: fix stash ordering bug

### DIFF
--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -163,8 +163,10 @@ class Experiments:
 
     @property
     def stash_reflog(self):
+        """Return stash reflog in Git 'stash@{...}' index order."""
         if "refs/stash" in self.scm.repo.refs:
-            return self.scm.repo.refs["refs/stash"].log()
+            # gitpython reflog log() returns commits oldest to newest
+            return reversed(self.scm.repo.refs["refs/stash"].log())
         return []
 
     @property


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Fixes a bug where the wrong experiments could be removed from experiments run stash/queue during execution. Cause was due to gitpython `log()` returning commits in reverse order of `git reflog`. So our stash indices would not be lining up properly with git's `stash@{index}` order.