### PR TITLE
erepo: get rid of get_checksum

### DIFF
--- a/dvc/dependency/repo.py
+++ b/dvc/dependency/repo.py
@@ -1,5 +1,7 @@
 from voluptuous import Required
 
+from dvc.path_info import PathInfo
+
 from .local import LocalDependency
 
 
@@ -48,7 +50,8 @@ class RepoDependency(LocalDependency):
         # we want stream but not fetch, so DVC out directories are
         # walked, but dir contents is not fetched
         with self._make_repo(locked=locked, fetch=False, stream=True) as repo:
-            return repo.get_checksum(self.def_path)
+            path_info = PathInfo(repo.root_dir) / self.def_path
+            return repo.repo_tree.get_hash(path_info, follow_subrepos=False)
 
     def workspace_status(self):
         current = self._get_hash(locked=True)

--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -218,15 +218,6 @@ class ExternalRepo(Repo):
             kw["fetch"] = True
         return RepoTree(repo, **kw)
 
-    def get_checksum(self, path):
-        path_info = PathInfo(self.root_dir) / path
-        with reraise(FileNotFoundError, PathMissingError(path, self.url)):
-            metadata = self.repo_tree.metadata(path_info)
-
-        # skip subrepos to check for
-        tree = self._get_tree_for(metadata.repo)
-        return tree.get_hash(path_info)
-
     @staticmethod
     def _fix_local_remote(orig_repo, src_repo, remote_name):
         # If a remote URL is relative to the source repo,

--- a/tests/func/test_external_repo.py
+++ b/tests/func/test_external_repo.py
@@ -194,7 +194,9 @@ def test_subrepos_are_ignored(tmp_dir, erepo_dir):
 
         expected_hash = HashInfo("md5", "e1d9e8eae5374860ae025ec84cfd85c7.dir")
         assert (
-            repo.get_checksum(os.path.join(repo.root_dir, "dir"))
+            repo.repo_tree.get_hash(
+                os.path.join(repo.root_dir, "dir"), follow_subrepos=False
+            )
             == expected_hash
         )
 


### PR DESCRIPTION
The intended behavior is to not ignore subrepos but not follow them. Think about it as `os.walk` seeing symlinks but not following them unless `followlinks` is set to `True`.

This is one of the pre-requisites to simplifying and possibly getting rid of ExternalRepo.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
