### PR TITLE
plots: fix plots path when calling from different dir

### DIFF
--- a/dvc/command/plots.py
+++ b/dvc/command/plots.py
@@ -65,12 +65,11 @@ class CmdPlots(CmdBase):
             html = PAGE_HTML.format(divs="\n".join(divs))
             path = self.args.out or "plots.html"
 
+            path = os.path.join(os.getcwd(), path)
             with open(path, "w") as fobj:
                 fobj.write(html)
 
-            logger.info(
-                "file://{}".format(os.path.join(self.repo.root_dir, path))
-            )
+            logger.info(f"file://{path}")
 
         except DvcException:
             logger.exception("")


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

We have been producing clickable HTML path basing on `repo.root_dir` while actually it was created relative to `cwd`.
This PR fixes the issue.