### PR TITLE
parametrization: Skip already used vars, even if they are in a relative path.

### DIFF
--- a/dvc/parsing/__init__.py
+++ b/dvc/parsing/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
@@ -35,11 +36,11 @@ class DataResolver:
         self.data: dict = d
         self.wdir = wdir
         self.repo = repo
-        self.imported_files: Set[PathInfo] = set()
+        self.imported_files: Set[str] = set()
 
         to_import: PathInfo = wdir / DEFAULT_PARAMS_FILE
         if repo.tree.exists(to_import):
-            self.imported_files = {to_import}
+            self.imported_files = {os.path.abspath(to_import)}
             self.global_ctx = Context.load_from(repo.tree, str(to_import))
         else:
             self.global_ctx = Context()
@@ -58,12 +59,12 @@ class DataResolver:
         context: "Context",
         vars_: List,
         wdir: PathInfo,
-        skip_imports: Set[PathInfo],
+        skip_imports: Set[str],
     ):
         for item in vars_:
             assert isinstance(item, (str, dict))
             if isinstance(item, str):
-                path = wdir / item
+                path = os.path.abspath(wdir / item)
                 if path in skip_imports:
                     continue
 

--- a/tests/func/test_stage_resolver.py
+++ b/tests/func/test_stage_resolver.py
@@ -485,3 +485,20 @@ def test_resolve_local_tries_to_load_globally_used_params_yaml(tmp_dir, dvc):
             }
         },
     )
+
+
+def test_vars_relpath_overwrite(tmp_dir, dvc):
+    iterable = {"bar": "bar", "foo": "foo"}
+    dump_yaml(tmp_dir / "params.yaml", iterable)
+    d = {
+        "vars": ["params.yaml"],
+        "stages": {
+            "build": {
+                "wdir": "data",
+                "cmd": "echo ${bar}",
+                "vars": ["../params.yaml"],
+            }
+        },
+    }
+    resolver = DataResolver(dvc, PathInfo(str(tmp_dir)), d)
+    resolver.resolve()


### PR DESCRIPTION

Previously, "dir/../params.yaml" would have thrown an OverwriteError.



* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
