### PR TITLE
stage: move is_cached logic to Stage.can_be_skipped

### DIFF
--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -181,7 +181,9 @@ def _create_stages(
             outs=[out],
             external=external,
         )
-        if stage:
+        if stage.can_be_skipped:
+            stage = None
+        else:
             Dvcfile(repo, stage.path).remove()
             if desc:
                 stage.outs[0].desc = desc

--- a/dvc/repo/imp_url.py
+++ b/dvc/repo/imp_url.py
@@ -44,7 +44,7 @@ def imp_url(
         erepo=erepo,
     )
 
-    if stage is None:
+    if stage.can_be_skipped:
         return None
 
     if desc:

--- a/dvc/repo/run.py
+++ b/dvc/repo/run.py
@@ -113,7 +113,7 @@ def run(self, fname=None, no_exec=False, single_stage=False, **kwargs):
     stage = create_stage(
         stage_cls, repo=self, path=path, params=params, **kwargs
     )
-    if stage is None:
+    if kwargs.get("run_cache", True) and stage.can_be_skipped:
         return None
 
     dvcfile = Dvcfile(self, stage.path)


### PR DESCRIPTION
Having that logic in `create_stage` is unnatural and also has some
side-effects for unsuspecting users. For example, it will check the
filesystem for existing dvcfile and will try to load a corresponding old
stage. I've adjusted it with minimal changes to better reflect the logic
behind it.

Pre-requisite for #4907

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
