### PR TITLE
dvc: include cache urls in info output.

### DIFF
--- a/dvc/info.py
+++ b/dvc/info.py
@@ -8,7 +8,7 @@ from dvc.exceptions import DvcException, NotDvcRepoError
 from dvc.repo import Repo
 from dvc.scm.base import SCMError
 from dvc.system import System
-from dvc.tree import TREES
+from dvc.tree import TREES, get_cloud_schemes
 from dvc.utils import error_link
 from dvc.utils.pkg import PKG
 from dvc.version import __version__
@@ -51,7 +51,9 @@ def get_dvc_info():
             info.append("Cache types: " + error_link("no-dvc-cache"))
 
         info.append(f"Caches: {_get_caches(repo.cache)}")
-        info.append(f"Remotes: {_get_configured_remotes(repo)}")
+
+        remotes = ", ".join(get_cloud_schemes(repo)) or "None"
+        info.append(f"Remotes: {remotes}")
 
     except NotDvcRepoError:
         pass

--- a/dvc/info.py
+++ b/dvc/info.py
@@ -67,20 +67,11 @@ def get_dvc_info():
 
 
 def _get_caches(cache):
-    from dvc.config import SCHEMA
-
-    caches = set()
-    for cache_type in SCHEMA["cache"].keys():
-        # Ignore any non cache types, e.g. LOCAL_COMMON objects
-        if not isinstance(cache_type, str):
-            continue
-
-        # Ignore the cache types not available in the repo
-        cache_instance = getattr(cache, cache_type, None)
-        if not cache_instance:
-            continue
-
-        caches.add(cache_type)
+    caches = (
+        cache_type
+        for cache_type, cache_instance in cache.by_scheme()
+        if cache_instance
+    )
 
     # Caches will be always non-empty including the local cache
     return ", ".join(caches)

--- a/dvc/info.py
+++ b/dvc/info.py
@@ -8,7 +8,7 @@ from dvc.exceptions import DvcException, NotDvcRepoError
 from dvc.repo import Repo
 from dvc.scm.base import SCMError
 from dvc.system import System
-from dvc.tree import TREES, get_cloud_schemes
+from dvc.tree import TREES, get_tree_cls, get_tree_config
 from dvc.utils import error_link
 from dvc.utils.pkg import PKG
 from dvc.version import __version__
@@ -52,8 +52,7 @@ def get_dvc_info():
 
         info.append(f"Caches: {_get_caches(repo.cache)}")
 
-        remotes = ", ".join(get_cloud_schemes(repo)) or "None"
-        info.append(f"Remotes: {remotes}")
+        info.append(f"Remotes: {_get_remotes(repo.config)}")
 
     except NotDvcRepoError:
         pass
@@ -77,6 +76,15 @@ def _get_caches(cache):
 
     # Caches will be always non-empty including the local cache
     return ", ".join(caches)
+
+
+def _get_remotes(config):
+    schemes = (
+        get_tree_cls(get_tree_config(config, name=remote)).scheme
+        for remote in config["remote"]
+    )
+
+    return ", ".join(schemes) or "None"
 
 
 def _get_linktype_support_info(repo):

--- a/dvc/info.py
+++ b/dvc/info.py
@@ -51,9 +51,8 @@ def get_dvc_info():
             info.append("Cache types: " + error_link("no-dvc-cache"))
 
         cache_urls = _get_cache_urls(repo.cache)
-        if cache_urls:
-            info.append("Cache paths:")
-            info.extend(f"  {c[0]}: {c[1]}" for c in cache_urls)
+        info.append("Cache paths:")
+        info.extend(f"  {c[0]}: {c[1]}" for c in cache_urls)
 
     except NotDvcRepoError:
         pass

--- a/dvc/info.py
+++ b/dvc/info.py
@@ -127,26 +127,6 @@ def _get_supported_remotes():
     return ", ".join(supported_remotes)
 
 
-def _get_configured_remotes(repo):
-    from urllib.parse import urlparse
-
-    from dvc.scheme import Schemes
-
-    # Get supported schemes, exclude the private variables
-    available_remotes = {
-        v
-        for k, v in vars(Schemes).items()
-        if not k.startswith("_") and isinstance(v, str)
-    }
-    remotes = set()
-    for remote_config in repo.config["remote"].values():
-        parsed = urlparse(remote_config["url"])
-        if parsed.scheme in available_remotes:
-            remotes.add(parsed.scheme)
-
-    return ", ".join(remotes) if len(remotes) > 0 else "None"
-
-
 def get_fs_type(path):
 
     partition = {

--- a/dvc/tree/__init__.py
+++ b/dvc/tree/__init__.py
@@ -88,3 +88,15 @@ def get_cloud_tree(repo, **kwargs):
     except Invalid as exc:
         raise ConfigError(str(exc)) from None
     return _get_tree(remote_conf)(repo, remote_conf)
+
+
+def get_cloud_schemes(repo):
+    """Get a list of remote schemes configured for a repo.
+
+    Args:
+        repo: dvc repository
+    """
+    return {
+        _get_tree(_get_conf(repo, name=remote)).scheme
+        for remote in repo.config["remote"]
+    }

--- a/dvc/tree/__init__.py
+++ b/dvc/tree/__init__.py
@@ -32,23 +32,23 @@ TREES = [
 ]
 
 
-def _get_tree(remote_conf):
+def get_tree_cls(remote_conf):
     for tree_cls in TREES:
         if tree_cls.supported(remote_conf):
             return tree_cls
     return LocalTree
 
 
-def _get_conf(repo, **kwargs):
+def get_tree_config(config, **kwargs):
     name = kwargs.get("name")
     if name:
-        remote_conf = repo.config["remote"][name.lower()]
+        remote_conf = config["remote"][name.lower()]
     else:
         remote_conf = kwargs
-    return _resolve_remote_refs(repo, remote_conf)
+    return _resolve_remote_refs(config, remote_conf)
 
 
-def _resolve_remote_refs(repo, remote_conf):
+def _resolve_remote_refs(config, remote_conf):
     # Support for cross referenced remotes.
     # This will merge the settings, shadowing base ref with remote_conf.
     # For example, having:
@@ -74,7 +74,7 @@ def _resolve_remote_refs(repo, remote_conf):
     if parsed.scheme != "remote":
         return remote_conf
 
-    base = _get_conf(repo, name=parsed.netloc)
+    base = get_tree_config(config, name=parsed.netloc)
     url = posixpath.join(base["url"], parsed.path.lstrip("/"))
     return {**base, **remote_conf, "url": url}
 
@@ -82,21 +82,9 @@ def _resolve_remote_refs(repo, remote_conf):
 def get_cloud_tree(repo, **kwargs):
     from dvc.config import SCHEMA, ConfigError, Invalid
 
-    remote_conf = _get_conf(repo, **kwargs)
+    remote_conf = get_tree_config(repo.config, **kwargs)
     try:
         remote_conf = SCHEMA["remote"][str](remote_conf)
     except Invalid as exc:
         raise ConfigError(str(exc)) from None
-    return _get_tree(remote_conf)(repo, remote_conf)
-
-
-def get_cloud_schemes(repo):
-    """Get a list of remote schemes configured for a repo.
-
-    Args:
-        repo: dvc repository
-    """
-    return {
-        _get_tree(_get_conf(repo, name=remote)).scheme
-        for remote in repo.config["remote"]
-    }
+    return get_tree_cls(remote_conf)(repo, remote_conf)

--- a/tests/func/test_version.py
+++ b/tests/func/test_version.py
@@ -11,6 +11,6 @@ def test_(tmp_dir, dvc, scm, caplog):
     assert re.search(f"Platform: {PYTHON_VERSION_REGEX} on .*", caplog.text)
     assert re.search(r"Supports: .*", caplog.text)
     assert re.search(r"Cache types: .*", caplog.text)
-    assert re.search(r"Cache paths:", caplog.text)
-    assert re.search(r"\s\slocal: .*", caplog.text)
+    assert re.search(r"Caches: local", caplog.text)
+    assert re.search(r"Remotes: None", caplog.text)
     assert "Repo: dvc, git" in caplog.text

--- a/tests/func/test_version.py
+++ b/tests/func/test_version.py
@@ -11,4 +11,6 @@ def test_(tmp_dir, dvc, scm, caplog):
     assert re.search(f"Platform: {PYTHON_VERSION_REGEX} on .*", caplog.text)
     assert re.search(r"Supports: .*", caplog.text)
     assert re.search(r"Cache types: .*", caplog.text)
+    assert re.search(r"Cache paths:", caplog.text)
+    assert re.search(r"\s\slocal: .*", caplog.text)
     assert "Repo: dvc, git" in caplog.text

--- a/tests/unit/test_info.py
+++ b/tests/unit/test_info.py
@@ -74,16 +74,15 @@ def test_remotes_empty(tmp_dir, dvc, caplog):
 
 
 def test_remotes(tmp_dir, dvc, caplog):
+    tmp_dir.add_remote(name="server", url="ssh://localhost", default=False)
     tmp_dir.add_remote(
-        name="azure", url="azure://example.com/path", default=False
+        name="r1", url="azure://example.com/path", default=False
     )
-    tmp_dir.add_remote(
-        name="remote", url="remote://example.com/path", default=False
-    )
+    tmp_dir.add_remote(name="r2", url="remote://server/path", default=False)
 
     dvc_info = get_dvc_info()
 
-    assert "Remotes: azure\n" in dvc_info
+    assert re.search("Remotes: (ssh, azure|azure, ssh)", dvc_info)
 
 
 @pytest.mark.skipif(psutil is None, reason="No psutil.")

--- a/tests/unit/test_info.py
+++ b/tests/unit/test_info.py
@@ -62,14 +62,15 @@ def test_caches(tmp_dir, dvc, caplog):
 
     dvc_info = get_dvc_info()
 
-    assert "Caches: local, ssh\n" in dvc_info
+    # Order of cache types is runtime dependent
+    assert re.search("Caches: (local, ssh|ssh, local)", dvc_info)
 
 
 def test_remotes_empty(tmp_dir, dvc, caplog):
-    # no remotes are configured
+    # No remotes are configured
     dvc_info = get_dvc_info()
 
-    assert "Remotes: None\n" in dvc_info
+    assert "Remotes: None" in dvc_info
 
 
 def test_remotes(tmp_dir, dvc, caplog):

--- a/tests/unit/test_info.py
+++ b/tests/unit/test_info.py
@@ -53,7 +53,7 @@ def test_info_in_broken_git_repo(tmp_dir, dvc, scm, caplog):
     assert "Repo: dvc, git (broken)" in dvc_info
 
 
-def test_cache_paths_in_repo(tmp_dir, dvc, caplog):
+def test_caches(tmp_dir, dvc, caplog):
     tmp_dir.add_remote(
         name="sshcache", url="ssh://example.com/path", default=False
     )
@@ -62,9 +62,27 @@ def test_cache_paths_in_repo(tmp_dir, dvc, caplog):
 
     dvc_info = get_dvc_info()
 
-    assert "Cache paths:" in dvc_info
-    assert "  ssh: ssh://example.com/path" in dvc_info
-    assert f"  local: {dvc.cache.local.cache_dir}" in dvc_info
+    assert "Caches: local, ssh\n" in dvc_info
+
+
+def test_remotes_empty(tmp_dir, dvc, caplog):
+    # no remotes are configured
+    dvc_info = get_dvc_info()
+
+    assert "Remotes: None\n" in dvc_info
+
+
+def test_remotes(tmp_dir, dvc, caplog):
+    tmp_dir.add_remote(
+        name="azure", url="azure://example.com/path", default=False
+    )
+    tmp_dir.add_remote(
+        name="remote", url="remote://example.com/path", default=False
+    )
+
+    dvc_info = get_dvc_info()
+
+    assert "Remotes: azure\n" in dvc_info
 
 
 @pytest.mark.skipif(psutil is None, reason="No psutil.")

--- a/tests/unit/test_info.py
+++ b/tests/unit/test_info.py
@@ -53,6 +53,20 @@ def test_info_in_broken_git_repo(tmp_dir, dvc, scm, caplog):
     assert "Repo: dvc, git (broken)" in dvc_info
 
 
+def test_cache_paths_in_repo(tmp_dir, dvc, caplog):
+    tmp_dir.add_remote(
+        name="sshcache", url="ssh://example.com/path", default=False
+    )
+    with tmp_dir.dvc.config.edit() as conf:
+        conf["cache"]["ssh"] = "sshcache"
+
+    dvc_info = get_dvc_info()
+
+    assert "Cache paths:" in dvc_info
+    assert "  ssh: ssh://example.com/path" in dvc_info
+    assert f"  local: {dvc.cache.local.cache_dir}" in dvc_info
+
+
 @pytest.mark.skipif(psutil is None, reason="No psutil.")
 def test_fs_info_in_repo(tmp_dir, dvc, caplog):
     os.mkdir(dvc.cache.local.cache_dir)

--- a/tests/unit/tree/test_tree.py
+++ b/tests/unit/tree/test_tree.py
@@ -5,7 +5,7 @@ import pytest
 
 from dvc.config import ConfigError
 from dvc.path_info import CloudURLInfo, PathInfo
-from dvc.tree import LocalTree, get_cloud_tree
+from dvc.tree import LocalTree, get_cloud_schemes, get_cloud_tree
 
 
 def test_get_cloud_tree(tmp_dir, dvc):
@@ -64,3 +64,22 @@ def test_upload_file_mode(tmp_dir, mode, expected):
     assert (tmp_dir / "dest").exists()
     assert (tmp_dir / "dest").read_text() == "foo"
     assert stat.S_IMODE(os.stat(dest).st_mode) == expected
+
+
+def test_get_cloud_schemes_empty(tmp_dir, dvc):
+    remotes = get_cloud_schemes(dvc)
+
+    assert len(remotes) == 0
+
+
+def test_get_cloud_schemes(tmp_dir, dvc):
+    tmp_dir.add_remote(name="server", url="ssh://localhost", default=False)
+    tmp_dir.add_remote(
+        name="remote", url="remote://server/path", default=False
+    )
+    tmp_dir.add_remote(name="s3", url="s3://bucket/path", default=False)
+    tmp_dir.add_remote(name="local remote", url="/tmp/path", default=True)
+
+    remotes = get_cloud_schemes(dvc)
+
+    assert {"ssh", "s3", "local"} == remotes

--- a/tests/unit/tree/test_tree.py
+++ b/tests/unit/tree/test_tree.py
@@ -5,7 +5,7 @@ import pytest
 
 from dvc.config import ConfigError
 from dvc.path_info import CloudURLInfo, PathInfo
-from dvc.tree import LocalTree, get_cloud_schemes, get_cloud_tree
+from dvc.tree import LocalTree, get_cloud_tree
 
 
 def test_get_cloud_tree(tmp_dir, dvc):
@@ -64,22 +64,3 @@ def test_upload_file_mode(tmp_dir, mode, expected):
     assert (tmp_dir / "dest").exists()
     assert (tmp_dir / "dest").read_text() == "foo"
     assert stat.S_IMODE(os.stat(dest).st_mode) == expected
-
-
-def test_get_cloud_schemes_empty(tmp_dir, dvc):
-    remotes = get_cloud_schemes(dvc)
-
-    assert len(remotes) == 0
-
-
-def test_get_cloud_schemes(tmp_dir, dvc):
-    tmp_dir.add_remote(name="server", url="ssh://localhost", default=False)
-    tmp_dir.add_remote(
-        name="remote", url="remote://server/path", default=False
-    )
-    tmp_dir.add_remote(name="s3", url="s3://bucket/path", default=False)
-    tmp_dir.add_remote(name="local remote", url="/tmp/path", default=True)
-
-    remotes = get_cloud_schemes(dvc)
-
-    assert {"ssh", "s3", "local"} == remotes


### PR DESCRIPTION
Show caches and remotes in the info output to assist in diagnosis of issues.

Fixes #4574.

Sample output

```sh
> dvc version
DVC version: 1.9.1+8f6350
---------------------------------
Platform: Python 3.8.6 on Linux-5.9.6-arch1-1-x86_64-with-glibc2.2.5
Supports: All remotes
Cache types: hardlink, symlink
Cache directory: ext4 on /dev/sda4
Caches: ssh, local
Remotes: ssh, azure
Workspace directory: ext4 on /dev/sda4
Repo: dvc, git
```

This change will require an update to the docs for [version](https://dvc.org/doc/command-reference/version) command. Will create a docs PR if the output format looks good for this change.

---

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
