### PR TITLE
[WIP] 'dvc vdir' command for updating large remote datasets 

### DIFF
--- a/dvc/cache/base.py
+++ b/dvc/cache/base.py
@@ -291,9 +291,10 @@ class CloudCache:
             desc="Saving " + path_info.name,
             unit="file",
         ):
-            self._save_file(
-                entry_info, tree, entry_hash, save_link=False, **kwargs
-            )
+            if entry_hash.size:
+                self._save_file(
+                    entry_info, tree, entry_hash, save_link=False, **kwargs
+                )
 
         if save_link:
             self.tree.state.save_link(path_info)

--- a/dvc/cli.py
+++ b/dvc/cli.py
@@ -39,6 +39,7 @@ from .command import (
     run,
     unprotect,
     update,
+    vdir,
     version,
 )
 from .command.base import fix_subparsers
@@ -76,6 +77,7 @@ COMMANDS = [
     commit,
     completion,
     diff,
+    vdir,
     version,
     update,
     git_hook,

--- a/dvc/command/vdir.py
+++ b/dvc/command/vdir.py
@@ -30,7 +30,9 @@ class CmdVdirPull(CmdVdirBase):
 class CmdVdirCp(CmdVdirBase):
     def run(self):
         try:
-            self.repo.vdir.cp(self.args.paths)
+            self.repo.vdir.cp(
+                self.args.src, self.args.dst, self.args.local_src
+            )
         except DvcException:
             logger.exception(
                 "failed to cp into the virtual directory: {}".format(

--- a/dvc/command/vdir.py
+++ b/dvc/command/vdir.py
@@ -1,0 +1,103 @@
+import argparse
+import logging
+
+from dvc.command import completion
+from dvc.command.base import CmdBase, append_doc_link, fix_subparsers
+from dvc.exceptions import DvcException
+
+logger = logging.getLogger(__name__)
+
+
+class CmdVdirBase(CmdBase):
+    UNINITIALIZED = True
+
+
+class CmdVdirPull(CmdVdirBase):
+    def run(self):
+        try:
+            self.repo.vdir.pull(self.args.targets)
+        except DvcException:
+            logger.exception(
+                "failed to pull virtual directory from: {}".format(
+                    self.args.targets
+                )
+            )
+            return 1
+
+        return 0
+
+
+class CmdVdirAdd(CmdVdirBase):
+    def run(self):
+        try:
+            self.repo.vdir.add(self.args.paths)
+        except DvcException:
+            logger.exception(
+                "failed to add into the virtual directory: {}".format(
+                    self.args.paths
+                )
+            )
+            return 1
+
+        return 0
+
+
+def add_parser(subparsers, parent_parser):
+    VDIR_HELP = "Commands to transact with virtual directories."
+
+    vdir_parser = subparsers.add_parser(
+        "vdir",
+        parents=[parent_parser],
+        description=append_doc_link(VDIR_HELP, "vdir"),
+        help=VDIR_HELP,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    vdir_subparsers = vdir_parser.add_subparsers(
+        dest="cmd",
+        help="Use `dvc vdir CMD --help` to display command-specific help.",
+    )
+
+    fix_subparsers(vdir_subparsers)
+
+    VDIR_PULL_HELP = (
+        "Download the list of tracked files or directories from remote storage"
+        " and treat them as virtual directories in the local workspace."
+    )
+    vdir_pull_parser = vdir_subparsers.add_parser(
+        "pull",
+        parents=[parent_parser],
+        description=append_doc_link(VDIR_PULL_HELP, "vdir/pull"),
+        help=VDIR_PULL_HELP,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    vdir_pull_parser.add_argument(
+        "targets",
+        nargs="*",
+        help=(
+            "Limit command scope to these tracked files/directories, .dvc "
+            "files, or stage names."
+        ),
+        metavar="<targets>",
+    ).complete = completion.FILE
+    vdir_pull_parser.set_defaults(func=CmdVdirPull)
+
+    VDIR_ADD_HELP = "Adds files or directories into the virtual directory."
+
+    vdir_add_parser = vdir_subparsers.add_parser(
+        "add",
+        parents=[parent_parser],
+        description=append_doc_link(VDIR_ADD_HELP, "vdir/add"),
+        help=VDIR_ADD_HELP,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    vdir_add_parser.add_argument(
+        "paths",
+        nargs="*",
+        help=(
+            "Local paths of the files and directories that is added to the "
+            "virtual directory."
+        ),
+        metavar="<paths>",
+    ).complete = completion.FILE
+    vdir_add_parser.set_defaults(func=CmdVdirAdd)

--- a/dvc/command/vdir.py
+++ b/dvc/command/vdir.py
@@ -27,13 +27,13 @@ class CmdVdirPull(CmdVdirBase):
         return 0
 
 
-class CmdVdirAdd(CmdVdirBase):
+class CmdVdirCp(CmdVdirBase):
     def run(self):
         try:
-            self.repo.vdir.add(self.args.paths)
+            self.repo.vdir.cp(self.args.paths)
         except DvcException:
             logger.exception(
-                "failed to add into the virtual directory: {}".format(
+                "failed to cp into the virtual directory: {}".format(
                     self.args.paths
                 )
             )
@@ -43,7 +43,10 @@ class CmdVdirAdd(CmdVdirBase):
 
 
 def add_parser(subparsers, parent_parser):
-    VDIR_HELP = "Commands to transact with virtual directories."
+    VDIR_HELP = (
+        "Commands to transact with virtual directories representing remote "
+        "storages."
+    )
 
     vdir_parser = subparsers.add_parser(
         "vdir",
@@ -82,22 +85,32 @@ def add_parser(subparsers, parent_parser):
     ).complete = completion.FILE
     vdir_pull_parser.set_defaults(func=CmdVdirPull)
 
-    VDIR_ADD_HELP = "Adds files or directories into the virtual directory."
+    VDIR_CP_HELP = "Copies files or directories into the virtual directory."
 
-    vdir_add_parser = vdir_subparsers.add_parser(
-        "add",
+    vdir_cp_parser = vdir_subparsers.add_parser(
+        "cp",
         parents=[parent_parser],
-        description=append_doc_link(VDIR_ADD_HELP, "vdir/add"),
-        help=VDIR_ADD_HELP,
+        description=append_doc_link(VDIR_CP_HELP, "vdir/cp"),
+        help=VDIR_CP_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    vdir_add_parser.add_argument(
-        "paths",
-        nargs="*",
+    vdir_cp_parser.add_argument(
+        "src",
+        help="Source path of the file or directory to be copied.",
+        metavar="<src>",
+    )
+    vdir_cp_parser.add_argument(
+        "dst",
+        help="Destination target path for the file or directory",
+        metavar="<dst>",
+    )
+    vdir_cp_parser.add_argument(
+        "--local-src",
+        action="store_true",
+        default=False,
         help=(
-            "Local paths of the files and directories that is added to the "
-            "virtual directory."
+            "Declare that the src file/dir is from the local workspace instead"
+            "of being remotely tracked by DVC or Git."
         ),
-        metavar="<paths>",
-    ).complete = completion.FILE
-    vdir_add_parser.set_defaults(func=CmdVdirAdd)
+    )
+    vdir_cp_parser.set_defaults(func=CmdVdirCp)

--- a/dvc/dir_info.py
+++ b/dvc/dir_info.py
@@ -47,16 +47,22 @@ def _merge(ancestor, our, their):
 class DirInfo:
     PARAM_RELPATH = "relpath"
 
-    def __init__(self):
+    def __init__(self, vdir=None):
         self.trie = Trie()
+        self.vdir = vdir
 
     @property
     def size(self):
         try:
-            return sum(
-                hash_info.size
+            total = sum(
+                hash_info.size or 0
                 for _, hash_info in self.trie.iteritems()  # noqa: B301
             )
+
+            if not self.vdir:
+                return total
+            return self.vdir.hash_info.size + total
+
         except TypeError:
             return None
 

--- a/dvc/output/base.py
+++ b/dvc/output/base.py
@@ -180,7 +180,8 @@ class BaseOutput:
     def get_hash(self):
         if not self.use_cache:
             return self.tree.get_hash(self.path_info)
-        return self.cache.get_hash(self.tree, self.path_info)
+        self.hash_info = self.cache.get_hash(self.tree, self.path_info)
+        return self.hash_info
 
     @property
     def is_dir_checksum(self):
@@ -287,6 +288,9 @@ class BaseOutput:
     def commit(self):
         if not self.exists:
             raise self.DoesNotExistError(self)
+
+        if self.tree.vdir:
+            self.hash_info = self.stage.outs[0].tree.vdir.hash_info
 
         assert self.hash_info
         if self.use_cache:

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -129,6 +129,7 @@ class Repo:
         from dvc.repo.metrics import Metrics
         from dvc.repo.params import Params
         from dvc.repo.plots import Plots
+        from dvc.repo.vdir import Vdir
         from dvc.stage.cache import StageCache
         from dvc.state import State, StateNoop
         from dvc.tree.local import LocalTree
@@ -177,6 +178,7 @@ class Repo:
             self._ignore()
 
         self.metrics = Metrics(self)
+        self.vdir = Vdir(self)
         self.plots = Plots(self)
         self.params = Params(self)
 

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -30,6 +30,7 @@ def add(
     fname=None,
     external=False,
     glob=False,
+    vdir=None,
 ):
     if recursive and fname:
         raise RecursiveAddingWhileUsingFilename()
@@ -69,6 +70,7 @@ def add(
                 pbar=pbar,
                 external=external,
                 glob=glob,
+                vdir=vdir,
             )
 
             try:
@@ -161,7 +163,7 @@ def _find_all_targets(repo, target, recursive):
 
 
 def _create_stages(
-    repo, targets, fname, pbar=None, external=False, glob=False
+    repo, targets, fname, pbar=None, external=False, glob=False, vdir=None,
 ):
     from glob import iglob
 
@@ -191,7 +193,14 @@ def _create_stages(
             wdir=wdir,
             outs=[out],
             external=external,
+            vdir=vdir,
         )
+        if vdir:
+            vdir.hash_info = stage.reload().outs[0].hash_info
+
+            # inject the dependency
+            stage.outs[0].tree.vdir = vdir
+
         if stage:
             Dvcfile(repo, stage.path).remove()
 

--- a/dvc/repo/vdir/__init__.py
+++ b/dvc/repo/vdir/__init__.py
@@ -7,7 +7,7 @@ class Vdir:
 
         return pull(self.repo, *args, **kwargs)
 
-    def add(self, *args, **kwargs):
-        from .add import add
+    def cp(self, *args, **kwargs):
+        from .cp import cp
 
-        return add(self.repo, *args, **kwargs)
+        return cp(self.repo, *args, **kwargs)

--- a/dvc/repo/vdir/__init__.py
+++ b/dvc/repo/vdir/__init__.py
@@ -1,0 +1,13 @@
+class Vdir:
+    def __init__(self, repo):
+        self.repo = repo
+
+    def pull(self, *args, **kwargs):
+        from .pull import pull
+
+        return pull(self.repo, *args, **kwargs)
+
+    def add(self, *args, **kwargs):
+        from .add import add
+
+        return add(self.repo, *args, **kwargs)

--- a/dvc/repo/vdir/__init__.py
+++ b/dvc/repo/vdir/__init__.py
@@ -1,3 +1,8 @@
+from dataclasses import dataclass
+
+from dvc.hash_info import HashInfo
+
+
 class Vdir:
     def __init__(self, repo):
         self.repo = repo
@@ -11,3 +16,14 @@ class Vdir:
         from .cp import cp
 
         return cp(self.repo, *args, **kwargs)
+
+
+@dataclass
+class VirtualDirData:
+    operation: str  # e.g. cp, mv, rm
+    src: str
+    dst: str
+    rm_paths: list
+
+    local_src: bool = True  # only for cp
+    hash_info: HashInfo = None

--- a/dvc/repo/vdir/add.py
+++ b/dvc/repo/vdir/add.py
@@ -1,2 +1,0 @@
-def add(repo, *args, **kwargs):
-    return ""

--- a/dvc/repo/vdir/add.py
+++ b/dvc/repo/vdir/add.py
@@ -1,0 +1,2 @@
+def add(repo, *args, **kwargs):
+    return ""

--- a/dvc/repo/vdir/cp.py
+++ b/dvc/repo/vdir/cp.py
@@ -1,2 +1,28 @@
-def cp(repo, *args, **kwargs):
-    return ""
+from glob import glob
+from shutil import copy
+
+from dvc.path_info import PosixPathInfo
+from dvc.repo.add import add
+
+from . import VirtualDirData
+
+
+def cp(repo, src=None, dst=None, local_src=False):
+
+    if local_src:
+        copy(src, dst)
+
+    vdir = VirtualDirData(
+        operation="cp", src=src, dst=dst, rm_paths=None, local_src=local_src
+    )
+    target = _derive_target(dst)
+
+    return add(repo, target, vdir=vdir)
+
+
+# TODO: find similar util func in dvc
+def _derive_target(dst):
+    for p in PosixPathInfo(dst).parts:
+        for g in glob("*.dvc"):
+            if p in g:
+                return p

--- a/dvc/repo/vdir/cp.py
+++ b/dvc/repo/vdir/cp.py
@@ -1,0 +1,2 @@
+def cp(repo, *args, **kwargs):
+    return ""

--- a/dvc/repo/vdir/pull.py
+++ b/dvc/repo/vdir/pull.py
@@ -1,0 +1,2 @@
+def pull(repo, *args, **kwargs):
+    return ""

--- a/dvc/repo/vdir/pull.py
+++ b/dvc/repo/vdir/pull.py
@@ -1,2 +1,42 @@
-def pull(repo, *args, **kwargs):
-    return ""
+from pathlib import Path
+
+from .. import locked
+
+
+@locked
+def pull(
+    repo,
+    targets=None,
+    jobs=None,
+    remote=None,
+    all_branches=False,
+    with_deps=False,
+    all_tags=False,
+    recursive=False,
+    all_commits=False,
+):
+    used = repo.used_cache(
+        targets,
+        all_branches=all_branches,
+        all_tags=all_tags,
+        all_commits=all_commits,
+        with_deps=with_deps,
+        force=True,
+        remote=remote,
+        jobs=jobs,
+        recursive=recursive,
+    )
+
+    dirs = _create_dirs(used)
+
+    return dirs
+
+
+def _create_dirs(used):
+    dirs = set()
+    for _, files in used.scheme_names("local"):
+        for f in files:
+            d = Path(f).parent
+            dirs.add(d)
+            d.mkdir(parents=True, exist_ok=True)
+    return dirs


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

---------

# 1. Overview
Attempts to introduce a **Proof of Concept** for #4657 

> **NOTES**: I haven't added the tests for now in case the entire approach **could change** based on users' feedback. Though I've tested it in my local env to make sure that the mechanism works okay.

# 2. Proposal

The proposed approach is to create a “virtual” directory inside the local workspace that reflects the large data sets being contained in remote storage. In this way, users can **navigate** and **transact** with it without the need for the actual data files to be present locally.

# 3. Current State of the POC

## 3.1 Sample Workflow

Suppose we have the following remote storage directory structure:
```
$ tree data/
data
├── train
│   ├── dog.1.jpg
│   ├── ...
│   └── dog.800_000.jpg
└── validation
    ├── dog.800_001.jpg
    ├── ...
    └── dog.1_000_000.jpg
```

As we can see, it contains **1 Million images** which can take a long time to download.  🐌  

The main objective is to create a workflow that prevents us from downloading 100% of the dataset and yet is still able to perform the following file transactions:

- **cp** (_because we're still at the POC stage, only this one is implemented for now._)
- **rm**
- **mv**

	> **NOTES:** Only the `cp` and `rm` operations were primarily discussed in the #4657 issue. However, I think it’s also worth considering the `mv` use case since it can potentially affect the overall implementation.

The first step is to perform the following new `dvc vdir` command with its `pull` subcommand:

```
$ dvc vdir pull data/
$ tree data/
data
├── train
└── validation
```

This does the following:
1. Recreate the directory structure of the remote storage into the local workspace.
	* This is useful for helping users navigate the directory structure so they can easily `add` files around.
	* However, this becomes a bit of a challenge for `rm` and `mv` operations since only the directory structure is created and the actual files are not.
2. Downloads the hash values and tracked data files in `.dvc/cache/xx/<hash>.dir`. This is important to recalculate the new hash later on, as well as being used as a reference for other operations. This is how it looks like:
```
$ jq '.[0:3]' .dvc/cache/22/e3f61e52c0ba45334d973244efc155.dir
[
  {
    "md5": "ed779276108738fdb2179ccabf9680d9",
    "relpath": "data/train/dog.1.jpg"
  },
  {
    "md5": "10d2a131081a3095726c5721ed31c21f",
    "relpath": "data/train/dog.10.jpg"
  },
  {
    "md5": "0f2bfe74e9c363064087d0cd8a322106",
    "relpath": "data/train/dog.100.jpg"
  }
]
```

Now that we have the essential information about the data set, we can now add a single file using:
```
$ dvc vdir cp --local-data ~/my-personal-dataset/dog.1_000_001.jpg ./data/validation/
```

It does the following:
* Copies the local `<src>` file into the workspace
* Calculate the hash for the new `dog.1_000_001.jpg` file
* Update `.dvc/cache/xx/<hash>.dir` with the new data entry
* Update the `data.dvc`

So far, this is the current status of our workspace:
```
$ tree data/
data
├── train
└── validation
    └── dog.1_000_001.jpg

$ git status  # note: truncated some other output lines below

        modified:   data.dvc

$ cat data.dvc
outs:
- md5: e1a0cf7fcebe1c12bc0adeaf7ca38dfd.dir
  size: 247416247
  nfiles: 1000001
  path: data
```
> **NOTE:** The `md5`, `size`, `nfiles` were updated inside the `data.dvc` file.

The user can then proceed with the **_usual_ workflow**:

```
$ dvc push data/

$ git add data.dvc
$ git commit -m "update validation set"
$ git push
```

# 4. Other functionalities beyond the MVP/POC

## 4.1 Proposed additional commands/behavior

To create a more hollistic user workflow revolving around **_"partially updating large data sets"_**, the following features in **section 4.1.x** are also proposed:

### 4.1.1 `dvc vdir cp` <sup>_(default: `<src>` file is in remote storage)_</sup>

The current implementation only works when a `--local-src` flag is present since adding additional files is only supported locally (_it was the one that was specifically required in #4657)_.

In the future, users could opt to use tracked files from remote storages as sources directly. However, it's mostly an illusion because it's mainly an abstraction of:
1. Download the `<src>` file from the **source** remote storage into the local workspace.
2. Proceed with the usual `dvc vdir cp --local-src <src-somewhere-in-tmp> <dst>`

### ~4.1.2 `dvc vdir list` <sup>✨ new subcommand ✨</sup>~

(_**UPDATE**: dropped the proposed `dvc vdir list` in lieu of the existing `dvc list` command. See https://github.com/iterative/dvc/pull/4900#issuecomment-731583821 below._)

~Since the files are not downloaded when performing `dvc vdir pull`, users need a way to navigate through this “virtual” directory. We can use the file paths in `.dvc/cache/xx/<hash>.dir` as reference for listing out the files:~
```
$ tree data/
data
├── train
└── validation

$ dvc vdir list data/train
dog.1.jpg
dog.10.jpg
dog.100.jpg

# ... and so on ...
```

~Filtering out the files could then be something like:~

- `dvc vdir list data/train | head`
- `dvc vdir list data/train | tail`
- `dvc vdir list data/train | less`
- `dvc vdir list data/train | grep <expr>`


### 4.1.3 `dvc vdir rm` <sup>✨ new subcommand ✨</sup>

```
$ dvc vdir rm ./data/validation/dog.999_999.jpg
```

Does the following:
- Removes the corresponding entries in `.dvc/cache/xx/<hash>.dir`, specifically removing the deleted file.
- Calculate the hash for the entire `data/`
- Update `.dvc/cache/xx/<hash>.dir` with the deleted file entry

### 4.1.4 `dvc vdir mv` <sup>✨ new subcommand ✨</sup>

```
$ dvc vdir mv ./data/validation/dog.800_001.jpg ./data/validation/dog.800_001-renamed.jpg
```

Does the following:
- Calculate the hash of the new `dog.800_001-renamed.jpg file` _(or even just reuse the hash)_
- Updates the corresponding entries in `.dvc/cache/xx/<hash>.dir`, specifically the paths that were moved.

> **NOTES:** Could just reuse `dvc vdir cp` and `dvc vdir rm` underneath.

# 5. Caveats

- A user that is **renaming/moving** a file could **_unintentionally_ overwrite** another file if the `<dst>` path already exists for another file.
	- We could implement a check during `dvc vdir mv <src> <dst>` if another file from the `<dst>` is already being tracked.
- However, it’s a much harder scenario for copying a file with potential conflicts.
	- We could create a check during `dvc vdir cp` but the system could treat it as a valid and intentional file update operation.


# 6. Tracking some Thoughts/Ideas

Some thoughts/ideas after discussing with @shcheklein and @dmpetrov.

1. The `dvc vdir pull <target>` could simply be merged into the existing `dvc pull` command by adding a param like `--vdir`, or `--dir-only`, etc.

~2. The `dvc vdir list` could also be merged into the existing `dvc list` command using a new param like `--vdir`, or `--dir-only`, etc.~ (_**UPDATE**: dropped the proposed `dvc vdir list` in lieu of the existing `dvc list` command. See https://github.com/iterative/dvc/pull/4900#issuecomment-731583821 below._)

3. Consider defining `--rev` for **src** and **dst**. 


# 7. Checklist

## 7.1 Documentation Updates

- [ ] New Command: `dvc vdir` (doc/command-reference/vdir)
	- [ ] subcommand: `pull`
	- [ ] ~subcommand: `list` <sup>_(not implemented yet for the POC)_</sup>~  (_**UPDATE**: dropped the proposed `dvc vdir list` in lieu of the existing `dvc list` command. See https://github.com/iterative/dvc/pull/4900#issuecomment-731583821 below._)
	- [ ] subcommand: `cp`
	- [ ] subcommand: `rm` <sup>_(not implemented yet for the POC)_</sup>
	- [ ] subcommand: `mv` <sup>_(not implemented yet for the POC)_</sup>
- [ ] New User Guide: **"Partially Updating Large Datasets"** (doc/user-guide/how-to)
	- Focus on without the need to download them first.
	- Also emphasize on the dangers mentioned in the “Caveats” section.
	- Show some examples for piping UNIX commands in the dvc vdir list <path> approach in order to better filter out large quantities of - results.

## 7.2 Tests

> **NOTE**: I'll be working on this as soon as the users are happy with the proposed workflow/apprach.

- [ ] Fix Failing tests
- [ ] Create new tests







