### PR TITLE
experiments: add `dvc exp push/pull/list`

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -527,7 +527,7 @@ class CmdExperimentsBranch(CmdBase):
 class CmdExperimentsList(CmdBase):
     def run(self):
 
-        exps = self.repo.experiments.list(
+        exps = self.repo.experiments.ls(
             rev=self.args.rev,
             git_remote=self.args.git_remote,
             all_=self.args.all,

--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -913,7 +913,6 @@ def add_parser(subparsers, parent_parser):
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     experiments_list_parser.add_argument(
-        "-r",
         "--rev",
         type=str,
         default=None,
@@ -924,7 +923,7 @@ def add_parser(subparsers, parent_parser):
         metavar="<rev>",
     )
     experiments_list_parser.add_argument(
-        "-a", "--all", action="store_true", help="List all experiments.",
+        "--all", action="store_true", help="List all experiments.",
     )
     experiments_list_parser.add_argument(
         "git_remote",

--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -524,6 +524,68 @@ class CmdExperimentsBranch(CmdBase):
         return 0
 
 
+class CmdExperimentsList(CmdBase):
+    def run(self):
+
+        exps = self.repo.experiments.list(
+            rev=self.args.rev,
+            git_remote=self.args.git_remote,
+            all_=self.args.all,
+        )
+        for baseline in exps:
+            tag = self.repo.scm.describe(baseline)
+            if not tag:
+                branch = self.repo.scm.describe(baseline, base="refs/heads")
+                if branch:
+                    tag = branch.split("/")[-1]
+            name = tag if tag else baseline[:7]
+            logger.info(f"{name}:")
+            for exp_name in exps[baseline]:
+                logger.info(f"\t{exp_name}")
+
+        return 0
+
+
+class CmdExperimentsPush(CmdBase):
+    def run(self):
+
+        self.repo.experiments.push(
+            self.args.git_remote, self.args.experiment, force=self.args.force
+        )
+
+        logger.info(
+            (
+                "Pushed experiment '%s' to Git remote '%s'. "
+                "To push cache for this experiment to a DVC remote run:\n\n"
+                "\tdvc push ..."
+            ),
+            self.args.experiment,
+            self.args.git_remote,
+        )
+
+        return 0
+
+
+class CmdExperimentsPull(CmdBase):
+    def run(self):
+
+        self.repo.experiments.pull(
+            self.args.git_remote, self.args.experiment, force=self.args.force
+        )
+
+        logger.info(
+            (
+                "Pulled experiment '%s' from Git remote '%s'. "
+                "To pull cache for this experiment from a DVC remote run:\n\n"
+                "\tdvc pull ..."
+            ),
+            self.args.experiment,
+            self.args.git_remote,
+        )
+
+        return 0
+
+
 def add_parser(subparsers, parent_parser):
     EXPERIMENTS_HELP = "Commands to run and compare experiments."
 
@@ -841,6 +903,89 @@ def add_parser(subparsers, parent_parser):
         "branch", help="Git branch name to use.",
     )
     experiments_branch_parser.set_defaults(func=CmdExperimentsBranch)
+
+    EXPERIMENTS_LIST_HELP = "List local and remote experiments."
+    experiments_list_parser = experiments_subparsers.add_parser(
+        "list",
+        parents=[parent_parser],
+        description=append_doc_link(EXPERIMENTS_LIST_HELP, "experiments/list"),
+        help=EXPERIMENTS_LIST_HELP,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    experiments_list_parser.add_argument(
+        "-r",
+        "--rev",
+        type=str,
+        default=None,
+        help=(
+            "List experiments derived from the specified revision. "
+            "Defaults to HEAD if neither `--rev` nor `--all` are specified."
+        ),
+        metavar="<rev>",
+    )
+    experiments_list_parser.add_argument(
+        "-a", "--all", action="store_true", help="List all experiments.",
+    )
+    experiments_list_parser.add_argument(
+        "git_remote",
+        nargs="?",
+        default=None,
+        help=(
+            "Optional Git remote name or Git URL. If provided, experiments "
+            "from the specified Git repository will be listed instead of "
+            "local experiments."
+        ),
+        metavar="[<git_remote>]",
+    )
+    experiments_list_parser.set_defaults(func=CmdExperimentsList)
+
+    EXPERIMENTS_PUSH_HELP = "Push a local experiment to a Git remote."
+    experiments_push_parser = experiments_subparsers.add_parser(
+        "push",
+        parents=[parent_parser],
+        description=append_doc_link(EXPERIMENTS_PUSH_HELP, "experiments/push"),
+        help=EXPERIMENTS_PUSH_HELP,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    experiments_push_parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="Replace experiment in the remote if it already exists.",
+    )
+    experiments_push_parser.add_argument(
+        "git_remote",
+        help="Git remote name or Git URL.",
+        metavar="<git_remote>",
+    )
+    experiments_push_parser.add_argument(
+        "experiment", help="Experiment to push.", metavar="<experiment>",
+    )
+    experiments_push_parser.set_defaults(func=CmdExperimentsPush)
+
+    EXPERIMENTS_PULL_HELP = "Pull an experiment from a Git remote."
+    experiments_pull_parser = experiments_subparsers.add_parser(
+        "pull",
+        parents=[parent_parser],
+        description=append_doc_link(EXPERIMENTS_PULL_HELP, "experiments/pull"),
+        help=EXPERIMENTS_PULL_HELP,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    experiments_pull_parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="Replace local experiment already exists.",
+    )
+    experiments_pull_parser.add_argument(
+        "git_remote",
+        help="Git remote name or Git URL.",
+        metavar="<git_remote>",
+    )
+    experiments_pull_parser.add_argument(
+        "experiment", help="Experiment to pull.", metavar="<experiment>",
+    )
+    experiments_pull_parser.set_defaults(func=CmdExperimentsPull)
 
 
 def _add_run_common(parser):

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -663,7 +663,7 @@ class Experiments:
 
         return pull(self.repo, *args, **kwargs)
 
-    def list(self, *args, **kwargs):
-        from dvc.repo.experiments.list import list_
+    def ls(self, *args, **kwargs):
+        from dvc.repo.experiments.ls import ls
 
-        return list_(self.repo, *args, **kwargs)
+        return ls(self.repo, *args, **kwargs)

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -652,3 +652,8 @@ class Experiments:
         from dvc.repo.experiments.gc import gc
 
         return gc(self.repo, *args, **kwargs)
+
+    def push(self, *args, **kwargs):
+        from dvc.repo.experiments.push import push
+
+        return push(self.repo, *args, **kwargs)

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -658,6 +658,11 @@ class Experiments:
 
         return push(self.repo, *args, **kwargs)
 
+    def pull(self, *args, **kwargs):
+        from dvc.repo.experiments.pull import pull
+
+        return pull(self.repo, *args, **kwargs)
+
     def list(self, *args, **kwargs):
         from dvc.repo.experiments.list import list_
 

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -657,3 +657,8 @@ class Experiments:
         from dvc.repo.experiments.push import push
 
         return push(self.repo, *args, **kwargs)
+
+    def list(self, *args, **kwargs):
+        from dvc.repo.experiments.list import list_
+
+        return list_(self.repo, *args, **kwargs)

--- a/dvc/repo/experiments/executor.py
+++ b/dvc/repo/experiments/executor.py
@@ -152,21 +152,18 @@ class BaseExecutor:
             if not ref.startswith(EXEC_NAMESPACE) and ref != EXPS_STASH:
                 refs.append(ref)
 
-        def on_diverged_ref(orig_ref, new_rev):
+        def on_diverged_ref(orig_ref: str, new_rev: str):
             orig_rev = dest_scm.get_ref(orig_ref)
             if dest_scm.diff(orig_rev, new_rev):
                 if force:
                     logger.debug(
-                        "Replacing existing experiment '%s'",
-                        os.fsdecode(orig_ref),
+                        "Replacing existing experiment '%s'", orig_ref,
                     )
                     return True
                 if on_diverged:
                     checkpoint = self.scm.get_ref(EXEC_CHECKPOINT) is not None
                     on_diverged(orig_ref, checkpoint)
-            logger.debug(
-                "Reproduced existing experiment '%s'", os.fsdecode(orig_ref)
-            )
+            logger.debug("Reproduced existing experiment '%s'", orig_ref)
             return False
 
         # fetch experiments

--- a/dvc/repo/experiments/list.py
+++ b/dvc/repo/experiments/list.py
@@ -1,0 +1,46 @@
+import logging
+from collections import defaultdict
+
+from dvc.repo import locked
+from dvc.repo.scm_context import scm_context
+
+from .utils import (
+    exp_refs,
+    exp_refs_by_baseline,
+    remote_exp_refs,
+    remote_exp_refs_by_baseline,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@locked
+@scm_context
+def list_(repo, *args, rev=None, git_remote=None, all_=False, **kwargs):
+
+    if rev:
+        rev = repo.scm.resolve_rev(rev)
+    elif not all_:
+        rev = repo.scm.get_rev()
+
+    results = defaultdict(list)
+
+    if rev:
+        if git_remote:
+            gen = remote_exp_refs_by_baseline(repo.scm, git_remote, rev)
+        else:
+            gen = exp_refs_by_baseline(repo.scm, rev)
+        for info in gen:
+            results[rev].append(info.name)
+        # results[rev].extend(
+        #     [info.name for info in gen]
+        # )
+    elif all_:
+        if git_remote:
+            gen = remote_exp_refs(repo.scm, git_remote)
+        else:
+            gen = exp_refs(repo.scm)
+        for info in gen:
+            results[info.baseline_sha].append(info.name)
+
+    return results

--- a/dvc/repo/experiments/ls.py
+++ b/dvc/repo/experiments/ls.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 @locked
 @scm_context
-def list_(repo, *args, rev=None, git_remote=None, all_=False, **kwargs):
+def ls(repo, *args, rev=None, git_remote=None, all_=False, **kwargs):
 
     if rev:
         rev = repo.scm.resolve_rev(rev)
@@ -32,9 +32,6 @@ def list_(repo, *args, rev=None, git_remote=None, all_=False, **kwargs):
             gen = exp_refs_by_baseline(repo.scm, rev)
         for info in gen:
             results[rev].append(info.name)
-        # results[rev].extend(
-        #     [info.name for info in gen]
-        # )
     elif all_:
         if git_remote:
             gen = remote_exp_refs(repo.scm, git_remote)

--- a/dvc/repo/experiments/pull.py
+++ b/dvc/repo/experiments/pull.py
@@ -24,14 +24,9 @@ def pull(repo, git_remote, exp_name, *args, force=False, **kwargs):
         )
 
     refspec = f"{exp_ref}:{exp_ref}"
+    logger.debug("Pull '%s' -> '%s'", git_remote, refspec)
     repo.scm.fetch_refspecs(
         git_remote, [refspec], force=force, on_diverged=on_diverged
-    )
-
-    logger.info(
-        f"Pulled experiment '{exp_name}' from Git remote '{git_remote}'. "
-        "To pull cache for this experiment from a DVC remote run:\n\n"
-        "\tdvc pull ..."
     )
 
 
@@ -42,7 +37,7 @@ def _get_exp_ref(repo, git_remote, exp_name):
     exp_refs = list(remote_exp_refs_by_name(repo.scm, git_remote, exp_name))
     if not exp_refs:
         raise InvalidArgumentError(
-            f"'{exp_name}' is not a valid experiment name"
+            f"Experiment '{exp_name}' does not exist in '{git_remote}'"
         )
     if len(exp_refs) > 1:
         cur_rev = repo.scm.get_rev()

--- a/dvc/repo/experiments/pull.py
+++ b/dvc/repo/experiments/pull.py
@@ -1,0 +1,62 @@
+import logging
+
+from dvc.exceptions import DvcException, InvalidArgumentError
+from dvc.repo import locked
+from dvc.repo.scm_context import scm_context
+
+from .utils import remote_exp_refs_by_name
+
+logger = logging.getLogger(__name__)
+
+
+@locked
+@scm_context
+def pull(repo, git_remote, exp_name, *args, force=False, **kwargs):
+    exp_ref = _get_exp_ref(repo, git_remote, exp_name)
+
+    def on_diverged(refname: str, rev: str) -> bool:
+        if repo.scm.get_ref(refname) == rev:
+            return True
+        raise DvcException(
+            f"Local experiment '{exp_name}' has diverged from remote "
+            "experiment with the same name. To override the local experiment "
+            "re-run with '--force'."
+        )
+
+    refspec = f"{exp_ref}:{exp_ref}"
+    repo.scm.fetch_refspecs(
+        git_remote, [refspec], force=force, on_diverged=on_diverged
+    )
+
+    logger.info(
+        f"Pulled experiment '{exp_name}' from Git remote '{git_remote}'. "
+        "To pull cache for this experiment from a DVC remote run:\n\n"
+        "\tdvc pull ..."
+    )
+
+
+def _get_exp_ref(repo, git_remote, exp_name):
+    if exp_name.startswith("refs/"):
+        return exp_name
+
+    exp_refs = list(remote_exp_refs_by_name(repo.scm, git_remote, exp_name))
+    if not exp_refs:
+        raise InvalidArgumentError(
+            f"'{exp_name}' is not a valid experiment name"
+        )
+    if len(exp_refs) > 1:
+        cur_rev = repo.scm.get_rev()
+        for info in exp_refs:
+            if info.baseline_sha == cur_rev:
+                return info
+        msg = [
+            (
+                f"Ambiguous name '{exp_name}' refers to multiple "
+                "experiments in '{git_remote}'. Use full refname to pull one "
+                "of the following:"
+            ),
+            "",
+        ]
+        msg.extend([f"\t{info}" for info in exp_refs])
+        raise InvalidArgumentError("\n".join(msg))
+    return exp_refs[0]

--- a/dvc/repo/experiments/push.py
+++ b/dvc/repo/experiments/push.py
@@ -24,14 +24,9 @@ def push(repo, git_remote, exp_name, *args, force=False, **kwargs):
         )
 
     refname = str(exp_ref)
+    logger.debug("Push '%s' -> '%s'", exp_ref, git_remote)
     repo.scm.push_refspec(
         git_remote, refname, refname, force=force, on_diverged=on_diverged
-    )
-
-    logger.info(
-        f"Pushed experiment '{exp_name}' to Git remote '{git_remote}'. "
-        "To push cache for this experiment to a DVC remote run:\n\n"
-        "\tdvc push ..."
     )
 
 

--- a/dvc/repo/experiments/push.py
+++ b/dvc/repo/experiments/push.py
@@ -36,6 +36,9 @@ def push(repo, git_remote, exp_name, *args, force=False, **kwargs):
 
 
 def _get_exp_ref(repo, exp_name):
+    if exp_name.startswith("refs/"):
+        return exp_name
+
     exp_refs = list(exp_refs_by_name(repo.scm, exp_name))
     if not exp_refs:
         raise InvalidArgumentError(

--- a/dvc/repo/experiments/push.py
+++ b/dvc/repo/experiments/push.py
@@ -1,0 +1,59 @@
+import logging
+
+from dvc.exceptions import DvcException, InvalidArgumentError
+from dvc.repo import locked
+from dvc.repo.scm_context import scm_context
+
+from .utils import exp_refs_by_name
+
+logger = logging.getLogger(__name__)
+
+
+@locked
+@scm_context
+def push(repo, git_remote, exp_name, *args, force=False, **kwargs):
+    exp_ref = _get_exp_ref(repo, exp_name)
+
+    def on_diverged(refname: str, rev: str) -> bool:
+        if repo.scm.get_ref(refname) == rev:
+            return True
+        raise DvcException(
+            f"Local experiment '{exp_name}' has diverged from remote "
+            "experiment with the same name. To override the remote experiment "
+            "re-run with '--force'."
+        )
+
+    refname = str(exp_ref)
+    repo.scm.push_refspec(
+        git_remote, refname, refname, force=force, on_diverged=on_diverged
+    )
+
+    logger.info(
+        f"Pushed experiment '{exp_name}' to Git remote '{git_remote}'. "
+        "To push cache for this experiment to a DVC remote run:\n\n"
+        "\tdvc push ..."
+    )
+
+
+def _get_exp_ref(repo, exp_name):
+    exp_refs = list(exp_refs_by_name(repo.scm, exp_name))
+    if not exp_refs:
+        raise InvalidArgumentError(
+            f"'{exp_name}' is not a valid experiment name"
+        )
+    if len(exp_refs) > 1:
+        cur_rev = repo.scm.get_rev()
+        for info in exp_refs:
+            if info.baseline_sha == cur_rev:
+                return info
+        msg = [
+            (
+                f"Ambiguous name '{exp_name}' refers to multiple "
+                "experiments. Use full refname to push one of the "
+                "following:"
+            ),
+            "",
+        ]
+        msg.extend([f"\t{info}" for info in exp_refs])
+        raise InvalidArgumentError("\n".join(msg))
+    return exp_refs[0]

--- a/dvc/repo/experiments/utils.py
+++ b/dvc/repo/experiments/utils.py
@@ -30,3 +30,44 @@ def exp_refs_by_name(
     for ref_info in exp_refs(scm):
         if ref_info.name == name:
             yield ref_info
+
+
+def exp_refs_by_baseline(
+    scm: "Git", rev: str
+) -> Generator["ExpRefInfo", None, None]:
+    """Iterate over all experiment refs with the specified baseline."""
+    ref_info = ExpRefInfo(baseline_sha=rev)
+    for ref in scm.iter_refs(base=str(ref_info)):
+        if ref.startswith(EXEC_NAMESPACE) or ref == EXPS_STASH:
+            continue
+        yield ExpRefInfo.from_ref(ref)
+
+
+def remote_exp_refs(
+    scm: "Git", url: str
+) -> Generator["ExpRefInfo", None, None]:
+    """Iterate over all remote experiment refs."""
+    for ref in scm.iter_remote_refs(url, base=EXPS_NAMESPACE):
+        if ref.startswith(EXEC_NAMESPACE) or ref == EXPS_STASH:
+            continue
+        yield ExpRefInfo.from_ref(ref)
+
+
+def remote_exp_refs_by_name(
+    scm: "Git", url: str, name: str
+) -> Generator["ExpRefInfo", None, None]:
+    """Iterate over all remote experiment refs matching the specified name."""
+    for ref_info in remote_exp_refs(scm, url):
+        if ref_info.name == name:
+            yield ref_info
+
+
+def remote_exp_refs_by_baseline(
+    scm: "Git", url: str, rev: str
+) -> Generator["ExpRefInfo", None, None]:
+    """Iterate over all remote experiment refs with the specified baseline."""
+    ref_info = ExpRefInfo(baseline_sha=rev)
+    for ref in scm.iter_remote_refs(url, base=str(ref_info)):
+        if ref.startswith(EXEC_NAMESPACE) or ref == EXPS_STASH:
+            continue
+        yield ExpRefInfo.from_ref(ref)

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -321,6 +321,7 @@ class Git(Base):
     get_ref = partialmethod(_backend_func, "get_ref")
     remove_ref = partialmethod(_backend_func, "remove_ref")
     iter_refs = partialmethod(_backend_func, "iter_refs")
+    iter_remote_refs = partialmethod(_backend_func, "iter_remote_refs")
     get_refs_containing = partialmethod(_backend_func, "get_refs_containing")
     push_refspec = partialmethod(_backend_func, "push_refspec")
     fetch_refspecs = partialmethod(_backend_func, "fetch_refspecs")

--- a/dvc/scm/git/backend/base.py
+++ b/dvc/scm/git/backend/base.py
@@ -179,17 +179,29 @@ class BaseGitBackend(ABC):
         """Iterate over all git refs containing the specfied revision."""
 
     @abstractmethod
-    def push_refspec(self, url: str, src: Optional[str], dest: str):
+    def push_refspec(
+        self,
+        url: str,
+        src: Optional[str],
+        dest: str,
+        force: bool = False,
+        on_diverged: Optional[Callable[[str, str], bool]] = None,
+    ):
         """Push refspec to a remote Git repo.
 
         Args:
-            url: Remote repo Git URL (Note this must be a Git URL and not
-                a remote name).
+            url: Git remote name or absolute Git URL.
             src: Local refspec. If src ends with "/" it will be treated as a
                 prefix, and all refs inside src will be pushed using dest
                 as destination refspec prefix. If src is None, dest will be
                 deleted from the remote.
             dest: Remote refspec.
+            force: If True, remote refs will be overwritten.
+            on_diverged: Callback function which will be called if local ref
+                and remote have diverged and force is False. If the callback
+                returns True the remote ref will be overwritten.
+                Callback will be of the form:
+                    on_diverged(local_refname, remote_sha)
         """
 
     @abstractmethod
@@ -198,7 +210,7 @@ class BaseGitBackend(ABC):
         url: str,
         refspecs: Iterable[str],
         force: Optional[bool] = False,
-        on_diverged: Optional[Callable[[bytes, bytes], bool]] = None,
+        on_diverged: Optional[Callable[[str, str], bool]] = None,
     ):
         """Fetch refspecs from a remote Git repo.
 
@@ -211,6 +223,8 @@ class BaseGitBackend(ABC):
             on_diverged: Callback function which will be called if local ref
                 and remote have diverged and force is False. If the callback
                 returns True the local ref will be overwritten.
+                Callback will be of the form:
+                    on_diverged(local_refname, remote_sha)
         """
 
     @abstractmethod

--- a/dvc/scm/git/backend/base.py
+++ b/dvc/scm/git/backend/base.py
@@ -175,6 +175,14 @@ class BaseGitBackend(ABC):
         """
 
     @abstractmethod
+    def iter_remote_refs(self, url: str, base: Optional[str] = None):
+        """Iterate over all refs in the specified remote Git repo.
+
+        If base is specified, only refs which begin with base will be yielded.
+        URL can be a named Git remote or URL.
+        """
+
+    @abstractmethod
     def get_refs_containing(self, rev: str, pattern: Optional[str] = None):
         """Iterate over all git refs containing the specfied revision."""
 

--- a/dvc/scm/git/backend/dulwich.py
+++ b/dvc/scm/git/backend/dulwich.py
@@ -218,7 +218,7 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
         on_diverged: Optional[Callable[[str, str], bool]] = None,
     ):
         from dulwich.client import get_transport_and_path
-        from dulwich.errors import SendPackError
+        from dulwich.errors import NotGitRepository, SendPackError
         from dulwich.porcelain import (
             DivergedBranches,
             check_diverged,
@@ -265,7 +265,7 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
                 self.repo.object_store.generate_pack_data,
                 progress=progress,
             )
-        except SendPackError as exc:
+        except (NotGitRepository, SendPackError) as exc:
             raise SCMError("Git failed to push '{src}' to '{url}'") from exc
 
     def _push_dest_refs(

--- a/dvc/scm/git/backend/dulwich.py
+++ b/dvc/scm/git/backend/dulwich.py
@@ -188,8 +188,68 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
     def get_refs_containing(self, rev: str, pattern: Optional[str] = None):
         raise NotImplementedError
 
-    def push_refspec(self, url: str, src: Optional[str], dest: str):
+    def push_refspec(
+        self,
+        url: str,
+        src: Optional[str],
+        dest: str,
+        force: bool = False,
+        on_diverged: Optional[Callable[[str, str], bool]] = None,
+    ):
         from dulwich.client import get_transport_and_path
+        from dulwich.errors import SendPackError
+        from dulwich.porcelain import (
+            DivergedBranches,
+            check_diverged,
+            get_remote_repo,
+        )
+
+        dest_refs, values = self._push_dest_refs(src, dest)
+
+        try:
+            _remote, location = get_remote_repo(self.repo, url)
+            client, path = get_transport_and_path(location)
+        except Exception as exc:
+            raise SCMError(
+                f"'{url}' is not a valid Git remote or URL"
+            ) from exc
+
+        def update_refs(refs):
+            new_refs = {}
+            for ref, value in zip(dest_refs, values):
+                if ref in refs:
+                    local_sha = self.repo.refs[ref]
+                    remote_sha = refs[ref]
+                    try:
+                        check_diverged(self.repo, remote_sha, local_sha)
+                    except DivergedBranches:
+                        if not force:
+                            overwrite = False
+                            if on_diverged:
+                                overwrite = on_diverged(
+                                    os.fsdecode(ref), os.fsdecode(remote_sha),
+                                )
+                            if not overwrite:
+                                continue
+                new_refs[ref] = value
+            return new_refs
+
+        def progress(msg):
+            logger.trace("git send_pack: %s", msg)
+
+        try:
+            client.send_pack(
+                path,
+                update_refs,
+                self.repo.object_store.generate_pack_data,
+                progress=progress,
+            )
+        except SendPackError as exc:
+            raise SCMError("Git failed to push '{src}' to '{url}'") from exc
+
+    def _push_dest_refs(
+        self, src: str, dest: str
+    ) -> Tuple[Iterable[bytes], Iterable[bytes]]:
         from dulwich.objects import ZERO_SHA
 
         if src is not None and src.endswith("/"):
@@ -203,37 +263,22 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
             else:
                 values = [self.repo.refs[os.fsencode(src)]]
             dest_refs = [os.fsencode(dest)]
-
-        def update_refs(refs):
-            for ref, value in zip(dest_refs, values):
-                refs[ref] = value
-            return refs
-
-        try:
-            client, path = get_transport_and_path(url)
-        except Exception as exc:
-            raise SCMError("Could not get remote client") from exc
-
-        def progress(msg):
-            logger.trace("git send_pack: %s", msg)
-
-        client.send_pack(
-            path,
-            update_refs,
-            self.repo.object_store.generate_pack_data,
-            progress=progress,
-        )
+        return dest_refs, values
 
     def fetch_refspecs(
         self,
         url: str,
         refspecs: Iterable[str],
         force: Optional[bool] = False,
-        on_diverged: Optional[Callable[[bytes, bytes], bool]] = None,
+        on_diverged: Optional[Callable[[str, str], bool]] = None,
     ):
         from dulwich.client import get_transport_and_path
         from dulwich.objectspec import parse_reftuples
-        from dulwich.porcelain import DivergedBranches, check_diverged
+        from dulwich.porcelain import (
+            DivergedBranches,
+            check_diverged,
+            get_remote_repo,
+        )
 
         fetch_refs = []
 
@@ -253,10 +298,12 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
             ]
 
         try:
-            client, path = get_transport_and_path(url)
+            _remote, location = get_remote_repo(self.repo, url)
+            client, path = get_transport_and_path(location)
         except Exception as exc:
-
-            raise SCMError("Could not get remote client") from exc
+            raise SCMError(
+                f"'{url}' is not a valid Git remote or URL"
+            ) from exc
 
         def progress(msg):
             logger.trace("git fetch: %s", msg)

--- a/dvc/scm/git/backend/gitpython.py
+++ b/dvc/scm/git/backend/gitpython.py
@@ -379,7 +379,14 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
         except GitCommandError:
             pass
 
-    def push_refspec(self, url: str, src: Optional[str], dest: str):
+    def push_refspec(
+        self,
+        url: str,
+        src: Optional[str],
+        dest: str,
+        force: bool = False,
+        on_diverged: Optional[Callable[[str, str], bool]] = None,
+    ):
         raise NotImplementedError
 
     def fetch_refspecs(
@@ -387,7 +394,7 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
         url: str,
         refspecs: Iterable[str],
         force: Optional[bool] = False,
-        on_diverged: Optional[Callable[[bytes, bytes], bool]] = None,
+        on_diverged: Optional[Callable[[str, str], bool]] = None,
     ):
         raise NotImplementedError
 

--- a/dvc/scm/git/backend/gitpython.py
+++ b/dvc/scm/git/backend/gitpython.py
@@ -362,6 +362,9 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
                 base = base[:-1]
             yield "/".join([base, ref.name])
 
+    def iter_remote_refs(self, url: str, base: Optional[str] = None):
+        raise NotImplementedError
+
     def get_refs_containing(self, rev: str, pattern: Optional[str] = None):
         from git.exc import GitCommandError
 

--- a/tests/func/experiments/test_experiments.py
+++ b/tests/func/experiments/test_experiments.py
@@ -414,16 +414,16 @@ def test_list(tmp_dir, scm, dvc, exp_stage):
     exp_c = first(results)
     ref_info_c = first(exp_refs_by_rev(scm, exp_c))
 
-    assert dvc.experiments.list() == {
+    assert dvc.experiments.ls() == {
         baseline_c: [ref_info_c.name],
     }
 
-    exp_list = dvc.experiments.list(rev=ref_info_a.baseline_sha)
+    exp_list = dvc.experiments.ls(rev=ref_info_a.baseline_sha)
     assert {key: set(val) for key, val in exp_list.items()} == {
         baseline_a: {ref_info_a.name, ref_info_b.name}
     }
 
-    exp_list = dvc.experiments.list(all_=True)
+    exp_list = dvc.experiments.ls(all_=True)
     assert {key: set(val) for key, val in exp_list.items()} == {
         baseline_a: {ref_info_a.name, ref_info_b.name},
         baseline_c: {ref_info_c.name},

--- a/tests/func/experiments/test_experiments.py
+++ b/tests/func/experiments/test_experiments.py
@@ -5,14 +5,13 @@ import stat
 import pytest
 from funcy import first
 
+from dvc.repo.experiments.utils import exp_refs_by_rev
 from dvc.utils.serialize import PythonFileCorruptedError
 from tests.func.test_repro_multistage import COPY_SCRIPT
 
 
 @pytest.mark.parametrize("name", [None, "foo"])
 def test_new_simple(tmp_dir, scm, dvc, exp_stage, mocker, name):
-    from dvc.repo.experiments.utils import exp_refs_by_rev
-
     baseline = scm.get_rev()
     tmp_dir.gen("params.yaml", "foo: 2")
 
@@ -397,3 +396,35 @@ def test_packed_args_exists(tmp_dir, scm, dvc, exp_stage, caplog):
     with caplog.at_level(logging.WARNING):
         dvc.experiments.run(exp_stage.addressing)
         assert "Temporary DVC file" in caplog.text
+
+
+def test_list(tmp_dir, scm, dvc, exp_stage):
+    baseline_a = scm.get_rev()
+    results = dvc.experiments.run(exp_stage.addressing, params=["foo=2"])
+    exp_a = first(results)
+    ref_info_a = first(exp_refs_by_rev(scm, exp_a))
+
+    results = dvc.experiments.run(exp_stage.addressing, params=["foo=3"])
+    exp_b = first(results)
+    ref_info_b = first(exp_refs_by_rev(scm, exp_b))
+
+    tmp_dir.scm_gen("new", "new", commit="new")
+    baseline_c = scm.get_rev()
+    results = dvc.experiments.run(exp_stage.addressing, params=["foo=4"])
+    exp_c = first(results)
+    ref_info_c = first(exp_refs_by_rev(scm, exp_c))
+
+    assert dvc.experiments.list() == {
+        baseline_c: [ref_info_c.name],
+    }
+
+    exp_list = dvc.experiments.list(rev=ref_info_a.baseline_sha)
+    assert {key: set(val) for key, val in exp_list.items()} == {
+        baseline_a: {ref_info_a.name, ref_info_b.name}
+    }
+
+    exp_list = dvc.experiments.list(all_=True)
+    assert {key: set(val) for key, val in exp_list.items()} == {
+        baseline_a: {ref_info_a.name, ref_info_b.name},
+        baseline_c: {ref_info_c.name},
+    }

--- a/tests/func/experiments/test_remote.py
+++ b/tests/func/experiments/test_remote.py
@@ -1,0 +1,70 @@
+import pytest
+from funcy import first
+
+from dvc.exceptions import DvcException
+from dvc.repo.experiments.utils import exp_refs_by_rev
+
+
+@pytest.fixture
+def git_remote(tmp_dir, scm, make_tmp_dir):
+    name = "git-remote"
+    remote_dir = make_tmp_dir(name, scm=True)
+    url = "file://{}".format(remote_dir.resolve().as_posix())
+    tmp_dir.scm.gitpython.repo.create_remote(name, url)
+    remote_dir.remote = name
+    remote_dir.url = url
+    return remote_dir
+
+
+@pytest.mark.parametrize("use_url", [True, False])
+def test_push(tmp_dir, scm, dvc, git_remote, exp_stage, use_url):
+    from dvc.exceptions import InvalidArgumentError
+
+    remote = git_remote.url if use_url else git_remote.remote
+    with pytest.raises(InvalidArgumentError):
+        dvc.experiments.push(remote, "foo")
+
+    results = dvc.experiments.run(exp_stage.addressing, params=["foo=2"])
+    exp = first(results)
+    ref_info = first(exp_refs_by_rev(scm, exp))
+
+    dvc.experiments.push(remote, ref_info.name)
+    assert git_remote.scm.get_ref(str(ref_info)) == exp
+
+
+def test_push_diverged(tmp_dir, scm, dvc, git_remote, exp_stage):
+    git_remote.scm_gen("foo", "foo", commit="init")
+    remote_rev = git_remote.scm.get_rev()
+
+    results = dvc.experiments.run(exp_stage.addressing, params=["foo=2"])
+    exp = first(results)
+    ref_info = first(exp_refs_by_rev(scm, exp))
+
+    git_remote.scm.set_ref(str(ref_info), remote_rev)
+
+    with pytest.raises(DvcException):
+        dvc.experiments.push(git_remote.remote, ref_info.name)
+    assert git_remote.scm.get_ref(str(ref_info)) == remote_rev
+
+    dvc.experiments.push(git_remote.remote, ref_info.name, force=True)
+    assert git_remote.scm.get_ref(str(ref_info)) == exp
+
+
+def test_push_checkpoint(tmp_dir, scm, dvc, git_remote, checkpoint_stage):
+    results = dvc.experiments.run(
+        checkpoint_stage.addressing, params=["foo=2"]
+    )
+    exp_a = first(results)
+    ref_info_a = first(exp_refs_by_rev(scm, exp_a))
+
+    dvc.experiments.push(git_remote.remote, ref_info_a.name, force=True)
+    assert git_remote.scm.get_ref(str(ref_info_a)) == exp_a
+
+    results = dvc.experiments.run(
+        checkpoint_stage.addressing, checkpoint_resume=exp_a
+    )
+    exp_b = first(results)
+    ref_info_b = first(exp_refs_by_rev(scm, exp_b))
+
+    dvc.experiments.push(git_remote.remote, ref_info_b.name, force=True)
+    assert git_remote.scm.get_ref(str(ref_info_b)) == exp_b

--- a/tests/func/experiments/test_remote.py
+++ b/tests/func/experiments/test_remote.py
@@ -6,21 +6,32 @@ from dvc.repo.experiments.utils import exp_refs_by_rev
 
 
 @pytest.fixture
-def git_remote(tmp_dir, scm, make_tmp_dir):
-    name = "git-remote"
+def git_upstream(tmp_dir, scm, make_tmp_dir):
+    name = "git-upstream"
     remote_dir = make_tmp_dir(name, scm=True)
     url = "file://{}".format(remote_dir.resolve().as_posix())
-    tmp_dir.scm.gitpython.repo.create_remote(name, url)
-    remote_dir.remote = name
+    tmp_dir.scm.gitpython.repo.create_remote("upstream", url)
+    remote_dir.remote = "upstream"
+    remote_dir.url = url
+    return remote_dir
+
+
+@pytest.fixture
+def git_downstream(tmp_dir, scm, dvc, make_tmp_dir):
+    name = "git-downstream"
+    remote_dir = make_tmp_dir(name, scm=True, dvc=True)
+    url = "file://{}".format(tmp_dir.resolve().as_posix())
+    remote_dir.scm.gitpython.repo.create_remote("upstream", url)
+    remote_dir.remote = "upstream"
     remote_dir.url = url
     return remote_dir
 
 
 @pytest.mark.parametrize("use_url", [True, False])
-def test_push(tmp_dir, scm, dvc, git_remote, exp_stage, use_url):
+def test_push(tmp_dir, scm, dvc, git_upstream, exp_stage, use_url):
     from dvc.exceptions import InvalidArgumentError
 
-    remote = git_remote.url if use_url else git_remote.remote
+    remote = git_upstream.url if use_url else git_upstream.remote
     with pytest.raises(InvalidArgumentError):
         dvc.experiments.push(remote, "foo")
 
@@ -29,36 +40,41 @@ def test_push(tmp_dir, scm, dvc, git_remote, exp_stage, use_url):
     ref_info = first(exp_refs_by_rev(scm, exp))
 
     dvc.experiments.push(remote, ref_info.name)
-    assert git_remote.scm.get_ref(str(ref_info)) == exp
+    assert git_upstream.scm.get_ref(str(ref_info)) == exp
+
+    git_upstream.scm.remove_ref(str(ref_info))
+
+    dvc.experiments.push(remote, str(ref_info))
+    assert git_upstream.scm.get_ref(str(ref_info)) == exp
 
 
-def test_push_diverged(tmp_dir, scm, dvc, git_remote, exp_stage):
-    git_remote.scm_gen("foo", "foo", commit="init")
-    remote_rev = git_remote.scm.get_rev()
+def test_push_diverged(tmp_dir, scm, dvc, git_upstream, exp_stage):
+    git_upstream.scm_gen("foo", "foo", commit="init")
+    remote_rev = git_upstream.scm.get_rev()
 
     results = dvc.experiments.run(exp_stage.addressing, params=["foo=2"])
     exp = first(results)
     ref_info = first(exp_refs_by_rev(scm, exp))
 
-    git_remote.scm.set_ref(str(ref_info), remote_rev)
+    git_upstream.scm.set_ref(str(ref_info), remote_rev)
 
     with pytest.raises(DvcException):
-        dvc.experiments.push(git_remote.remote, ref_info.name)
-    assert git_remote.scm.get_ref(str(ref_info)) == remote_rev
+        dvc.experiments.push(git_upstream.remote, ref_info.name)
+    assert git_upstream.scm.get_ref(str(ref_info)) == remote_rev
 
-    dvc.experiments.push(git_remote.remote, ref_info.name, force=True)
-    assert git_remote.scm.get_ref(str(ref_info)) == exp
+    dvc.experiments.push(git_upstream.remote, ref_info.name, force=True)
+    assert git_upstream.scm.get_ref(str(ref_info)) == exp
 
 
-def test_push_checkpoint(tmp_dir, scm, dvc, git_remote, checkpoint_stage):
+def test_push_checkpoint(tmp_dir, scm, dvc, git_upstream, checkpoint_stage):
     results = dvc.experiments.run(
         checkpoint_stage.addressing, params=["foo=2"]
     )
     exp_a = first(results)
     ref_info_a = first(exp_refs_by_rev(scm, exp_a))
 
-    dvc.experiments.push(git_remote.remote, ref_info_a.name, force=True)
-    assert git_remote.scm.get_ref(str(ref_info_a)) == exp_a
+    dvc.experiments.push(git_upstream.remote, ref_info_a.name, force=True)
+    assert git_upstream.scm.get_ref(str(ref_info_a)) == exp_a
 
     results = dvc.experiments.run(
         checkpoint_stage.addressing, checkpoint_resume=exp_a
@@ -66,14 +82,12 @@ def test_push_checkpoint(tmp_dir, scm, dvc, git_remote, checkpoint_stage):
     exp_b = first(results)
     ref_info_b = first(exp_refs_by_rev(scm, exp_b))
 
-    dvc.experiments.push(git_remote.remote, ref_info_b.name, force=True)
-    assert git_remote.scm.get_ref(str(ref_info_b)) == exp_b
+    dvc.experiments.push(git_upstream.remote, ref_info_b.name, force=True)
+    assert git_upstream.scm.get_ref(str(ref_info_b)) == exp_b
 
 
 @pytest.mark.parametrize("use_url", [True, False])
-def test_list_remote(tmp_dir, scm, dvc, git_remote, exp_stage, use_url):
-    from dvc.repo.experiments.utils import exp_refs
-
+def test_list_remote(tmp_dir, scm, dvc, git_downstream, exp_stage, use_url):
     baseline_a = scm.get_rev()
     results = dvc.experiments.run(exp_stage.addressing, params=["foo=2"])
     exp_a = first(results)
@@ -89,20 +103,18 @@ def test_list_remote(tmp_dir, scm, dvc, git_remote, exp_stage, use_url):
     exp_c = first(results)
     ref_info_c = first(exp_refs_by_rev(scm, exp_c))
 
-    for info in exp_refs(scm):
-        dvc.experiments.push(git_remote.remote, str(info))
+    remote = git_downstream.url if use_url else git_downstream.remote
 
-    remote = git_remote.url if use_url else git_remote.remote
-    assert dvc.experiments.list(git_remote=remote) == {
-        baseline_c: [ref_info_c.name],
-    }
+    assert git_downstream.scm.get_ref("HEAD") != scm.get_ref("HEAD")
+    downstream_exp = git_downstream.dvc.experiments
+    assert downstream_exp.list(git_upstream=remote) == {}
 
-    exp_list = dvc.experiments.list(rev=baseline_a, git_remote=remote)
+    exp_list = downstream_exp.list(rev=baseline_a, git_upstream=remote)
     assert {key: set(val) for key, val in exp_list.items()} == {
         baseline_a: {ref_info_a.name, ref_info_b.name}
     }
 
-    exp_list = dvc.experiments.list(all_=True, git_remote=remote)
+    exp_list = downstream_exp.list(all_=True, git_upstream=remote)
     assert {key: set(val) for key, val in exp_list.items()} == {
         baseline_a: {ref_info_a.name, ref_info_b.name},
         baseline_c: {ref_info_c.name},

--- a/tests/func/experiments/test_remote.py
+++ b/tests/func/experiments/test_remote.py
@@ -107,14 +107,14 @@ def test_list_remote(tmp_dir, scm, dvc, git_downstream, exp_stage, use_url):
 
     assert git_downstream.scm.get_ref("HEAD") != scm.get_ref("HEAD")
     downstream_exp = git_downstream.dvc.experiments
-    assert downstream_exp.list(git_upstream=remote) == {}
+    assert downstream_exp.ls(git_upstream=remote) == {}
 
-    exp_list = downstream_exp.list(rev=baseline_a, git_upstream=remote)
+    exp_list = downstream_exp.ls(rev=baseline_a, git_upstream=remote)
     assert {key: set(val) for key, val in exp_list.items()} == {
         baseline_a: {ref_info_a.name, ref_info_b.name}
     }
 
-    exp_list = downstream_exp.list(all_=True, git_upstream=remote)
+    exp_list = downstream_exp.ls(all_=True, git_upstream=remote)
     assert {key: set(val) for key, val in exp_list.items()} == {
         baseline_a: {ref_info_a.name, ref_info_b.name},
         baseline_c: {ref_info_c.name},

--- a/tests/func/experiments/test_remote.py
+++ b/tests/func/experiments/test_remote.py
@@ -6,25 +6,21 @@ from dvc.repo.experiments.utils import exp_refs_by_rev
 
 
 @pytest.fixture
-def git_upstream(tmp_dir, scm, make_tmp_dir):
-    name = "git-upstream"
-    remote_dir = make_tmp_dir(name, scm=True)
-    url = "file://{}".format(remote_dir.resolve().as_posix())
+def git_upstream(tmp_dir, erepo_dir):
+    url = "file://{}".format(erepo_dir.resolve().as_posix())
     tmp_dir.scm.gitpython.repo.create_remote("upstream", url)
-    remote_dir.remote = "upstream"
-    remote_dir.url = url
-    return remote_dir
+    erepo_dir.remote = "upstream"
+    erepo_dir.url = url
+    return erepo_dir
 
 
 @pytest.fixture
-def git_downstream(tmp_dir, scm, dvc, make_tmp_dir):
-    name = "git-downstream"
-    remote_dir = make_tmp_dir(name, scm=True, dvc=True)
+def git_downstream(tmp_dir, erepo_dir):
     url = "file://{}".format(tmp_dir.resolve().as_posix())
-    remote_dir.scm.gitpython.repo.create_remote("upstream", url)
-    remote_dir.remote = "upstream"
-    remote_dir.url = url
-    return remote_dir
+    erepo_dir.scm.gitpython.repo.create_remote("upstream", url)
+    erepo_dir.remote = "upstream"
+    erepo_dir.url = url
+    return erepo_dir
 
 
 @pytest.mark.parametrize("use_url", [True, False])
@@ -107,14 +103,14 @@ def test_list_remote(tmp_dir, scm, dvc, git_downstream, exp_stage, use_url):
 
     assert git_downstream.scm.get_ref("HEAD") != scm.get_ref("HEAD")
     downstream_exp = git_downstream.dvc.experiments
-    assert downstream_exp.ls(git_upstream=remote) == {}
+    assert downstream_exp.ls(git_remote=remote) == {}
 
-    exp_list = downstream_exp.ls(rev=baseline_a, git_upstream=remote)
+    exp_list = downstream_exp.ls(rev=baseline_a, git_remote=remote)
     assert {key: set(val) for key, val in exp_list.items()} == {
         baseline_a: {ref_info_a.name, ref_info_b.name}
     }
 
-    exp_list = downstream_exp.ls(all_=True, git_upstream=remote)
+    exp_list = downstream_exp.ls(all_=True, git_remote=remote)
     assert {key: set(val) for key, val in exp_list.items()} == {
         baseline_a: {ref_info_a.name, ref_info_b.name},
         baseline_c: {ref_info_c.name},

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -6,6 +6,9 @@ from dvc.command.experiments import (
     CmdExperimentsBranch,
     CmdExperimentsDiff,
     CmdExperimentsGC,
+    CmdExperimentsList,
+    CmdExperimentsPull,
+    CmdExperimentsPush,
     CmdExperimentsRun,
     CmdExperimentsShow,
 )
@@ -150,3 +153,47 @@ def test_experiments_branch(dvc, scm, mocker):
     assert cmd.run() == 0
 
     m.assert_called_once_with(cmd.repo, "expname", "branchname")
+
+
+def test_experiments_list(dvc, scm, mocker):
+    cli_args = parse_args(
+        ["experiments", "list", "origin", "--rev", "foo", "--all"]
+    )
+    assert cli_args.func == CmdExperimentsList
+
+    cmd = cli_args.func(cli_args)
+    m = mocker.patch("dvc.repo.experiments.list.list_", return_value={})
+
+    assert cmd.run() == 0
+
+    m.assert_called_once_with(
+        cmd.repo, git_remote="origin", rev="foo", all_=True
+    )
+
+
+def test_experiments_push(dvc, scm, mocker):
+    cli_args = parse_args(
+        ["experiments", "push", "origin", "experiment", "--force"]
+    )
+    assert cli_args.func == CmdExperimentsPush
+
+    cmd = cli_args.func(cli_args)
+    m = mocker.patch("dvc.repo.experiments.push.push", return_value={})
+
+    assert cmd.run() == 0
+
+    m.assert_called_once_with(cmd.repo, "origin", "experiment", force=True)
+
+
+def test_experiments_pull(dvc, scm, mocker):
+    cli_args = parse_args(
+        ["experiments", "pull", "origin", "experiment", "--force"]
+    )
+    assert cli_args.func == CmdExperimentsPull
+
+    cmd = cli_args.func(cli_args)
+    m = mocker.patch("dvc.repo.experiments.pull.pull", return_value={})
+
+    assert cmd.run() == 0
+
+    m.assert_called_once_with(cmd.repo, "origin", "experiment", force=True)

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -162,7 +162,7 @@ def test_experiments_list(dvc, scm, mocker):
     assert cli_args.func == CmdExperimentsList
 
     cmd = cli_args.func(cli_args)
-    m = mocker.patch("dvc.repo.experiments.list.list_", return_value={})
+    m = mocker.patch("dvc.repo.experiments.ls.ls", return_value={})
 
     assert cmd.run() == 0
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Related to #4897.

* Adds `dvc exp list [--rev <rev>] [--all] [<git_remote>]` to list available local or remote experiments.
    * Experiments will be organized according to their parent/baseline commit (same as in `exp show`).
    * If `git_remote` is provided, command will list remote experiments, otherwise it will list local experiments. `git_remote` should be either a Git remote name (i.e. `origin`) or a full Git repo URL (supports all Git URL specs, HTTP/SSH/etc)
    * If `--rev <revision>` is provided, all experiments derived from the specified revision will be listed (defaults to current HEAD).
    * If `--all` is provided, all experiments (derived from any revision) will be listed.
* Adds `dvc exp push [-f] <git_remote> <experiment>` to push a single experiment to a Git remote.
    * `git_remote` should be a Git remote or full Git URL.
    * `experiment` should be the name of a local experiment
    * If `-f/--force` is provided, the remote experiment will be overridden if it already exists. Otherwise, a pre-existing remote experiment will only be updated if it can be fast-forwarded. 
        * This is essentially the same as `git push origin <branch>` vs `git push --force origin <branch>`.
        * Fast-forwarding only applies to checkpoints in the event that I run some checkpoints, push them, then `resume` locally to generate more checkpoints, and then push again.
* Adds `dvc exp pull [-f] <git_remote> <experiment>` to pull a single experiment from a Git remote.
    * Args work the same as `dvc exp push`.

**Note: this does not implement `dvc push/pull` for experiment cache artifacts yet, it only implements `git push/pull` (even though the CLI output will suggest that the user run `dvc push/pull`).**

[![asciicast](https://asciinema.org/a/k3REVSPaiSiiSz5lYjTJZRpQJ.svg)](https://asciinema.org/a/k3REVSPaiSiiSz5lYjTJZRpQJ)