### PR TITLE
experiments: preserve file permissions across tmpdir execution

### DIFF
--- a/dvc/tree/base.py
+++ b/dvc/tree/base.py
@@ -225,7 +225,7 @@ class BaseTree:
         raise RemoteActionNotImplemented("reflink", self.scheme)
 
     @staticmethod
-    def protect(path_info):
+    def protect(path_info, mode=None):
         pass
 
     def is_protected(self, path_info):
@@ -338,7 +338,14 @@ class BaseTree:
         hash_info.size = dir_info.size
         return hash_info
 
-    def upload(self, from_info, to_info, name=None, no_progress_bar=False):
+    def upload(
+        self,
+        from_info,
+        to_info,
+        name=None,
+        no_progress_bar=False,
+        file_mode=None,
+    ):
         if not hasattr(self, "_upload"):
             raise RemoteActionNotImplemented("upload", self.scheme)
 
@@ -357,6 +364,7 @@ class BaseTree:
             to_info,
             name=name,
             no_progress_bar=no_progress_bar,
+            file_mode=file_mode,
         )
 
     def download(

--- a/dvc/tree/base.py
+++ b/dvc/tree/base.py
@@ -225,7 +225,7 @@ class BaseTree:
         raise RemoteActionNotImplemented("reflink", self.scheme)
 
     @staticmethod
-    def protect(path_info, mode=None):
+    def protect(path_info):
         pass
 
     def is_protected(self, path_info):

--- a/dvc/tree/gdrive.py
+++ b/dvc/tree/gdrive.py
@@ -564,7 +564,9 @@ class GDriveTree(BaseTree):
     def get_file_hash(self, path_info):
         raise NotImplementedError
 
-    def _upload(self, from_file, to_info, name=None, no_progress_bar=False):
+    def _upload(
+        self, from_file, to_info, name=None, no_progress_bar=False, **_kwargs
+    ):
         dirname = to_info.parent
         assert dirname
         parent_id = self._get_item_id(dirname, True)

--- a/dvc/tree/gs.py
+++ b/dvc/tree/gs.py
@@ -200,7 +200,9 @@ class GSTree(BaseTree):
             size=blob.size,
         )
 
-    def _upload(self, from_file, to_info, name=None, no_progress_bar=False):
+    def _upload(
+        self, from_file, to_info, name=None, no_progress_bar=False, **_kwargs
+    ):
         bucket = self.gs.bucket(to_info.bucket)
         _upload_to_bucket(
             bucket,

--- a/dvc/tree/http.py
+++ b/dvc/tree/http.py
@@ -181,7 +181,9 @@ class HTTPTree(BaseTree):  # pylint:disable=abstract-method
                 for chunk in response.iter_content(chunk_size=self.CHUNK_SIZE):
                     fd_wrapped.write(chunk)
 
-    def _upload(self, from_file, to_info, name=None, no_progress_bar=False):
+    def _upload(
+        self, from_file, to_info, name=None, no_progress_bar=False, **_kwargs
+    ):
         def chunks():
             with open(from_file, "rb") as fd:
                 with Tqdm.wrapattr(

--- a/dvc/tree/local.py
+++ b/dvc/tree/local.py
@@ -275,9 +275,9 @@ class LocalTree(BaseTree):
         else:
             self._unprotect_file(path)
 
-    def protect(self, path_info):
+    def protect(self, path_info, mode=None):
         path = os.fspath(path_info)
-        mode = self.CACHE_MODE
+        mode = mode if mode is not None else self.CACHE_MODE
 
         try:
             os.chmod(path, mode)
@@ -316,7 +316,13 @@ class LocalTree(BaseTree):
         return os.path.getsize(path_info)
 
     def _upload(
-        self, from_file, to_info, name=None, no_progress_bar=False, **_kwargs
+        self,
+        from_file,
+        to_info,
+        name=None,
+        no_progress_bar=False,
+        file_mode=None,
+        **_kwargs,
     ):
         makedirs(to_info.parent, exist_ok=True)
 
@@ -325,7 +331,7 @@ class LocalTree(BaseTree):
             from_file, tmp_file, name=name, no_progress_bar=no_progress_bar
         )
 
-        self.protect(tmp_file)
+        self.protect(tmp_file, mode=file_mode)
         os.replace(tmp_file, to_info)
 
     @staticmethod

--- a/dvc/tree/local.py
+++ b/dvc/tree/local.py
@@ -239,6 +239,24 @@ class LocalTree(BaseTree):
         os.chmod(tmp_info, self.file_mode)
         os.rename(tmp_info, to_info)
 
+    def chmod(self, path_info, mode):
+        path = os.fspath(path_info)
+        try:
+            os.chmod(path, mode)
+        except OSError as exc:
+            # There is nothing we need to do in case of a read-only file system
+            if exc.errno == errno.EROFS:
+                return
+
+            # In shared cache scenario, we might not own the cache file, so we
+            # need to check if cache file is already protected.
+            if exc.errno not in [errno.EPERM, errno.EACCES]:
+                raise
+
+            actual = stat.S_IMODE(os.stat(path).st_mode)
+            if actual != mode:
+                raise
+
     def _unprotect_file(self, path):
         if System.is_symlink(path) or System.is_hardlink(path):
             logger.debug(f"Unprotecting '{path}'")
@@ -275,25 +293,8 @@ class LocalTree(BaseTree):
         else:
             self._unprotect_file(path)
 
-    def protect(self, path_info, mode=None):
-        path = os.fspath(path_info)
-        mode = mode if mode is not None else self.CACHE_MODE
-
-        try:
-            os.chmod(path, mode)
-        except OSError as exc:
-            # There is nothing we need to do in case of a read-only file system
-            if exc.errno == errno.EROFS:
-                return
-
-            # In shared cache scenario, we might not own the cache file, so we
-            # need to check if cache file is already protected.
-            if exc.errno not in [errno.EPERM, errno.EACCES]:
-                raise
-
-            actual = stat.S_IMODE(os.stat(path).st_mode)
-            if actual != mode:
-                raise
+    def protect(self, path_info):
+        self.chmod(path_info, self.CACHE_MODE)
 
     def is_protected(self, path_info):
         try:
@@ -331,7 +332,10 @@ class LocalTree(BaseTree):
             from_file, tmp_file, name=name, no_progress_bar=no_progress_bar
         )
 
-        self.protect(tmp_file, mode=file_mode)
+        if file_mode is not None:
+            self.chmod(tmp_file, file_mode)
+        else:
+            self.protect(tmp_file)
         os.replace(tmp_file, to_info)
 
     @staticmethod

--- a/dvc/tree/s3.py
+++ b/dvc/tree/s3.py
@@ -342,7 +342,9 @@ class S3Tree(BaseTree):
                 size=obj.content_length,
             )
 
-    def _upload(self, from_file, to_info, name=None, no_progress_bar=False):
+    def _upload(
+        self, from_file, to_info, name=None, no_progress_bar=False, **_kwargs
+    ):
         with self._get_obj(to_info) as obj:
             total = os.path.getsize(from_file)
             with Tqdm(

--- a/dvc/tree/ssh/__init__.py
+++ b/dvc/tree/ssh/__init__.py
@@ -260,7 +260,9 @@ class SSHTree(BaseTree):
                 no_progress_bar=no_progress_bar,
             )
 
-    def _upload(self, from_file, to_info, name=None, no_progress_bar=False):
+    def _upload(
+        self, from_file, to_info, name=None, no_progress_bar=False, **_kwargs
+    ):
         with self.ssh(to_info) as ssh:
             ssh.upload(
                 from_file,

--- a/dvc/tree/webdav.py
+++ b/dvc/tree/webdav.py
@@ -211,7 +211,7 @@ class WebDAVTree(BaseTree):  # pylint:disable=abstract-method
 
     # Uploads file to remote
     def _upload(
-        self, from_file, to_info, name=None, no_progress_bar=False,
+        self, from_file, to_info, name=None, no_progress_bar=False, **_kwargs,
     ):
         # First try to create parent directories
         self.makedirs(to_info.parent)

--- a/tests/func/experiments/test_experiments.py
+++ b/tests/func/experiments/test_experiments.py
@@ -8,8 +8,6 @@ from funcy import first
 from dvc.utils.serialize import PythonFileCorruptedError
 from tests.func.test_repro_multistage import COPY_SCRIPT
 
-SCRIPT_MODE = 0o755
-
 
 def test_new_simple(tmp_dir, scm, dvc, exp_stage, mocker):
     tmp_dir.gen("params.yaml", "foo: 2")
@@ -25,9 +23,14 @@ def test_new_simple(tmp_dir, scm, dvc, exp_stage, mocker):
 
 @pytest.mark.skipif(os.name == "nt", reason="Not supported for Windows.")
 def test_file_permissions(tmp_dir, scm, dvc, exp_stage, mocker):
+    mode = 0o755
+    os.chmod(tmp_dir / "copy.py", mode)
+    scm.add(["copy.py"])
+    scm.commit("set exec")
+
     tmp_dir.gen("params.yaml", "foo: 2")
     dvc.experiments.run(exp_stage.addressing)
-    assert stat.S_IMODE(os.stat(tmp_dir / "copy.py").st_mode) == SCRIPT_MODE
+    assert stat.S_IMODE(os.stat(tmp_dir / "copy.py").st_mode) == mode
 
 
 def test_failed_exp(tmp_dir, scm, dvc, exp_stage, mocker, caplog):

--- a/tests/func/experiments/test_experiments.py
+++ b/tests/func/experiments/test_experiments.py
@@ -18,10 +18,16 @@ def test_new_simple(tmp_dir, scm, dvc, exp_stage, mocker):
     dvc.experiments.run(exp_stage.addressing)
 
     new_mock.assert_called_once()
-    assert stat.S_IMODE(os.stat(tmp_dir / "copy.py").st_mode) == SCRIPT_MODE
     assert (
         tmp_dir / ".dvc" / "experiments" / "metrics.yaml"
     ).read_text() == "foo: 2"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Not supported for Windows.")
+def test_file_permissions(tmp_dir, scm, dvc, exp_stage, mocker):
+    tmp_dir.gen("params.yaml", "foo: 2")
+    dvc.experiments.run(exp_stage.addressing)
+    assert stat.S_IMODE(os.stat(tmp_dir / "copy.py").st_mode) == SCRIPT_MODE
 
 
 def test_failed_exp(tmp_dir, scm, dvc, exp_stage, mocker, caplog):

--- a/tests/func/experiments/test_experiments.py
+++ b/tests/func/experiments/test_experiments.py
@@ -1,10 +1,14 @@
 import logging
+import os
+import stat
 
 import pytest
 from funcy import first
 
 from dvc.utils.serialize import PythonFileCorruptedError
 from tests.func.test_repro_multistage import COPY_SCRIPT
+
+SCRIPT_MODE = 0o755
 
 
 def test_new_simple(tmp_dir, scm, dvc, exp_stage, mocker):
@@ -14,6 +18,7 @@ def test_new_simple(tmp_dir, scm, dvc, exp_stage, mocker):
     dvc.experiments.run(exp_stage.addressing)
 
     new_mock.assert_called_once()
+    assert stat.S_IMODE(os.stat(tmp_dir / "copy.py").st_mode) == SCRIPT_MODE
     assert (
         tmp_dir / ".dvc" / "experiments" / "metrics.yaml"
     ).read_text() == "foo: 2"

--- a/tests/unit/tree/test_tree.py
+++ b/tests/unit/tree/test_tree.py
@@ -51,6 +51,7 @@ def test_get_cloud_tree_validate(tmp_dir, dvc):
         get_cloud_tree(dvc, name="second")
 
 
+@pytest.mark.skipif(os.name == "nt", reason="Not supported for Windows.")
 @pytest.mark.parametrize(
     "mode, expected", [(None, LocalTree.CACHE_MODE), (0o777, 0o777)],
 )

--- a/tests/unit/tree/test_tree.py
+++ b/tests/unit/tree/test_tree.py
@@ -1,8 +1,11 @@
+import os
+import stat
+
 import pytest
 
 from dvc.config import ConfigError
-from dvc.path_info import CloudURLInfo
-from dvc.tree import get_cloud_tree
+from dvc.path_info import CloudURLInfo, PathInfo
+from dvc.tree import LocalTree, get_cloud_tree
 
 
 def test_get_cloud_tree(tmp_dir, dvc):
@@ -46,3 +49,17 @@ def test_get_cloud_tree_validate(tmp_dir, dvc):
 
     with pytest.raises(ConfigError):
         get_cloud_tree(dvc, name="second")
+
+
+@pytest.mark.parametrize(
+    "mode, expected", [(None, LocalTree.CACHE_MODE), (0o777, 0o777)],
+)
+def test_upload_file_mode(tmp_dir, mode, expected):
+    tmp_dir.gen("src", "foo")
+    src = PathInfo(tmp_dir / "src")
+    dest = PathInfo(tmp_dir / "dest")
+    tree = LocalTree(None, {"url": os.fspath(tmp_dir)})
+    tree.upload(src, dest, file_mode=mode)
+    assert (tmp_dir / "dest").exists()
+    assert (tmp_dir / "dest").read_text() == "foo"
+    assert stat.S_IMODE(os.stat(dest).st_mode) == expected


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will fix #4850.

* `BaseTree.upload()` now supports `file_mode` kwarg for applicable trees (currently LocalTree only).
    * Behaves the same way as `download(file_mode=...)` - if the tree supports modes, the specified mode will be applied.
    * For LocalTree, if mode is unspecified file will default to `LocalTree.CACHE_MODE` (same as existing behavior)