### PR TITLE
send TAP result to flaky service only on master

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,7 +69,7 @@ jobs:
     - name: Post TAP
       # Running custom fork with an option, that does not fail CI on error
       uses: skshetry/flaky-service/packages/action@master
-      if: ${{ always() }}
+      if: always() && github.ref == 'refs/heads/master'
       with:
         file-path: ${{github.workspace}}/testresults.tap
         repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The tests added on pending PRs were making noise on the flaky service. Changed it to only send on the `master` branch.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
