### PR TITLE
hdfs: Replace deprecated pyarrow.hdfs.connect

### DIFF
--- a/tests/remotes/hdfs.py
+++ b/tests/remotes/hdfs.py
@@ -1,6 +1,7 @@
 import locale
 import os
 import platform
+import subprocess
 import uuid
 from contextlib import contextmanager
 
@@ -118,6 +119,15 @@ def hadoop(test_config):
     os.environ["JAVA_HOME"] = java_home
     os.environ["HADOOP_HOME"] = hadoop_home
     os.environ["PATH"] += f":{hadoop_home}/bin:{hadoop_home}/sbin"
+
+    # NOTE: must set CLASSPATH to connect using pyarrow.fs.HadoopFileSystem
+    result = subprocess.run(
+        [f"{hadoop_home}/bin/hdfs", "classpath", "--glob"],
+        universal_newlines=True,
+        stdout=subprocess.PIPE,
+        check=False,
+    )
+    os.environ["CLASSPATH"] = result.stdout
 
 
 @pytest.fixture(scope="session")

--- a/tests/remotes/hdfs.py
+++ b/tests/remotes/hdfs.py
@@ -1,7 +1,6 @@
 import locale
 import os
 import platform
-import subprocess
 import uuid
 from contextlib import contextmanager
 
@@ -119,15 +118,6 @@ def hadoop(test_config):
     os.environ["JAVA_HOME"] = java_home
     os.environ["HADOOP_HOME"] = hadoop_home
     os.environ["PATH"] += f":{hadoop_home}/bin:{hadoop_home}/sbin"
-
-    # NOTE: must set CLASSPATH to connect using pyarrow.fs.HadoopFileSystem
-    result = subprocess.run(
-        [f"{hadoop_home}/bin/hdfs", "classpath", "--glob"],
-        universal_newlines=True,
-        stdout=subprocess.PIPE,
-        check=False,
-    )
-    os.environ["CLASSPATH"] = result.stdout
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Replace with pyarrow.fs.HadoopFileSystem, which has a different API.

Fixes #4905

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Hi,

This is my first PR to this project, and I'd appreciate some feedback to keep going in the right direction. [pyarrow.hdfs](http://arrow.apache.org/docs/python/filesystems_deprecated.html) and [pyarrow.fs.HadoopFileSystem](https://arrow.apache.org/docs/python/generated/pyarrow.fs.HadoopFileSystem.html) have different APIs. I've updated affected methods but would appreciate guidance on the following:

1. The new API doesn't have a `close()` method, which is used in `/dvc/tree/pool.py`. One way to do this is to set each `close()` in try-except blocks. But is there a better way than this for example?
```
# /dvc/tree/pool.py
@contextmanager
def get_connection(conn_func, *args, **kwargs):
    pool = get_pool(conn_func, *args, **kwargs)
    conn = pool.get_connection()
    try:
        yield conn
    except BaseException:
        try:
            conn.close()
        except AttributeError:
            pass
        raise
    else:
        pool.release(conn)
```

2. In `/dvc/tree/hdfs.py`, I also need to replace the `ls` in `walk_files()`. It seems to me that I could use `hadoop_fs()` for what I need; however, I'm getting errors when this function is called:

```
    def hadoop_fs(self, cmd, user=None):
         cmd = "hadoop fs -" + cmd
         if user:
             cmd = f"HADOOP_USER_NAME={user} " + cmd
     
         # NOTE: close_fds doesn't work with redirected stdin/stdout/stderr.
         # See https://github.com/iterative/dvc/issues/1197.
         close_fds = os.name != "nt" 
     
         executable = os.getenv("SHELL") if os.name != "nt" else None 
         p = subprocess.Popen(
             cmd, 
             shell=True,
             close_fds=close_fds,
             executable=executable,
             env=fix_env(os.environ),
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )    
         out, err = p.communicate()
         if p.returncode != 0:
            raise RemoteCmdError(self.scheme, cmd, p.returncode, err) 
 E           dvc.tree.base.RemoteCmdError: hdfs command 'hadoop fs -checksum hdfs://127.0.0.1:32916/c3d4bcf3-ceb2-4aaf-9b2c-6f25e18d3cae/file' finished with non-zero return code 127': b'/usr/local/hadoop/bin/hadoop: line 204: hadoop_abs: command not found\n/usr/local/hadoop/bin/hadoop: line 213: hadoop_need_reexec: command not found\n/usr/local/hadoop/bin/hadoop: line 221: hadoop_verify_user_perm: command not found\n/usr/local/hadoop/bin/hadoop: line 232: hadoop_add_client_opts: command not found\n/usr/local/hadoop/bin/hadoop: line 239: hadoop_subcommand_opts: command not found\n/usr/local/hadoop/bin/hadoop: line 242: hadoop_generic_java_subcmd_handler: command not found
```

I know this is likely a configuration issue on my part since Hadoop is installed at `/opt/hadoop` in docker. I saw there are example remote settings for other remotes in `/tests/remotes_env` but not hdfs. I also noticed environment variables were set in `/tests/remotes/hdfs.py` and I couldn't connect to the hdfs docker until I set the CLASSPATH there (which I realize I should remove if I can get the configuration right). Could you share what if any configurations are used when testing hdfs?