### PR TITLE
parametrization: prevent dumping parametrized stages

### DIFF
--- a/dvc/dvcfile.py
+++ b/dvc/dvcfile.py
@@ -203,7 +203,7 @@ class PipelineFile(FileMixin):
 
     @staticmethod
     def _check_if_parametrized(stage):
-        if stage.meta.parametrized:
+        if stage.raw_data.parametrized:
             raise ParametrizedDumpError(f"cannot dump a parametrized {stage}")
 
     def _dump_pipeline_file(self, stage):

--- a/dvc/dvcfile.py
+++ b/dvc/dvcfile.py
@@ -36,6 +36,10 @@ class LockfileCorruptedError(DvcException):
     pass
 
 
+class ParametrizedDumpError(DvcException):
+    pass
+
+
 def is_valid_filename(path):
     return path.endswith(DVC_FILE_SUFFIX) or os.path.basename(path) in [
         DVC_FILE,
@@ -197,7 +201,13 @@ class PipelineFile(FileMixin):
     def _dump_lockfile(self, stage):
         self._lockfile.dump(stage)
 
+    @staticmethod
+    def _check_if_parametrized(stage):
+        if stage.meta.parametrized:
+            raise ParametrizedDumpError(f"cannot dump a parametrized {stage}")
+
     def _dump_pipeline_file(self, stage):
+        self._check_if_parametrized(stage)
         stage_data = serialize.to_pipeline_file(stage)
 
         with modify_yaml(self.path, tree=self.repo.tree) as data:

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -2,6 +2,8 @@ import logging
 import os
 import string
 from collections import defaultdict
+from dataclasses import dataclass
+from typing import Optional
 
 from funcy import cached_property, project
 
@@ -58,6 +60,12 @@ def loads_from(cls, repo, path, wdir, data):
         ),
     }
     return cls(**kw)
+
+
+@dataclass
+class Meta:
+    parametrized: bool = False
+    generated_from: Optional[str] = None
 
 
 def create_stage(cls, repo, path, external=False, **kwargs):
@@ -131,6 +139,7 @@ class Stage(params.StageParams):
         self._stage_text = stage_text
         self._dvcfile = dvcfile
         self.desc = desc
+        self.meta = Meta()
 
     @property
     def path(self) -> str:

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -63,7 +63,7 @@ def loads_from(cls, repo, path, wdir, data):
 
 
 @dataclass
-class Meta:
+class RawData:
     parametrized: bool = False
     generated_from: Optional[str] = None
 
@@ -139,7 +139,7 @@ class Stage(params.StageParams):
         self._stage_text = stage_text
         self._dvcfile = dvcfile
         self.desc = desc
-        self.meta = Meta()
+        self.raw_data = RawData()
 
     @property
     def path(self) -> str:

--- a/dvc/stage/loader.py
+++ b/dvc/stage/loader.py
@@ -116,9 +116,9 @@ class StageLoader(Mapping):
 
         group, *keys = name.rsplit(JOIN, maxsplit=1)
         if group and keys and name in self.stages_data:
-            stage.meta.generated_from = group
+            stage.raw_data.generated_from = group
 
-        stage.meta.parametrized = (
+        stage.raw_data.parametrized = (
             self.stages_data.get(name, {}) != self.resolved_data[name]
         )
 

--- a/dvc/stage/loader.py
+++ b/dvc/stage/loader.py
@@ -7,7 +7,7 @@ from funcy import cached_property, get_in, lcat, log_durations, project
 
 from dvc import dependency, output
 from dvc.hash_info import HashInfo
-from dvc.parsing import DataResolver
+from dvc.parsing import JOIN, DataResolver
 from dvc.path_info import PathInfo
 
 from . import PipelineStage, Stage, loads_from
@@ -22,6 +22,7 @@ class StageLoader(Mapping):
     def __init__(self, dvcfile, data, lockfile_data=None):
         self.dvcfile = dvcfile
         self.data = data or {}
+        self.stages_data = self.data.get("stages", {})
         self.repo = self.dvcfile.repo
         self._enable_parametrization = self.repo.config["feature"][
             "parametrization"
@@ -106,12 +107,22 @@ class StageLoader(Mapping):
                 "No lock entry found for '%s:%s'", self.dvcfile.relpath, name,
             )
 
-        return self.load_stage(
+        stage = self.load_stage(
             self.dvcfile,
             name,
             self.resolved_data[name],
             self.lockfile_data.get(name, {}),
         )
+
+        group, *keys = name.rsplit(JOIN, maxsplit=1)
+        if group and keys and name in self.stages_data:
+            stage.meta.generated_from = group
+
+        stage.meta.parametrized = (
+            self.stages_data.get(name, {}) != self.resolved_data[name]
+        )
+
+        return stage
 
     def __iter__(self):
         return iter(self.resolved_data)

--- a/dvc/stage/loader.py
+++ b/dvc/stage/loader.py
@@ -115,7 +115,7 @@ class StageLoader(Mapping):
         )
 
         group, *keys = name.rsplit(JOIN, maxsplit=1)
-        if group and keys and name in self.stages_data:
+        if group and keys and name not in self.stages_data:
             stage.raw_data.generated_from = group
 
         stage.raw_data.parametrized = (


### PR DESCRIPTION
This is a bit hackish, but does the job done.
It feels like we need some unified way to be able to load
and dump, but not sure how. Till then, this data class
will be helpful in communicating between those.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
