### PR TITLE
parametrization: disable `set` keyword

### DIFF
--- a/dvc/parsing/__init__.py
+++ b/dvc/parsing/__init__.py
@@ -313,6 +313,7 @@ class DataResolver:
 
     @classmethod
     def set_context_from(cls, context: Context, to_set, source=None):
+        # NOTE: `set` is disabled in the schema
         try:
             for key, value in to_set.items():
                 src_set = [*(source or []), key]

--- a/dvc/schema.py
+++ b/dvc/schema.py
@@ -3,7 +3,7 @@ from voluptuous import Any, Optional, Required, Schema
 from dvc import dependency, output
 from dvc.hash_info import HashInfo
 from dvc.output import CHECKSUMS_SCHEMA, BaseOutput
-from dvc.parsing import DO_KWD, FOREACH_KWD, SET_KWD, VARS_KWD
+from dvc.parsing import DO_KWD, FOREACH_KWD, VARS_KWD
 from dvc.stage.params import StageParams
 
 STAGES = "stages"
@@ -64,7 +64,6 @@ VARS_SCHEMA = [str, dict]
 
 STAGE_DEFINITION = {
     StageParams.PARAM_CMD: Any(str, list),
-    Optional(SET_KWD): dict,
     Optional(StageParams.PARAM_WDIR): str,
     Optional(StageParams.PARAM_DEPS): [str],
     Optional(StageParams.PARAM_PARAMS): [Any(str, dict)],
@@ -81,7 +80,6 @@ STAGE_DEFINITION = {
 }
 
 FOREACH_IN = {
-    Optional(SET_KWD): dict,
     Required(FOREACH_KWD): Any(dict, list, str),
     Required(DO_KWD): STAGE_DEFINITION,
 }


### PR DESCRIPTION
Only handling it through schema for now. There have been some discussions on supporting parameterization on `vars`, so internals could be repurposed. Rushing with it for the pre-release builds. 

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
