### PR TITLE
scm/git: add support for resolving experiment names

### DIFF
--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -13,7 +13,10 @@ from funcy import cached_property, first
 
 from dvc.exceptions import DvcException
 from dvc.path_info import PathInfo
-from dvc.repo.experiments.base import (
+from dvc.stage.run import CheckpointKilledError
+from dvc.utils import relpath
+
+from .base import (
     EXEC_BASELINE,
     EXEC_CHECKPOINT,
     EXEC_HEAD,
@@ -21,14 +24,14 @@ from dvc.repo.experiments.base import (
     EXEC_NAMESPACE,
     EXPS_NAMESPACE,
     EXPS_STASH,
+    BaselineMismatchError,
     CheckpointExistsError,
     ExperimentExistsError,
     ExpRefInfo,
-    InvalidExpRefError,
+    MultipleBranchError,
 )
-from dvc.repo.experiments.executor import BaseExecutor, LocalExecutor
-from dvc.stage.run import CheckpointKilledError
-from dvc.utils import relpath
+from .executor import BaseExecutor, LocalExecutor
+from .utils import exp_refs_by_rev
 
 logger = logging.getLogger(__name__)
 
@@ -42,27 +45,6 @@ def scm_locked(f):
             return f(exp, *args, **kwargs)
 
     return wrapper
-
-
-class BaselineMismatchError(DvcException):
-    def __init__(self, rev, expected):
-        if hasattr(rev, "hexsha"):
-            rev = rev.hexsha
-        rev_str = f"{rev[:7]}" if rev is not None else "invalid commit"
-        super().__init__(
-            f"Experiment derived from '{rev_str}', expected '{expected[:7]}'."
-        )
-        self.rev = rev
-        self.expected_rev = expected
-
-
-class MultipleBranchError(DvcException):
-    def __init__(self, rev):
-        super().__init__(
-            f"Ambiguous commit '{rev[:7]}' belongs to multiple experiment "
-            "branches."
-        )
-        self.rev = rev
 
 
 class Experiments:
@@ -165,7 +147,7 @@ class Experiments:
                 the human-readable name in the experiment branch ref. Has no
                 effect of branch is specified.
         """
-        with self.scm.stash_workspace(include_untracked=True) as workspace:
+        with self.scm.stash_workspace() as workspace:
             # If we are not extending an existing branch, apply current
             # workspace changes to be made in new branch
             if not branch and workspace:
@@ -317,7 +299,7 @@ class Experiments:
         else:
             resume_rev = self.scm.resolve_rev(checkpoint_resume)
         allow_multiple = "params" in kwargs
-        branch = self.get_branch_containing(
+        branch = self.get_branch_by_rev(
             resume_rev, allow_multiple=allow_multiple
         )
         if not branch:
@@ -564,53 +546,41 @@ class Experiments:
     @scm_locked
     def get_baseline(self, rev):
         """Return the baseline rev for an experiment rev."""
-        rev = self.scm.resolve_rev(rev)
         return self._get_baseline(rev)
 
     def _get_baseline(self, rev):
+        rev = self.scm.resolve_rev(rev)
+
         if rev in self.stash_revs:
             entry = self.stash_revs.get(rev)
             if entry:
                 return entry.baseline_rev
             return None
-        ref = first(self._get_exps_containing(rev))
-        if not ref:
-            return None
-        try:
-            ref_info = ExpRefInfo.from_ref(ref)
+
+        ref_info = first(exp_refs_by_rev(self.scm, rev))
+        if ref_info:
             return ref_info.baseline_sha
-        except InvalidExpRefError:
-            return None
+        return None
 
-    def _get_exps_containing(self, rev):
-        for ref in self.scm.get_refs_containing(rev, EXPS_NAMESPACE):
-            if not (ref.startswith(EXEC_NAMESPACE) or ref == EXPS_STASH):
-                yield ref
-
-    def get_branch_containing(
-        self, rev: str, allow_multiple: bool = False
-    ) -> str:
-        names = list(self._get_exps_containing(rev))
-        if not names:
+    def get_branch_by_rev(self, rev: str, allow_multiple: bool = False) -> str:
+        """Returns full refname for the experiment branch containing rev."""
+        ref_infos = list(exp_refs_by_rev(self.scm, rev))
+        if not ref_infos:
             return None
-        if len(names) > 1 and not allow_multiple:
+        if len(ref_infos) > 1 and not allow_multiple:
             raise MultipleBranchError(rev)
-        return names[0]
+        return str(ref_infos[0])
 
     def get_exact_name(self, rev: str):
+        """Returns preferred name for the specified revision.
+
+        Prefers tags, branches (heads), experiments in that orer.
+        """
         exclude = f"{EXEC_NAMESPACE}/*"
         ref = self.scm.describe(rev, base=EXPS_NAMESPACE, exclude=exclude)
         if ref:
             return ExpRefInfo.from_ref(ref).name
         return None
-
-    def iter_ref_infos_by_name(self, name: str):
-        for ref in self.scm.iter_refs(base=EXPS_NAMESPACE):
-            if ref.startswith(EXEC_NAMESPACE) or ref == EXPS_STASH:
-                continue
-            ref_info = ExpRefInfo.from_ref(ref)
-            if ref_info.name == name:
-                yield ref_info
 
     def apply(self, *args, **kwargs):
         from dvc.repo.experiments.apply import apply

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -147,7 +147,7 @@ class Experiments:
                 the human-readable name in the experiment branch ref. Has no
                 effect of branch is specified.
         """
-        with self.scm.stash_workspace() as workspace:
+        with self.scm.stash_workspace(include_untracked=True) as workspace:
             # If we are not extending an existing branch, apply current
             # workspace changes to be made in new branch
             if not branch and workspace:

--- a/dvc/repo/experiments/apply.py
+++ b/dvc/repo/experiments/apply.py
@@ -1,20 +1,15 @@
 import logging
 import os
 
-from dvc.exceptions import InvalidArgumentError
 from dvc.repo import locked
-from dvc.repo.experiments.executor import BaseExecutor
 from dvc.repo.scm_context import scm_context
+from dvc.scm.base import RevError
 from dvc.utils.fs import remove
 
+from .base import BaselineMismatchError, InvalidExpRevError
+from .executor import BaseExecutor
+
 logger = logging.getLogger(__name__)
-
-
-class ApplyError(InvalidArgumentError):
-    def __init__(self, rev):
-        super().__init__(
-            f"'{rev}' does not appear to be an experiment commit."
-        )
 
 
 @locked
@@ -23,22 +18,22 @@ def apply(repo, rev, *args, **kwargs):
     from git.exc import GitCommandError
 
     from dvc.repo.checkout import checkout as dvc_checkout
-    from dvc.repo.experiments import BaselineMismatchError
 
     exps = repo.experiments
 
     try:
+        rev = repo.scm.resolve_rev(rev)
         exps.check_baseline(rev)
-    except BaselineMismatchError as exc:
-        raise ApplyError(rev) from exc
+    except (RevError, BaselineMismatchError) as exc:
+        raise InvalidExpRevError(rev) from exc
 
     stash_rev = rev in exps.stash_revs
     if stash_rev:
         branch = rev
     else:
-        branch = exps.get_branch_containing(rev)
+        branch = exps.get_branch_by_rev(rev)
         if not branch:
-            raise ApplyError(rev)
+            raise InvalidExpRevError(rev)
 
     # Note that we don't use stash_workspace() here since we need finer control
     # over the merge behavior when we unstash everything

--- a/dvc/repo/experiments/base.py
+++ b/dvc/repo/experiments/base.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from dvc.exceptions import DvcException
+from dvc.exceptions import DvcException, InvalidArgumentError
 
 # Experiment refs are stored according baseline git SHA:
 #   refs/exps/01/234abcd.../<exp_name>
@@ -18,6 +18,18 @@ class UnchangedExperimentError(DvcException):
     def __init__(self, rev):
         super().__init__(f"Experiment unchanged from '{rev[:7]}'.")
         self.rev = rev
+
+
+class BaselineMismatchError(DvcException):
+    def __init__(self, rev, expected):
+        if hasattr(rev, "hexsha"):
+            rev = rev.hexsha
+        rev_str = f"{rev[:7]}" if rev is not None else "invalid commit"
+        super().__init__(
+            f"Experiment derived from '{rev_str}', expected '{expected[:7]}'."
+        )
+        self.rev = rev
+        self.expected_rev = expected
 
 
 class ExperimentExistsError(DvcException):
@@ -51,6 +63,22 @@ class InvalidExpRefError(DvcException):
     def __init__(self, ref):
         super().__init__(f"'{ref}' is not a valid experiment refname.")
         self.ref = ref
+
+
+class InvalidExpRevError(InvalidArgumentError):
+    def __init__(self, rev):
+        super().__init__(
+            f"'{rev}' does not appear to be an experiment commit."
+        )
+
+
+class MultipleBranchError(DvcException):
+    def __init__(self, rev):
+        super().__init__(
+            f"Ambiguous commit '{rev[:7]}' belongs to multiple experiment "
+            "branches."
+        )
+        self.rev = rev
 
 
 class ExpRefInfo:

--- a/dvc/repo/experiments/branch.py
+++ b/dvc/repo/experiments/branch.py
@@ -3,6 +3,10 @@ import logging
 from dvc.exceptions import InvalidArgumentError
 from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
+from dvc.scm.base import RevError
+
+from .base import InvalidExpRevError
+from .utils import exp_refs_by_rev
 
 logger = logging.getLogger(__name__)
 
@@ -10,49 +14,33 @@ logger = logging.getLogger(__name__)
 @locked
 @scm_context
 def branch(repo, exp_rev, branch_name, *args, **kwargs):
-    from dvc.repo.experiments.base import ExpRefInfo, InvalidExpRefError
-    from dvc.scm.base import RevError
-    from dvc.scm.git import Git
-
+    try:
+        rev = repo.scm.resolve_rev(exp_rev)
+    except RevError:
+        raise InvalidArgumentError(exp_rev)
     ref_info = None
-    if exp_rev.startswith("refs/"):
-        try:
-            ref_info = ExpRefInfo.from_ref(exp_rev)
-        except InvalidExpRefError:
-            pass
-    elif Git.is_sha(exp_rev):
-        try:
-            rev = repo.scm.resolve_rev(exp_rev)
-            ref = repo.experiments.get_branch_containing(rev)
-            if ref:
-                ref_info = ExpRefInfo.from_ref(ref)
-        except RevError:
-            pass
+
+    ref_infos = list(exp_refs_by_rev(repo.scm, rev))
+    if len(ref_infos) == 1:
+        ref_info = ref_infos[0]
+    elif len(ref_infos) > 1:
+        current_rev = repo.scm.get_rev()
+        for info in ref_infos:
+            if info.baseline_sha == current_rev:
+                ref_info = info
+                break
+        if not ref_info:
+            msg = [
+                f"Ambiguous experiment name '{exp_rev}' can refer to "
+                "multiple experiments. To create a branch use a full "
+                "experiment ref:",
+                "",
+            ]
+            msg.extend([str(info) for info in ref_infos])
+            raise InvalidArgumentError("\n".join(msg))
 
     if not ref_info:
-        infos = list(repo.experiments.iter_ref_infos_by_name(exp_rev))
-        if len(infos) == 1:
-            ref_info = infos[0]
-        else:
-            current_rev = repo.scm.get_rev()
-            for info in infos:
-                if info.baseline_sha == current_rev:
-                    ref_info = info
-                    break
-            if not ref_info:
-                msg = [
-                    f"Ambiguous experiment name '{exp_rev}' can refer to "
-                    "multiple experiments. To create a branch use a full "
-                    "experiment ref:",
-                    "",
-                ]
-                msg.extend([str(info) for info in infos])
-                raise InvalidArgumentError("\n".join(msg))
-
-    if not ref_info:
-        raise InvalidArgumentError(
-            f"'{exp_rev}' does not appear to be a valid experiment."
-        )
+        raise InvalidExpRevError(exp_rev)
 
     branch_ref = f"refs/heads/{branch_name}"
     if repo.scm.get_ref(branch_ref):

--- a/dvc/repo/experiments/gc.py
+++ b/dvc/repo/experiments/gc.py
@@ -2,12 +2,8 @@ import logging
 from typing import Optional
 
 from dvc.repo import locked
-from dvc.repo.experiments.base import (
-    EXEC_NAMESPACE,
-    EXPS_NAMESPACE,
-    EXPS_STASH,
-    ExpRefInfo,
-)
+
+from .utils import exp_refs
 
 logger = logging.getLogger(__name__)
 
@@ -36,12 +32,9 @@ def gc(
         return 0
 
     removed = 0
-    for ref in repo.scm.iter_refs(EXPS_NAMESPACE):
-        if ref.startswith(EXEC_NAMESPACE) or ref == EXPS_STASH:
-            continue
-        ref_info = ExpRefInfo.from_ref(ref)
+    for ref_info in exp_refs(repo.scm):
         if ref_info.baseline_sha not in keep_revs:
-            repo.scm.remove_ref(ref)
+            repo.scm.remove_ref(str(ref_info))
             removed += 1
 
     delete_stashes = []

--- a/dvc/repo/experiments/utils.py
+++ b/dvc/repo/experiments/utils.py
@@ -1,0 +1,32 @@
+from typing import TYPE_CHECKING, Generator
+
+from .base import EXEC_NAMESPACE, EXPS_NAMESPACE, EXPS_STASH, ExpRefInfo
+
+if TYPE_CHECKING:
+    from dvc.scm.git import Git
+
+
+def exp_refs(scm: "Git") -> Generator["ExpRefInfo", None, None]:
+    """Iterate over all experiment refs."""
+    for ref in scm.iter_refs(base=EXPS_NAMESPACE):
+        if ref.startswith(EXEC_NAMESPACE) or ref == EXPS_STASH:
+            continue
+        yield ExpRefInfo.from_ref(ref)
+
+
+def exp_refs_by_rev(
+    scm: "Git", rev: str
+) -> Generator["ExpRefInfo", None, None]:
+    """Iterate over all experiment refs pointing to the specified revision."""
+    for ref in scm.get_refs_containing(rev, EXPS_NAMESPACE):
+        if not (ref.startswith(EXEC_NAMESPACE) or ref == EXPS_STASH):
+            yield ExpRefInfo.from_ref(ref)
+
+
+def exp_refs_by_name(
+    scm: "Git", name: str
+) -> Generator["ExpRefInfo", None, None]:
+    """Iterate over all experiment refs matching the specified name."""
+    for ref_info in exp_refs(scm):
+        if ref_info.name == name:
+            yield ref_info

--- a/tests/func/experiments/test_checkpoints.py
+++ b/tests/func/experiments/test_checkpoints.py
@@ -111,7 +111,7 @@ def test_resume_branch(tmp_dir, scm, dvc, checkpoint_stage):
         assert fobj.read().strip() == "foo: 100"
 
     with pytest.raises(MultipleBranchError):
-        dvc.experiments.get_branch_containing(branch_rev)
+        dvc.experiments.get_branch_by_rev(branch_rev)
 
     assert branch_rev == dvc.experiments.scm.gitpython.repo.git.merge_base(
         checkpoint_a, checkpoint_b

--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -163,7 +163,7 @@ def test_show_checkpoint_branch(tmp_dir, scm, dvc, checkpoint_stage, capsys):
     cap = capsys.readouterr()
 
     for rev in (checkpoint_a, checkpoint_b):
-        ref = dvc.experiments.get_branch_containing(rev)
+        ref = dvc.experiments.get_branch_by_rev(rev)
         ref_info = ExpRefInfo.from_ref(ref)
         name = ref_info.name
         assert f"╓ {name}" in cap.out


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

* Moves some general exp ref related functions out of `Experiments` class and into `experiments.utils`
* `scm.resolve_rev()` now resolves human-readable experiment short names
* This adds support for using exp names in regular DVC commands like `diff`/`metrics`/`plots`/etc (using these commands with experiment git SHAs was already supported)