### PR TITLE
git: use dulwich for .gitignore

### DIFF
--- a/dvc/scm/git.py
+++ b/dvc/scm/git.py
@@ -183,13 +183,12 @@ class Git(Base):
         return entry, gitignore
 
     def _ignored(self, path):
-        from git.exc import GitCommandError
+        from dulwich import ignore
+        from dulwich.repo import Repo
 
-        try:
-            self.repo.git.check_ignore(path)
-            return True
-        except GitCommandError:
-            return False
+        repo = Repo(self.root_dir)
+        manager = ignore.IgnoreFilterManager.from_repo(repo)
+        return manager.is_ignored(relpath(path, self.root_dir))
 
     def ignore(self, path):
         entry, gitignore = self._get_gitignore(path)

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ install_requires = [
     "colorama>=0.3.9",
     "configobj>=5.0.6",
     "gitpython>3",
+    "dulwich>=0.20.6",
     "setuptools>=34.0.0",
     "nanotime>=0.5.2",
     "pyasn1>=0.4.1",


### PR DESCRIPTION
In my tests `Git._ignore` is taking around ~65seconds for the whole test
suit(~50K invocations). The reason is that `gitpython` is launching a real
`git check-ignore` process, that takes time and resources.

Switching to `pygit2` or `dulwich` makes it drop to ~5seconds, saving us
almost a minute of the test run time and a lot of resources by not
launching any processes.

I've chosen `dulwich` over `pygit2` here because it is much more
pythonic and the performance is on-par with `pygit2`.

Related to #2215

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
