### PR TITLE
parametrization: fix `merge_update` not converting data to `Node` object

### DIFF
--- a/dvc/parsing/__init__.py
+++ b/dvc/parsing/__init__.py
@@ -136,7 +136,7 @@ class DataResolver:
             suffix = str(key if key is not DEFAULT_SENTINEL else value)
             return self._resolve_stage(c, f"{name}-{suffix}", in_data)
 
-        iterable = context.resolve(foreach_data)
+        iterable = context.resolve(foreach_data, unwrap=False)
 
         assert isinstance(iterable, (Sequence, Mapping)) and not isinstance(
             iterable, str

--- a/tests/unit/test_interpolate.py
+++ b/tests/unit/test_interpolate.py
@@ -3,6 +3,7 @@ from math import inf, pi
 import pytest
 
 from dvc.parsing import Context
+from tests.func.test_stage_resolver import recurse_not_a_node
 
 
 @pytest.mark.parametrize(
@@ -97,4 +98,6 @@ def test_resolve_collection():
     )
 
     context = Context(CONTEXT_DATA)
-    assert context.resolve(TEMPLATED_DVC_YAML_DATA) == RESOLVED_DVC_YAML_DATA
+    resolved = context.resolve(TEMPLATED_DVC_YAML_DATA)
+    assert resolved == RESOLVED_DVC_YAML_DATA
+    assert recurse_not_a_node(resolved)


### PR DESCRIPTION
We wrap every data to one of the `Node` object. But, since we were
passing `self.data` instead of `self`, it was skipping the conversion
and instead was just trying to set data as-is, which would have make
our latter assumptions incorrect, as other codebases assume it to be
a `Node`.

I have added asserts in a few places. Also, I noticed that, on a few
test assumptions, when `resolving`, we were not converting values
back to it's original form (`CtxDict` -> `dict`, `CtxList` -> `list`
and `Value` -> _). So, I have added `node.value` property, as it is
a complement of the above fix.

This caused a ripple effect for the changes in the API as `foreach`
now resolved and changed the data to the original form,
which prevents us from tracking the data later in the "field".
So, `resolve`/`select` got a real `unwrap` option that should
reliably work for all kinds of `Node` objects.
