### PR TITLE
Skip building graph for dependencies without path_info

### DIFF
--- a/dvc/repo/graph.py
+++ b/dvc/repo/graph.py
@@ -136,6 +136,9 @@ def build_outs_graph(graph, outs_trie):
     G.add_nodes_from(outs_trie.values())
     for stage in graph.nodes():
         for dep in stage.deps:
+            if dep.path_info is None:
+                # RepoDependency don't have a path_info
+                continue
             dep_key = dep.path_info.parts
             overlapping = [n.value for n in outs_trie.prefixes(dep_key)]
             if outs_trie.has_subtrie(dep_key):


### PR DESCRIPTION
RepoDependency, for example, don't have any path_info

See: https://github.com/iterative/dvc/pull/4938#issuecomment-743709176
Related: #5035

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
