### PR TITLE
setup.py: limit responses version for moto

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -131,10 +131,13 @@ tests_requirements = [
     "pydocstyle<4.0",
     "jaraco.windows==3.9.2",
     "mock-ssh-server>=0.8.2",
-    "moto==1.3.14.dev464",
+    "moto==1.3.16.dev110",
     # moto's indirect dependency that is causing problems with flufl.lock's
     # dependency (atpublic). See https://github.com/iterative/dvc/pull/4853
     "aws-sam-translator<1.29.0",
+    # for moto's indirect dependency.
+    # See https://github.com/iterative/dvc/pull/4879
+    "urllib3<1.26.0",
     "rangehttpserver==1.2.0",
     "beautifulsoup4==4.4.0",
     "flake8-bugbear",


### PR DESCRIPTION
Tests started to fail recently with
```
c:\hostedtoolcache\windows\python\3.6.8\x64\lib\site-packages\moto\core\models.py:17: in <module>
    import responses
c:\hostedtoolcache\windows\python\3.6.8\x64\lib\site-packages\responses.py:29: in <module>
    from urllib3.connection import HTTPHeaderDict
E   ImportError: cannot import name 'HTTPHeaderDict'
```

caused by https://github.com/getsentry/responses/issues/354

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
