### PR TITLE
ci: reduce no. of macOS jobs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,13 +37,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, windows-2019, macos-10.15, macos-11.0]
+        os: [ubuntu-18.04, windows-2019, macos-10.15]
         pyv: ["3.6", "3.7", "3.8", "3.9"]
+        include:
+          - os: "macos-11.0"
+            pyv: "3.9"
         exclude:
-          - os: macos-11.0
-            pyv: "3.6"
-          - os: macos-11.0
-            pyv: "3.7"
+          - os: macos-10.15
+            pyv: "3.9"
+
     steps:
     - uses: actions/checkout@v2.3.2
     - name: Set up Python
@@ -70,7 +72,7 @@ jobs:
       uses: codecov/codecov-action@v1.0.13
       with:
         file: ./coverage.xml
-        fail_ci_if_error: true
+        fail_ci_if_error: false
     - name: Post TAP
       # Running custom fork with an option, that does not fail CI on error
       uses: skshetry/flaky-service/packages/action@master


### PR DESCRIPTION
This was increasing the wait times of the CI.

Also enabled codecov failure to not fail the whole CI pipeline, while I was at it.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
