### PR TITLE
params/metrics diff: collect from revisions/workspace twice

### DIFF
--- a/dvc/repo/metrics/diff.py
+++ b/dvc/repo/metrics/diff.py
@@ -3,12 +3,10 @@ from dvc.utils.diff import diff as _diff
 from dvc.utils.diff import format_dict
 
 
-def _get_metrics(repo, *args, rev=None, **kwargs):
+def _get_metrics(repo, *args, revs=None, **kwargs):
     try:
-        metrics = repo.metrics.show(
-            *args, **kwargs, revs=[rev] if rev else None
-        )
-        return metrics.get(rev or "", {})
+        metrics = repo.metrics.show(*args, **kwargs, revs=revs)
+        return metrics
     except NoMetricsError:
         return {}
 
@@ -19,8 +17,12 @@ def diff(repo, *args, a_rev=None, b_rev=None, **kwargs):
 
     with_unchanged = kwargs.pop("all", False)
 
-    old = _get_metrics(repo, *args, **kwargs, rev=(a_rev or "HEAD"))
-    new = _get_metrics(repo, *args, **kwargs, rev=b_rev)
+    a_rev = a_rev or "HEAD"
+    b_rev = b_rev or "workspace"
+
+    metrics = _get_metrics(repo, *args, **kwargs, revs=[a_rev, b_rev])
+    old = metrics.get(a_rev, {})
+    new = metrics.get(b_rev, {})
 
     return _diff(
         format_dict(old), format_dict(new), with_unchanged=with_unchanged

--- a/dvc/repo/params/diff.py
+++ b/dvc/repo/params/diff.py
@@ -4,10 +4,10 @@ from dvc.utils.diff import format_dict
 from .show import NoParamsError
 
 
-def _get_params(repo, *args, rev=None, **kwargs):
+def _get_params(repo, *args, revs=None, **kwargs):
     try:
-        params = repo.params.show(*args, **kwargs, revs=[rev] if rev else None)
-        return params.get(rev or "", {})
+        params = repo.params.show(*args, **kwargs, revs=revs)
+        return params
     except NoParamsError:
         return {}
 
@@ -18,8 +18,12 @@ def diff(repo, *args, a_rev=None, b_rev=None, **kwargs):
 
     with_unchanged = kwargs.pop("all", False)
 
-    old = _get_params(repo, *args, **kwargs, rev=(a_rev or "HEAD"))
-    new = _get_params(repo, *args, **kwargs, rev=b_rev)
+    a_rev = a_rev or "HEAD"
+    b_rev = b_rev or "workspace"
+
+    params = _get_params(repo, *args, **kwargs, revs=[a_rev, b_rev])
+    old = params.get(a_rev, {})
+    new = params.get(b_rev, {})
 
     return _diff(
         format_dict(old), format_dict(new), with_unchanged=with_unchanged


### PR DESCRIPTION
During diff, we were loading the stages from the current `repo.tree`'s state, from the workspace and from the revisions provided, which would collect 3-4 times (noticed while looking at the logs in https://github.com/iterative/dvc/issues/5117#issue-769158964).
This is good for using `params.diff()` and `metrics.diff()` as an API, but slows down the cli usage.


* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
