### PR TITLE
[WIP] Osf remote

### DIFF
--- a/.dvcignore
+++ b/.dvcignore
@@ -1,2 +1,0 @@
-# add patterns of files dvc should ignore, can improve performance
-# Learn more at https://dvc.org/doc/user-guide/dvcignore

--- a/.dvcignore
+++ b/.dvcignore
@@ -1,0 +1,2 @@
+# add patterns of files dvc should ignore, can improve performance
+# Learn more at https://dvc.org/doc/user-guide/dvcignore

--- a/dvc/cache/__init__.py
+++ b/dvc/cache/__init__.py
@@ -46,6 +46,7 @@ class Cache:
         Schemes.SSH,
         Schemes.HDFS,
         Schemes.WEBHDFS,
+        Schemes.OSF,
     ]
 
     def __init__(self, repo):

--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -154,6 +154,7 @@ SCHEMA = {
                     "grant_full_control": str,
                     **REMOTE_COMMON,
                 },
+                "osf": {"osf_username": str, "project": str},
                 "gs": {
                     "projectname": str,
                     "credentialpath": str,

--- a/dvc/dependency/__init__.py
+++ b/dvc/dependency/__init__.py
@@ -8,6 +8,7 @@ from dvc.dependency.hdfs import HDFSDependency
 from dvc.dependency.http import HTTPDependency
 from dvc.dependency.https import HTTPSDependency
 from dvc.dependency.local import LocalDependency
+from dvc.dependency.osf import OSFDependency
 from dvc.dependency.param import ParamsDependency
 from dvc.dependency.s3 import S3Dependency
 from dvc.dependency.ssh import SSHDependency
@@ -31,6 +32,7 @@ DEPS = [
     WebDAVDependency,
     WebDAVSDependency,
     WebHDFSDependency,
+    OSFDependency,
     # NOTE: LocalDependency is the default choice
 ]
 
@@ -46,6 +48,7 @@ DEP_MAP = {
     Schemes.WEBDAV: WebDAVDependency,
     Schemes.WEBDAVS: WebDAVSDependency,
     Schemes.WEBHDFS: WebHDFSDependency,
+    Schemes.OSF: OSFDependency,
 }
 
 

--- a/dvc/dependency/osf.py
+++ b/dvc/dependency/osf.py
@@ -1,0 +1,8 @@
+from dvc.dependency.base import BaseDependency
+from dvc.output.base import BaseOutput
+
+from ..tree.osf import OSFTree
+
+
+class OSFDependency(BaseDependency, BaseOutput):
+    TREE_CLS = OSFTree

--- a/dvc/scheme.py
+++ b/dvc/scheme.py
@@ -12,3 +12,4 @@ class Schemes:
     OSS = "oss"
     WEBDAV = "webdav"
     WEBDAVS = "webdavs"
+    OSF = "osf"

--- a/dvc/tree/__init__.py
+++ b/dvc/tree/__init__.py
@@ -8,6 +8,7 @@ from .hdfs import HDFSTree
 from .http import HTTPTree
 from .https import HTTPSTree
 from .local import LocalTree
+from .osf import OSFTree
 from .oss import OSSTree
 from .s3 import S3Tree
 from .ssh import SSHTree
@@ -27,7 +28,8 @@ TREES = [
     OSSTree,
     WebDAVTree,
     WebDAVSTree,
-    WebHDFSTree
+    WebHDFSTree,
+    OSFTree,
     # NOTE: LocalTree is the default
 ]
 

--- a/dvc/tree/osf.py
+++ b/dvc/tree/osf.py
@@ -24,6 +24,7 @@ class OSFAuthError(DvcException):
         )
         super().__init__(message)
 
+
 class OSFTree(BaseTree):
     scheme = Schemes.OSF
     REQUIRES = {"ofsclient": "osfclient"}

--- a/dvc/tree/osf.py
+++ b/dvc/tree/osf.py
@@ -41,6 +41,8 @@ class OSFTree(BaseTree):
         self.password = os.getenv(
             "OSF_PASSWORD", None
         )  # need for private projects
+        if self.password is None:
+            self.password = config.get("password")
         logger.debug(OSFTree)
 
     @wrap_prop(threading.Lock())

--- a/dvc/tree/osf.py
+++ b/dvc/tree/osf.py
@@ -87,7 +87,6 @@ class OSFTree(BaseTree):
         return any(path_info.path == path for path in paths)
 
     def _list_paths(self):
-        # print(list(self.storage.files))
         for file in self.storage.files:
             yield file.path
 
@@ -117,16 +116,16 @@ class OSFTree(BaseTree):
         self, from_info, to_file, name=None, no_progress_bar=False, **_kwargs
     ):
         file = self._get_file_obj(from_info)
-
         # hack to get size of file
         # This will be no longer needed after the
         # pull-request https://github.com/osfclient/osfclient/pull/185 merge
-
-        # pylint: disable=W0212
-        resp = self.osf._get(file._endpoint)
-        json = self.osf._json(resp, 200)
-        total = self.osf._get_attribute(json, "data", "attributes", "size")
-        # pylint: enable=W0212
+        total = None
+        if not no_progress_bar:
+            # pylint: disable=W0212
+            resp = self.osf._get(file._endpoint)
+            json = self.osf._json(resp, 200)
+            total = self.osf._get_attribute(json, "data", "attributes", "size")
+            # pylint: enable=W0212
 
         with open(to_file, "wb") as fobj:
             with Tqdm.wrapattr(
@@ -142,6 +141,6 @@ class OSFTree(BaseTree):
             with Tqdm.wrapattr(
                 fobj, "read", desc=name, total=total, disable=no_progress_bar
             ) as wrapped:
-                self.project.storage().create_file(
+                self.storage.create_file(
                     to_info.path, wrapped, force=False, update=False
                 )

--- a/dvc/tree/osf.py
+++ b/dvc/tree/osf.py
@@ -5,8 +5,8 @@ import threading
 from funcy import cached_property, wrap_prop
 
 from dvc.exceptions import DvcException
-from dvc.hash_info import HashInfo
 from dvc.path_info import URLInfo
+from dvc.hash_info import HashInfo
 from dvc.progress import Tqdm
 from dvc.scheme import Schemes
 
@@ -23,7 +23,6 @@ class OSFAuthError(DvcException):
             " to a private project."
         )
         super().__init__(message)
-
 
 class OSFTree(BaseTree):
     scheme = Schemes.OSF

--- a/dvc/tree/osf.py
+++ b/dvc/tree/osf.py
@@ -19,8 +19,9 @@ class OSFAuthError(DvcException):
     def __init__(self):
         message = (
             "OSF authorization failed. Please check or provide"
-            " osf_username and password. See "
-            "https://bit.ly/375On32 for details"
+            " user and password. See "
+            "https://dvc.org/doc/command-reference/remote"
+            " for details"
         )
         super().__init__(message)
 
@@ -36,13 +37,9 @@ class OSFTree(BaseTree):
 
         self.path_info = self.PATH_CLS(config["url"])
 
-        self.osf_username = config.get("username")
+        self.user = config.get("user")
         self.project_guid = config.get("project")
-        self.password = os.getenv(
-            "OSF_PASSWORD", None
-        )  # need for private projects
-        if self.password is None:
-            self.password = config.get("password")
+        self.password = os.getenv("OSF_PASSWORD", config.get("password"))
         logger.debug(OSFTree)
 
     @wrap_prop(threading.Lock())
@@ -59,7 +56,7 @@ class OSFTree(BaseTree):
         from osfclient.exceptions import UnauthorizedException
 
         osf = self.osf
-        osf.login(self.osf_username, self.password)
+        osf.login(self.user, self.password)
         try:
             project = osf.project(self.project_guid)
         except UnauthorizedException:

--- a/dvc/tree/osf.py
+++ b/dvc/tree/osf.py
@@ -77,7 +77,7 @@ class OSFTree(BaseTree):
         return md5
 
     def exists(self, path_info, use_dvcignore=True):
-        paths = self.list_paths()
+        paths = self._list_paths()
         return any(path_info.path == path for path in paths)
 
     def _list_paths(self):

--- a/dvc/tree/osf.py
+++ b/dvc/tree/osf.py
@@ -5,7 +5,6 @@ import threading
 from funcy import cached_property, wrap_prop
 
 from dvc.exceptions import DvcException
-from dvc.path_info import URLInfo
 from dvc.hash_info import HashInfo
 from dvc.path_info import URLInfo
 from dvc.progress import Tqdm

--- a/dvc/tree/osf.py
+++ b/dvc/tree/osf.py
@@ -1,0 +1,92 @@
+import logging
+import os
+import threading
+
+from funcy import cached_property, wrap_prop
+
+from dvc.hash_info import HashInfo
+from dvc.progress import Tqdm
+from dvc.scheme import Schemes
+
+from .base import BaseTree
+
+logger = logging.getLogger(__name__)
+
+
+class OSFTree(BaseTree):
+    scheme = Schemes.OSF
+    REQUIRES = {"ofsclient": "osfclient"}
+    PARAM_CHECKSUM = "md5"
+
+    def __init__(self, repo, config):
+        super().__init__(repo, config)
+
+        self.osf_username = config.get("osf_username")
+        self.project = config.get("project")
+        self.password = os.getenv(
+            "OSF_PASSWORD", None
+        )  # need for private projects
+
+    @wrap_prop(threading.Lock())
+    @cached_property
+    def storage(self):
+        import osfclient
+
+        osf = osfclient.OSF()
+        osf.login(self.osf_username, self.password)
+        storage = osf.project(self.project).storage()
+        return storage
+
+    def _get_file_obj(self, path_info):
+        for file in self.storage.files:
+            if file.path == path_info.path:
+                return file
+
+    def get_md5(self, path_info):
+        file = self._get_file_obj(path_info)
+        md5 = file.hashes.get("md5")
+        return md5
+
+    def exists(self, path_info, use_dvcignore=True):
+        paths = self.list_paths()
+        return any(path_info.path == path for path in paths)
+
+    def _list_paths(self):
+        for file in self.storage.files:
+            yield file.path
+
+    def walk_files(self, path_info, **kwargs):
+        for fname in self._list_paths():
+            if fname.endswith("/"):
+                continue
+
+            yield path_info.replace(path=fname)
+
+    def remove(self, path_info):
+        if path_info.scheme != self.scheme:
+            raise NotImplementedError
+
+        file = self._get_file_obj(path_info)
+        file.remove()
+        logger.debug(f"Removing {path_info}")
+
+    def get_file_hash(self, path_info):
+        return HashInfo(self.PARAM_CHECKSUM, self.get_md5(path_info))
+
+    def _download(self, from_info, to_file, **_kwargs):
+        file = self._get_file_obj(from_info)
+        # total = file._get_attribute(file, "attributes", "self", "size")
+        with open(to_file, "wb") as fobj:
+            file.write_to(fobj)
+
+    def _upload(
+        self, from_file, to_info, name=None, no_progress_bar=False, **_kwargs
+    ):
+        total = os.path.getsize(from_file)
+        with open(from_file, "rb") as fobj:
+            with Tqdm.wrapattr(
+                fobj, "read", desc=name, total=total, disable=no_progress_bar
+            ) as wrapped:
+                self.storage.create_file(
+                    to_info.path, wrapped, force=False, update=False
+                )

--- a/dvc/tree/osf.py
+++ b/dvc/tree/osf.py
@@ -6,7 +6,7 @@ from funcy import cached_property, wrap_prop
 
 from dvc.exceptions import DvcException
 from dvc.hash_info import HashInfo
-from dvc.path_info import CloudURLInfo
+from dvc.path_info import URLInfo
 from dvc.progress import Tqdm
 from dvc.scheme import Schemes
 
@@ -29,7 +29,7 @@ class OSFTree(BaseTree):
     scheme = Schemes.OSF
     REQUIRES = {"ofsclient": "osfclient"}
     PARAM_CHECKSUM = "md5"
-    PATH_CLS = CloudURLInfo
+    PATH_CLS = URLInfo
 
     def __init__(self, repo, config):
         super().__init__(repo, config)
@@ -100,7 +100,7 @@ class OSFTree(BaseTree):
 
     def _download(self, from_info, to_file, **_kwargs):
         file = self._get_file_obj(from_info)
-        # total = file._get_attribute(file, "attributes", "self", "size")
+
         with open(to_file, "wb") as fobj:
             file.write_to(fobj)
 

--- a/dvc/tree/osf.py
+++ b/dvc/tree/osf.py
@@ -125,7 +125,7 @@ class OSFTree(BaseTree):
 
         with open(to_file, "wb") as fobj:
             with Tqdm.wrapattr(
-                fobj, "read", desc=name, total=total, disable=no_progress_bar
+                fobj, "write", desc=name, total=total, disable=no_progress_bar
             ) as wrapped:
                 file.write_to(wrapped)
 

--- a/dvc/tree/osf.py
+++ b/dvc/tree/osf.py
@@ -67,8 +67,13 @@ class OSFTree(BaseTree):
             raise OSFAuthError
         return project
 
+    @wrap_prop(threading.Lock())
+    @cached_property
+    def storage(self):
+        return self.project.storage()
+
     def _get_file_obj(self, path_info):
-        for file in self.project.storage().files:
+        for file in self.storage.files:
             if file.path == path_info.path:
                 return file
 
@@ -82,7 +87,8 @@ class OSFTree(BaseTree):
         return any(path_info.path == path for path in paths)
 
     def _list_paths(self):
-        for file in self.project.storage().files:
+        # print(list(self.storage.files))
+        for file in self.storage.files:
             yield file.path
 
     def isdir(self, path_info):

--- a/dvc/tree/osf.py
+++ b/dvc/tree/osf.py
@@ -7,7 +7,7 @@ from funcy import cached_property, wrap_prop
 from dvc.exceptions import DvcException
 from dvc.path_info import URLInfo
 from dvc.hash_info import HashInfo
-from dvc.path_info import CloudURLInfo
+from dvc.path_info import URLInfo
 from dvc.progress import Tqdm
 from dvc.scheme import Schemes
 
@@ -42,16 +42,8 @@ class OSFTree(BaseTree):
         self.password = os.getenv(
             "OSF_PASSWORD", None
         )  # need for private projects
-<<<<<<< HEAD
-<<<<<<< HEAD
         if self.password is None:
             self.password = config.get("password")
-=======
->>>>>>> rebase on master
-=======
-        if self.password is None:
-            self.password = config.get("password")
->>>>>>> add password field to osf config
         logger.debug(OSFTree)
 
     @wrap_prop(threading.Lock())
@@ -120,6 +112,7 @@ class OSFTree(BaseTree):
     ):
         file = self._get_file_obj(from_info)
 
+<<<<<<< HEAD
         # hack to get size of file
         # This will be no longer needed after the
         # pull-request https://github.com/osfclient/osfclient/pull/185 merge
@@ -130,6 +123,8 @@ class OSFTree(BaseTree):
         total = self.osf._get_attribute(json, "data", "attributes", "size")
         # pylint: enable=W0212
 
+=======
+>>>>>>> change part_info class
         with open(to_file, "wb") as fobj:
             with Tqdm.wrapattr(
                 fobj, "read", desc=name, total=total, disable=no_progress_bar

--- a/dvc/tree/osf.py
+++ b/dvc/tree/osf.py
@@ -19,9 +19,8 @@ class OSFAuthError(DvcException):
     def __init__(self):
         message = (
             "OSF authorization failed. Please check or provide"
-            " osf_username and password."
-            " It is also possible that you do not have access"
-            " to a project."
+            " osf_username and password. See "
+            "https://bit.ly/375On32 for details"
         )
         super().__init__(message)
 
@@ -37,7 +36,7 @@ class OSFTree(BaseTree):
 
         self.path_info = self.PATH_CLS(config["url"])
 
-        self.osf_username = config.get("osf_username")
+        self.osf_username = config.get("username")
         self.project_guid = config.get("project")
         self.password = os.getenv(
             "OSF_PASSWORD", None

--- a/dvc/tree/osf.py
+++ b/dvc/tree/osf.py
@@ -30,11 +30,7 @@ class OSFTree(BaseTree):
     scheme = Schemes.OSF
     REQUIRES = {"ofsclient": "osfclient"}
     PARAM_CHECKSUM = "md5"
-<<<<<<< HEAD
     PATH_CLS = URLInfo
-=======
-    PATH_CLS = CloudURLInfo
->>>>>>> rebase on master
 
     def __init__(self, repo, config):
         super().__init__(repo, config)
@@ -47,10 +43,15 @@ class OSFTree(BaseTree):
             "OSF_PASSWORD", None
         )  # need for private projects
 <<<<<<< HEAD
+<<<<<<< HEAD
         if self.password is None:
             self.password = config.get("password")
 =======
 >>>>>>> rebase on master
+=======
+        if self.password is None:
+            self.password = config.get("password")
+>>>>>>> add password field to osf config
         logger.debug(OSFTree)
 
     @wrap_prop(threading.Lock())

--- a/dvc/tree/osf.py
+++ b/dvc/tree/osf.py
@@ -59,8 +59,8 @@ class OSFTree(BaseTree):
         osf.login(self.user, self.password)
         try:
             project = osf.project(self.project_guid)
-        except UnauthorizedException:
-            raise OSFAuthError
+        except UnauthorizedException as e:
+            raise OSFAuthError from e
         return project
 
     @wrap_prop(threading.Lock())

--- a/dvc/tree/osf.py
+++ b/dvc/tree/osf.py
@@ -6,6 +6,7 @@ from funcy import cached_property, wrap_prop
 
 from dvc.exceptions import DvcException
 from dvc.hash_info import HashInfo
+from dvc.path_info import CloudURLInfo
 from dvc.progress import Tqdm
 from dvc.scheme import Schemes
 
@@ -28,15 +29,19 @@ class OSFTree(BaseTree):
     scheme = Schemes.OSF
     REQUIRES = {"ofsclient": "osfclient"}
     PARAM_CHECKSUM = "md5"
+    PATH_CLS = CloudURLInfo
 
     def __init__(self, repo, config):
         super().__init__(repo, config)
+
+        self.path_info = self.PATH_CLS(config["url"])
 
         self.osf_username = config.get("osf_username")
         self.project = config.get("project")
         self.password = os.getenv(
             "OSF_PASSWORD", None
         )  # need for private projects
+        logger.debug(OSFTree)
 
     @wrap_prop(threading.Lock())
     @cached_property

--- a/dvc/tree/osf.py
+++ b/dvc/tree/osf.py
@@ -112,7 +112,6 @@ class OSFTree(BaseTree):
     ):
         file = self._get_file_obj(from_info)
 
-<<<<<<< HEAD
         # hack to get size of file
         # This will be no longer needed after the
         # pull-request https://github.com/osfclient/osfclient/pull/185 merge
@@ -123,8 +122,6 @@ class OSFTree(BaseTree):
         total = self.osf._get_attribute(json, "data", "attributes", "size")
         # pylint: enable=W0212
 
-=======
->>>>>>> change part_info class
         with open(to_file, "wb") as fobj:
             with Tqdm.wrapattr(
                 fobj, "read", desc=name, total=total, disable=no_progress_bar

--- a/dvc/tree/osf.py
+++ b/dvc/tree/osf.py
@@ -76,6 +76,10 @@ class OSFTree(BaseTree):
         for file in self.storage.files:
             yield file.path
 
+    def isdir(self, path_info):
+        file = self._get_file_obj(path_info)
+        return file.path.endswith("/")
+
     def walk_files(self, path_info, **kwargs):
         for fname in self._list_paths():
             if fname.endswith("/"):

--- a/dvc/tree/osf.py
+++ b/dvc/tree/osf.py
@@ -7,6 +7,7 @@ from funcy import cached_property, wrap_prop
 from dvc.exceptions import DvcException
 from dvc.path_info import URLInfo
 from dvc.hash_info import HashInfo
+from dvc.path_info import CloudURLInfo
 from dvc.progress import Tqdm
 from dvc.scheme import Schemes
 
@@ -29,7 +30,11 @@ class OSFTree(BaseTree):
     scheme = Schemes.OSF
     REQUIRES = {"ofsclient": "osfclient"}
     PARAM_CHECKSUM = "md5"
+<<<<<<< HEAD
     PATH_CLS = URLInfo
+=======
+    PATH_CLS = CloudURLInfo
+>>>>>>> rebase on master
 
     def __init__(self, repo, config):
         super().__init__(repo, config)
@@ -41,8 +46,11 @@ class OSFTree(BaseTree):
         self.password = os.getenv(
             "OSF_PASSWORD", None
         )  # need for private projects
+<<<<<<< HEAD
         if self.password is None:
             self.password = config.get("password")
+=======
+>>>>>>> rebase on master
         logger.debug(OSFTree)
 
     @wrap_prop(threading.Lock())

--- a/dvc/tree/osf.py
+++ b/dvc/tree/osf.py
@@ -9,6 +9,7 @@ from dvc.hash_info import HashInfo
 from dvc.path_info import URLInfo
 from dvc.progress import Tqdm
 from dvc.scheme import Schemes
+from dvc.tree.base import RemoteActionNotImplemented
 from dvc.utils import format_link
 
 from .base import BaseTree
@@ -148,3 +149,6 @@ class OSFTree(BaseTree):
                 self.storage.create_file(
                     to_info.path, wrapped, force=False, update=False
                 )
+
+    def open(self, path_info, mode="r", encoding=None):
+        raise RemoteActionNotImplemented("open", self.scheme)

--- a/dvc/tree/osf.py
+++ b/dvc/tree/osf.py
@@ -9,6 +9,7 @@ from dvc.hash_info import HashInfo
 from dvc.path_info import URLInfo
 from dvc.progress import Tqdm
 from dvc.scheme import Schemes
+from dvc.utils import format_link
 
 from .base import BaseTree
 
@@ -18,9 +19,9 @@ logger = logging.getLogger(__name__)
 class OSFAuthError(DvcException):
     def __init__(self):
         message = (
-            "OSF authorization failed. Please check or provide"
+            f"OSF authorization failed. Please check or provide"
             " user and password. See "
-            "https://dvc.org/doc/command-reference/remote"
+            f"{format_link('https://man.dvc.org/remote/modify')}"
             " for details"
         )
         super().__init__(message)

--- a/dvc/tree/osf.py
+++ b/dvc/tree/osf.py
@@ -70,9 +70,17 @@ class OSFTree(BaseTree):
         return self.project.storage()
 
     def _get_file_obj(self, path_info):
-        for file in self.storage.files:
-            if file.path == path_info.path:
-                return file
+        folder_names = path_info.path.split("/")[1:-1]
+        file_name = path_info.path.split("/")[-1]
+        folders = self.storage.folders
+        for name in folder_names:
+            try:
+                item = next((i for i in folders if i.name == name))
+            except StopIteration:
+                return None
+            folders = item.folders
+        file = next((i for i in item.files if i.name == file_name), None)
+        return file
 
     def get_md5(self, path_info):
         file = self._get_file_obj(path_info)

--- a/dvc/tree/osf.py
+++ b/dvc/tree/osf.py
@@ -37,12 +37,23 @@ class OSFTree(BaseTree):
     def __init__(self, repo, config):
         super().__init__(repo, config)
 
-        self.path_info = self.PATH_CLS(config["url"])
+        url = config.get("url", "osf://")
+        self.path_info = self.PATH_CLS(url)
 
         self.user = os.getenv("OSF_USER", config.get("user"))
         self.project_guid = os.getenv("OSF_PROJECT", config.get("project"))
         self.password = os.getenv("OSF_PASSWORD", config.get("password"))
-        logger.debug(OSFTree)
+
+        if (
+            self.user is None
+            or self.password is None
+            or self.project_guid is None
+        ):
+            raise DvcException(
+                f"Empty OSF user, project or password."
+                f" Learn more at "
+                f"{format_link('https://man.dvc.org/remote/modify')}"
+            )
 
     @wrap_prop(threading.Lock())
     @cached_property

--- a/dvc/tree/osf.py
+++ b/dvc/tree/osf.py
@@ -156,16 +156,7 @@ class OSFTree(BaseTree):
         self, from_info, to_file, name=None, no_progress_bar=False, **_kwargs
     ):
         file = self._get_file_obj(from_info)
-        # hack to get size of file
-        # This will be no longer needed after the
-        # pull-request https://github.com/osfclient/osfclient/pull/185 merge
-        total = None
-        if not no_progress_bar:
-            # pylint: disable=W0212
-            resp = self.osf._get(file._endpoint)
-            json = self.osf._json(resp, 200)
-            total = self.osf._get_attribute(json, "data", "attributes", "size")
-            # pylint: enable=W0212
+        total = file.size
 
         with open(to_file, "wb") as fobj:
             with Tqdm.wrapattr(
@@ -201,5 +192,5 @@ class OSFTree(BaseTree):
                     )
                     raise DvcException(message) from e
 
-    def open(self, path_info, mode="r", encoding=None):
+    def open(self, path_info, mode="r", encoding: str = None, **kwargs):
         raise RemoteActionNotImplemented("open", self.scheme)

--- a/dvc/tree/osf.py
+++ b/dvc/tree/osf.py
@@ -39,8 +39,8 @@ class OSFTree(BaseTree):
 
         self.path_info = self.PATH_CLS(config["url"])
 
-        self.user = config.get("user")
-        self.project_guid = config.get("project")
+        self.user = os.getenv("OSF_USER", config.get("user"))
+        self.project_guid = os.getenv("OSF_PROJECT", config.get("project"))
         self.password = os.getenv("OSF_PASSWORD", config.get("password"))
         logger.debug(OSFTree)
 

--- a/dvc/tree/osf.py
+++ b/dvc/tree/osf.py
@@ -88,8 +88,7 @@ class OSFTree(BaseTree):
         return md5
 
     def exists(self, path_info, use_dvcignore=True):
-        paths = self._list_paths()
-        return any(path_info.path == path for path in paths)
+        return self._get_file_obj(path_info) is not None
 
     def _list_paths(self):
         for file in self.storage.files:

--- a/setup.py
+++ b/setup.py
@@ -105,12 +105,14 @@ ssh = ["paramiko[invoke]>=2.7.0"]
 hdfs = ["pyarrow>=2.0.0"]
 webhdfs = ["hdfs==2.5.8"]
 webdav = ["webdavclient3>=3.14.5"]
+osf = ["osfclient==0.0.4"]
 # gssapi should not be included in all_remotes, because it doesn't have wheels
 # for linux and mac, so it will fail to compile if user doesn't have all the
 # requirements, including kerberos itself. Once all the wheels are available,
 # we can start shipping it by default.
 ssh_gssapi = ["paramiko[invoke,gssapi]>=2.7.0"]
-all_remotes = gs + s3 + azure + ssh + oss + gdrive + hdfs + webhdfs + webdav
+all_remotes = gs + s3 + azure + ssh + oss + gdrive + hdfs + webhdfs + webdav + osf
+
 
 # Extra dependecies to run tests
 tests_requirements = [
@@ -152,6 +154,7 @@ tests_requirements = [
     "mypy",
     "wsgidav",
     "crc32c",
+    "osfclient==0.0.4",
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ ssh = ["paramiko[invoke]>=2.7.0"]
 hdfs = ["pyarrow>=2.0.0"]
 webhdfs = ["hdfs==2.5.8"]
 webdav = ["webdavclient3>=3.14.5"]
-osf = ["osfclient==0.0.4"]
+osf = ["osfclient==0.0.5"]
 # gssapi should not be included in all_remotes, because it doesn't have wheels
 # for linux and mac, so it will fail to compile if user doesn't have all the
 # requirements, including kerberos itself. Once all the wheels are available,
@@ -155,7 +155,7 @@ tests_requirements = [
     "mypy",
     "wsgidav",
     "crc32c",
-    "osfclient==0.0.4",
+    "osfclient==0.0.5",
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,6 @@ install_requires = [
     "fsspec>=0.8.5",
 ]
 
-
 # Extra dependencies for remote integrations
 
 gs = ["google-cloud-storage==1.19.0"]
@@ -111,7 +110,9 @@ osf = ["osfclient==0.0.4"]
 # requirements, including kerberos itself. Once all the wheels are available,
 # we can start shipping it by default.
 ssh_gssapi = ["paramiko[invoke,gssapi]>=2.7.0"]
-all_remotes = gs + s3 + azure + ssh + oss + gdrive + hdfs + webhdfs + webdav + osf
+all_remotes = (
+    gs + s3 + azure + ssh + oss + gdrive + hdfs + webhdfs + webdav + osf
+)
 
 
 # Extra dependecies to run tests

--- a/tests/unit/tree/test_osf.py
+++ b/tests/unit/tree/test_osf.py
@@ -1,0 +1,67 @@
+import os
+
+import pytest
+from mock import call, patch
+from osfclient.models import OSFCore, Project
+from osfclient.tests import mocks
+from osfclient.tests.fake_responses import project_node
+
+from dvc.tree.osf import OSFTree
+
+username = "example@mail.com"
+data_dir = "data"
+url = f"osf://odf.io/{data_dir}"
+project = "abcd"
+password = "12345"
+
+
+@pytest.fixture
+def passwd_env_var():
+    os.environ["OSF_PASSWORD"] = password
+    yield
+
+    del os.environ["OSF_PASSWORD"]
+
+
+def test_init(dvc):
+    config = {
+        "url": url,
+        "project": project,
+        "osf_username": username,
+        "password": password,
+    }
+    tree = OSFTree(dvc, config)
+
+    assert tree.path_info == url
+    assert tree.project_guid == project
+    assert tree.password == password
+    assert tree.osf_username == username
+
+
+def test_init_envvar(dvc, passwd_env_var):
+    config = {"url": url, "project": project, "osf_username": username}
+    tree = OSFTree(dvc, config)
+
+    assert tree.password == password
+
+
+@patch.object(
+    OSFCore, "_get", return_value=mocks.FakeResponse(200, project_node)
+)
+def test_project(OSFCore_get, dvc):
+    config = {
+        "url": url,
+        "project": project,
+        "osf_username": username,
+        "password": password,
+    }
+    tree = OSFTree(dvc, config)
+    storage = tree.project
+
+    calls = [
+        call("https://api.osf.io/v2//guids/abcd/"),
+        call("https://api.osf.io/v2//nodes/abcd/"),
+    ]
+    OSFCore_get.assert_has_calls(calls)
+
+    assert isinstance(storage, Project)

--- a/tests/unit/tree/test_osf.py
+++ b/tests/unit/tree/test_osf.py
@@ -17,7 +17,7 @@ password = "12345"
 config = {
     "url": url,
     "project": project,
-    "osf_username": username,
+    "username": username,
     "password": password,
 }
 

--- a/tests/unit/tree/test_osf.py
+++ b/tests/unit/tree/test_osf.py
@@ -2,9 +2,9 @@ import os
 
 import pytest
 from mock import call, patch
-from osfclient.models import OSFCore, Project
+from osfclient.models import Folder, OSFCore, Project
 from osfclient.tests import mocks
-from osfclient.tests.fake_responses import project_node
+from osfclient.tests.fake_responses import files_node, project_node
 
 from dvc.tree.osf import OSFTree
 
@@ -56,7 +56,7 @@ def test_project(OSFCore_get, dvc):
         "password": password,
     }
     tree = OSFTree(dvc, config)
-    storage = tree.project
+    proj = tree.project
 
     calls = [
         call("https://api.osf.io/v2//guids/abcd/"),
@@ -64,4 +64,33 @@ def test_project(OSFCore_get, dvc):
     ]
     OSFCore_get.assert_has_calls(calls)
 
-    assert isinstance(storage, Project)
+    assert isinstance(proj, Project)
+
+
+@patch.object(OSFCore, "_get")
+def test_list_paths(OSFCore_get, dvc):
+    config = {
+        "url": url,
+        "project": project,
+        "osf_username": username,
+        "password": password,
+    }
+
+    _files_url = (
+        f"https://api.osf.io/v2//nodes/{project}/files/osfstorage/foo123"
+    )
+    json = files_node(project, "osfstorage", ["foo/hello.txt", "foo/bye.txt"])
+    response = mocks.FakeResponse(200, json)
+    OSFCore_get.return_value = response
+
+    store = Folder({})
+    store._files_url = _files_url
+
+    with patch.object(OSFTree, "storage", new=store):
+        tree = OSFTree(dvc, config)
+        files = list(tree._list_paths())
+        assert len(files) == 2
+        assert "/foo/hello.txt" in files
+        assert "/foo/bye.txt" in files
+
+    OSFCore_get.assert_called_once_with(_files_url)

--- a/tests/unit/tree/test_osf.py
+++ b/tests/unit/tree/test_osf.py
@@ -107,3 +107,32 @@ def test_get_file_obj(OSFCore_get, dvc):
         assert file.path == "/data/hello.txt"
 
     OSFCore_get.assert_called_once_with(_files_url)
+
+
+def test_is_dir(dvc):
+    path_info = URLInfo(url) / "dir/"
+    f = File({})
+
+    f.path = "/data/dir/"
+    with patch.object(OSFTree, "_get_file_obj", return_value=f):
+        tree = OSFTree(dvc, config)
+        assert tree.isdir(path_info)
+
+    f.path = "/data/file"
+    with patch.object(OSFTree, "_get_file_obj", return_value=f):
+        tree = OSFTree(dvc, config)
+        assert not tree.isdir(path_info)
+
+
+def test_walk_files(dvc):
+    path_info = URLInfo(url)
+
+    f1 = "/data/dir/"
+    f2 = "/data/file1"
+    f3 = "/data/file2"
+
+    with patch.object(OSFTree, "_list_paths", return_value=[f1, f2, f3]):
+        tree = OSFTree(dvc, config)
+        files = [i.url for i in tree.walk_files(path_info)]
+        assert "osf://odf.io/data/file1" in files
+        assert "osf://odf.io/data/file2" in files

--- a/tests/unit/tree/test_osf.py
+++ b/tests/unit/tree/test_osf.py
@@ -17,7 +17,7 @@ password = "12345"
 config = {
     "url": url,
     "project": project,
-    "username": username,
+    "user": username,
     "password": password,
 }
 
@@ -36,7 +36,7 @@ def test_init(dvc):
     assert tree.path_info == url
     assert tree.project_guid == project
     assert tree.password == password
-    assert tree.osf_username == username
+    assert tree.user == username
 
 
 def test_init_envvar(dvc, passwd_env_var):

--- a/tests/unit/tree/test_osf.py
+++ b/tests/unit/tree/test_osf.py
@@ -25,9 +25,13 @@ config = {
 @pytest.fixture
 def passwd_env_var():
     os.environ["OSF_PASSWORD"] = password
+    os.environ["OSF_USER"] = username
+    os.environ["OSF_PROJECT0"] = project
     yield
 
     del os.environ["OSF_PASSWORD"]
+    del os.environ["OSF_USER"]
+    del os.environ["OSF_PROJECT0"]
 
 
 def test_init(dvc):


### PR DESCRIPTION
close #4176 

I have implemented the OSFTree class and I open this pull request to get feedback on these changes. Now I will write the tests and make changes to the documentation.

Note on method ```_download``` in ```dvc/tree/osf.py```. The currently used osfclient library does not have a public attribute of the File class to get the file size. Although the API itself has this feature. I opend the pull request with the necessary changes https://github.com/osfclient/osfclient/pull/185. So it should be possible to add tqdm progress bar for ```_downlod``` method after next osfclient release.