### PR TITLE
dvcignore: Fix incorrect ignored output computation

### DIFF
--- a/dvc/ignore.py
+++ b/dvc/ignore.py
@@ -353,6 +353,7 @@ class DvcIgnoreFilter:
             return self.is_ignored_file(path)
         if os.path.isdir(path):
             return self.is_ignored_dir(path)
+        return self.is_ignored_file(path) or self.is_ignored_dir(path)
 
 
 def init(path):

--- a/dvc/ignore.py
+++ b/dvc/ignore.py
@@ -98,8 +98,7 @@ class DvcIgnorePatterns(DvcIgnore):
 
         if details:
             return self._ignore_details(path, is_dir)
-        else:
-            return self.ignore(path, is_dir)
+        return self.ignore(path, is_dir)
 
     def ignore(self, path, is_dir):
         def matches(pattern, path, is_dir) -> bool:

--- a/dvc/ignore.py
+++ b/dvc/ignore.py
@@ -118,11 +118,11 @@ class DvcIgnorePatterns(DvcIgnore):
                 break
         return result
 
-    def _ignore_details(self, path, is_dir):
+    def _ignore_details(self, path, is_dir: bool):
         result = []
-        for (regex, ignore), pattern_info in list(
+        for (regex, _), pattern_info in list(
             zip(self.regex_pattern_list, self.pattern_list)
-        )[::-1]:
+        ):
             # skip system pattern
             if not pattern_info.file_info:
                 continue
@@ -134,11 +134,9 @@ class DvcIgnorePatterns(DvcIgnore):
                 matches |= bool(regex.match(f"{path}/"))
 
             if matches:
-                if not ignore and len(result) == 0:
-                    break
                 result.append(pattern_info.file_info)
 
-        return result[::-1]
+        return result
 
     def __hash__(self):
         return hash(self.dirname + ":" + str(self.pattern_list))

--- a/dvc/ignore.py
+++ b/dvc/ignore.py
@@ -331,6 +331,8 @@ class DvcIgnoreFilter:
         return False
 
     def check_ignore(self, target):
+        # NOTE: can only be used in `dvc check-ignore`, see
+        # https://github.com/iterative/dvc/issues/5046
         full_target = os.path.abspath(target)
         if not self._outside_repo(full_target):
             dirname, basename = os.path.split(os.path.normpath(full_target))
@@ -347,7 +349,10 @@ class DvcIgnoreFilter:
     def is_ignored(self, path):
         # NOTE: can't use self.check_ignore(path).match for now, see
         # https://github.com/iterative/dvc/issues/4555
-        return self.is_ignored_dir(path) or self.is_ignored_file(path)
+        if os.path.isfile(path):
+            return self.is_ignored_file(path)
+        if os.path.isdir(path):
+            return self.is_ignored_dir(path)
 
 
 def init(path):

--- a/dvc/output/base.py
+++ b/dvc/output/base.py
@@ -559,10 +559,9 @@ class BaseOutput:
             raise cls.IsStageFileError(path)
 
         if stage:
-            check = stage.repo.tree.dvcignore.check_ignore(
-                os.path.join(stage.wdir, path)
-            )
-            if check.match:
+            abs_path = os.path.join(stage.wdir, path)
+            if stage.repo.tree.dvcignore.is_ignored(abs_path):
+                check = stage.repo.tree.dvcignore.check_ignore(abs_path)
                 raise cls.IsIgnoredError(check)
 
     def _check_can_merge(self, out):

--- a/dvc/output/base.py
+++ b/dvc/output/base.py
@@ -559,7 +559,9 @@ class BaseOutput:
             raise cls.IsStageFileError(path)
 
         if stage:
-            check = stage.repo.tree.dvcignore.check_ignore(path)
+            check = stage.repo.tree.dvcignore.check_ignore(
+                os.path.join(stage.wdir, path)
+            )
             if check.match:
                 raise cls.IsIgnoredError(check)
 

--- a/tests/dir_helpers.py
+++ b/tests/dir_helpers.py
@@ -332,10 +332,14 @@ def run_copy(tmp_dir, dvc):
     )
 
     def run_copy(src, dst, **run_kwargs):
+        wdir = pathlib.Path(run_kwargs.get("wdir", "."))
+        wdir = pathlib.Path("../" * len(wdir.parts))
+        script_path = wdir / "copy.py"
+
         return dvc.run(
-            cmd=f"python copy.py {src} {dst}",
+            cmd=f"python {script_path} {src} {dst}",
             outs=[dst],
-            deps=[src, "copy.py"],
+            deps=[src, f"{script_path}"],
             **run_kwargs,
         )
 

--- a/tests/func/test_check_ignore.py
+++ b/tests/func/test_check_ignore.py
@@ -21,7 +21,7 @@ def test_check_ignore(tmp_dir, dvc, file, ret, output, caplog):
     "file,ret,output",
     [
         ("file", 0, "{}:1:f*\tfile\n".format(DvcIgnore.DVCIGNORE_FILE)),
-        ("foo", 0, "{}:2:!foo\tfoo\n".format(DvcIgnore.DVCIGNORE_FILE)),
+        ("foo", 1, ""),
         (
             os.path.join("dir", "foobar"),
             0,
@@ -121,9 +121,8 @@ def test_check_sub_dir_ignore_file(tmp_dir, dvc, caplog):
 def test_check_ignore_details_all(tmp_dir, dvc, caplog):
     tmp_dir.gen(DvcIgnore.DVCIGNORE_FILE, "f*\n!foo")
 
-    assert main(["check-ignore", "-d", "-a", "foo"]) == 0
-    assert "{}:1:f*\tfoo\n".format(DvcIgnore.DVCIGNORE_FILE) in caplog.text
-    assert "{}:2:!foo\tfoo\n".format(DvcIgnore.DVCIGNORE_FILE) in caplog.text
+    assert main(["check-ignore", "-d", "-a", "file"]) == 0
+    assert "{}:1:f*\tfile\n".format(DvcIgnore.DVCIGNORE_FILE) in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/tests/func/test_check_ignore.py
+++ b/tests/func/test_check_ignore.py
@@ -21,7 +21,7 @@ def test_check_ignore(tmp_dir, dvc, file, ret, output, caplog):
     "file,ret,output",
     [
         ("file", 0, "{}:1:f*\tfile\n".format(DvcIgnore.DVCIGNORE_FILE)),
-        ("foo", 1, ""),
+        ("foo", 0, "{}:2:!foo\tfoo\n".format(DvcIgnore.DVCIGNORE_FILE)),
         (
             os.path.join("dir", "foobar"),
             0,
@@ -121,8 +121,9 @@ def test_check_sub_dir_ignore_file(tmp_dir, dvc, caplog):
 def test_check_ignore_details_all(tmp_dir, dvc, caplog):
     tmp_dir.gen(DvcIgnore.DVCIGNORE_FILE, "f*\n!foo")
 
-    assert main(["check-ignore", "-d", "-a", "file"]) == 0
-    assert "{}:1:f*\tfile\n".format(DvcIgnore.DVCIGNORE_FILE) in caplog.text
+    assert main(["check-ignore", "-d", "-a", "foo"]) == 0
+    assert "{}:1:f*\tfoo\n".format(DvcIgnore.DVCIGNORE_FILE) in caplog.text
+    assert "{}:2:!foo\tfoo\n".format(DvcIgnore.DVCIGNORE_FILE) in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/tests/func/test_ignore.py
+++ b/tests/func/test_ignore.py
@@ -404,20 +404,13 @@ def test_ignore_in_added_dir(tmp_dir, dvc):
     assert not ignored_path.exists()
 
 
-@pytest.mark.parametrize(
-    "ignore_patterns,raise_error",
-    [("*.log", True), ("*.log\n!foo.log", False)],
-)
-def test_ignored_output(
-    tmp_dir, scm, dvc, run_copy, ignore_patterns, raise_error
-):
-    tmp_dir.gen({".dvcignore": ignore_patterns, "foo": "foo content"})
+def test_ignored_output(tmp_dir, scm, dvc, run_copy):
+    tmp_dir.gen({".dvcignore": "*.log\n!foo.log", "foo": "foo content"})
 
-    if raise_error:
-        with pytest.raises(OutputIsIgnoredError):
-            run_copy("foo", "foo.log", name="copy")
-    else:
-        run_copy("foo", "foo.log", name="copy")
+    with pytest.raises(OutputIsIgnoredError):
+        run_copy("foo", "abc.log", name="copy")
+
+    run_copy("foo", "foo.log", name="copy")
 
 
 def test_ignored_output_nested(tmp_dir, scm, dvc, run_copy):

--- a/tests/func/test_ignore.py
+++ b/tests/func/test_ignore.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -408,3 +409,11 @@ def test_ignored_output(tmp_dir, scm, dvc, run_copy):
 
     with pytest.raises(OutputIsIgnoredError):
         run_copy("foo", "foo.log", name="copy")
+
+
+def test_ignored_output_nested(tmp_dir, scm, dvc, run_copy):
+    tmp_dir.gen({".dvcignore": "/*.log", "copy": {"foo": "foo content"}})
+
+    run_copy("foo", "foo.log", name="copy", wdir="copy")
+
+    assert Path("copy/foo.log").exists()

--- a/tests/func/test_ignore.py
+++ b/tests/func/test_ignore.py
@@ -404,10 +404,19 @@ def test_ignore_in_added_dir(tmp_dir, dvc):
     assert not ignored_path.exists()
 
 
-def test_ignored_output(tmp_dir, scm, dvc, run_copy):
-    tmp_dir.gen({".dvcignore": "*.log", "foo": "foo content"})
+@pytest.mark.parametrize(
+    "ignore_patterns,raise_error",
+    [("*.log", True), ("*.log\n!foo.log", False)],
+)
+def test_ignored_output(
+    tmp_dir, scm, dvc, run_copy, ignore_patterns, raise_error
+):
+    tmp_dir.gen({".dvcignore": ignore_patterns, "foo": "foo content"})
 
-    with pytest.raises(OutputIsIgnoredError):
+    if raise_error:
+        with pytest.raises(OutputIsIgnoredError):
+            run_copy("foo", "foo.log", name="copy")
+    else:
         run_copy("foo", "foo.log", name="copy")
 
 

--- a/tests/unit/output/test_output.py
+++ b/tests/unit/output/test_output.py
@@ -73,6 +73,7 @@ def test_get_used_cache(exists, expected_message, mocker, caplog):
     stage = mocker.MagicMock()
     mocker.patch.object(stage, "__str__", return_value="stage: 'stage.dvc'")
     mocker.patch.object(stage, "addressing", "stage.dvc")
+    mocker.patch.object(stage, "wdir", ".")
     mocker.patch.object(
         stage.repo.tree.dvcignore,
         "check_ignore",

--- a/tests/unit/output/test_output.py
+++ b/tests/unit/output/test_output.py
@@ -75,6 +75,9 @@ def test_get_used_cache(exists, expected_message, mocker, caplog):
     mocker.patch.object(stage, "addressing", "stage.dvc")
     mocker.patch.object(stage, "wdir", ".")
     mocker.patch.object(
+        stage.repo.tree.dvcignore, "is_ignored", return_value=False,
+    )
+    mocker.patch.object(
         stage.repo.tree.dvcignore,
         "check_ignore",
         return_value=_no_match("path"),


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Fixes #4985 

* [x] Failing test created
* [x] Fixed `_validate_output_path`
* [x] Fix awkward behavior of `dvc check-ignore`, when it lists unignored files as ignored and returns non-zero exit code
* [ ] More tests