### PR TITLE
git: drop scm requirement from backends

### DIFF
--- a/dvc/scm/git/backend/base.py
+++ b/dvc/scm/git/backend/base.py
@@ -150,7 +150,9 @@ class BaseGitBackend(ABC):
         """
 
     @abstractmethod
-    def get_ref(self, name, follow: Optional[bool] = True) -> Optional[str]:
+    def get_ref(
+        self, name: str, follow: Optional[bool] = True
+    ) -> Optional[str]:
         """Return the value of specified ref.
 
         If follow is false, symbolic refs will not be dereferenced.

--- a/dvc/scm/git/backend/base.py
+++ b/dvc/scm/git/backend/base.py
@@ -15,9 +15,7 @@ class BaseGitBackend(ABC):
     """Base Git backend class."""
 
     @abstractmethod
-    def __init__(
-        self, scm, root_dir=os.curdir, search_parent_directories=True
-    ):
+    def __init__(self, root_dir=os.curdir, search_parent_directories=True):
         pass
 
     def close(self):

--- a/dvc/scm/git/backend/base.py
+++ b/dvc/scm/git/backend/base.py
@@ -231,7 +231,9 @@ class BaseGitBackend(ABC):
         """Apply the specified stash revision."""
 
     @abstractmethod
-    def reflog_delete(self, ref: str, updateref: bool = False):
+    def reflog_delete(
+        self, ref: str, updateref: bool = False, rewrite: bool = False
+    ):
         """Delete the specified reflog entry."""
 
     @abstractmethod

--- a/dvc/scm/git/backend/dulwich.py
+++ b/dvc/scm/git/backend/dulwich.py
@@ -323,7 +323,7 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
                 exclude and fnmatch.fnmatch(ref, exclude)
             ):
                 continue
-            if self.scm.get_ref(ref, follow=False) == rev:
+            if self.get_ref(ref, follow=False) == rev:
                 return ref
         return None
 

--- a/dvc/scm/git/backend/dulwich.py
+++ b/dvc/scm/git/backend/dulwich.py
@@ -306,7 +306,9 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
     def _stash_apply(self, rev: str):
         raise NotImplementedError
 
-    def reflog_delete(self, ref: str, updateref: bool = False):
+    def reflog_delete(
+        self, ref: str, updateref: bool = False, rewrite: bool = False
+    ):
         raise NotImplementedError
 
     def describe(

--- a/dvc/scm/git/backend/dulwich.py
+++ b/dvc/scm/git/backend/dulwich.py
@@ -17,12 +17,10 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
     """Dulwich Git backend."""
 
     def __init__(  # pylint:disable=W0231
-        self, scm, root_dir=os.curdir, search_parent_directories=True
+        self, root_dir=os.curdir, search_parent_directories=True
     ):
         from dulwich.errors import NotGitRepository
         from dulwich.repo import Repo
-
-        self.scm = scm
 
         try:
             if search_parent_directories:
@@ -56,7 +54,7 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
 
     @property
     def dir(self) -> str:
-        raise NotImplementedError
+        return self.repo.commondir()
 
     def add(self, paths: Iterable[str]):
         raise NotImplementedError

--- a/dvc/scm/git/backend/gitpython.py
+++ b/dvc/scm/git/backend/gitpython.py
@@ -310,7 +310,7 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
                 if old_ref:
                     args.append(old_ref)
                 if message:
-                    self.git.update_ref(*args, m=message)
+                    self.git.update_ref(*args, m=message, create_reflog=True)
                 else:
                     self.git.update_ref(*args)
         except GitCommandError as exc:

--- a/dvc/scm/git/backend/gitpython.py
+++ b/dvc/scm/git/backend/gitpython.py
@@ -51,12 +51,10 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
     """git-python Git backend."""
 
     def __init__(  # pylint:disable=W0231
-        self, scm, root_dir=os.curdir, search_parent_directories=True
+        self, root_dir=os.curdir, search_parent_directories=True
     ):
         import git
         from git.exc import InvalidGitRepositoryError
-
-        self.scm = scm
 
         try:
             self.repo = git.Repo(
@@ -131,7 +129,7 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
             raise CloneError(url, to_path) from exc
 
         # NOTE: using our wrapper to make sure that env is fixed in __init__
-        repo = GitPythonBackend(None, to_path)
+        repo = GitPythonBackend(to_path)
 
         if rev:
             try:
@@ -367,7 +365,7 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
             # `git stash create` is intended to be used for this kind of
             # behavior but it doesn't support --include-untracked so we need to
             # use push
-            self.scm.dulwich.set_ref(
+            self.set_ref(
                 ref, commit.hexsha, message=commit.message
             )
             self.git.stash("drop")

--- a/dvc/scm/git/backend/gitpython.py
+++ b/dvc/scm/git/backend/gitpython.py
@@ -423,10 +423,14 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
     def _stash_apply(self, rev: str):
         self.git.stash("apply", rev)
 
-    def reflog_delete(self, ref: str, updateref: bool = False):
+    def reflog_delete(
+        self, ref: str, updateref: bool = False, rewrite: bool = False
+    ):
         args = ["delete"]
         if updateref:
             args.append("--updateref")
+        if rewrite:
+            args.append("--rewrite")
         args.append(ref)
         self.git.reflog(*args)
 

--- a/dvc/scm/git/stash.py
+++ b/dvc/scm/git/stash.py
@@ -65,14 +65,15 @@ class Stash:
         if index < 0 or index >= len(self):
             raise SCMError(f"Invalid stash ref '{ref}'")
         logger.debug("Dropping '%s'", ref)
-        self.scm.reflog_delete(ref, updateref=True)
+        self.scm.reflog_delete(ref, updateref=True, rewrite=True)
 
         # if we removed the last reflog entry, delete the ref and reflog
         if len(self) == 0:
             self.scm.remove_ref(self.ref)
             parts = self.ref.split("/")
             reflog = os.path.join(self.scm.root_dir, ".git", "logs", *parts)
-            remove(reflog)
+            if os.path.exists(reflog):
+                remove(reflog)
 
     def clear(self):
         logger.debug("Clear stash '%s'", self.ref)

--- a/dvc/scm/git/stash.py
+++ b/dvc/scm/git/stash.py
@@ -45,7 +45,7 @@ class Stash:
             self.ref, message=message, include_untracked=include_untracked
         )
         if reset:
-            self.scm.gitpython.repo.git.reset(hard=True)
+            self.scm.reset(hard=True)
         return rev
 
     def pop(self):


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

* Removes `scm` attribute from Git backends
* Makes backends configurable in `Git.__init__`
* Adds fixture for testing individual backends in `tests/unit/scm/test_git`
* Implements get/set/remove ref functions in gitpython backend
* Implements required dir/root_dir properties for dulwich backend
* Fixes some stash/reflog behavior that applied to all backends