### PR TITLE
params diff: skip params dependency for vars

### DIFF
--- a/dvc/repo/params/show.py
+++ b/dvc/repo/params/show.py
@@ -51,7 +51,7 @@ def _read_params(repo, configs, rev):
     return res
 
 
-def _add_vars(repo, params):
+def _collect_vars(repo, params):
     vars_params = defaultdict(dict)
     for stage in repo.stages:
         if isinstance(stage, PipelineStage) and stage.tracked_vars:
@@ -72,7 +72,7 @@ def show(repo, revs=None):
     for branch in repo.brancher(revs=revs):
         configs = _collect_configs(repo, branch)
         params = _read_params(repo, configs, branch)
-        vars_params = _add_vars(repo, params)
+        vars_params = _collect_vars(repo, params)
 
         # NOTE: only those that are not added as a ParamDependency are included
         # so we don't need to recursively merge them yet.

--- a/dvc/repo/params/show.py
+++ b/dvc/repo/params/show.py
@@ -1,4 +1,5 @@
 import logging
+from collections import defaultdict
 from typing import TYPE_CHECKING, List
 
 from dvc.dependency.param import ParamsDependency
@@ -51,7 +52,7 @@ def _read_params(repo, configs, rev):
 
 
 def _add_vars(repo, params):
-    vars_params = {}
+    vars_params = defaultdict(dict)
     for stage in repo.stages:
         if isinstance(stage, PipelineStage) and stage.tracked_vars:
             for file, vars_ in stage.tracked_vars.items():
@@ -60,9 +61,7 @@ def _add_vars(repo, params):
                 if file in params:
                     continue
 
-                vars_params[file] = vars_params.get(file, {})
                 vars_params[file].update(vars_)
-
     return vars_params
 
 


### PR DESCRIPTION
Previously, `configs` which was a list of PathInfo was being used
to check if the `vars` should be skipped or not.

But, the file is stored as a string that made that check redundant
which might have caused #5117 as they were being stored twice,
once as an expanded paramdependency and next as a flattened dict
from vars, which later during `flatten`, it might have panicked
from that duplication.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
