### PR TITLE
utils/fs: checking files ownership in 'move' (#4348)

### DIFF
--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -218,6 +218,11 @@ class FileMissingError(DvcException):
         )
 
 
+class FileOwnershipError(DvcException):
+    def __init__(self, path):
+        super().__init__(f"file '{path}' not owned by user! ")
+
+
 class DvcIgnoreInCollectedDirError(DvcException):
     def __init__(self, ignore_dirname):
         super().__init__(

--- a/dvc/utils/fs.py
+++ b/dvc/utils/fs.py
@@ -106,7 +106,7 @@ def move(src, dst, mode=None):
 
     if os.path.islink(src):
         shutil.copy(src, tmp)
-        os.unlink(src)
+        _unlink(src, _chmod)
     else:
         shutil.move(src, tmp)
 

--- a/dvc/utils/fs.py
+++ b/dvc/utils/fs.py
@@ -95,14 +95,18 @@ def move(src, dst, mode=None):
     dst = os.path.abspath(dst)
     tmp = f"{dst}.{uuid()}"
 
+    try:
+        if mode is not None:
+            os.chmod(src, mode)
+    except OSError:
+        # File not owned by us, raise exception
+        raise DvcException(f"File not owned by user:  {src}")
+
     if os.path.islink(src):
         shutil.copy(src, tmp)
         os.unlink(src)
     else:
         shutil.move(src, tmp)
-
-    if mode is not None:
-        os.chmod(tmp, mode)
 
     shutil.move(tmp, dst)
 

--- a/dvc/utils/fs.py
+++ b/dvc/utils/fs.py
@@ -6,9 +6,10 @@ import stat
 import sys
 
 import nanotime
+from funcy import reraise
 from shortuuid import uuid
 
-from dvc.exceptions import DvcException
+from dvc.exceptions import DvcException, FileOwnershipError
 from dvc.system import System
 from dvc.utils import dict_md5
 
@@ -95,11 +96,9 @@ def move(src, dst, mode=None):
     dst = os.path.abspath(dst)
     tmp = f"{dst}.{uuid()}"
 
-    try:
+    with reraise(OSError, FileOwnershipError(src)):
         if mode is not None:
             os.chmod(src, mode)
-    except OSError:
-        raise DvcException(f"File not owned by user:  {src}")
 
     if os.path.islink(src):
         shutil.copy(src, tmp)

--- a/dvc/utils/fs.py
+++ b/dvc/utils/fs.py
@@ -99,7 +99,6 @@ def move(src, dst, mode=None):
         if mode is not None:
             os.chmod(src, mode)
     except OSError:
-        # File not owned by us, raise exception
         raise DvcException(f"File not owned by user:  {src}")
 
     if os.path.islink(src):


### PR DESCRIPTION
Files are checked for ownership by trying to `chmod` them before moving them around; if fail, return a verbose exception.
Previous behavior: moving files to a temp folder and then do the check; when fail, files seemed to be missing.

Should fix #4348 and maybe fix #2992.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [X] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
