### PR TITLE
git: move branch iteration functionality from experiments into scm.git

### DIFF
--- a/tests/unit/scm/test_git.py
+++ b/tests/unit/scm/test_git.py
@@ -109,3 +109,17 @@ def test_no_commits(tmp_dir):
     Git().commit("foo")
 
     assert not Git().no_commits
+
+
+def test_branch_revs(tmp_dir, scm):
+    tmp_dir.scm_gen({"file": "0"}, commit="init")
+    init_rev = scm.get_rev()
+
+    expected = []
+    for i in range(1, 5):
+        tmp_dir.scm_gen({"file": f"{i}"}, commit=f"{i}")
+        expected.append(scm.get_rev())
+
+    for rev in scm.branch_revs("master", init_rev):
+        assert rev == expected.pop()
+    assert len(expected) == 0


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

We are going to end up needing to re-use this code for iterating over commits in a git branch in several places for checkpoints related functionality. It's general enough that I think it makes more sense for this to go in scm.git rather than in some experiments specific helper function