### PR TITLE
experiments: fix logging bugs

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -1093,7 +1093,7 @@ def _add_run_common(parser):
         "--run-all",
         action="store_true",
         default=False,
-        help="Execute all experiments in the run queue.",
+        help="Execute all experiments in the run queue. Implies --temp.",
     )
     parser.add_argument(
         "-j",
@@ -1108,7 +1108,6 @@ def _add_run_common(parser):
         dest="tmp_dir",
         help=(
             "Run this experiment in a separate temporary directory instead of "
-            "your workspace. Only applies when running a single experiment "
-            "without --queue."
+            "your workspace."
         ),
     )

--- a/dvc/repo/experiments/executor/base.py
+++ b/dvc/repo/experiments/executor/base.py
@@ -62,6 +62,7 @@ class BaseExecutor(ABC):
 
     PACKED_ARGS_FILE = "repro.dat"
     WARN_UNTRACKED = False
+    QUIET = False
 
     def __init__(
         self,
@@ -255,6 +256,9 @@ class BaseExecutor(ABC):
             else:
                 old_cwd = None
             logger.debug("Running repro in '%s'", os.getcwd())
+
+            if cls.QUIET:
+                dvc.scm.quiet = cls.QUIET
 
             args_path = os.path.join(
                 dvc.tmp_dir, BaseExecutor.PACKED_ARGS_FILE

--- a/dvc/repo/experiments/executor/local.py
+++ b/dvc/repo/experiments/executor/local.py
@@ -25,7 +25,11 @@ class BaseLocalExecutor(BaseExecutor):
 class TempDirExecutor(BaseLocalExecutor):
     """Temp directory experiment executor."""
 
+    # Temp dir executors should warn if untracked files exist (to help with
+    # debugging user code), and suppress other DVC hints (like `git add`
+    # suggestions) that are not applicable outside of workspace runs
     WARN_UNTRACKED = True
+    QUIET = True
 
     def __init__(
         self,

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -1,11 +1,11 @@
 import logging
-import os
 import typing
 from functools import partial
 
 from dvc.exceptions import ReproductionError
 from dvc.repo.scm_context import scm_context
 from dvc.stage.run import CheckpointKilledError
+from dvc.utils import relpath
 
 from . import locked
 from .graph import get_pipeline, get_pipelines
@@ -60,19 +60,19 @@ def _dump_stage(stage):
 
 
 def _track_stage(stage):
-    stage.repo.scm.track_file(stage.dvcfile.path)
+    stage.repo.scm.track_file(stage.dvcfile.relpath)
     for dep in stage.deps:
         if not dep.use_scm_ignore and dep.is_in_repo:
-            stage.repo.scm.track_file(os.fspath(dep.path_info))
+            stage.repo.scm.track_file(relpath(dep.path_info))
     for out in stage.outs:
         if not out.use_scm_ignore and out.is_in_repo:
-            stage.repo.scm.track_file(os.fspath(out.path_info))
+            stage.repo.scm.track_file(relpath(out.path_info))
             if out.live:
                 from dvc.repo.live import summary_path_info
 
                 summary = summary_path_info(out)
                 if summary:
-                    stage.repo.scm.track_file(os.fspath(summary))
+                    stage.repo.scm.track_file(relpath(summary))
     stage.repo.scm.track_changed_files()
 
 

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -45,6 +45,7 @@ class Git(Base):
     ):
         self.ignored_paths: List[str] = []
         self.files_to_track: Set[str] = set()
+        self.quiet: bool = False
 
         selected = backends if backends else self.DEFAULT_BACKENDS.keys()
         self.backends = OrderedDict(
@@ -243,7 +244,7 @@ class Git(Base):
         self.files_to_track = set()
 
     def remind_to_track(self):
-        if not self.files_to_track:
+        if self.quiet or not self.files_to_track:
             return
 
         files = " ".join(shlex.quote(path) for path in self.files_to_track)


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will fix #5177.
Will fix #5176.

* SCM hints for workspace runs now shows relpaths instead of abspaths
* SCM hints for tempdir runs are suppressed since they have no meaning until `exp apply` is used
* Errors for tempdir runs are now logged inside executor child process instead of in the parent process