### PR TITLE
Bugfix: pop checkpoint resume from kwargs in experiments

### DIFF
--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -437,15 +437,21 @@ class Experiments:
 
     @scm_locked
     def new(
-        self, *args, branch: Optional[str] = None, **kwargs,
+        self,
+        *args,
+        branch: Optional[str] = None,
+        checkpoint_resume: Optional[str] = None,
+        **kwargs,
     ):
         """Create a new experiment.
 
         Experiment will be reproduced and checked out into the user's
         workspace.
         """
-        if kwargs.get("checkpoint_resume", None) is not None:
-            return self._resume_checkpoint(*args, **kwargs)
+        if checkpoint_resume is not None:
+            return self._resume_checkpoint(
+                *args, **kwargs, checkpoint_resume=checkpoint_resume
+            )
 
         if branch:
             rev = self.scm.resolve_rev(branch)


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

## Purpose
I believe #4855 introduced a regression to do with experiments, checkpoints, and run cache. #4911 seems to have tried to address it, but I still get the same error:
```
2020-11-19 19:10:05,223 ERROR: Failed to reproduce experiment 'a32ea21' - failed to reproduce 'dvc.yaml': restore() got an unexpected keyword argument 'checkpoint_resume'
------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/dvc/repo/reproduce.py", line 175, in _reproduce_stages
    ret = _reproduce_stage(stage, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/dvc/repo/reproduce.py", line 36, in _reproduce_stage
    stage = stage.reproduce(**kwargs)
  File "/usr/local/lib/python3.8/dist-packages/funcy/decorators.py", line 39, in wrapper
    return deco(call, *dargs, **dkwargs)
  File "/usr/local/lib/python3.8/dist-packages/dvc/stage/decorators.py", line 36, in rwlocked
    return call()
  File "/usr/local/lib/python3.8/dist-packages/funcy/decorators.py", line 60, in __call__
    return self._func(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.8/dist-packages/dvc/stage/__init__.py", line 339, in reproduce
    self.run(**kwargs)
  File "/usr/local/lib/python3.8/dist-packages/funcy/decorators.py", line 39, in wrapper
    return deco(call, *dargs, **dkwargs)
  File "/usr/local/lib/python3.8/dist-packages/dvc/stage/decorators.py", line 36, in rwlocked
    return call()
  File "/usr/local/lib/python3.8/dist-packages/funcy/decorators.py", line 60, in __call__
    return self._func(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.8/dist-packages/dvc/stage/__init__.py", line 465, in run
    run_stage(self, dry, force, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/dvc/stage/run.py", line 106, in run_stage
    stage.repo.stage_cache.restore(stage, **kwargs)
TypeError: restore() got an unexpected keyword argument 'checkpoint_resume'
```

## Approach
After digging through the code, I found a spot where it seems like the `checkpoint_resume` parameter should be removed from the set of `kwargs` before continuing. I don't see `checkpoint_resume` being used anywhere outside of `dvc.repo.experiments.new` and `dvc.repo.experiments._resume_checkpoint()`, and the former calls the latter and is the only function to do so, so I think this fix is correct.

I spent **a lot** of time trying to write a test that captured this bug, but I failed. :cry: When I compare what's happening in the stack trace between my repo and the test case, I find a difference here:
https://github.com/iterative/dvc/blob/4cf2f8139bdd2c30d439dea1bb7375ddb63e46d0/dvc/repo/reproduce.py#L169-L172

In my repo `kwargs["checkpoint_func"]` gets set to None, whereas it's a function in the test case. Then when we get to `dvc.stage.run.run_stage()`, we hit this condition:
https://github.com/iterative/dvc/blob/4cf2f8139bdd2c30d439dea1bb7375ddb63e46d0/dvc/stage/run.py#L101-L109

Which then causes the error.