### PR TITLE
dvc: add --no-shell argument for dvc run

### DIFF
--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -64,6 +64,7 @@ class CmdRepro(CmdBase):
             "force_downstream": self.args.force_downstream,
             "pull": self.args.pull,
             "glob": self.args.glob,
+            "use_shell": not self.args.no_shell,
         }
 
 
@@ -181,6 +182,12 @@ def add_arguments(repro_parser):
         action="store_true",
         default=False,
         help="Allows targets containing shell-style wildcards.",
+    )
+    repro_parser.add_argument(
+        "--no-shell",
+        action="store_true",
+        default=False,
+        help="Executes command without shell, directly.",
     )
 
 

--- a/dvc/command/run.py
+++ b/dvc/command/run.py
@@ -255,10 +255,7 @@ def add_parser(subparsers, parent_parser):
         "--no-shell",
         action="store_true",
         default=False,
-        help=(
-            "Executes command without shell, directly "
-            "feeding it to subprocess"
-        ),
+        help="Executes command without shell, directly.",
     )
     run_parser.add_argument(
         "command", nargs=argparse.REMAINDER, help="Command to execute."

--- a/dvc/command/run.py
+++ b/dvc/command/run.py
@@ -58,6 +58,7 @@ class CmdRun(CmdBase):
                 single_stage=self.args.single_stage,
                 external=self.args.external,
                 desc=self.args.desc,
+                use_shell=not self.args.no_shell,
             )
         except DvcException:
             logger.exception("")
@@ -248,6 +249,15 @@ def add_parser(subparsers, parent_parser):
         help=(
             "User description of the stage (optional). "
             "This doesn't affect any DVC operations."
+        ),
+    )
+    run_parser.add_argument(
+        "--no-shell",
+        action="store_true",
+        default=False,
+        help=(
+            "Executes command without shell, directly "
+            "feeding it to subprocess"
         ),
     )
     run_parser.add_argument(

--- a/dvc/repo/run.py
+++ b/dvc/repo/run.py
@@ -133,6 +133,7 @@ def run(self, fname=None, no_exec=False, single_stage=False, **kwargs):
         stage.run(
             no_commit=kwargs.get("no_commit", False),
             run_cache=kwargs.get("run_cache", True),
+            use_shell=kwargs.get("use_shell", True),
         )
 
     dvcfile.dump(stage, update_lock=not no_exec)

--- a/dvc/stage/cache.py
+++ b/dvc/stage/cache.py
@@ -166,7 +166,7 @@ class StageCache:
         dump_yaml(tmp, cache)
         self.tree.move(PathInfo(tmp), path)
 
-    def restore(self, stage, run_cache=True, pull=False, **kwargs):
+    def restore(self, stage, run_cache=True, pull=False):
         if stage.is_callback or stage.always_changed:
             raise RunCacheNotFoundError(stage)
 

--- a/dvc/stage/cache.py
+++ b/dvc/stage/cache.py
@@ -166,7 +166,7 @@ class StageCache:
         dump_yaml(tmp, cache)
         self.tree.move(PathInfo(tmp), path)
 
-    def restore(self, stage, run_cache=True, pull=False):
+    def restore(self, stage, run_cache=True, pull=False, **kwargs):
         if stage.is_callback or stage.always_changed:
             raise RunCacheNotFoundError(stage)
 

--- a/dvc/stage/run.py
+++ b/dvc/stage/run.py
@@ -107,7 +107,11 @@ def run_stage(stage, dry=False, force=False, checkpoint_func=None, **kwargs):
         from .cache import RunCacheNotFoundError
 
         try:
-            stage.repo.stage_cache.restore(stage, **kwargs)
+            stage.repo.stage_cache.restore(
+                stage,
+                run_cache=kwargs.get("run_cache", True),
+                pull=kwargs.get("pull", False),
+            )
             return
         except RunCacheNotFoundError:
             pass

--- a/tests/func/test_run_cache.py
+++ b/tests/func/test_run_cache.py
@@ -33,7 +33,7 @@ def test_restore(tmp_dir, dvc, run_copy, mocker):
 
     (stage,) = dvc.reproduce("copy-foo-bar")
 
-    mock_restore.assert_called_once_with(stage)
+    mock_restore.assert_called_once_with(stage, run_cache=True, pull=False)
     mock_run.assert_not_called()
     assert (tmp_dir / "bar").exists() and not (tmp_dir / "foo").unlink()
     assert (tmp_dir / PIPELINE_LOCK).exists()
@@ -100,7 +100,7 @@ def test_memory_for_multiple_runs_of_same_stage(
     assert (tmp_dir / PIPELINE_LOCK).exists()
     assert (tmp_dir / "bar").read_text() == "foobar"
     mock_run.assert_not_called()
-    mock_restore.assert_called_once_with(stage)
+    mock_restore.assert_called_once_with(stage, run_cache=True, pull=False)
     mock_restore.reset_mock()
 
     (tmp_dir / PIPELINE_LOCK).unlink()
@@ -109,7 +109,7 @@ def test_memory_for_multiple_runs_of_same_stage(
 
     assert (tmp_dir / "bar").read_text() == "foo"
     mock_run.assert_not_called()
-    mock_restore.assert_called_once_with(stage)
+    mock_restore.assert_called_once_with(stage, run_cache=True, pull=False)
     assert (tmp_dir / "bar").exists() and not (tmp_dir / "foo").unlink()
     assert (tmp_dir / PIPELINE_LOCK).exists()
 
@@ -138,7 +138,7 @@ def test_memory_runs_of_multiple_stages(tmp_dir, dvc, run_copy, mocker):
     assert (tmp_dir / "foo.bak").read_text() == "foo"
     assert (tmp_dir / PIPELINE_LOCK).exists()
     mock_run.assert_not_called()
-    mock_restore.assert_called_once_with(stage)
+    mock_restore.assert_called_once_with(stage, run_cache=True, pull=False)
     mock_restore.reset_mock()
 
     (stage,) = dvc.reproduce("backup-bar")
@@ -146,7 +146,7 @@ def test_memory_runs_of_multiple_stages(tmp_dir, dvc, run_copy, mocker):
     assert (tmp_dir / "bar.bak").read_text() == "bar"
     assert (tmp_dir / PIPELINE_LOCK).exists()
     mock_run.assert_not_called()
-    mock_restore.assert_called_once_with(stage)
+    mock_restore.assert_called_once_with(stage, run_cache=True, pull=False)
 
 
 def test_restore_pull(tmp_dir, dvc, run_copy, mocker, local_remote):
@@ -166,7 +166,7 @@ def test_restore_pull(tmp_dir, dvc, run_copy, mocker, local_remote):
 
     (stage,) = dvc.reproduce("copy-foo-bar", pull=True)
 
-    mock_restore.assert_called_once_with(stage, pull=True)
+    mock_restore.assert_called_once_with(stage, pull=True, run_cache=True)
     mock_run.assert_not_called()
     mock_checkout.assert_called_once()
     assert (tmp_dir / "bar").exists() and not (tmp_dir / "foo").unlink()

--- a/tests/func/test_run_single_stage.py
+++ b/tests/func/test_run_single_stage.py
@@ -1035,7 +1035,7 @@ def test_run_force_doesnot_preserve_comments_and_meta(tmp_dir, dvc, run_copy):
 
 
 def test_run_noshell_skips_extra_quoting(dvc, mocker):
-    cmd = "Rscript -e 'saveRDS(1:10, \"ops-data.rds\")'"
+    cmd = 'sample_script arg1 arg2 "literal_arg"'
     proc = mocker.Mock()
     communicate = mocker.Mock()
     proc.configure_mock(returncode=0, communicate=communicate)

--- a/tests/func/test_run_single_stage.py
+++ b/tests/func/test_run_single_stage.py
@@ -1032,3 +1032,18 @@ def test_run_force_doesnot_preserve_comments_and_meta(tmp_dir, dvc, run_copy):
 
     assert "comment" not in (tmp_dir / "bar.dvc").read_text()
     assert "meta" not in (tmp_dir / "bar.dvc").read_text()
+
+
+def test_run_noshell_skips_extra_quoting(dvc, mocker):
+    cmd = "Rscript -e 'saveRDS(1:10, \"ops-data.rds\")'"
+    proc = mocker.Mock()
+    communicate = mocker.Mock()
+    proc.configure_mock(returncode=0, communicate=communicate)
+    popen_mock = mocker.patch("subprocess.Popen", return_value=proc)
+
+    ret = main(["run", "--no-shell", "-f", "-n test", cmd])
+
+    assert ret == 0
+    popen_mock.assert_called_with(
+        cmd, cwd=mock.ANY, env=mock.ANY, close_fds=mock.ANY, shell=False,
+    )

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -77,6 +77,7 @@ def test_experiments_run(dvc, mocker, args, resume):
         "run_all": False,
         "jobs": None,
         "checkpoint_resume": resume,
+        "use_shell": True,
     }
 
     default_arguments.update(repro_arguments)

--- a/tests/unit/command/test_repro.py
+++ b/tests/unit/command/test_repro.py
@@ -16,6 +16,7 @@ default_arguments = {
     "force_downstream": False,
     "pull": False,
     "glob": False,
+    "use_shell": True,
 }
 
 

--- a/tests/unit/command/test_run.py
+++ b/tests/unit/command/test_run.py
@@ -78,6 +78,7 @@ def test_run(mocker, dvc):
         single_stage=False,
         external=True,
         desc="description",
+        use_shell=True,
     )
 
 
@@ -110,6 +111,7 @@ def test_run_args_from_cli(mocker, dvc):
         single_stage=False,
         external=False,
         desc=None,
+        use_shell=True,
     )
 
 
@@ -142,4 +144,5 @@ def test_run_args_with_spaces(mocker, dvc):
         single_stage=False,
         external=False,
         desc=None,
+        use_shell=True,
     )


### PR DESCRIPTION
Allows to execute dvc run commands directly, without shell.
It comes in handy when solving commands quotation problems.
Details: #2381

Documentation issue: https://github.com/iterative/dvc.org/issues/1984 (will make pr after merging of this one).
