### PR TITLE
config: temporarily forbid --show-origin without level

### DIFF
--- a/dvc/command/config.py
+++ b/dvc/command/config.py
@@ -43,6 +43,12 @@ class CmdConfig(CmdBaseNoRepo):
                     "options: -u/--unset, value"
                 )
                 return 1
+            if not self.args.level:
+                logger.error(
+                    "--show-origin requires one of these options: "
+                    "--system, --global, --repo, --local"
+                )
+                return 1
 
         if self.args.list:
             if any((self.args.name, self.args.value, self.args.unset)):

--- a/tests/func/test_config.py
+++ b/tests/func/test_config.py
@@ -261,14 +261,16 @@ def test_config_show_origin(tmp_dir, dvc, caplog):
     )
 
     caplog.clear()
-    assert main(["config", "--show-origin", "remote.myremote.url"]) == 0
+    assert (
+        main(["config", "--show-origin", "--repo", "remote.myremote.url"]) == 0
+    )
     assert (
         "{}\t{}\n".format(os.path.join(".dvc", "config"), "s3://bucket/path")
         in caplog.text
     )
 
     caplog.clear()
-    assert main(["config", "--list", "--show-origin"]) == 0
+    assert main(["config", "--list", "--repo", "--show-origin"]) == 0
     assert (
         "{}\t{}\n".format(
             os.path.join(".dvc", "config"),


### PR DESCRIPTION
Not yet supported https://github.com/iterative/dvc/pull/5126#pullrequestreview-555287092

This is a temporary limitation, we will support it ASAP. No docs updates are necessary.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
