### PR TITLE
Add flaky-service (Again)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,9 +60,20 @@ jobs:
         mkdir -p scripts/ci
         echo "$GS_CREDS_JSON" > scripts/ci/gcp-creds.json
     - name: run tests
-      run: python -m tests -ra --cov-report=xml --cov-report=term
+      run: python -m tests -ra --cov-report=xml --cov-report=term --tap-combined
     - name: upload coverage report
       uses: codecov/codecov-action@v1.0.13
       with:
         file: ./coverage.xml
         fail_ci_if_error: true
+    - name: Post TAP
+      # Running custom fork with an option, that does not fail CI on error
+      uses: skshetry/flaky-service/packages/action@master
+      if: ${{ always() }}
+      with:
+        file-path: ${{github.workspace}}/testresults.tap
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        os: ${{runner.os}}
+        matrix: ${{toJson(matrix)}}
+        repo-description: ${{github.event.repository.description}}
+        fail_ci_if_error: false

--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,7 @@ tests_requirements = [
     "pytest-xdist>=1.26.1",
     "pytest-mock==1.11.2",
     "pytest-lazy-fixture",
+    "pytest-tap",
     "flaky>=3.5.3",
     "mock>=3.0.0",
     "xmltodict>=0.11.0",


### PR DESCRIPTION
Use master branch for flaky-service

Generate TAP results during pytest

I have added my own fork of github action that does not fail even on an error. I'll be monitoring the CI frequently and will rollback if anything explodes.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
