### PR TITLE
git: don't list all commits to check for an empty repo

### DIFF
--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -285,7 +285,7 @@ class Git(Base):
 
     @property
     def no_commits(self):
-        return not self.list_all_commits()
+        return not bool(self.get_ref("HEAD"))
 
     def _backend_func(self, name, *args, **kwargs):
         for backend in self.backends.values():


### PR DESCRIPTION
Saves us around 2sec (from ~7.5 to ~5.5) when parsing gitlab repo (dvc metrics diff).

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
