### PR TITLE
parametrization: change `use` and `vars` to just `vars`

### DIFF
--- a/dvc/parsing/context.py
+++ b/dvc/parsing/context.py
@@ -256,6 +256,14 @@ class Context(CtxDict):
         meta = Meta(source=file)
         return cls(loader(file, tree=tree), meta=meta)
 
+    def merge_from(self, tree, path, overwrite=False):
+        if not tree.exists(path):
+            raise FileNotFoundError(path)
+
+        self.merge_update(
+            Context.load_from(tree, str(path)), overwrite=overwrite
+        )
+
     @classmethod
     def clone(cls, ctx: "Context") -> "Context":
         """Clones given context."""

--- a/dvc/schema.py
+++ b/dvc/schema.py
@@ -3,7 +3,7 @@ from voluptuous import Any, Optional, Required, Schema
 from dvc import dependency, output
 from dvc.hash_info import HashInfo
 from dvc.output import CHECKSUMS_SCHEMA, BaseOutput
-from dvc.parsing import FOREACH_KWD, IN_KWD, SET_KWD, USE_KWD, VARS_KWD
+from dvc.parsing import FOREACH_KWD, IN_KWD, SET_KWD, VARS_KWD
 from dvc.stage.params import StageParams
 
 STAGES = "stages"
@@ -60,14 +60,15 @@ PLOT_PSTAGE_SCHEMA = {str: Any(PLOT_PROPS_SCHEMA, [PLOT_PROPS_SCHEMA])}
 
 PARAM_PSTAGE_NON_DEFAULT_SCHEMA = {str: [str]}
 
+VARS_SCHEMA = [str, dict]
+
 STAGE_DEFINITION = {
     StageParams.PARAM_CMD: str,
     Optional(SET_KWD): dict,
     Optional(StageParams.PARAM_WDIR): str,
     Optional(StageParams.PARAM_DEPS): [str],
-    Optional(StageParams.PARAM_PARAMS): [
-        Any(str, PARAM_PSTAGE_NON_DEFAULT_SCHEMA)
-    ],
+    Optional(StageParams.PARAM_PARAMS): [Any(str, dict)],
+    Optional(VARS_KWD): VARS_SCHEMA,
     Optional(StageParams.PARAM_FROZEN): bool,
     Optional(StageParams.PARAM_META): object,
     Optional(StageParams.PARAM_DESC): str,
@@ -87,8 +88,7 @@ FOREACH_IN = {
 SINGLE_PIPELINE_STAGE_SCHEMA = {str: Any(STAGE_DEFINITION, FOREACH_IN)}
 MULTI_STAGE_SCHEMA = {
     STAGES: SINGLE_PIPELINE_STAGE_SCHEMA,
-    USE_KWD: str,
-    VARS_KWD: dict,
+    VARS_KWD: VARS_SCHEMA,
 }
 
 COMPILED_SINGLE_STAGE_SCHEMA = Schema(SINGLE_STAGE_SCHEMA)

--- a/tests/func/test_stage_resolver.py
+++ b/tests/func/test_stage_resolver.py
@@ -77,7 +77,7 @@ def test_simple(tmp_dir, dvc):
 
 def test_vars(tmp_dir, dvc):
     d = deepcopy(TEMPLATED_DVC_YAML_DATA)
-    d["vars"] = CONTEXT_DATA
+    d["vars"] = [CONTEXT_DATA]
     resolver = DataResolver(dvc, PathInfo(str(tmp_dir)), d)
     resolved_data = deepcopy(RESOLVED_DVC_YAML_DATA)
 
@@ -95,14 +95,14 @@ def test_no_params_yaml_and_vars(tmp_dir, dvc):
         resolver.resolve()
 
 
-def test_use(tmp_dir, dvc):
+def test_vars_import(tmp_dir, dvc):
     """
     Test that different file can be loaded using `use`
     instead of default params.yaml.
     """
     dump_yaml(tmp_dir / "params2.yaml", CONTEXT_DATA)
     d = deepcopy(TEMPLATED_DVC_YAML_DATA)
-    d["use"] = "params2.yaml"
+    d["vars"] = ["params2.yaml"]
     resolver = DataResolver(dvc, PathInfo(str(tmp_dir)), d)
 
     resolved_data = deepcopy(RESOLVED_DVC_YAML_DATA)
@@ -119,8 +119,7 @@ def test_vars_and_params_import(tmp_dir, dvc):
     whilst tracking the "used" variables from params.
     """
     d = {
-        "use": DEFAULT_PARAMS_FILE,
-        "vars": {"dict": {"foo": "foobar"}},
+        "vars": [DEFAULT_PARAMS_FILE, {"dict": {"foo": "foobar"}}],
         "stages": {"stage1": {"cmd": "echo ${dict.foo} ${dict.bar}"}},
     }
     dump_yaml(tmp_dir / DEFAULT_PARAMS_FILE, {"dict": {"bar": "bar"}})
@@ -139,12 +138,12 @@ def test_vars_and_params_import(tmp_dir, dvc):
 def test_with_params_section(tmp_dir, dvc):
     """Test that params section is also loaded for interpolation"""
     d = {
-        "use": "params.yaml",
-        "vars": {"dict": {"foo": "foo"}},
+        "vars": [DEFAULT_PARAMS_FILE, {"dict": {"foo": "foo"}}],
         "stages": {
             "stage1": {
                 "cmd": "echo ${dict.foo} ${dict.bar} ${dict.foobar}",
                 "params": [{"params.json": ["value1"]}],
+                "vars": ["params.json"],
             },
         },
     }
@@ -177,6 +176,7 @@ def test_stage_with_wdir(tmp_dir, dvc):
                 "cmd": "echo ${dict.foo} ${dict.bar}",
                 "params": ["value1"],
                 "wdir": "data",
+                "vars": [DEFAULT_PARAMS_FILE],
             },
         },
     }
@@ -217,6 +217,7 @@ def test_with_templated_wdir(tmp_dir, dvc):
                 "cmd": "echo ${dict.foo} ${dict.bar}",
                 "params": ["value1"],
                 "wdir": "${dict.ws}",
+                "vars": [DEFAULT_PARAMS_FILE],
             },
         },
     }
@@ -295,7 +296,7 @@ def test_foreach_loop_dict(tmp_dir, dvc):
 
 def test_foreach_loop_templatized(tmp_dir, dvc):
     params = {"models": {"us": {"thresh": 10}}}
-    vars_ = {"models": {"gb": {"thresh": 15}}}
+    vars_ = [{"models": {"gb": {"thresh": 15}}}]
     dump_yaml(tmp_dir / DEFAULT_PARAMS_FILE, params)
     d = {
         "vars": vars_,
@@ -401,7 +402,7 @@ def test_set_with_foreach_and_on_stage_definition(tmp_dir, dvc):
     dump_json(tmp_dir / "params.json", iterable)
 
     d = {
-        "use": "params.json",
+        "vars": ["params.json"],
         "stages": {
             "build": {
                 "set": {"data": "${models}"},
@@ -436,11 +437,12 @@ def test_resolve_local_tries_to_load_globally_used_files(tmp_dir, dvc):
     dump_json(tmp_dir / "params.json", iterable)
 
     d = {
-        "use": "params.json",
+        "vars": ["params.json"],
         "stages": {
             "build": {
                 "cmd": "command --value ${bar}",
                 "params": [{"params.json": ["foo"]}],
+                "vars": ["params.json"],
             },
         },
     }
@@ -467,6 +469,7 @@ def test_resolve_local_tries_to_load_globally_used_params_yaml(tmp_dir, dvc):
             "build": {
                 "cmd": "command --value ${bar}",
                 "params": [{"params.yaml": ["foo"]}],
+                "vars": ["params.yaml"],
             },
         },
     }

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -3,6 +3,7 @@ from math import pi
 
 import pytest
 
+from dvc.parsing import DEFAULT_PARAMS_FILE
 from dvc.parsing.context import Context, CtxDict, CtxList, Value
 from dvc.tree.local import LocalTree
 from dvc.utils.serialize import dump_yaml
@@ -379,3 +380,9 @@ def test_resolve_resolves_dict_keys():
     assert context.resolve({"${dct.foo}": {"persist": "${dct.persist}"}}) == {
         "foobar": {"persist": True}
     }
+
+
+def test_merge_from_raises_if_file_not_exist(tmp_dir, dvc):
+    context = Context(foo="bar")
+    with pytest.raises(FileNotFoundError):
+        context.merge_from(dvc.tree, DEFAULT_PARAMS_FILE)


### PR DESCRIPTION
The schema is changed of `vars` to accommodate both use of
imports (`use` previously) and setting variables locally (`vars`).

Now:
```yaml
vars:
  - params.yaml
  - foo: foo
    bar: bar
```

So, if it's the string, it's an import. If it's a dictionary, it's a local variable.

Also, the same distinction occurs for the stages.
```yaml
stages:
  build:
    cmd: "command --thresh ${thresh}
    params:
     - foo
    vars:
    - params.yaml
    - foobar: foobar
```

Note that the distinction is not made internally for `vars` and `params` yet, not in `dvc.lock` as well.


* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
