### PR TITLE
Remove version restriction from networkx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ install_requires = [
     "flufl.lock>=3.2,<4",
     "win-unicode-console>=0.5; sys_platform == 'win32'",
     "pywin32>=225; sys_platform == 'win32'",
-    "networkx>=2.1,<2.5",
+    "networkx>=2.1",
     "pydot>=1.2.4",
     "speedcopy>=2.0.1; python_version < '3.8' and sys_platform == 'win32'",
     "dataclasses==0.7; python_version < '3.7'",


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Some libraries are starting to use networkx 2.5, which is the latest version released on August.
DVC however depends on networkx < 2.5, which causes some incompatibilities. This restriction was likely to prevent future breaking changes, since it was added before the release of 2.5 (https://github.com/iterative/dvc/pull/4219).
I've removed the version restriction, ran all tests and everything worked ok.