### PR TITLE
experiments: handle state where tmp args file was committed to git

### DIFF
--- a/dvc/repo/experiments/executor.py
+++ b/dvc/repo/experiments/executor.py
@@ -117,7 +117,7 @@ class BaseExecutor:
 
     # TODO: come up with better way to stash repro arguments
     @staticmethod
-    def pack_repro_args(path, *args, tree=None, **kwargs):
+    def pack_repro_args(path, *args, tree=None, extra=None, **kwargs):
         dpath = os.path.dirname(path)
         if tree:
             open_func = tree.open
@@ -127,7 +127,10 @@ class BaseExecutor:
 
             open_func = open
             makedirs(dpath, exist_ok=True)
+
         data = {"args": args, "kwargs": kwargs}
+        if extra is not None:
+            data["extra"] = extra
         with open_func(path, "wb") as fobj:
             pickle.dump(data, fobj)
 

--- a/dvc/scm/git/backend/dulwich.py
+++ b/dvc/scm/git/backend/dulwich.py
@@ -302,8 +302,8 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
 
         stash = self._get_stash(ref)
         message_b = message.encode("utf-8") if message else None
-        stash.push(message=message_b)
-        return os.fsdecode(stash[0].new_sha), True
+        rev = stash.push(message=message_b)
+        return os.fsdecode(rev), True
 
     def _stash_apply(self, rev: str):
         raise NotImplementedError

--- a/dvc/scm/git/stash.py
+++ b/dvc/scm/git/stash.py
@@ -32,9 +32,7 @@ class Stash:
         return list(iter(self))
 
     def push(
-        self,
-        message: Optional[str] = None,
-        include_untracked: Optional[bool] = False,
+        self, message: Optional[str] = None, include_untracked: bool = False,
     ) -> Optional[str]:
         if not self.scm.is_dirty(untracked_files=include_untracked):
             logger.debug("No changes to stash")

--- a/tests/func/experiments/test_experiments.py
+++ b/tests/func/experiments/test_experiments.py
@@ -383,3 +383,17 @@ def test_dirty_lockfile(tmp_dir, scm, dvc, exp_stage):
         assert fobj.read().strip() == "foo: 2"
 
     assert (tmp_dir / "dvc.lock").read_text() == "foo"
+
+
+def test_packed_args_exists(tmp_dir, scm, dvc, exp_stage, caplog):
+    from dvc.repo.experiments.executor import BaseExecutor
+
+    tmp_dir.scm_gen(
+        tmp_dir / ".dvc" / "tmp" / BaseExecutor.PACKED_ARGS_FILE,
+        "",
+        commit="commit args file",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        dvc.experiments.run(exp_stage.addressing)
+        assert "Temporary DVC file" in caplog.text


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

In certain situations it was possible for the staged/added args file to remain staged if an error occurred while trying queue/stash the experiment commit. This would lead to the file being committed into git, and then prevent the same experiment from being staged in the future (since workspace would always appear clean w/no experiment to stash due to the args file already existing).

* args file should no longer remain staged if an error occurs
* If args file exists and is Git-tracked we will output a warning and suggest how to remove it when running experiments