### PR TITLE
experiments: ignore untracked files

### DIFF
--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -148,10 +148,12 @@ class Experiments:
                 the human-readable name in the experiment branch ref. Has no
                 effect of branch is specified.
         """
-        with self.scm.stash_workspace() as workspace:
+        with self.scm.stash_workspace(
+            include_untracked=detach_rev or branch
+        ) as workspace:
             # If we are not extending an existing branch, apply current
             # workspace changes to be made in new branch
-            if not branch and workspace:
+            if not (branch or detach_rev) and workspace:
                 self.stash.apply(workspace)
                 self._prune_lockfiles()
 

--- a/dvc/repo/experiments/executor.py
+++ b/dvc/repo/experiments/executor.py
@@ -88,7 +88,7 @@ class BaseExecutor:
             self.scm.gitpython.repo.git.merge(
                 EXEC_MERGE, squash=True, no_commit=True
             )
-            self.scm.gitpython.repo.git.reset()
+            self.scm.reset()
             self._prune_lockfiles()
         finally:
             os.chdir(cwd)

--- a/dvc/repo/experiments/executor.py
+++ b/dvc/repo/experiments/executor.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Callable, Iterable, Optional, Tuple, Union
 
 from funcy import cached_property
 
-from dvc.dvcfile import is_lock_file
 from dvc.path_info import PathInfo
 from dvc.repo import Repo
 from dvc.repo.experiments.base import (
@@ -88,27 +87,8 @@ class BaseExecutor:
             self.scm.gitpython.repo.git.merge(
                 EXEC_MERGE, squash=True, no_commit=True
             )
-            self.scm.reset()
-            self._prune_lockfiles()
         finally:
             os.chdir(cwd)
-
-    def _prune_lockfiles(self):
-        # NOTE: dirty DVC lock files must be restored to index state to
-        # avoid checking out incorrect persist or checkpoint outs
-        dirty = [
-            diff.a_path for diff in self.scm.gitpython.repo.index.diff(None)
-        ]
-        to_checkout = [fname for fname in dirty if is_lock_file(fname)]
-        self.scm.gitpython.repo.index.checkout(paths=to_checkout, force=True)
-
-        untracked = self.scm.gitpython.repo.untracked_files
-        to_remove = [fname for fname in untracked if is_lock_file(fname)]
-        for fname in to_remove:
-            remove(fname)
-        return (
-            len(dirty) - len(to_checkout) + len(untracked) - len(to_remove)
-        ) != 0
 
     @cached_property
     def scm(self):
@@ -324,7 +304,7 @@ class BaseExecutor:
             old_ref = None
             logger.debug("Commit to new experiment branch '%s'", branch)
 
-        scm.gitpython.repo.git.add(A=True)
+        scm.gitpython.repo.git.add(update=True)
         scm.commit(f"dvc: commit experiment {exp_hash}")
         new_rev = scm.get_rev()
         scm.set_ref(branch, new_rev, old_ref=old_ref)

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -326,6 +326,7 @@ class Git(Base):
     reflog_delete = partialmethod(_backend_func, "reflog_delete")
     describe = partialmethod(_backend_func, "describe")
     diff = partialmethod(_backend_func, "diff")
+    reset = partialmethod(_backend_func, "reset")
 
     def resolve_rev(self, rev: str) -> str:
         from dvc.repo.experiments.utils import exp_refs_by_name

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -327,6 +327,7 @@ class Git(Base):
     describe = partialmethod(_backend_func, "describe")
     diff = partialmethod(_backend_func, "diff")
     reset = partialmethod(_backend_func, "reset")
+    checkout_paths = partialmethod(_backend_func, "checkout_paths")
 
     def resolve_rev(self, rev: str) -> str:
         from dvc.repo.experiments.utils import exp_refs_by_name

--- a/dvc/scm/git/backend/base.py
+++ b/dvc/scm/git/backend/base.py
@@ -261,5 +261,9 @@ class BaseGitBackend(ABC):
         """Return the git diff for two commits."""
 
     @abstractmethod
-    def reset(self, hard: bool = False):
+    def reset(self, hard: bool = False, paths: Iterable[str] = None):
         """Reset current git HEAD."""
+
+    @abstractmethod
+    def checkout_paths(self, paths: Iterable[str], force: bool = False):
+        """Checkout the specified paths from HEAD index."""

--- a/dvc/scm/git/backend/base.py
+++ b/dvc/scm/git/backend/base.py
@@ -259,3 +259,7 @@ class BaseGitBackend(ABC):
     @abstractmethod
     def diff(self, rev_a: str, rev_b: str, binary=False) -> str:
         """Return the git diff for two commits."""
+
+    @abstractmethod
+    def reset(self, hard: bool = False):
+        """Reset current git HEAD."""

--- a/dvc/scm/git/backend/dulwich.py
+++ b/dvc/scm/git/backend/dulwich.py
@@ -340,3 +340,6 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
             buf, self.repo.object_store, commit_a.tree, commit_b.tree
         )
         return buf.getvalue().decode("utf-8")
+
+    def reset(self, hard: bool = False):
+        raise NotImplementedError

--- a/dvc/scm/git/backend/dulwich.py
+++ b/dvc/scm/git/backend/dulwich.py
@@ -341,5 +341,8 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
         )
         return buf.getvalue().decode("utf-8")
 
-    def reset(self, hard: bool = False):
+    def reset(self, hard: bool = False, paths: Iterable[str] = None):
+        raise NotImplementedError
+
+    def checkout_paths(self, paths: Iterable[str], force: bool = False):
         raise NotImplementedError

--- a/dvc/scm/git/backend/gitpython.py
+++ b/dvc/scm/git/backend/gitpython.py
@@ -394,3 +394,10 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
 
     def diff(self, rev_a: str, rev_b: str, binary=False) -> str:
         raise NotImplementedError
+
+    def reset(self, hard: bool = False):
+        reset = partial(self.git.reset)
+        if hard:
+            reset(hard=hard)
+        else:
+            reset()

--- a/dvc/scm/git/backend/gitpython.py
+++ b/dvc/scm/git/backend/gitpython.py
@@ -395,9 +395,10 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
     def diff(self, rev_a: str, rev_b: str, binary=False) -> str:
         raise NotImplementedError
 
-    def reset(self, hard: bool = False):
-        reset = partial(self.git.reset)
-        if hard:
-            reset(hard=hard)
-        else:
-            reset()
+    def reset(self, hard: bool = False, paths: Iterable[str] = None):
+        self.repo.head.reset(index=True, working_tree=hard, paths=paths)
+
+    def checkout_paths(self, paths: Iterable[str], force: bool = False):
+        """Checkout the specified paths from HEAD index."""
+        if paths:
+            self.repo.index.checkout(paths=paths, force=force)

--- a/dvc/stage/run.py
+++ b/dvc/stage/run.py
@@ -186,6 +186,9 @@ def _kill_nt(proc):
 def _run_callback(stage, callback_func):
     stage.save(allow_missing=True)
     stage.commit(allow_missing=True)
+    for out in stage.outs:
+        if not out.use_scm_ignore and out.is_in_repo:
+            stage.repo.scm.track_file(os.fspath(out.path_info))
     stage.repo.scm.track_changed_files()
     logger.debug("Running checkpoint callback for stage '%s'", stage)
     callback_func()

--- a/dvc/stage/run.py
+++ b/dvc/stage/run.py
@@ -186,5 +186,6 @@ def _kill_nt(proc):
 def _run_callback(stage, callback_func):
     stage.save(allow_missing=True)
     stage.commit(allow_missing=True)
+    stage.repo.scm.track_changed_files()
     logger.debug("Running checkpoint callback for stage '%s'", stage)
     callback_func()

--- a/tests/func/experiments/test_checkpoints.py
+++ b/tests/func/experiments/test_checkpoints.py
@@ -13,11 +13,14 @@ def test_new_checkpoint(tmp_dir, scm, dvc, checkpoint_stage, mocker):
     exp = first(results)
 
     new_mock.assert_called_once()
-    tree = scm.get_tree(exp)
-    with tree.open(tmp_dir / "foo") as fobj:
-        assert fobj.read().strip() == "5"
-    with tree.open(tmp_dir / "metrics.yaml") as fobj:
-        assert fobj.read().strip() == "foo: 2"
+    for rev in dvc.brancher([exp]):
+        if rev == "workspace":
+            continue
+        tree = dvc.repo_tree
+        with tree.open(tmp_dir / "foo") as fobj:
+            assert fobj.read().strip() == "5"
+        with tree.open(tmp_dir / "metrics.yaml") as fobj:
+            assert fobj.read().strip() == "foo: 2"
 
 
 @pytest.mark.parametrize(
@@ -49,11 +52,14 @@ def test_resume_checkpoint(
     )
     exp = first(results)
 
-    tree = scm.get_tree(exp)
-    with tree.open(tmp_dir / "foo") as fobj:
-        assert fobj.read().strip() == "10"
-    with tree.open(tmp_dir / "metrics.yaml") as fobj:
-        assert fobj.read().strip() == "foo: 2"
+    for rev in dvc.brancher([exp]):
+        if rev == "workspace":
+            continue
+        tree = dvc.repo_tree
+        with tree.open(tmp_dir / "foo") as fobj:
+            assert fobj.read().strip() == "10"
+        with tree.open(tmp_dir / "metrics.yaml") as fobj:
+            assert fobj.read().strip() == "foo: 2"
 
 
 def test_reset_checkpoint(tmp_dir, scm, dvc, checkpoint_stage, caplog):
@@ -73,11 +79,14 @@ def test_reset_checkpoint(tmp_dir, scm, dvc, checkpoint_stage, caplog):
     )
     exp = first(results)
 
-    tree = scm.get_tree(exp)
-    with tree.open(tmp_dir / "foo") as fobj:
-        assert fobj.read().strip() == "5"
-    with tree.open(tmp_dir / "metrics.yaml") as fobj:
-        assert fobj.read().strip() == "foo: 2"
+    for rev in dvc.brancher([exp]):
+        if rev == "workspace":
+            continue
+        tree = dvc.repo_tree
+        with tree.open(tmp_dir / "foo") as fobj:
+            assert fobj.read().strip() == "5"
+        with tree.open(tmp_dir / "metrics.yaml") as fobj:
+            assert fobj.read().strip() == "foo: 2"
 
 
 def test_resume_branch(tmp_dir, scm, dvc, checkpoint_stage):
@@ -98,17 +107,23 @@ def test_resume_branch(tmp_dir, scm, dvc, checkpoint_stage):
     )
     checkpoint_b = first(results)
 
-    tree = scm.get_tree(checkpoint_a)
-    with tree.open(tmp_dir / "foo") as fobj:
-        assert fobj.read().strip() == "10"
-    with tree.open(tmp_dir / "metrics.yaml") as fobj:
-        assert fobj.read().strip() == "foo: 2"
+    for rev in dvc.brancher([checkpoint_a]):
+        if rev == "workspace":
+            continue
+        tree = dvc.repo_tree
+        with tree.open(tmp_dir / "foo") as fobj:
+            assert fobj.read().strip() == "10"
+        with tree.open(tmp_dir / "metrics.yaml") as fobj:
+            assert fobj.read().strip() == "foo: 2"
 
-    tree = scm.get_tree(checkpoint_b)
-    with tree.open(tmp_dir / "foo") as fobj:
-        assert fobj.read().strip() == "10"
-    with tree.open(tmp_dir / "metrics.yaml") as fobj:
-        assert fobj.read().strip() == "foo: 100"
+    for rev in dvc.brancher([checkpoint_b]):
+        if rev == "workspace":
+            continue
+        tree = dvc.repo_tree
+        with tree.open(tmp_dir / "foo") as fobj:
+            assert fobj.read().strip() == "10"
+        with tree.open(tmp_dir / "metrics.yaml") as fobj:
+            assert fobj.read().strip() == "foo: 100"
 
     with pytest.raises(MultipleBranchError):
         dvc.experiments.get_branch_by_rev(branch_rev)

--- a/tests/func/experiments/test_experiments.py
+++ b/tests/func/experiments/test_experiments.py
@@ -337,3 +337,31 @@ def test_no_scm(tmp_dir):
 
     with pytest.raises(NoSCMError):
         dvc.experiments.gc()
+
+
+def test_untracked(tmp_dir, scm, dvc, caplog):
+    tmp_dir.gen("copy.py", COPY_SCRIPT)
+    tmp_dir.gen("params.yaml", "foo: 1")
+    stage = dvc.run(
+        cmd="python copy.py params.yaml metrics.yaml",
+        metrics_no_cache=["metrics.yaml"],
+        params=["foo"],
+        name="copy-file",
+    )
+    scm.add(["dvc.yaml", "dvc.lock", "params.yaml", "metrics.yaml"])
+    scm.commit("init")
+
+    # copy.py is untracked
+    with caplog.at_level(logging.ERROR):
+        results = dvc.experiments.run(stage.addressing, params=["foo=2"])
+        assert "Failed to reproduce experiment" in caplog.text
+        assert not results
+
+    # copy.py is staged as new file but not committed
+    scm.add(["copy.py"])
+    results = dvc.experiments.run(stage.addressing, params=["foo=2"])
+    exp = first(results)
+    tree = scm.get_tree(exp)
+    assert tree.exists("copy.py")
+    with tree.open(tmp_dir / "metrics.yaml") as fobj:
+        assert fobj.read().strip() == "foo: 2"


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

* Untracked files are now ignored when populating experiment executor. Only workspace changes to git-tracked files will be passed into the executor.
* To explicitly pass untracked files (such as a new code classes/files) into the experiment, the file should be staged as a new file via `git add <file>` or `git add --intent-to-add <file>` before running the experiment.
    * Closes #4594.
* Only tracked files (including any "new" files which were staged via `git add`) will be included in the experiment commit.
    * **This is a change from prior behavior (#4452)**. Support for the inclusion of untracked files should no longer be needed, as the types of intermediate files which were discussed in the original issue, should now be explicitly handled as checkpoint outs.
    * DVC outputs/artifacts will always be included in the experiment commit, this includes `dvc.lock` files and uncached (git-tracked) outputs which did not exist in git prior to running the experiment.

This change is needed to avoid issues where users are not `.gitignore`ing things properly (such as build directories, `__pycache__`, `pyc` files, etc). Otherwise, all of these types of run/build artifiacts would be included in the experiment git commits.