### PR TITLE
cli: config: add support for --show-origin

### DIFF
--- a/dvc/command/config.py
+++ b/dvc/command/config.py
@@ -1,8 +1,10 @@
 import argparse
 import logging
+import os
 
 from dvc.command.base import CmdBaseNoRepo, append_doc_link
 from dvc.config import Config, ConfigError
+from dvc.repo import Repo
 from dvc.utils.flatten import flatten
 
 logger = logging.getLogger(__name__)
@@ -34,6 +36,14 @@ class CmdConfig(CmdBaseNoRepo):
         self.config = Config(validate=False)
 
     def run(self):
+        if self.args.show_origin:
+            if any((self.args.value, self.args.unset)):
+                logger.error(
+                    "--show-origin can't be used together with any of these "
+                    "options: -u/--unset, value"
+                )
+                return 1
+
         if self.args.list:
             if any((self.args.name, self.args.value, self.args.unset)):
                 logger.error(
@@ -43,7 +53,13 @@ class CmdConfig(CmdBaseNoRepo):
                 return 1
 
             conf = self.config.load_one(self.args.level)
-            logger.info("\n".join(self._format_config(conf)))
+            prefix = self._config_file_prefix(
+                self.args.show_origin,
+                self.config,
+                self.args.level
+            )
+
+            logger.info("\n".join(self._format_config(conf, prefix)))
             return 0
 
         if self.args.name is None:
@@ -54,10 +70,16 @@ class CmdConfig(CmdBaseNoRepo):
 
         if self.args.value is None and not self.args.unset:
             conf = self.config.load_one(self.args.level)
+            prefix = self._config_file_prefix(
+                self.args.show_origin,
+                self.config,
+                self.args.level
+            )
+
             if remote:
                 conf = conf["remote"]
             self._check(conf, remote, section, opt)
-            logger.info(conf[section][opt])
+            logger.info("{}{}".format(prefix, conf[section][opt]))
             return 0
 
         with self.config.edit(self.args.level) as conf:
@@ -90,9 +112,22 @@ class CmdConfig(CmdBaseNoRepo):
             )
 
     @staticmethod
-    def _format_config(config):
+    def _format_config(config, prefix):
         for key, value in flatten(config).items():
-            yield f"{key}={value}"
+            yield f"{prefix}{key}={value}"
+
+    @staticmethod
+    def _config_file_prefix(show_origin, config, level):
+        if not show_origin:
+            return ''
+
+        fname = config.files[level]
+
+        if level in ['local', 'repo']:
+            common = os.path.commonprefix([fname, Repo.find_root()])
+            fname = fname[len(common) + 1:]
+
+        return fname + '\t'
 
 
 parent_config_parser = argparse.ArgumentParser(add_help=False)
@@ -151,5 +186,11 @@ def add_parser(subparsers, parent_parser):
         default=False,
         action="store_true",
         help="List all defined config values.",
+    )
+    config_parser.add_argument(
+        "--show-origin",
+        default=False,
+        action="store_true",
+        help="Show the source file containing each config value."
     )
     config_parser.set_defaults(func=CmdConfig)

--- a/dvc/command/config.py
+++ b/dvc/command/config.py
@@ -120,8 +120,7 @@ class CmdConfig(CmdBaseNoRepo):
         fname = config.files[level]
 
         if level in ["local", "repo"]:
-            common = os.path.commonprefix([fname, Repo.find_root()])
-            fname = fname[len(common) + 1 :]
+            fname = os.path.relpath(fname, start=Repo.find_root())
 
         return fname + "\t"
 

--- a/dvc/command/config.py
+++ b/dvc/command/config.py
@@ -54,9 +54,7 @@ class CmdConfig(CmdBaseNoRepo):
 
             conf = self.config.load_one(self.args.level)
             prefix = self._config_file_prefix(
-                self.args.show_origin,
-                self.config,
-                self.args.level
+                self.args.show_origin, self.config, self.args.level
             )
 
             logger.info("\n".join(self._format_config(conf, prefix)))
@@ -71,9 +69,7 @@ class CmdConfig(CmdBaseNoRepo):
         if self.args.value is None and not self.args.unset:
             conf = self.config.load_one(self.args.level)
             prefix = self._config_file_prefix(
-                self.args.show_origin,
-                self.config,
-                self.args.level
+                self.args.show_origin, self.config, self.args.level
             )
 
             if remote:
@@ -112,22 +108,22 @@ class CmdConfig(CmdBaseNoRepo):
             )
 
     @staticmethod
-    def _format_config(config, prefix):
+    def _format_config(config, prefix=""):
         for key, value in flatten(config).items():
             yield f"{prefix}{key}={value}"
 
     @staticmethod
     def _config_file_prefix(show_origin, config, level):
         if not show_origin:
-            return ''
+            return ""
 
         fname = config.files[level]
 
-        if level in ['local', 'repo']:
+        if level in ["local", "repo"]:
             common = os.path.commonprefix([fname, Repo.find_root()])
-            fname = fname[len(common) + 1:]
+            fname = fname[len(common) + 1 :]
 
-        return fname + '\t'
+        return fname + "\t"
 
 
 parent_config_parser = argparse.ArgumentParser(add_help=False)
@@ -191,6 +187,6 @@ def add_parser(subparsers, parent_parser):
         "--show-origin",
         default=False,
         action="store_true",
-        help="Show the source file containing each config value."
+        help="Show the source file containing each config value.",
     )
     config_parser.set_defaults(func=CmdConfig)

--- a/tests/func/test_config.py
+++ b/tests/func/test_config.py
@@ -188,7 +188,7 @@ def test_config_remote(tmp_dir, dvc, caplog):
     assert "myregion" in caplog.text
 
 
-def test_config_list(tmp_dir, dvc, caplog):
+def test_config_show_origin(tmp_dir, dvc, caplog):
     (tmp_dir / ".dvc" / "config").write_text(
         "['remote \"myremote\"']\n"
         "  url = s3://bucket/path\n"

--- a/tests/func/test_config.py
+++ b/tests/func/test_config.py
@@ -186,3 +186,28 @@ def test_config_remote(tmp_dir, dvc, caplog):
     caplog.clear()
     assert main(["config", "remote.myremote.region"]) == 0
     assert "myregion" in caplog.text
+
+
+def test_config_list(tmp_dir, dvc, caplog):
+    (tmp_dir / ".dvc" / "config").write_text(
+        "['remote \"myremote\"']\n"
+        "  url = s3://bucket/path\n"
+        "  region = myregion\n"
+    )
+
+    caplog.clear()
+    assert main(["config", "--show-origin", "remote.myremote.url"]) == 0
+    assert (
+        "{}\t{}\n".format(os.path.join(".dvc", "config"), "s3://bucket/path")
+        in caplog.text
+    )
+
+    caplog.clear()
+    assert main(["config", "--list", "--show-origin"]) == 0
+    assert (
+        "{}\t{}\n".format(
+            os.path.join(".dvc", "config"),
+            "remote.myremote.url=s3://bucket/path",
+        )
+        in caplog.text
+    )

--- a/tests/func/test_config.py
+++ b/tests/func/test_config.py
@@ -48,7 +48,13 @@ class TestConfigCLI(TestDvc):
         self.assertEqual(ret, 0)
         self.assertTrue(self._contains(section, field, value, local))
 
+        ret = main(base + [section_field, value, "--show-origin"])
+        self.assertEqual(ret, 1)
+
         ret = main(base + [section_field])
+        self.assertEqual(ret, 0)
+
+        ret = main(base + ["--show-origin", section_field])
         self.assertEqual(ret, 0)
 
         ret = main(base + [section_field, newvalue])
@@ -60,7 +66,13 @@ class TestConfigCLI(TestDvc):
         self.assertEqual(ret, 0)
         self.assertFalse(self._contains(section, field, value, local))
 
+        ret = main(base + [section_field, "--unset", "--show-origin"])
+        self.assertEqual(ret, 1)
+
         ret = main(base + ["--list"])
+        self.assertEqual(ret, 0)
+
+        ret = main(base + ["--list", "--show-origin"])
         self.assertEqual(ret, 0)
 
     def test(self):


### PR DESCRIPTION
Support the --show-origin option for config, which, similar to git,
prefixes each config option with the source file it originated from.

Fixes #5119

* [X] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [X] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
