### PR TITLE
parse: parse target correctly for generated stages

### DIFF
--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -409,14 +409,20 @@ def error_link(name):
     return format_link(f"https://error.dvc.org/{name}")
 
 
-def parse_target(target, default=None):
+def parse_target(target: str, default: str = None):
     from dvc.dvcfile import PIPELINE_FILE, PIPELINE_LOCK, is_valid_filename
     from dvc.exceptions import DvcException
+    from dvc.parsing import JOIN
 
     if not target:
         return None, None
 
-    match = TARGET_REGEX.match(target)
+    # look for first "@", so as not to assume too much about stage name
+    # eg: it might contain ":" in a generated stages from dict which might
+    # affect further parsings with the regex.
+    group, _, key = target.partition(JOIN)
+    match = TARGET_REGEX.match(group)
+
     if not match:
         return target, None
 
@@ -424,6 +430,10 @@ def parse_target(target, default=None):
         match.group("path"),
         match.group("name"),
     )
+
+    if name and key:
+        name += f"{JOIN}{key}"
+
     if path:
         if os.path.basename(path) == PIPELINE_LOCK:
             raise DvcException(

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -149,6 +149,31 @@ def test_resolve_output(inp, out, is_dir, expected, mocker):
         ["something.dvc:name", ("something.dvc", "name"), None],
         ["../something.dvc:name", ("../something.dvc", "name"), None],
         ["file", (None, "file"), None],
+        ["build@15", (None, "build@15"), None],
+        ["build@{'level': 35}", (None, "build@{'level': 35}"), None],
+        [":build@15", ("dvc.yaml", "build@15"), None],
+        [":build@{'level': 35}", ("dvc.yaml", "build@{'level': 35}"), None],
+        ["dvc.yaml:build@15", ("dvc.yaml", "build@15"), None],
+        [
+            "dvc.yaml:build@{'level': 35}",
+            ("dvc.yaml", "build@{'level': 35}"),
+            None,
+        ],
+        [
+            "build2@{'level': [1, 2, 3]}",
+            (None, "build2@{'level': [1, 2, 3]}"),
+            None,
+        ],
+        [
+            ":build2@{'level': [1, 2, 3]}",
+            ("dvc.yaml", "build2@{'level': [1, 2, 3]}"),
+            None,
+        ],
+        [
+            "dvc.yaml:build2@{'level': [1, 2, 3]}",
+            ("dvc.yaml", "build2@{'level': [1, 2, 3]}"),
+            None,
+        ],
     ],
 )
 def test_parse_target(inp, out, default):


### PR DESCRIPTION
Even the title says _correctly_, this is done to support stages that was generated using a complex data, which is not officially supported.

eg:
```yaml
stages:
  build:
    foreach:
      - level: 15
      - level: 25
      - level: 35
    do:
      cmd: echo ${item.level}
```

Here, the list has dict inside which is something that's not supported officially. This will generate stages having name similar to the
`build@{'level': 15}`, which works, but the `dvc repro <stage>` fails as the target parser looks for `:` to differentiate between file path and the stage name (eg: we support running single stage via `dvc repro ../dvc.yaml:build2`).

Though, I have to say, the parsing is getting complex. :( 

Fixes #4957 

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
