### PR TITLE
import: add --no-exec param

### DIFF
--- a/dvc/command/imp.py
+++ b/dvc/command/imp.py
@@ -17,6 +17,7 @@ class CmdImport(CmdBase):
                 out=self.args.out,
                 fname=self.args.file,
                 rev=self.args.rev,
+                no_exec=self.args.no_exec,
             )
         except DvcException:
             logger.exception(
@@ -64,5 +65,11 @@ def add_parser(subparsers, parent_parser):
         "--file",
         help="Specify name of the DVC-file this command will generate.",
         metavar="<filename>",
+    )
+    import_parser.add_argument(
+        "--no-exec",
+        action="store_true",
+        default=False,
+        help="Only create DVC-file without actually downloading it.",
     )
     import_parser.set_defaults(func=CmdImport)

--- a/dvc/repo/imp.py
+++ b/dvc/repo/imp.py
@@ -1,6 +1,8 @@
-def imp(self, url, path, out=None, fname=None, rev=None):
+def imp(self, url, path, out=None, fname=None, rev=None, no_exec=False):
     erepo = {"url": url}
     if rev is not None:
         erepo["rev"] = rev
 
-    return self.imp_url(path, out=out, fname=fname, erepo=erepo, frozen=True)
+    return self.imp_url(
+        path, out=out, fname=fname, erepo=erepo, frozen=True, no_exec=no_exec
+    )

--- a/tests/func/test_import.py
+++ b/tests/func/test_import.py
@@ -465,3 +465,13 @@ def test_try_import_complete_repo(tmp_dir, dvc, erepo_dir):
     with pytest.raises(IsADVCRepoError) as exc_info:
         dvc.imp(os.fspath(erepo_dir), os.curdir, out="out")
     assert expected_message == str(exc_info.value)
+
+
+def test_import_with_no_exec(tmp_dir, dvc, erepo_dir):
+    with erepo_dir.chdir():
+        erepo_dir.dvc_gen("foo", "foo content", commit="create foo")
+
+    dvc.imp(os.fspath(erepo_dir), "foo", out="foo_imported", no_exec=True)
+
+    dst = tmp_dir / "foo_imported"
+    assert not dst.exists()

--- a/tests/unit/command/test_imp.py
+++ b/tests/unit/command/test_imp.py
@@ -24,5 +24,41 @@ def test_import(mocker):
     assert cmd.run() == 0
 
     m.assert_called_once_with(
-        "repo_url", path="src", out="out", fname="file", rev="version"
+        "repo_url",
+        path="src",
+        out="out",
+        fname="file",
+        rev="version",
+        no_exec=False,
+    )
+
+
+def test_import_no_exec(mocker):
+    cli_args = parse_args(
+        [
+            "import",
+            "repo_url",
+            "src",
+            "--out",
+            "out",
+            "--file",
+            "file",
+            "--rev",
+            "version",
+            "--no-exec",
+        ]
+    )
+
+    cmd = cli_args.func(cli_args)
+    m = mocker.patch.object(cmd.repo, "imp", autospec=True)
+
+    assert cmd.run() == 0
+
+    m.assert_called_once_with(
+        "repo_url",
+        path="src",
+        out="out",
+        fname="file",
+        rev="version",
+        no_exec=True,
     )


### PR DESCRIPTION
To be consistent with the same `--no-exec` param in import-url.

Fixes #4567.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

* [ ] I'll be going through the failed tests tomorrow.
------

Related docs change: https://github.com/iterative/dvc.org/pull/1900