### PR TITLE
tests: move some flags from `python -m tests` to config

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -67,7 +67,7 @@ jobs:
         mkdir -p scripts/ci
         echo "$GS_CREDS_JSON" > scripts/ci/gcp-creds.json
     - name: run tests
-      run: python -m tests --all -ra --cov-report=xml --cov-report=term --tap-combined
+      run: python -m tests --all --cov-report=xml --cov-report=term --tap-combined
     - name: upload coverage report
       uses: codecov/codecov-action@v1.0.13
       with:

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,3 +18,9 @@ count=true
 profile=black
 known_first_party=dvc,tests
 line_length=79
+
+[tool:pytest]
+timeout = 600
+timeout_method = thread
+log_level = debug
+addopts = -ra

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -16,8 +16,5 @@ os.putenv("DVC_HOME", REPO_ROOT)
 
 params = " ".join(sys.argv[1:])
 
-cmd = (
-    "py.test -v -n=4 --timeout=600 --timeout_method=thread --log-level=debug"
-    " --cov=dvc {params} --durations=0".format(params=params)
-)
+cmd = "pytest -v -n=4 --cov=dvc --durations=0 {params}".format(params=params)
 check_call(cmd, shell=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+from contextlib import suppress
 
 import pytest
 
@@ -30,7 +31,11 @@ def reset_loglevel(request, caplog):
     Use it to ensure log level at the start of each test
     regardless of dvc.logger.setup(), Repo configs or whatever.
     """
-    level = request.config.getoption("--log-level")
+    ini_opt = None
+    with suppress(ValueError):
+        ini_opt = request.config.getini("log_level")
+
+    level = request.config.getoption("--log-level") or ini_opt
     if level:
         with caplog.at_level(level.upper(), logger="dvc"):
             yield


### PR DESCRIPTION
Some of the flags from `python -m tests` are moved to `setup.cfg`, so that plain `pytest` works the same way.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
