### PR TITLE
dvc: use DirInfo instead of dicts/lists

### DIFF
--- a/dvc/dir_info.py
+++ b/dvc/dir_info.py
@@ -1,0 +1,102 @@
+import posixpath
+from operator import itemgetter
+
+from pygtrie import Trie
+
+from .hash_info import HashInfo
+
+
+def _diff(ancestor, other, allow_removed=False):
+    from dictdiffer import diff
+
+    from dvc.exceptions import MergeError
+
+    allowed = ["add"]
+    if allow_removed:
+        allowed.append("remove")
+
+    result = list(diff(ancestor, other))
+    for typ, _, _ in result:
+        if typ not in allowed:
+            raise MergeError(
+                "unable to auto-merge directories with diff that contains "
+                f"'{typ}'ed files"
+            )
+    return result
+
+
+def _merge(ancestor, our, their):
+    import copy
+
+    from dictdiffer import patch
+
+    our_diff = _diff(ancestor, our)
+    if not our_diff:
+        return copy.deepcopy(their)
+
+    their_diff = _diff(ancestor, their)
+    if not their_diff:
+        return copy.deepcopy(our)
+
+    # make sure there are no conflicting files
+    _diff(our, their, allow_removed=True)
+
+    return patch(our_diff + their_diff, ancestor)
+
+
+class DirInfo:
+    PARAM_RELPATH = "relpath"
+
+    def __init__(self):
+        self.trie = Trie()
+
+    @property
+    def size(self):
+        try:
+            return sum(
+                hash_info.size
+                for _, hash_info in self.trie.iteritems()  # noqa: B301
+            )
+        except TypeError:
+            return None
+
+    @property
+    def nfiles(self):
+        return len(self.trie)
+
+    def items(self, path_info=None):
+        for key, hash_info in self.trie.iteritems():  # noqa: B301
+            path = posixpath.sep.join(key)
+            if path_info is not None:
+                path = path_info / path
+            yield path, hash_info
+
+    @classmethod
+    def from_list(cls, lst):
+        ret = DirInfo()
+        for _entry in lst:
+            entry = _entry.copy()
+            relpath = entry.pop(cls.PARAM_RELPATH)
+            parts = tuple(relpath.split(posixpath.sep))
+            ret.trie[parts] = HashInfo.from_dict(entry)
+        return ret
+
+    def to_list(self):
+        # Sorting the list by path to ensure reproducibility
+        return sorted(
+            (
+                {
+                    # NOTE: not using hash_info.to_dict() because we don't want
+                    # size/nfiles fields at this point.
+                    hash_info.name: hash_info.value,
+                    self.PARAM_RELPATH: posixpath.sep.join(parts),
+                }
+                for parts, hash_info in self.trie.iteritems()  # noqa: B301
+            ),
+            key=itemgetter(self.PARAM_RELPATH),
+        )
+
+    def merge(self, ancestor, their):
+        merged = DirInfo()
+        merged.trie = _merge(ancestor.trie, self.trie, their.trie)
+        return merged

--- a/dvc/output/base.py
+++ b/dvc/output/base.py
@@ -448,9 +448,7 @@ class BaseOutput:
         path = str(self.path_info)
         filter_path = str(filter_info) if filter_info else None
         is_win = os.name == "nt"
-        for entry in self.dir_cache:
-            checksum = entry[self.tree.PARAM_CHECKSUM]
-            entry_relpath = entry[self.tree.PARAM_RELPATH]
+        for entry_relpath, entry_hash_info in self.dir_cache.items():
             if is_win:
                 entry_relpath = entry_relpath.replace("/", os.sep)
             entry_path = os.path.join(path, entry_relpath)
@@ -459,7 +457,7 @@ class BaseOutput:
                 or entry_path == filter_path
                 or entry_path.startswith(filter_path + os.sep)
             ):
-                cache.add(self.scheme, checksum, entry_path)
+                cache.add(self.scheme, entry_hash_info.value, entry_path)
 
         return cache
 

--- a/tests/func/remote/test_index.py
+++ b/tests/func/remote/test_index.py
@@ -32,14 +32,16 @@ def remote(tmp_dir, dvc, tmp_path_factory, mocker):
 def test_indexed_on_status(tmp_dir, dvc, tmp_path_factory, remote):
     foo = tmp_dir.dvc_gen({"foo": "foo content"})[0].outs[0]
     bar = tmp_dir.dvc_gen({"bar": {"baz": "baz content"}})[0].outs[0]
-    baz = bar.dir_cache[0]
+    baz_hash = bar.dir_cache.trie.get(("baz",))
     dvc.push()
     with remote.index:
         remote.index.clear()
 
     dvc.status(cloud=True)
     with remote.index:
-        assert {bar.hash_info.value, baz["md5"]} == set(remote.index.hashes())
+        assert {bar.hash_info.value, baz_hash.value} == set(
+            remote.index.hashes()
+        )
         assert [bar.hash_info.value] == list(remote.index.dir_hashes())
         assert foo.hash_info.value not in remote.index.hashes()
 
@@ -47,11 +49,13 @@ def test_indexed_on_status(tmp_dir, dvc, tmp_path_factory, remote):
 def test_indexed_on_push(tmp_dir, dvc, tmp_path_factory, remote):
     foo = tmp_dir.dvc_gen({"foo": "foo content"})[0].outs[0]
     bar = tmp_dir.dvc_gen({"bar": {"baz": "baz content"}})[0].outs[0]
-    baz = bar.dir_cache[0]
+    baz_hash = bar.dir_cache.trie.get(("baz",))
 
     dvc.push()
     with remote.index:
-        assert {bar.hash_info.value, baz["md5"]} == set(remote.index.hashes())
+        assert {bar.hash_info.value, baz_hash.value} == set(
+            remote.index.hashes()
+        )
         assert [bar.hash_info.value] == list(remote.index.dir_hashes())
         assert foo.hash_info.value not in remote.index.hashes()
 

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -80,8 +80,8 @@ def test_add_directory(tmp_dir, dvc):
     hash_info = stage.outs[0].hash_info
 
     dir_info = dvc.cache.local.load_dir_cache(hash_info)
-    for info in dir_info:
-        assert "\\" not in info["relpath"]
+    for path, _ in dir_info.trie.items():
+        assert "\\" not in path
 
 
 class TestAddDirectoryRecursive(TestDvc):

--- a/tests/func/test_cache.py
+++ b/tests/func/test_cache.py
@@ -6,6 +6,7 @@ import pytest
 
 from dvc.cache import Cache
 from dvc.cache.base import DirCacheError
+from dvc.dir_info import DirInfo
 from dvc.hash_info import HashInfo
 from dvc.main import main
 from dvc.utils import relpath
@@ -60,9 +61,11 @@ class TestCacheLoadBadDirCache(TestDvc):
             self.dvc.cache.local.tree.hash_to_path_info(dir_hash)
         )
         self.create(fname, '{"a": "b"}')
-        self._do_test(
-            self.dvc.cache.local.load_dir_cache(HashInfo("md5", dir_hash))
+        dir_info = self.dvc.cache.local.load_dir_cache(
+            HashInfo("md5", dir_hash)
         )
+        self.assertTrue(isinstance(dir_info, DirInfo))
+        self.assertEqual(dir_info.nfiles, 0)
 
 
 class TestExternalCacheDir(TestDvc):

--- a/tests/func/test_checkout.py
+++ b/tests/func/test_checkout.py
@@ -100,10 +100,11 @@ class TestCheckoutCorruptedCacheDir(TestDvc):
 
         # NOTE: modifying cache file for one of the files inside the directory
         # to check if dvc will detect that the cache is corrupted.
-        entry = self.dvc.cache.local.load_dir_cache(out.hash_info)[0]
-        entry_hash = entry[self.dvc.cache.local.tree.PARAM_CHECKSUM]
+        _, entry_hash = next(
+            self.dvc.cache.local.load_dir_cache(out.hash_info).items()
+        )
         cache = os.fspath(
-            self.dvc.cache.local.tree.hash_to_path_info(entry_hash)
+            self.dvc.cache.local.tree.hash_to_path_info(entry_hash.value)
         )
 
         os.chmod(cache, 0o644)

--- a/tests/func/test_tree.py
+++ b/tests/func/test_tree.py
@@ -198,9 +198,9 @@ def test_repotree_walk_fetch(tmp_dir, dvc, scm, local_remote):
         pass
 
     assert os.path.exists(out.cache_path)
-    for entry in out.dir_cache:
-        hash_ = entry[out.tree.PARAM_CHECKSUM]
-        assert os.path.exists(dvc.cache.local.tree.hash_to_path_info(hash_))
+    for _, hi in out.dir_cache.items():
+        assert hi.name == out.tree.PARAM_CHECKSUM
+        assert os.path.exists(dvc.cache.local.tree.hash_to_path_info(hi.value))
 
 
 def test_repotree_cache_save(tmp_dir, dvc, scm, erepo_dir, local_cloud):

--- a/tests/unit/output/test_local.py
+++ b/tests/unit/output/test_local.py
@@ -3,6 +3,7 @@ import os
 from mock import patch
 
 from dvc.cache.local import LocalCache
+from dvc.dir_info import DirInfo
 from dvc.hash_info import HashInfo
 from dvc.output import LocalOutput
 from dvc.stage import Stage
@@ -81,7 +82,12 @@ class TestGetFilesNumber(TestDvc):
     @patch.object(
         LocalCache,
         "get_dir_cache",
-        return_value=[{"md5": "asdf"}, {"md5": "qwe"}],
+        return_value=DirInfo.from_list(
+            [
+                {"relpath": "foo", "md5": "asdf"},
+                {"relpath": "bar", "md5": "qwe"},
+            ]
+        ),
     )
     def test_return_multiple_for_dir(self, _mock_get_dir_cache):
         o = self._get_output()

--- a/tests/unit/test_dir_info.py
+++ b/tests/unit/test_dir_info.py
@@ -1,0 +1,273 @@
+from operator import itemgetter
+
+import pytest
+from pygtrie import Trie
+
+from dvc.dir_info import DirInfo, _merge
+from dvc.hash_info import HashInfo
+from dvc.path_info import PosixPathInfo, WindowsPathInfo
+
+
+@pytest.mark.parametrize(
+    "lst, trie_dict",
+    [
+        ([], {}),
+        (
+            [
+                {"md5": "def", "relpath": "zzz"},
+                {"md5": "123", "relpath": "foo"},
+                {"md5": "abc", "relpath": "aaa"},
+                {"md5": "456", "relpath": "bar"},
+            ],
+            {
+                ("zzz",): HashInfo("md5", "def"),
+                ("foo",): HashInfo("md5", "123"),
+                ("bar",): HashInfo("md5", "456"),
+                ("aaa",): HashInfo("md5", "abc"),
+            },
+        ),
+        (
+            [
+                {"md5": "123", "relpath": "dir/b"},
+                {"md5": "456", "relpath": "dir/z"},
+                {"md5": "789", "relpath": "dir/a"},
+                {"md5": "abc", "relpath": "b"},
+                {"md5": "def", "relpath": "a"},
+                {"md5": "ghi", "relpath": "z"},
+                {"md5": "jkl", "relpath": "dir/subdir/b"},
+                {"md5": "mno", "relpath": "dir/subdir/z"},
+                {"md5": "pqr", "relpath": "dir/subdir/a"},
+            ],
+            {
+                ("dir", "b"): HashInfo("md5", "123"),
+                ("dir", "z"): HashInfo("md5", "456"),
+                ("dir", "a"): HashInfo("md5", "789"),
+                ("b",): HashInfo("md5", "abc"),
+                ("a",): HashInfo("md5", "def"),
+                ("z",): HashInfo("md5", "ghi"),
+                ("dir", "subdir", "b"): HashInfo("md5", "jkl"),
+                ("dir", "subdir", "z"): HashInfo("md5", "mno"),
+                ("dir", "subdir", "a"): HashInfo("md5", "pqr"),
+            },
+        ),
+    ],
+)
+def test_list(lst, trie_dict):
+    dir_info = DirInfo.from_list(lst)
+    assert dir_info.trie == Trie(trie_dict)
+    assert dir_info.to_list() == sorted(lst, key=itemgetter("relpath"))
+
+
+@pytest.mark.parametrize(
+    "trie_dict, size",
+    [
+        ({}, 0),
+        (
+            {
+                ("a",): HashInfo("md5", "abc", size=1),
+                ("b",): HashInfo("md5", "def", size=2),
+                ("c",): HashInfo("md5", "ghi", size=3),
+                ("dir", "foo"): HashInfo("md5", "jkl", size=4),
+                ("dir", "bar"): HashInfo("md5", "mno", size=5),
+                ("dir", "baz"): HashInfo("md5", "pqr", size=6),
+            },
+            21,
+        ),
+        (
+            {
+                ("a",): HashInfo("md5", "abc", size=1),
+                ("b",): HashInfo("md5", "def", size=None),
+            },
+            None,
+        ),
+    ],
+)
+def test_size(trie_dict, size):
+    dir_info = DirInfo()
+    dir_info.trie = Trie(trie_dict)
+    assert dir_info.size == size
+
+
+@pytest.mark.parametrize(
+    "trie_dict, nfiles",
+    [
+        ({}, 0),
+        (
+            {
+                ("a",): HashInfo("md5", "abc", size=1),
+                ("b",): HashInfo("md5", "def", size=2),
+                ("c",): HashInfo("md5", "ghi", size=3),
+                ("dir", "foo"): HashInfo("md5", "jkl", size=4),
+                ("dir", "bar"): HashInfo("md5", "mno", size=5),
+                ("dir", "baz"): HashInfo("md5", "pqr", size=6),
+            },
+            6,
+        ),
+        (
+            {
+                ("a",): HashInfo("md5", "abc", size=1),
+                ("b",): HashInfo("md5", "def", size=None),
+            },
+            2,
+        ),
+    ],
+)
+def test_nfiles(trie_dict, nfiles):
+    dir_info = DirInfo()
+    dir_info.trie = Trie(trie_dict)
+    assert dir_info.nfiles == nfiles
+
+
+@pytest.mark.parametrize(
+    "trie_dict, items",
+    [
+        ({}, []),
+        (
+            {
+                ("a",): HashInfo("md5", "abc"),
+                ("b",): HashInfo("md5", "def"),
+                ("c",): HashInfo("md5", "ghi"),
+                ("dir", "foo"): HashInfo("md5", "jkl"),
+                ("dir", "bar"): HashInfo("md5", "mno"),
+                ("dir", "baz"): HashInfo("md5", "pqr"),
+                ("dir", "subdir", "1"): HashInfo("md5", "stu"),
+                ("dir", "subdir", "2"): HashInfo("md5", "vwx"),
+                ("dir", "subdir", "3"): HashInfo("md5", "yz"),
+            },
+            [
+                ("a", HashInfo("md5", "abc")),
+                ("b", HashInfo("md5", "def")),
+                ("c", HashInfo("md5", "ghi")),
+                ("dir/foo", HashInfo("md5", "jkl")),
+                ("dir/bar", HashInfo("md5", "mno")),
+                ("dir/baz", HashInfo("md5", "pqr")),
+                ("dir/subdir/1", HashInfo("md5", "stu")),
+                ("dir/subdir/2", HashInfo("md5", "vwx")),
+                ("dir/subdir/3", HashInfo("md5", "yz")),
+            ],
+        ),
+    ],
+)
+def test_items(trie_dict, items):
+    dir_info = DirInfo()
+    dir_info.trie = Trie(trie_dict)
+    assert list(dir_info.items()) == items
+
+
+@pytest.mark.parametrize(
+    "path_info, trie_dict, items",
+    [
+        (PosixPathInfo(), {}, []),
+        (WindowsPathInfo(), {}, []),
+        (
+            PosixPathInfo("/some/path"),
+            {
+                ("a",): HashInfo("md5", "abc"),
+                ("dir", "foo"): HashInfo("md5", "jkl"),
+                ("dir", "sub", "1"): HashInfo("md5", "stu"),
+            },
+            [
+                (PosixPathInfo("/some/path/a"), HashInfo("md5", "abc")),
+                (PosixPathInfo("/some/path/dir/foo"), HashInfo("md5", "jkl")),
+                (
+                    PosixPathInfo("/some/path/dir/sub/1"),
+                    HashInfo("md5", "stu"),
+                ),
+            ],
+        ),
+        (
+            WindowsPathInfo("C:\\some\\path"),
+            {
+                ("a",): HashInfo("md5", "abc"),
+                ("dir", "foo"): HashInfo("md5", "jkl"),
+                ("dir", "sub", "1"): HashInfo("md5", "stu"),
+            },
+            [
+                (WindowsPathInfo("C:\\some\\path\\a"), HashInfo("md5", "abc")),
+                (
+                    WindowsPathInfo("C:\\some\\path\\dir\\foo"),
+                    HashInfo("md5", "jkl"),
+                ),
+                (
+                    WindowsPathInfo("C:\\some\\path\\dir\\sub\\1"),
+                    HashInfo("md5", "stu"),
+                ),
+            ],
+        ),
+    ],
+)
+def test_items_with_path(path_info, trie_dict, items):
+    dir_info = DirInfo()
+    dir_info.trie = Trie(trie_dict)
+    assert list(dir_info.items(path_info)) == items
+
+
+@pytest.mark.parametrize(
+    "ancestor_dict, our_dict, their_dict, merged_dict",
+    [
+        ({}, {}, {}, {}),
+        (
+            {("foo",): HashInfo("md5", "123")},
+            {
+                ("foo",): HashInfo("md5", "123"),
+                ("bar",): HashInfo("md5", "345"),
+            },
+            {
+                ("foo",): HashInfo("md5", "123"),
+                ("baz",): HashInfo("md5", "678"),
+            },
+            {
+                ("foo",): HashInfo("md5", "123"),
+                ("bar",): HashInfo("md5", "345"),
+                ("baz",): HashInfo("md5", "678"),
+            },
+        ),
+        (
+            {
+                ("common",): HashInfo("md5", "123"),
+                ("subdir", "foo"): HashInfo("md5", "345"),
+            },
+            {
+                ("common",): HashInfo("md5", "123"),
+                ("subdir", "foo"): HashInfo("md5", "345"),
+                ("subdir", "bar"): HashInfo("md5", "678"),
+            },
+            {
+                ("common",): HashInfo("md5", "123"),
+                ("subdir", "foo"): HashInfo("md5", "345"),
+                ("subdir", "baz"): HashInfo("md5", "91011"),
+            },
+            {
+                ("common",): HashInfo("md5", "123"),
+                ("subdir", "foo"): HashInfo("md5", "345"),
+                ("subdir", "bar"): HashInfo("md5", "678"),
+                ("subdir", "baz"): HashInfo("md5", "91011"),
+            },
+        ),
+        (
+            {},
+            {("foo",): HashInfo("md5", "123")},
+            {("bar",): HashInfo("md5", "456")},
+            {
+                ("foo",): HashInfo("md5", "123"),
+                ("bar",): HashInfo("md5", "456"),
+            },
+        ),
+        (
+            {},
+            {},
+            {("bar",): HashInfo("md5", "123")},
+            {("bar",): HashInfo("md5", "123")},
+        ),
+        (
+            {},
+            {("bar",): HashInfo("md5", "123")},
+            {},
+            {("bar",): HashInfo("md5", "123")},
+        ),
+    ],
+)
+def test_merge(ancestor_dict, our_dict, their_dict, merged_dict):
+    actual = _merge(Trie(ancestor_dict), Trie(our_dict), Trie(their_dict))
+    expected = Trie(merged_dict)
+    assert actual == expected

--- a/tests/unit/tree/test_repo.py
+++ b/tests/unit/tree/test_repo.py
@@ -560,7 +560,7 @@ def test_get_hash_dirty_dir(tmp_dir, dvc):
     actual = tree.get_hash(PathInfo(tmp_dir) / "dir")
     expected = HashInfo("md5", "ba75a2162ca9c29acecb7957105a0bc2.dir")
     assert actual == expected
-    assert len(actual.dir_info) == 3
+    assert actual.dir_info.nfiles == 3
 
 
 @pytest.mark.parametrize("traverse_subrepos", [True, False])


### PR DESCRIPTION
Currently, we are converting dir_info to/from lists all the time.
The reason is that dir_info is stored as list of dicts in *.dir files,
but that makes it hard to work with. In addition to that, we will likely
be changing .dir file format in the near future #829, so we need to
abstract away dir_info into something that we won't care how it will be
stored on disk.

Related #3256
Related #4847

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
