### PR TITLE
Copy features to exp repo

### DIFF
--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -593,6 +593,7 @@ class Experiments:
                 dvc_dir=self.dvc_dir,
                 cache_dir=self.repo.cache.local.cache_dir,
                 checkpoint_reset=checkpoint_reset,
+                features=self.repo.config.get("feature", {}),
             )
             self._collect_input(executor)
             executors[rev] = executor


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

# Purpose
I use both experiments and parameterization in my workflow. Unfortunately, when an experiment is run, the parametrization feature is not enabled in the experiment repo, causing parametrized stages to fail as the experiment repo looks for the non-parameterized stage:
```
2020-11-20 00:33:12,021 ERROR: unexpected error
------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/dvc/main.py", line 90, in main
    ret = cmd.run()
  File "/usr/local/lib/python3.8/dist-packages/dvc/command/experiments.py", line 462, in run
    self.repo.experiments.run(
  File "/usr/local/lib/python3.8/dist-packages/dvc/repo/experiments/__init__.py", line 990, in run
    return run(self.repo, *args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/dvc/repo/__init__.py", line 54, in wrapper
    return f(repo, *args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/dvc/repo/experiments/run.py", line 61, in run
    return repo.experiments.reproduce_one(
  File "/usr/local/lib/python3.8/dist-packages/dvc/repo/experiments/__init__.py", line 420, in reproduce_one
    results = self.reproduce([stash_rev], keep_stash=False)
  File "/usr/local/lib/python3.8/dist-packages/dvc/repo/experiments/__init__.py", line 38, in wrapper
    return f(exp, *args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/dvc/repo/experiments/__init__.py", line 601, in reproduce
    exec_results = self._reproduce(executors, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/dvc/repo/experiments/__init__.py", line 662, in _reproduce
    self._collect_executor(
  File "/usr/local/lib/python3.8/dist-packages/dvc/repo/experiments/__init__.py", line 679, in _collect_executor
    exp_hash = hash_exp(stages)
  File "/usr/local/lib/python3.8/dist-packages/dvc/repo/experiments/__init__.py", line 47, in hash_exp
    exp_data.update(to_lockfile(stage))
  File "/usr/local/lib/python3.8/dist-packages/dvc/stage/serialize.py", line 171, in to_lockfile
    return {stage.name: to_single_stage_lockfile(stage)}
  File "/usr/local/lib/python3.8/dist-packages/dvc/stage/serialize.py", line 142, in to_single_stage_lockfile
    assert stage.cmd
AssertionError
------------------------------------------------------------
2020-11-20 00:33:12,094 DEBUG: Version info for developers:
DVC version: 1.10.1 (pip)
---------------------------------
Platform: Python 3.8.0 on Linux-5.4.0-53-generic-x86_64-with-glibc2.27
Supports: http, https, s3
Cache types: hardlink, symlink
Caches: local
Remotes: s3, s3
Repo: dvc, git
```

## Approach
Copy over the features that are enabled in the main repo into the experiment repo. There are other configs that should probably be copied over as well (e.g. custom remotes, I had to stop using them because they didn't work with experiments), but I figured this is a good start.
