### PR TITLE
dvc info: follow the symlink when deciding filesystem type

### DIFF
--- a/dvc/info.py
+++ b/dvc/info.py
@@ -142,7 +142,8 @@ def get_fs_type(path):
         for part in psutil.disk_partitions(all=True)
     }
 
-    path = pathlib.Path(path)
+    # need to follow the symlink: https://github.com/iterative/dvc/issues/5065
+    path = pathlib.Path(path).resolve()
 
     for parent in itertools.chain([path], path.parents):
         if parent in partition:


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

When the cache dir is only a symlink to other file system, `dvc version` will provide a misleading result. This patch resolves and normalizes the `cache dir` so that it correctly detects the file system we're using.

adding a test for this is a little bit troublesome for me, I'm not very sure what I should test for.

Fixes #5065