### PR TITLE
parametrization: fix error when the file in `vars` is a directory

### DIFF
--- a/dvc/parsing/context.py
+++ b/dvc/parsing/context.py
@@ -350,16 +350,13 @@ class Context(CtxDict):
         file = relpath(path)
         if not tree.exists(path):
             raise ParamsLoadError(f"'{file}' does not exist")
+        if tree.isdir(path):
+            raise ParamsLoadError(f"'{file}' is a directory")
 
         _, ext = os.path.splitext(file)
         loader = LOADERS[ext]
 
-        try:
-            data = loader(path, tree=tree)
-        except IsADirectoryError as exc:
-            msg = f"Cannot load '{file}', '{file}' is a directory"
-            raise ParamsLoadError(msg) from exc
-
+        data = loader(path, tree=tree)
         if not isinstance(data, Mapping):
             typ = type(data).__name__
             raise ParamsLoadError(

--- a/dvc/parsing/context.py
+++ b/dvc/parsing/context.py
@@ -62,7 +62,7 @@ class MergeError(ContextError):
         )
 
 
-class ParamsFileNotFound(ContextError):
+class ParamsLoadError(ContextError):
     pass
 
 
@@ -349,15 +349,20 @@ class Context(CtxDict):
     def load_from(cls, tree, path: PathInfo, select_keys=None) -> "Context":
         file = relpath(path)
         if not tree.exists(path):
-            raise ParamsFileNotFound(f"'{file}' does not exist")
+            raise ParamsLoadError(f"'{file}' does not exist")
 
         _, ext = os.path.splitext(file)
         loader = LOADERS[ext]
 
-        data = loader(path, tree=tree)
+        try:
+            data = loader(path, tree=tree)
+        except IsADirectoryError as exc:
+            msg = f"Cannot load '{file}', '{file}' is a directory"
+            raise ParamsLoadError(msg) from exc
+
         if not isinstance(data, Mapping):
             typ = type(data).__name__
-            raise ContextError(
+            raise ParamsLoadError(
                 f"expected a dictionary, got '{typ}' in file '{file}'"
             )
 
@@ -367,7 +372,7 @@ class Context(CtxDict):
                 data = {key: data[key] for key in select_keys}
             except KeyError as exc:
                 key, *_ = exc.args
-                raise ContextError(
+                raise ParamsLoadError(
                     f"could not find '{key}' in '{file}'"
                 ) from exc
 

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -221,12 +221,12 @@ def test_load_from(mocker):
 
     mocker.patch("dvc.parsing.context.LOADERS", {".yaml": _yaml_load})
 
-    class tree:
-        def exists(self, _):
-            return True
+    tree = mocker.Mock(
+        **{"exists.return_value": True, "isdir.return_value": False}
+    )
 
     file = "params.yaml"
-    c = Context.load_from(tree(), file)
+    c = Context.load_from(tree, file)
 
     assert asdict(c["x"].meta) == {
         "source": file,
@@ -444,4 +444,4 @@ def test_load_from_raises_if_file_is_directory(tmp_dir, dvc):
     with pytest.raises(ParamsLoadError) as exc_info:
         Context.load_from(dvc.tree, data_dir)
 
-    assert str(exc_info.value) == "Cannot load 'data', 'data' is a directory"
+    assert str(exc_info.value) == "'data' is a directory"

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -1,5 +1,6 @@
 from dataclasses import asdict
 from math import pi
+from unittest.mock import mock_open
 
 import pytest
 
@@ -16,7 +17,7 @@ from dvc.parsing.context import (
 )
 from dvc.tree.local import LocalTree
 from dvc.utils import relpath
-from dvc.utils.serialize import dump_yaml
+from dvc.utils.serialize import dump_yaml, dumps_yaml
 
 
 def test_context():
@@ -216,15 +217,11 @@ def test_overwrite_with_setitem():
 
 
 def test_load_from(mocker):
-    def _yaml_load(*args, **kwargs):
-        return {"x": {"y": {"z": 5}, "lst": [1, 2, 3]}, "foo": "foo"}
-
-    mocker.patch("dvc.parsing.context.LOADERS", {".yaml": _yaml_load})
-
+    d = {"x": {"y": {"z": 5}, "lst": [1, 2, 3]}, "foo": "foo"}
     tree = mocker.Mock(
-        **{"exists.return_value": True, "isdir.return_value": False}
+        open=mock_open(read_data=dumps_yaml(d)),
+        **{"exists.return_value": True, "isdir.return_value": False},
     )
-
     file = "params.yaml"
     c = Context.load_from(tree, file)
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

---

Fixes one issue pointed out on #5165.

The error will look something like following in case of top-level `vars`:
```console
$ dvc repro
ERROR: failed to parse 'vars' in 'dvc.yaml': 'data' is a directory
```
