### PR TITLE
provide a callback to handle error during the stage collection

### DIFF
--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -8,7 +8,6 @@ from funcy import cached_property, cat
 from git import InvalidGitRepositoryError
 
 from dvc.config import Config
-from dvc.dvcfile import is_valid_filename
 from dvc.exceptions import FileMissingError
 from dvc.exceptions import IsADirectoryError as DvcIsADirectoryError
 from dvc.exceptions import NotDvcRepoError, OutputNotFoundError
@@ -189,6 +188,7 @@ class Repo:
         self.metrics = Metrics(self)
         self.plots = Plots(self)
         self.params = Params(self)
+        self.stage_collection_error_handler = None
         self._lock_depth = 0
 
     @cached_property
@@ -373,25 +373,8 @@ class Repo:
         NOTE: For large repos, this could be an expensive
               operation. Consider using some memoization.
         """
-        return self._collect_stages()
-
-    def _collect_stages(self):
-        stages = []
-        outs = set()
-
-        for root, dirs, files in self.tree.walk(self.root_dir):
-            for file_name in filter(is_valid_filename, files):
-                file_path = os.path.join(root, file_name)
-                new_stages = self.stage.load_file(file_path)
-                stages.extend(new_stages)
-                outs.update(
-                    out.fspath
-                    for stage in new_stages
-                    for out in stage.outs
-                    if out.scheme == "local"
-                )
-            dirs[:] = [d for d in dirs if os.path.join(root, d) not in outs]
-        return stages
+        error_handler = self.stage_collection_error_handler
+        return self.stage.collect_repo(onerror=error_handler)
 
     def find_outs_by_path(self, path, outs=None, recursive=False, strict=True):
         if not outs:

--- a/tests/func/test_remove.py
+++ b/tests/func/test_remove.py
@@ -23,7 +23,7 @@ def test_remove(tmp_dir, scm, dvc, run_copy, remove_outs):
     for stage in [stage1, stage2, stage3]:
         dvc.remove(stage.addressing, outs=remove_outs)
         out_exists = (out.exists for out in stage.outs)
-        assert stage not in dvc._collect_stages()
+        assert stage not in dvc.stage.collect_repo()
         if remove_outs:
             assert not any(out_exists)
         else:

--- a/tests/func/test_stage_load.py
+++ b/tests/func/test_stage_load.py
@@ -10,6 +10,7 @@ from dvc.path_info import PathInfo
 from dvc.repo import Repo
 from dvc.stage.exceptions import (
     StageFileDoesNotExistError,
+    StageFileFormatError,
     StageNameUnspecified,
     StageNotFound,
 )
@@ -435,3 +436,19 @@ def test_collect_optimization_on_stage_name(tmp_dir, dvc, mocker, run_copy):
     # Should read stage directly instead of collecting the whole graph
     assert dvc.stage.collect("copy-foo-bar") == [stage]
     assert dvc.stage.collect_granular("copy-foo-bar") == [(stage, None)]
+
+
+def test_collect_repo_callback(tmp_dir, dvc, mocker):
+    mock = mocker.Mock()
+    dvc.stage_collection_error_handler = mock
+
+    (stage,) = tmp_dir.dvc_gen("foo", "foo")
+    dump_yaml(tmp_dir / PIPELINE_FILE, {"stages": {"cmd": "echo hello world"}})
+
+    dvc._reset()
+    assert dvc.stages == [stage]
+    mock.assert_called_once()
+
+    file_path, exc = mock.call_args[0]
+    assert file_path == PIPELINE_FILE
+    assert isinstance(exc, StageFileFormatError)


### PR DESCRIPTION
Might be useful for Viewer, but anyway, it's a good thing to move this to a `dvc.repo.stage`.
See https://github.com/iterative/dvc/issues/5008#issuecomment-736706202

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
