### PR TITLE
parametrization: skip loading globally used params section again locally for stages

### DIFF
--- a/dvc/parsing/__init__.py
+++ b/dvc/parsing/__init__.py
@@ -89,12 +89,19 @@ class DataResolver:
                     "%s does not exist for stage %s", params_yaml_file, name
                 )
 
-        params_file = definition.get(PARAMS_KWD, [])
-        for item in params_file:
-            if item and isinstance(item, dict):
-                contexts.append(
-                    Context.load_from(self.repo.tree, str(wdir / first(item)))
-                )
+        params_deps = definition.get(PARAMS_KWD, [])
+        params_files = {
+            wdir / first(item)
+            for item in params_deps
+            if item and isinstance(item, dict)
+        }
+        for params_file in params_files - {
+            self.global_ctx_source,
+            params_yaml_file,
+        }:
+            contexts.append(
+                Context.load_from(self.repo.tree, str(params_file))
+            )
 
         context.merge_update(*contexts)
 


### PR DESCRIPTION
We were still trying to load params file used in `use`
for local stages which was throwing overwrite error.
Thanks to @dmpetrov for pointing out.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
