### PR TITLE
Run graph checks on `collect`/`find_outs_by_path`

### DIFF
--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -375,8 +375,8 @@ class Repo:
         return self.stage.collect_repo(onerror=error_handler)
 
     def find_outs_by_path(self, path, outs=None, recursive=False, strict=True):
-        if not outs:
-            outs = [out for stage in self.stages for out in stage.outs]
+        # using `outs_graph` to ensure graph checks are run
+        outs = outs or self.outs_graph
 
         abs_path = os.path.abspath(path)
         path_info = PathInfo(abs_path)

--- a/dvc/repo/collect.py
+++ b/dvc/repo/collect.py
@@ -21,7 +21,7 @@ def _collect_outs(
 ) -> Outputs:
     outs = {
         out
-        for stage in repo.stages
+        for stage in repo.graph  # using `graph` to ensure graph checks run
         for out in (stage.deps if deps else stage.outs)
     }
     return set(filter(output_filter, outs)) if output_filter else outs

--- a/tests/unit/repo/test_repo.py
+++ b/tests/unit/repo/test_repo.py
@@ -1,7 +1,9 @@
 import os
+import shutil
 
 import pytest
 
+from dvc.exceptions import OutputDuplicationError
 from dvc.repo import NotDvcRepoError, Repo, locked
 from dvc.utils.fs import remove
 
@@ -27,6 +29,15 @@ def test_find_outs_by_path(tmp_dir, dvc, path):
     outs = dvc.find_outs_by_path(path, strict=False)
     assert len(outs) == 1
     assert outs[0].path_info == stage.outs[0].path_info
+
+
+def test_find_outs_by_path_does_graph_checks(tmp_dir, dvc):
+    tmp_dir.dvc_gen("foo", "foo")
+    shutil.copyfile("foo.dvc", "foo-2.dvc")
+
+    dvc._reset()
+    with pytest.raises(OutputDuplicationError):
+        dvc.find_outs_by_path("foo")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
We try to optimize `tree.exists` calls and probably a few others
in that, they either look directly into the workspace or,
to the cache without running graph checks. It does not seem
to be possible just to run graph checks on `find_outs_by_path`
due to those optimizations.

So, that's why the `collect` also does a graph check for this
reason.

Fixes #5027
Fixes #4010

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
