### PR TITLE
dvc: limit aws-sam-translator version for moto

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,6 +132,9 @@ tests_requirements = [
     "jaraco.windows==3.9.2",
     "mock-ssh-server>=0.8.2",
     "moto==1.3.14.dev464",
+    # moto's indirect dependency that is causing problems with flufl.lock's
+    # dependency (atpublic). See https://github.com/iterative/dvc/pull/4853
+    "aws-sam-translator<1.29.0",
     "rangehttpserver==1.2.0",
     "beautifulsoup4==4.4.0",
     "flake8-bugbear",


### PR DESCRIPTION
moto has `aws-sam-translator` as an indirect dependency that since 1.29.0 started to have a `public` module
that causes conflicts in `flufl.lock` when it tries to use `atpublic` package (module is also called `public`).

```
tests/func/test_add.py:21: in <module>
    from dvc.main import main
dvc/main.py:7: in <module>
    from dvc import analytics
dvc/analytics.py:16: in <module>
    from dvc.lock import Lock, LockError
dvc/lock.py:8: in <module>
    import flufl.lock
/opt/hostedtoolcache/Python/3.6.12/x64/lib/python3.6/site-packages/flufl/lock/__init__.py:3: in <module>
    from flufl.lock._lockfile import (
/opt/hostedtoolcache/Python/3.6.12/x64/lib/python3.6/site-packages/flufl/lock/_lockfile.py:42: in <module>
    from public import public
E   ImportError: cannot import name 'public'
```

Oddly enough, this seems to also been causing pylint issues. `public` is a terrible name for a package/module SMH

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
