### PR TITLE
Cleanup debug log messages when loading stages

### DIFF
--- a/dvc/parsing/__init__.py
+++ b/dvc/parsing/__init__.py
@@ -246,11 +246,6 @@ class EntryDefinition:
         definition = deepcopy(self.definition)
 
         wdir = self._resolve_wdir(context, name, definition.get(WDIR_KWD))
-        if self.wdir != wdir:
-            logger.debug(
-                "Stage %s has different wdir than dvc.yaml file", name
-            )
-
         vars_ = definition.pop(VARS_KWD, [])
         # FIXME: Should `vars` be templatized?
         check_interpolations(vars_, f"{self.where}.{name}.vars", self.relpath)

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -256,7 +256,9 @@ class Stage(params.StageParams):
             return False
 
         if self.is_callback:
-            logger.debug("%s has a command but no dependencies", self.addressing)
+            logger.debug(
+                "%s has a command but no dependencies", self.addressing
+            )
             return True
 
         if self.always_changed or self.is_checkpoint:

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -256,7 +256,7 @@ class Stage(params.StageParams):
             return False
 
         if self.is_callback:
-            logger.debug("%s has no command and dependencies", self.addressing)
+            logger.debug("%s has a command but no dependencies", self.addressing)
             return True
 
         if self.always_changed or self.is_checkpoint:

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -256,12 +256,7 @@ class Stage(params.StageParams):
             return False
 
         if self.is_callback:
-            logger.debug(
-                '%s is a "callback" stage '
-                "(has a command and no dependencies) and thus always "
-                "considered as changed.",
-                self,
-            )
+            logger.debug("%s has no command and dependencies", self.addressing)
             return True
 
         if self.always_changed or self.is_checkpoint:


### PR DESCRIPTION
1. Simplified callback stage debug message
2. Reduced no lock entry message to trace
   If lock file does not have some entry, it will simply complain
   that lock file is not up to date once.
   If there is no lock file or empty lock file, it will complain that lock file not found.
3. Annoying parametrization related wdir-interpolated debug message removed.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
