### PR TITLE
Improve OverlappingOutputsError exception message.

### DIFF
--- a/dvc/repo/trie.py
+++ b/dvc/repo/trie.py
@@ -25,9 +25,10 @@ def build_outs_trie(stages):
                 overlapping = out
             if parent and overlapping:
                 msg = (
-                    "Paths for outs:\n'{}'('{}')\n'{}'('{}')\n"
-                    "overlap. To avoid unpredictable behaviour, "
-                    "rerun command with non overlapping outs paths."
+                    "The output paths:\n'{}'('{}')\n'{}'('{}')\n"
+                    "overlap and are thus in the same tracked directory.\n"
+                    "To keep reproducibility, outputs should be in separate "
+                    "tracked directories or tracked individually."
                 ).format(
                     str(parent),
                     parent.stage.addressing,

--- a/tests/func/test_run_single_stage.py
+++ b/tests/func/test_run_single_stage.py
@@ -830,14 +830,15 @@ class TestShouldRaiseOnOverlappingOutputPaths(TestDvc):
         data_dir_stage = self.DATA_DIR + DVC_FILE_SUFFIX
         data_stage = os.path.basename(self.DATA) + DVC_FILE_SUFFIX
 
-        self.assertIn("Paths for outs:\n", error_output)
+        self.assertIn("The output paths:\n", error_output)
         self.assertIn(
             f"\n'{self.DATA_DIR}'('{data_dir_stage}')\n", error_output,
         )
         self.assertIn(f"\n'{self.DATA}'('{data_stage}')\n", error_output)
         self.assertIn(
-            "\noverlap. To avoid unpredictable behaviour, rerun "
-            "command with non overlapping outs paths.",
+            "overlap and are thus in the same tracked directory.\n"
+            "To keep reproducibility, outputs should be in separate "
+            "tracked directories or tracked individually.",
             error_output,
         )
 


### PR DESCRIPTION
The message given by the exception is not verbose enough `why` this exception is thrown.
Now gives the user more information as to why the overlapping paths should be changed.

## Example
When running the `dvc repro` command with the following `params.yaml` and `dvc.yaml` files an exception is thrown because paths of the output overlap in the tracked datasets directory. The exception message is not verbose enough for a user to understand the problem at hand. 
```yaml
# params.yaml
buses:
- 1
- 2

# dvc.yaml
vars:
- params.yaml

stages:
  buses_pipe:
    foreach: ${buses}
    do:
      cmd: python filter.py --bus ${item}
      wdir: src/data_wizards_notebooks
      deps:
        - ../../datasets/raw data/file_${item}.csv
        - "filter.py" 
      outs:
        - ../../datasets/raw data/file_${item}_filter.csv
```
Exception:
```
.../dvc/repo/trie.py", line 37, in build_outs_trie
raise OverlappingOutputPathsError(parent, overlapping, msg)
dvc.exceptions.OverlappingOutputPathsError: Paths for outs:
'datasets'('datasets.dvc')
'datasets/raw data/file_1.csv'('buses_pipe@1')
overlap. To avoid unpredictable behaviour, rerun command with non overlapping outs paths.
```

Proposed Exception message:
```
.../dvc/repo/trie.py", line 37, in build_outs_trie
raise OverlappingOutputPathsError(parent, overlapping, msg)
dvc.exceptions.OverlappingOutputPathsError: The output paths:
'datasets'('datasets.dvc')
'datasets/raw data/file_1.csv'('buses_pipe@1')
overlap and are thus in the same tracked directory.
To keep reproducibility, outputs should be in separate tracked directories or tracked individually.
```

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

