### PR TITLE
cli: config: show merged config with --show-origin

### DIFF
--- a/dvc/command/config.py
+++ b/dvc/command/config.py
@@ -45,7 +45,7 @@ class CmdConfig(CmdBaseNoRepo):
                 return 1
 
         if self.args.list:
-            return self._handle_list()
+            return self._list()
 
         if self.args.name is None:
             logger.error("name argument is required")
@@ -54,11 +54,11 @@ class CmdConfig(CmdBaseNoRepo):
         remote, section, opt = self.args.name
 
         if self.args.value is None and not self.args.unset:
-            return self._handle_get(remote, section, opt)
+            return self._get(remote, section, opt)
 
-        return self._handle_set(remote, section, opt)
+        return self._set(remote, section, opt)
 
-    def _handle_list(self):
+    def _list(self):
         if any((self.args.name, self.args.value, self.args.unset)):
             logger.error(
                 "-l/--list can't be used together with any of these "
@@ -76,7 +76,7 @@ class CmdConfig(CmdBaseNoRepo):
 
         return 0
 
-    def _handle_get(self, remote, section, opt):
+    def _get(self, remote, section, opt):
         levels = [self.args.level] if self.args.level else Config.LEVELS[::-1]
 
         for level in levels:
@@ -98,7 +98,7 @@ class CmdConfig(CmdBaseNoRepo):
 
         return 0
 
-    def _handle_set(self, remote, section, opt):
+    def _set(self, remote, section, opt):
         with self.config.edit(self.args.level) as conf:
             if remote:
                 conf = conf["remote"]

--- a/tests/func/test_config.py
+++ b/tests/func/test_config.py
@@ -270,7 +270,23 @@ def test_config_show_origin(tmp_dir, dvc, caplog):
     )
 
     caplog.clear()
+    assert (
+        main(["config", "--show-origin", "--local", "remote.myremote.url"])
+        == 251
+    )
+
+    caplog.clear()
     assert main(["config", "--list", "--repo", "--show-origin"]) == 0
+    assert (
+        "{}\t{}\n".format(
+            os.path.join(".dvc", "config"),
+            "remote.myremote.url=s3://bucket/path",
+        )
+        in caplog.text
+    )
+
+    caplog.clear()
+    assert main(["config", "--list", "--show-origin"]) == 0
     assert (
         "{}\t{}\n".format(
             os.path.join(".dvc", "config"),

--- a/tests/func/test_config.py
+++ b/tests/func/test_config.py
@@ -253,7 +253,7 @@ def test_config_remote(tmp_dir, dvc, caplog):
     assert "myregion" in caplog.text
 
 
-def test_config_show_origin(tmp_dir, dvc, caplog):
+def test_config_show_origin_single(tmp_dir, dvc, caplog):
     (tmp_dir / ".dvc" / "config").write_text(
         "['remote \"myremote\"']\n"
         "  url = s3://bucket/path\n"
@@ -285,12 +285,31 @@ def test_config_show_origin(tmp_dir, dvc, caplog):
         in caplog.text
     )
 
+
+def test_config_show_origin_merged(tmp_dir, dvc, caplog):
+    (tmp_dir / ".dvc" / "config").write_text(
+        "['remote \"myremote\"']\n"
+        "  url = s3://bucket/path\n"
+        "  region = myregion\n"
+    )
+
+    (tmp_dir / ".dvc" / "config.local").write_text(
+        "['remote \"myremote\"']\n  timeout = 100\n"
+    )
+
     caplog.clear()
     assert main(["config", "--list", "--show-origin"]) == 0
     assert (
         "{}\t{}\n".format(
             os.path.join(".dvc", "config"),
             "remote.myremote.url=s3://bucket/path",
+        )
+        in caplog.text
+    )
+    assert (
+        "{}\t{}\n".format(
+            os.path.join(".dvc", "config.local"),
+            "remote.myremote.timeout=100",
         )
         in caplog.text
     )


### PR DESCRIPTION
Builds on #5126 and #5184 by showing the full merged config when
listing or getting config options.

References #5126
References #5184
References iterative/dvc.org#2028
Fixes #5119

* [X] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [X] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
