### PR TITLE
parametrization: Support keys of the dictionary to be interpolated

### DIFF
--- a/dvc/parsing/context.py
+++ b/dvc/parsing/context.py
@@ -297,7 +297,7 @@ class Context(CtxDict):
 
         resolve = rpartial(self.resolve, unwrap)
         if isinstance(src, Mapping):
-            return {key: resolve(value) for key, value in src.items()}
+            return dict(map(resolve, kv) for kv in src.items())
         elif isinstance(src, Seq):
             return type(src)(map(resolve, src))
         elif isinstance(src, str):

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -370,3 +370,12 @@ def test_node_value():
     assert context["lst"][1].value == 2
 
     assert context["foo"].value == "foo"
+
+
+def test_resolve_resolves_dict_keys():
+    d = {"dct": {"foo": "foobar", "persist": True}}
+
+    context = Context(d)
+    assert context.resolve({"${dct.foo}": {"persist": "${dct.persist}"}}) == {
+        "foobar": {"persist": True}
+    }


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Eg:
```yaml
outputs:
  - ${foo}:
       persist: ${persist}
```

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
