### PR TITLE
import-url: adjusting tests to run on Windows

### DIFF
--- a/tests/remotes/gdrive.py
+++ b/tests/remotes/gdrive.py
@@ -58,12 +58,19 @@ class GDrive(Base, CloudURLInfo):
         assert not exist_ok
 
     def write_bytes(self, contents):
-        with tempfile.NamedTemporaryFile() as f:
-            f.write(contents)
-            f.flush()
+        file_name = ""
+        try:
+            # Windows doesn't allow to read a file before closing.
+            with tempfile.NamedTemporaryFile(delete=False) as f:
+                file_name = f.name
+                f.write(contents)
 
-            local = PathInfo(pathlib.Path(f.name))
+            path_file_name = pathlib.Path(file_name)
+            local = PathInfo(path_file_name)
             self.tree.upload(local, self)
+        finally:
+            if file_name:
+                os.remove(path_file_name)
 
     def write_text(self, contents, encoding=None, errors=None):
         if not encoding:


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

A `tempfile.NamedTemporaryFile` cannot be read on Windows before closing. [REF](https://stackoverflow.com/questions/6416782/what-is-namedtemporaryfile-useful-for-on-windows) 