### PR TITLE
diff: add support for --targets

### DIFF
--- a/dvc/command/diff.py
+++ b/dvc/command/diff.py
@@ -174,9 +174,8 @@ def add_parser(subparsers, parent_parser):
         "--targets",
         nargs="*",
         help=(
-            "Source paths to a data files or directories. Default None. "
-            "If not specified, compares all files and directories `). "
-            "that are under DVC control in the current working space."
+            "Limit command scope to these tracked files or directories. "
+            "Accepts one or more file paths."
         ),
     ).complete = completion.FILE
     diff_parser.add_argument(

--- a/dvc/command/diff.py
+++ b/dvc/command/diff.py
@@ -127,7 +127,9 @@ class CmdDiff(CmdBase):
 
     def run(self):
         try:
-            diff = self.repo.diff(self.args.a_rev, self.args.b_rev)
+            diff = self.repo.diff(
+                self.args.a_rev, self.args.b_rev, self.args.target
+            )
             show_hash = self.args.show_hash
             hide_missing = self.args.b_rev or self.args.hide_missing
             if hide_missing:
@@ -166,6 +168,15 @@ def add_parser(subparsers, parent_parser):
         description=append_doc_link(DIFF_DESCRIPTION, "diff"),
         help=DIFF_DESCRIPTION,
         formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    diff_parser.add_argument(
+        "-t",
+        "--target",
+        help=(
+            "Source path to a data file or directory. Default None. "
+            "If not specified, compares all files and directories "
+            "that are under DVC control in the current working space."
+        ),
     )
     diff_parser.add_argument(
         "a_rev",

--- a/dvc/command/diff.py
+++ b/dvc/command/diff.py
@@ -5,6 +5,7 @@ import os
 
 import colorama
 
+from dvc.command import completion
 from dvc.command.base import CmdBase, append_doc_link
 from dvc.exceptions import DvcException
 
@@ -128,7 +129,7 @@ class CmdDiff(CmdBase):
     def run(self):
         try:
             diff = self.repo.diff(
-                self.args.a_rev, self.args.b_rev, self.args.target
+                self.args.a_rev, self.args.b_rev, self.args.targets
             )
             show_hash = self.args.show_hash
             hide_missing = self.args.b_rev or self.args.hide_missing
@@ -170,14 +171,14 @@ def add_parser(subparsers, parent_parser):
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     diff_parser.add_argument(
-        "-t",
-        "--target",
+        "--targets",
+        nargs="*",
         help=(
-            "Source path to a data file or directory. Default None. "
-            "If not specified, compares all files and directories "
+            "Source paths to a data files or directories. Default None. "
+            "If not specified, compares all files and directories `). "
             "that are under DVC control in the current working space."
         ),
-    )
+    ).complete = completion.FILE
     diff_parser.add_argument(
         "a_rev",
         help="Old Git commit to compare (defaults to HEAD)",

--- a/dvc/path_info.py
+++ b/dvc/path_info.py
@@ -19,7 +19,23 @@ class _BasePath:
         return self.isin_or_eq(other) or other.isin(self)
 
     def isin_or_eq(self, other):
+        if isinstance(other, list):
+            others = other
+
+            for other in others:
+                if self.isin_or_eq(other):
+                    return True
+
+            return False
+
         return self == other or self.isin(other)  # pylint: disable=no-member
+
+    def isinside(self, others):
+        for other in others:
+            if other.isin(self):
+                return True
+
+        return False
 
 
 class PathInfo(pathlib.PurePath, _BasePath):

--- a/dvc/path_info.py
+++ b/dvc/path_info.py
@@ -19,23 +19,7 @@ class _BasePath:
         return self.isin_or_eq(other) or other.isin(self)
 
     def isin_or_eq(self, other):
-        if isinstance(other, list):
-            others = other
-
-            for other in others:
-                if self.isin_or_eq(other):
-                    return True
-
-            return False
-
         return self == other or self.isin(other)  # pylint: disable=no-member
-
-    def isinside(self, others):
-        for other in others:
-            if other.isin(self):
-                return True
-
-        return False
 
 
 class PathInfo(pathlib.PurePath, _BasePath):

--- a/dvc/repo/diff.py
+++ b/dvc/repo/diff.py
@@ -118,16 +118,16 @@ def _output_paths(repo, targets):
     for stage in repo.stages:
         for output in stage.outs:
             if _exists(output):
-                if targets is None or any(
-                    output.path_info == target for target in targets
-                ):
+                yield_output = targets is None or any(
+                    output.path_info.isin_or_eq(target) for target in targets
+                )
+
+                if yield_output:
                     yield _to_path(output), _to_checksum(output)
 
-                    if output.is_dir_checksum:
-                        yield from _dir_output_paths(repo_tree, output)
-
-                elif output.is_dir_checksum and any(
-                    target.isin(output.path_info) for target in targets
+                if output.is_dir_checksum and (
+                    yield_output
+                    or any(target.isin(output.path_info) for target in targets)
                 ):
                     yield from _dir_output_paths(repo_tree, output, targets)
 

--- a/tests/func/test_diff.py
+++ b/tests/func/test_diff.py
@@ -274,9 +274,6 @@ def setup_targets_test(tmp_dir):
 
     tmp_dir.dvc_gen(os.path.join("dir_with", "file.txt"), "first")
 
-    remove(tmp_dir / ".dvc" / "cache")
-    (tmp_dir / ".dvc" / "tmp" / "state").unlink()
-
 
 def test_targets_missing_path(tmp_dir, scm, dvc):
     from dvc.exceptions import PathMissingError
@@ -326,8 +323,6 @@ def test_targets_single_dir(tmp_dir, scm, dvc):
 def test_targets_single_file_in_dir(tmp_dir, scm, dvc):
     setup_targets_test(tmp_dir)
 
-    dvc.diff(targets=["dir" + os.path.sep])
-
     assert dvc.diff(targets=[os.path.join("dir", "1")]) == {
         "added": [{"path": os.path.join("dir", "1"), "hash": digest("1")}],
         "deleted": [],
@@ -338,8 +333,6 @@ def test_targets_single_file_in_dir(tmp_dir, scm, dvc):
 
 def test_targets_two_files_in_dir(tmp_dir, scm, dvc):
     setup_targets_test(tmp_dir)
-
-    dvc.diff(targets=["dir" + os.path.sep])
 
     assert dvc.diff(
         targets=[os.path.join("dir", "1"), os.path.join("dir", "2")]

--- a/tests/func/test_diff.py
+++ b/tests/func/test_diff.py
@@ -274,6 +274,8 @@ def test_targets(tmp_dir, scm, dvc):
     tmp_dir.dvc_gen({"dir": {"1": "1", "2": "2"}})
     tmp_dir.dvc_gen("file", "second")
 
+    tmp_dir.dvc_gen(os.path.join("dir_with", "file.txt"), "first")
+
     remove(tmp_dir / ".dvc" / "cache")
     (tmp_dir / ".dvc" / "tmp" / "state").unlink()
 
@@ -305,7 +307,7 @@ def test_targets(tmp_dir, scm, dvc):
         "not in cache": [],
     }
 
-    assert dvc.diff(targets=["dir/"]) == {
+    assert dvc.diff(targets=["dir" + os.path.sep]) == {
         "added": [
             {"path": os.path.join("dir", ""), "hash": dir_checksum},
             {"path": os.path.join("dir", "1"), "hash": digest("1")},
@@ -316,14 +318,16 @@ def test_targets(tmp_dir, scm, dvc):
         "not in cache": [],
     }
 
-    assert dvc.diff(targets=["dir/1"]) == {
+    assert dvc.diff(targets=[os.path.join("dir", "1")]) == {
         "added": [{"path": os.path.join("dir", "1"), "hash": digest("1")}],
         "deleted": [],
         "modified": [],
         "not in cache": [],
     }
 
-    assert dvc.diff(targets=["dir/1", "dir/2"]) == {
+    assert dvc.diff(
+        targets=[os.path.join("dir", "1"), os.path.join("dir", "2")]
+    ) == {
         "added": [
             {"path": os.path.join("dir", "1"), "hash": digest("1")},
             {"path": os.path.join("dir", "2"), "hash": digest("2")},
@@ -346,5 +350,41 @@ def test_targets(tmp_dir, scm, dvc):
                 "hash": {"old": digest("first"), "new": digest("second")},
             }
         ],
+        "not in cache": [],
+    }
+
+    assert dvc.diff(targets=["dir_with"]) == {
+        "added": [
+            {
+                "path": os.path.join("dir_with", "file.txt"),
+                "hash": digest("first"),
+            },
+        ],
+        "deleted": [],
+        "modified": [],
+        "not in cache": [],
+    }
+
+    assert dvc.diff(targets=["dir_with" + os.path.sep]) == {
+        "added": [
+            {
+                "path": os.path.join("dir_with", "file.txt"),
+                "hash": digest("first"),
+            },
+        ],
+        "deleted": [],
+        "modified": [],
+        "not in cache": [],
+    }
+
+    assert dvc.diff(targets=[os.path.join("dir_with", "file.txt")]) == {
+        "added": [
+            {
+                "path": os.path.join("dir_with", "file.txt"),
+                "hash": digest("first"),
+            },
+        ],
+        "deleted": [],
+        "modified": [],
         "not in cache": [],
     }


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

***

Will close #3388.

The filter code needs to be improved (something smarter than starts with) and I think an error needs to be outputted if the target parameter is not found in the list of tracked files or folders. The documentation will also need to be updated accordingly once this is merged.

For now I've started with the original behaviour the issue started with (optional `--target` arg). Let me know if the behaviour from comment https://github.com/iterative/dvc/issues/3388#issuecomment-590692837 would be preferred (`dvc diff [-h] [-q | -v] [-t TARGET] [--show-json] [--show-hash] [--show-md] [--hide-missing] [a_rev] [b_rev] [targets [targets]]`).
