### PR TITLE
Fix exp checkout queued and cleanup

### DIFF
--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -841,7 +841,7 @@ class Experiments:
         self._scm_checkout(rev)
 
         branch = self._get_branch_containing(rev)
-        m = self.BRANCH_RE.match(branch)
+        m = self.BRANCH_RE.match(branch) if branch else None
         if m and m.group("checkpoint"):
             kwargs.update({"allow_missing": True, "quiet": True})
 
@@ -868,6 +868,9 @@ class Experiments:
             remove(tmp)
             if dirty:
                 self._unstash_workspace()
+            args_file = os.path.join(self.repo.tmp_dir, self.PACKED_ARGS_FILE)
+            if os.path.exists(args_file):
+                remove(args_file)
 
         if need_checkout:
             dvc_checkout(self.repo, **kwargs)


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

## Purpose
#4823 introduced a regression with checking out of queued experiments:
```
2020-11-19 22:42:52,775 DEBUG: Checking out experiment commit '243e010'
2020-11-19 22:42:52,788 DEBUG: fetched: [(793,)]
2020-11-19 22:42:52,806 ERROR: unexpected error - expected string or bytes-like object
------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/dvc/main.py", line 90, in main
    ret = cmd.run()
  File "/usr/local/lib/python3.8/dist-packages/dvc/command/experiments.py", line 360, in run
    self.repo.experiments.checkout(self.args.experiment)
  File "/usr/local/lib/python3.8/dist-packages/dvc/repo/experiments/__init__.py", line 965, in checkout
    return checkout(self.repo, *args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/dvc/repo/__init__.py", line 54, in wrapper
    return f(repo, *args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/dvc/repo/scm_context.py", line 4, in run
    result = method(repo, *args, **kw)
  File "/usr/local/lib/python3.8/dist-packages/dvc/repo/experiments/checkout.py", line 12, in checkout
    repo.experiments.checkout_exp(rev, *args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/dvc/repo/experiments/__init__.py", line 38, in wrapper
    return f(exp, *args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/dvc/repo/experiments/__init__.py", line 844, in checkout_exp
    m = self.BRANCH_RE.match(branch)
TypeError: expected string or bytes-like object
------------------------------------------------------------
2020-11-19 22:42:52,933 DEBUG: Version info for developers:
DVC version: 1.10.1 (pip)
---------------------------------
Platform: Python 3.8.0 on Linux-5.4.0-53-generic-x86_64-with-glibc2.27
Supports: http, https, s3
Cache types: hardlink, symlink
Caches: local
Remotes: s3, s3
Repo: dvc, git
```

## Approach
* Check if `branch` is not None (no branch = queued experiment) before trying to match with regex
* Added tests to check the queued case
* While fixing the code to make the tests pass, I found a fix to another issue that had been bothering me. `dvc/tmp/repro.dat` gets left behind after checkouts, leading to future checkouts failing because the file already exists. Specifically, the call to `git apply` below fails because the file already exists: https://github.com/iterative/dvc/blob/4cf2f8139bdd2c30d439dea1bb7375ddb63e46d0/dvc/repo/experiments/__init__.py#L858-L866