### PR TITLE
dvc: redefine is_callback as cmd and no outs/deps

### DIFF
--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -228,7 +228,7 @@ class Stage(params.StageParams):
         A callback stage is always considered as changed,
         so it runs on every `dvc repro` call.
         """
-        return not self.is_data_source and len(self.deps) == 0
+        return self.cmd and not any((self.deps, self.outs))
 
     @property
     def is_import(self):
@@ -265,13 +265,7 @@ class Stage(params.StageParams):
         if self.frozen:
             return False
 
-        if self.is_callback:
-            logger.debug(
-                "%s has a command but no dependencies", self.addressing
-            )
-            return True
-
-        if self.always_changed or self.is_checkpoint:
+        if self.is_callback or self.always_changed or self.is_checkpoint:
             return True
 
         return self._changed_deps()

--- a/dvc/stage/run.py
+++ b/dvc/stage/run.py
@@ -113,11 +113,7 @@ def _run(stage, executable, cmd, checkpoint_func, **kwargs):
 
 
 def cmd_run(stage, dry=False, checkpoint_func=None):
-    logger.info(
-        "Running %s" "stage '%s':",
-        "callback " if stage.is_callback else "",
-        stage.addressing,
-    )
+    logger.info("Running stage '%s':", stage.addressing)
     commands = _enforce_cmd_list(stage.cmd)
     kwargs = prepare_kwargs(stage, checkpoint_func=checkpoint_func)
     executable = get_executable()

--- a/tests/func/test_lockfile.py
+++ b/tests/func/test_lockfile.py
@@ -189,10 +189,7 @@ def v1_repo_lock(tmp_dir, dvc):
 
 def test_can_read_v1_lockfile(tmp_dir, dvc, v1_repo_lock):
     assert dvc.status() == {
-        "bar": [
-            {"changed outs": {"bar.txt": "not in cache"}},
-            "always changed",
-        ],
+        "bar": [{"changed outs": {"bar.txt": "not in cache"}}],
         "foo": ["always changed"],
     }
 

--- a/tests/func/test_repro.py
+++ b/tests/func/test_repro.py
@@ -266,28 +266,6 @@ class TestReproDepDirWithOutputsUnderIt(SingleStageRun, TestDvc):
         self.assertEqual(len(stages), 2)
 
 
-class TestReproNoDeps(TestRepro):
-    def test(self):
-        out = "out"
-        code_file = "out.py"
-        stage_file = "out.dvc"
-        code = (
-            'import uuid\nwith open("{}", "w+") as fd:\n'
-            "\tfd.write(str(uuid.uuid4()))\n".format(out)
-        )
-        with open(code_file, "w+") as fd:
-            fd.write(code)
-        stage = self._run(
-            fname=stage_file,
-            outs=[out],
-            cmd=f"python {code_file}",
-            name="uuid",
-        )
-
-        stages = self.dvc.reproduce(self._get_stage_target(stage))
-        self.assertEqual(len(stages), 1)
-
-
 class TestReproForce(TestRepro):
     def test(self):
         stages = self.dvc.reproduce(
@@ -572,11 +550,10 @@ class TestReproFrozenCallback(SingleStageRun, TestDvc):
     def test(self):
         file1 = "file1"
         file1_stage = file1 + ".dvc"
-        # NOTE: purposefully not specifying dependencies
+        # NOTE: purposefully not specifying deps or outs
         # to create a callback stage.
         stage = self._run(
             fname=file1_stage,
-            outs=[file1],
             cmd=f"python {self.CODE} {self.FOO} {file1}",
             name="copy-FOO-file1",
         )
@@ -864,6 +841,7 @@ class TestReproAlreadyCached(TestRepro):
     def test(self):
         stage = self._run(
             fname="datetime.dvc",
+            always_changed=True,
             deps=[],
             outs=["datetime.txt"],
             cmd='python -c "import time; print(time.time())" > datetime.txt',

--- a/tests/func/test_repro_multistage.py
+++ b/tests/func/test_repro_multistage.py
@@ -56,10 +56,6 @@ class TestReproDepDirWithOutputsUnderItMultiStage(
     pass
 
 
-class TestReproNoDepsMultiStage(MultiStageRun, test_repro.TestReproNoDeps):
-    pass
-
-
 class TestReproForceMultiStage(MultiStageRun, test_repro.TestReproForce):
     pass
 

--- a/tests/func/test_run_single_stage.py
+++ b/tests/func/test_run_single_stage.py
@@ -679,11 +679,7 @@ def test_rerun_deterministic_ignore_cache(tmp_dir, run_copy):
 def test_rerun_callback(dvc):
     def run_callback(force=False):
         return dvc.run(
-            cmd="echo content > out",
-            outs=["out"],
-            deps=[],
-            force=force,
-            single_stage=True,
+            cmd="echo content > out", force=force, single_stage=True,
         )
 
     assert run_callback() is not None
@@ -768,6 +764,7 @@ class TestRunPersist(TestDvc):
             [
                 "run",
                 "--single-stage",
+                "--always-changed",
                 self.outs_command,
                 file,
                 f"echo {file_content} >> {file}",

--- a/tests/unit/stage/test_run.py
+++ b/tests/unit/stage/test_run.py
@@ -19,6 +19,6 @@ def test_run_stage_dry(caplog, cmd, expected):
         run_stage(stage, dry=True)
 
     expected.insert(
-        0, "Running callback stage 'stage.dvc':",
+        0, "Running stage 'stage.dvc':",
     )
     assert caplog.messages == expected


### PR DESCRIPTION
Old cmd + no deps definiton has been obsoleted since 1.0 in favor
of --always-changed and doesn't affect our ability to read history for
metrics/plots/etc so we are safe to drop the support for 2.0 onwards.

Fixes https://github.com/iterative/dvc/issues/1407

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

We don't have any mention of callbacks since 1.0 so no changes for docs required.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
