### PR TITLE
dvc: add --pdb flag

### DIFF
--- a/dvc/cli.py
+++ b/dvc/cli.py
@@ -146,6 +146,10 @@ def get_parent_parser():
     )
     parent_parser.add_argument("--cprofile-dump", help=argparse.SUPPRESS)
 
+    parent_parser.add_argument(
+        "--pdb", action="store_true", default=False, help=argparse.SUPPRESS,
+    )
+
     log_level_group = parent_parser.add_mutually_exclusive_group()
     log_level_group.add_argument(
         "-q", "--quiet", action="count", default=0, help="Be quiet."

--- a/dvc/main.py
+++ b/dvc/main.py
@@ -42,6 +42,19 @@ def profile(enable, dump):
     prof.dump_stats(dump)
 
 
+@contextmanager
+def debug(enable):
+    try:
+        yield
+        return
+    except Exception:
+        if enable:
+            import pdb  # noqa: T100
+
+            pdb.post_mortem()
+        raise
+
+
 def main(argv=None):  # noqa: C901
     """Run dvc CLI command.
 
@@ -72,8 +85,9 @@ def main(argv=None):  # noqa: C901
         logger.trace(args)
 
         with profile(enable=args.cprofile, dump=args.cprofile_dump):
-            cmd = args.func(args)
-            ret = cmd.run()
+            with debug(args.pdb):
+                cmd = args.func(args)
+                ret = cmd.run()
     except ConfigError:
         logger.exception("configuration error")
         ret = 251


### PR DESCRIPTION
This is a hidden flag (no docs needed) for a handy shortcut to pdb when
we need it. E.g. binaries built by pyinstaller are much easier to debug
with it.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
