### PR TITLE
s3: use mocked s3 instead of the real one

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ tests_requirements = [
     "pydocstyle<4.0",
     "jaraco.windows==3.9.2",
     "mock-ssh-server>=0.8.2",
-    "moto==1.3.16.dev110",
+    "moto==1.3.16.dev122",
     # moto's indirect dependency that is causing problems with flufl.lock's
     # dependency (atpublic). See https://github.com/iterative/dvc/pull/4853
     "aws-sam-translator<1.29.0",

--- a/tests/func/test_api.py
+++ b/tests/func/test_api.py
@@ -75,7 +75,7 @@ def test_open(tmp_dir, dvc, remote):
     [
         pytest.lazy_fixture(cloud)
         for cloud in [
-            "real_s3",  # NOTE: moto's s3 fails in some tests
+            "s3",
             "gs",
             "azure",
             "gdrive",
@@ -128,7 +128,7 @@ def test_open_granular(tmp_dir, dvc, remote):
     [
         pytest.lazy_fixture(cloud)
         for cloud in [
-            "real_s3",  # NOTE: moto's s3 fails in some tests
+            "s3",
             "gs",
             "azure",
             "gdrive",


### PR DESCRIPTION
Looks like it works in the newer versions of `moto`.
Not removing the fixtures just yet, maybe in the next PR if this gets approved.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
