### PR TITLE
tests/ci: update docker image for Azurite

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.2'
 services:
   azurite:
-    image: mcr.microsoft.com/azure-storage/azurite:3.3.0-preview
+    image: mcr.microsoft.com/azure-storage/azurite:3.9.0
     ports:
       - "10000"
   oss:


### PR DESCRIPTION
`Azure` tests are flaky for some reason. When I investigated [one
of the job], something seemed wrong with the Azurite or
the client lib.

On `AzureTree.blob_service`, we do the following to check if the
container exists:
```python
try:
    container_client.get_container_properties()
except ResourceNotFoundError:
    container_client.create_container()
```

When looking at the test log, I found out that the
`get_container_properties` was failing with
`ErrorCode:ContainerNotFound` whereas `create_container`
successively was failing with `ErrorCode:ContainerAlreadyExists`.

`create_container` is correct, but `get_container_properties` is
wrong here, as many of the Azure tests have already run successfully
before.

So, either the Azurite has/had bug or the client lib has a bug.
Anyway, we'll find out after updating the Azurite.

[one of the job]: https://github.com/iterative/dvc/runs/1448864706#step:7:4029
