### PR TITLE
parametrization: show interpolated vars in params diff

### DIFF
--- a/dvc/repo/params/show.py
+++ b/dvc/repo/params/show.py
@@ -6,6 +6,7 @@ from dvc.exceptions import DvcException
 from dvc.path_info import PathInfo
 from dvc.repo import locked
 from dvc.repo.collect import collect
+from dvc.stage import PipelineStage
 from dvc.utils.serialize import LOADERS, ParseError
 
 if TYPE_CHECKING:
@@ -49,6 +50,20 @@ def _read_params(repo, configs, rev):
     return res
 
 
+def _add_vars(repo, params):
+    params_files = set(params)
+    for stage in repo.stages:
+        if isinstance(stage, PipelineStage) and stage.tracked_vars:
+            for file, vars_ in stage.tracked_vars.items():
+                # `params` file are shown regardless of `tracked` or not
+                # to reduce noise and duplication, they are skipped
+                if file in params_files:
+                    continue
+
+                params[file] = params.get(file, {})
+                params[file].update(vars_)
+
+
 @locked
 def show(repo, revs=None):
     res = {}
@@ -56,6 +71,7 @@ def show(repo, revs=None):
     for branch in repo.brancher(revs=revs):
         configs = _collect_configs(repo, branch)
         params = _read_params(repo, configs, branch)
+        _add_vars(repo, params)
 
         if params:
             res[branch] = params

--- a/dvc/repo/params/show.py
+++ b/dvc/repo/params/show.py
@@ -50,14 +50,13 @@ def _read_params(repo, configs, rev):
     return res
 
 
-def _add_vars(repo, params):
-    params_files = set(params)
+def _add_vars(repo, configs, params):
     for stage in repo.stages:
         if isinstance(stage, PipelineStage) and stage.tracked_vars:
             for file, vars_ in stage.tracked_vars.items():
                 # `params` file are shown regardless of `tracked` or not
                 # to reduce noise and duplication, they are skipped
-                if file in params_files:
+                if file in configs:
                     continue
 
                 params[file] = params.get(file, {})
@@ -71,7 +70,7 @@ def show(repo, revs=None):
     for branch in repo.brancher(revs=revs):
         configs = _collect_configs(repo, branch)
         params = _read_params(repo, configs, branch)
-        _add_vars(repo, params)
+        _add_vars(repo, configs, params)
 
         if params:
             res[branch] = params

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -630,6 +630,7 @@ class PipelineStage(Stage):
         super().__init__(*args, **kwargs)
         self.name = name
         self.cmd_changed = False
+        self.tracked_vars = {}
 
     def __eq__(self, other):
         return super().__eq__(other) and self.name == other.name

--- a/dvc/stage/loader.py
+++ b/dvc/stage/loader.py
@@ -3,7 +3,14 @@ from collections.abc import Mapping
 from copy import deepcopy
 from itertools import chain
 
-from funcy import cached_property, get_in, lcat, log_durations, project
+from funcy import (
+    cached_property,
+    get_in,
+    lcat,
+    log_durations,
+    nullcontext,
+    project,
+)
 
 from dvc import dependency, output
 from dvc.hash_info import HashInfo
@@ -49,7 +56,12 @@ class StageLoader(Mapping):
     @cached_property
     def resolved_data(self):
         data = self.data
-        with log_durations(logger.debug, "resolving values"):
+        log = (
+            log_durations(logger.debug, "resolving values")
+            if self._enable_parametrization
+            else nullcontext()
+        )
+        with log:
             data = self.resolver.resolve()
         return data.get("stages", {})
 


### PR DESCRIPTION
Previously, all of them were included in the `dvc.lock` file (which was just a hack) which made them appear on the `dvc params diff` automatically. This adds proper support of showing them, although the code has to be restructured later.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
