### PR TITLE
lock: fix AttributeError in dvc.lock.HardlinkLock

### DIFF
--- a/dvc/lock.py
+++ b/dvc/lock.py
@@ -148,9 +148,8 @@ class HardlinkLock(flufl.lock.Lock, LockBase):
     ):  # pylint: disable=super-init-not-called
         import socket
 
-        super().__init__(lockfile)
-
         self._tmp_dir = tmp_dir
+        super().__init__(lockfile)
 
         # NOTE: this is basically Lock.__init__ copy-paste, except that
         # instead of using `socket.getfqdn()` we use `socket.gethostname()`


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Fixes init order bug in `dvc.lock.HardlinkLock`

```
ERROR: unexpected error - 'HardlinkLock' object has no attribute '_tmp_dir'
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/dvc/main.py", line 75, in main
    cmd = args.func(args)
  File "/usr/local/lib/python3.6/dist-packages/dvc/command/base.py", line 40, in __init__
    self.repo = Repo(uninitialized=self.UNINITIALIZED)
  File "/usr/local/lib/python3.6/dist-packages/dvc/repo/__init__.py", line 141, in __init__
    friendly=True,
  File "/usr/local/lib/python3.6/dist-packages/dvc/lock.py", line 199, in make_lock
    return cls(lockfile, tmp_dir=tmp_dir, friendly=friendly)
  File "/usr/local/lib/python3.6/dist-packages/dvc/lock.py", line 148, in __init__
    super().__init__(lockfile)
  File "/usr/local/lib/python3.6/dist-packages/flufl/lock/_lockfile.py", line 113, in __init__
    self._set_claimfile()
  File "/usr/local/lib/python3.6/dist-packages/dvc/lock.py", line 180, in _set_claimfile
    if self._tmp_dir is not None:
AttributeError: 'HardlinkLock' object has no attribute '_tmp_dir'
```

discord context: https://discord.com/channels/485586884165107732/485596304961962003/791187309223608350