### PR TITLE
parametrization: support loading vars partially

### DIFF
--- a/tests/func/test_stage_resolver.py
+++ b/tests/func/test_stage_resolver.py
@@ -502,3 +502,25 @@ def test_vars_relpath_overwrite(tmp_dir, dvc):
     }
     resolver = DataResolver(dvc, PathInfo(str(tmp_dir)), d)
     resolver.resolve()
+
+
+@pytest.mark.parametrize("local", [True, False])
+@pytest.mark.parametrize(
+    "vars_",
+    [
+        ["test_params.yaml:bar", "test_params.yaml:foo"],
+        ["test_params.yaml:foo,bar"],
+        ["test_params.yaml"],
+        ["test_params.yaml", "test_params.yaml"],
+    ],
+)
+def test_vars_load_partial(tmp_dir, dvc, local, vars_):
+    iterable = {"bar": "bar", "foo": "foo"}
+    dump_yaml(tmp_dir / "test_params.yaml", iterable)
+    d = {"stages": {"build": {"cmd": "echo ${bar}"}}}
+    if local:
+        d["stages"]["build"]["vars"] = vars_
+    else:
+        d["vars"] = vars_
+    resolver = DataResolver(dvc, PathInfo(str(tmp_dir)), d)
+    resolver.resolve()


### PR DESCRIPTION
The syntax is the following:
```yaml
vars:
  - test_params.yaml:sub
  - test_params.yaml:sub2,sub3
stages:
  echo:
    cmd: "echo ${sub} ${sub2} ${sub3}"
```

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
