### PR TITLE
tests: increase ulimit to 4096

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,7 +12,7 @@ if os.name == "nt":
 
     import win32file  # pylint: disable=import-error
 
-    win32file._setmaxstdio(2048)
+    win32file._setmaxstdio(4096)
 
     # Workaround for two bugs:
     #
@@ -41,7 +41,7 @@ if os.name == "nt":
 else:
     import resource
 
-    resource.setrlimit(resource.RLIMIT_NOFILE, (2048, 2048))
+    resource.setrlimit(resource.RLIMIT_NOFILE, (4096, 4096))
 
     nproc_soft, nproc_hard = resource.getrlimit(resource.RLIMIT_NPROC)
     resource.setrlimit(resource.RLIMIT_NPROC, (nproc_hard, nproc_hard))


### PR DESCRIPTION
For some reason, tests on my machine started failing with 2048, though it's near to the end, so it needs to be a bit higher than 2048.

Also, the test was run without `--all`. 

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
