### PR TITLE
Add pyinstrument: a statistical profiler

### DIFF
--- a/dvc/_debug.py
+++ b/dvc/_debug.py
@@ -46,8 +46,10 @@ def debug():
     try:
         yield
     except Exception:  # pylint: disable=broad-except
-        import pdb  # noqa: T100
-
+        try:
+            import ipdb as pdb  # noqa: T100
+        except ImportError:
+            import pdb  # noqa: T100
         pdb.post_mortem()
 
 

--- a/dvc/_debug.py
+++ b/dvc/_debug.py
@@ -6,7 +6,7 @@ from contextlib import ExitStack, contextmanager
 def instrument(html_output):
     """Run a statistical profiler"""
     try:
-        from pyinstrument import Profiler
+        from pyinstrument import Profiler  # pylint: disable=import-error
     except ImportError:
         print("Failed to run profiler, pyinstrument is not installed")
         yield
@@ -47,7 +47,7 @@ def debug():
         yield
     except Exception:  # pylint: disable=broad-except
         try:
-            import ipdb as pdb  # noqa: T100
+            import ipdb as pdb  # noqa: T100, pylint: disable=import-error
         except ImportError:
             import pdb  # noqa: T100
         pdb.post_mortem()

--- a/dvc/_debug.py
+++ b/dvc/_debug.py
@@ -1,0 +1,88 @@
+import argparse
+from contextlib import ExitStack, contextmanager
+
+
+@contextmanager
+def instrument(html_output):
+    """Run a statistical profiler"""
+    try:
+        from pyinstrument import Profiler
+    except ImportError:
+        print("Failed to run profiler, pyinstrument is not installed")
+        yield
+        return
+
+    profiler = Profiler()
+
+    profiler.start()
+    yield
+    profiler.stop()
+
+    if html_output:
+        profiler.open_in_browser()
+        return
+    print(profiler.output_text(unicode=True, color=True))
+
+
+@contextmanager
+def profile(dump):
+    """Run a cprofile"""
+    import cProfile
+
+    prof = cProfile.Profile()
+    prof.enable()
+
+    yield
+
+    prof.disable()
+    if not dump:
+        prof.print_stats(sort="cumtime")
+        return
+    prof.dump_stats(dump)
+
+
+@contextmanager
+def debug():
+    try:
+        yield
+    except Exception:  # pylint: disable=broad-except
+        import pdb  # noqa: T100
+
+        pdb.post_mortem()
+
+
+@contextmanager
+def debugtools(args):
+    with ExitStack() as stack:
+        if args.pdb:
+            stack.enter_context(debug())
+        if args.cprofile:
+            stack.enter_context(profile(args.cprofile_dump))
+        if args.instrument:
+            stack.enter_context(instrument(args.instrument_open))
+        yield
+
+
+def add_debugging_flags(parser):
+    parser.add_argument(
+        "--cprofile",
+        action="store_true",
+        default=False,
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument("--cprofile-dump", help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--pdb", action="store_true", default=False, help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--instrument",
+        action="store_true",
+        default=False,
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--instrument-open",
+        action="store_true",
+        default=False,
+        help=argparse.SUPPRESS,
+    )

--- a/dvc/cli.py
+++ b/dvc/cli.py
@@ -4,6 +4,7 @@ import logging
 import os
 import sys
 
+from ._debug import add_debugging_flags
 from .command import (
     add,
     cache,
@@ -137,19 +138,7 @@ def get_parent_parser():
     in order to prevent some weird behavior.
     """
     parent_parser = argparse.ArgumentParser(add_help=False)
-
-    parent_parser.add_argument(
-        "--cprofile",
-        action="store_true",
-        default=False,
-        help=argparse.SUPPRESS,
-    )
-    parent_parser.add_argument("--cprofile-dump", help=argparse.SUPPRESS)
-
-    parent_parser.add_argument(
-        "--pdb", action="store_true", default=False, help=argparse.SUPPRESS,
-    )
-
+    add_debugging_flags(parent_parser)
     log_level_group = parent_parser.add_mutually_exclusive_group()
     log_level_group.add_argument(
         "-q", "--quiet", action="count", default=0, help="Be quiet."


### PR DESCRIPTION
It (https://github.com/joerick/pyinstrument) is easier and faster than cprofile, in that it can show stacktrace
of where things are slow.

<details>
<summary>Example Report</summary>

```console

  _     ._   __/__   _ _  _  _ _/_   Recorded: 14:34:14  Samples:  7227
 /_//_/// /_\ / //_// / //_'/ //     Duration: 12.487    CPU time: 7.442
/   _/                      v3.3.0

Program: /home/saugat/repos/iterative/dvc/.env/env39/bin/dvc dag --instrument

12.487 main  dvc/main.py:25
└─ 12.401 run  dvc/command/dag.py:94
   ├─ 5.872 _build  dvc/command/dag.py:87
   │  └─ 5.872 _transform  dvc/command/dag.py:53
   │     ├─ 5.545 __get__  funcy/objects.py:25
   │     │  └─ 5.545 graph  dvc/repo/__init__.py:357
   │     │     ├─ 5.292 __get__  funcy/objects.py:25
   │     │     │  └─ 5.201 stages  dvc/repo/__init__.py:369
   │     │     │     └─ 5.201 collect_repo  dvc/repo/stage.py:324
   │     │     │        ├─ 4.956 load_file  dvc/repo/stage.py:195
   │     │     │        │  └─ 4.956 load_all  dvc/repo/stage.py:149
   │     │     │        │     ├─ 2.697 stages  dvc/dvcfile.py:146
   │     │     │        │     │  └─ 2.694 _load  dvc/dvcfile.py:101
   │     │     │        │     │     ├─ 1.363 [self]  
   │     │     │        │     │     ├─ 0.761 parse_yaml  dvc/utils/serialize/_yaml.py:26
   │     │     │        │     │     │  ├─ 0.535 load  ruamel/yaml/main.py:328
   │     │     │        │     │     │  │     [135 frames hidden]  ruamel, .., re, sre_compile, sre_pars...
   │     │     │        │     │     │  └─ 0.153 __init__  ruamel/yaml/main.py:61
   │     │     │        │     │     │        [61 frames hidden]  ruamel, glob, .., fnmatch, posixpath
   │     │     │        │     │     ├─ 0.223 exists  dvc/dvcfile.py:98
   │     │     │        │     │     │  └─ 0.221 exists  dvc/tree/local.py:65
   │     │     │        │     │     └─ 0.148 validate  dvc/dvcfile.py:119
   │     │     │        │     │        └─ 0.146 __call__  voluptuous/schema_builder.py:269
   │     │     │        │     │              [107 frames hidden]  voluptuous, ..
   │     │     │        │     ├─ 0.928 __getitem__  dvc/stage/loader.py:160
   │     │     │        │     │  └─ 0.878 load_stage  dvc/stage/loader.py:173
   │     │     │        │     │     ├─ 0.466 loadd_from  dvc/output/__init__.py:135
   │     │     │        │     │     │  └─ 0.464 _get  dvc/output/__init__.py:75
   │     │     │        │     │     │     └─ 0.392 __init__  dvc/output/local.py:20
   │     │     │        │     │     │        └─ 0.352 __init__  dvc/output/base.py:97
   │     │     │        │     │     │           └─ 0.204 _validate_output_path  dvc/output/base.py:540
   │     │     │        │     │     │              └─ 0.190 check_ignore  dvc/ignore.py:326
   │     │     │        │     │     └─ 0.353 loadd_from  dvc/dependency/__init__.py:84
   │     │     │        │     │        └─ 0.351 _get  dvc/dependency/__init__.py:64
   │     │     │        │     │           └─ 0.267 __init__  dvc/output/local.py:20
   │     │     │        │     │              └─ 0.242 __init__  dvc/output/base.py:97
   │     │     │        │     │                 └─ 0.140 _validate_output_path  dvc/output/base.py:540
   │     │     │        │     │                    └─ 0.131 check_ignore  dvc/ignore.py:326
   │     │     │        │     ├─ 0.818 <listcomp>  dvc/repo/stage.py:179
   │     │     │        │     │  └─ 0.798 __getitem__  dvc/stage/loader.py:106
   │     │     │        │     │     └─ 0.686 load_stage  dvc/stage/loader.py:67
   │     │     │        │     │        ├─ 0.397 fill_stage_dependencies  dvc/stage/utils.py:72
   │     │     │        │     │        │  └─ 0.374 loads_from  dvc/dependency/__init__.py:92
   │     │     │        │     │        │     └─ 0.373 <listcomp>  dvc/dependency/__init__.py:95
   │     │     │        │     │        │        └─ 0.373 _get  dvc/dependency/__init__.py:64
   │     │     │        │     │        │           └─ 0.306 __init__  dvc/output/local.py:20
   │     │     │        │     │        │              └─ 0.275 __init__  dvc/output/base.py:97
   │     │     │        │     │        │                 └─ 0.163 _validate_output_path  dvc/output/base.py:540
   │     │     │        │     │        │                    └─ 0.155 check_ignore  dvc/ignore.py:326
   │     │     │        │     │        └─ 0.270 lcat  funcy/seqs.py:178
   │     │     │        │     │              [2 frames hidden]  funcy
   │     │     │        │     │                 0.268 <genexpr>  dvc/stage/loader.py:87
   │     │     │        │     │                 └─ 0.267 wrapper  funcy/decorators.py:37
   │     │     │        │     │                       [6 frames hidden]  funcy
   │     │     │        │     │                          0.263 post_processing  funcy/flow.py:194
   │     │     │        │     │                          └─ 0.262 load_from_pipeline  dvc/output/__init__.py:211
   │     │     │        │     │                             └─ 0.250 _get  dvc/output/__init__.py:75
   │     │     │        │     │                                └─ 0.232 __init__  dvc/output/local.py:20
   │     │     │        │     │                                   └─ 0.205 __init__  dvc/output/base.py:97
   │     │     │        │     └─ 0.500 stages  dvc/dvcfile.py:238
   │     │     │        │        └─ 0.498 _load  dvc/dvcfile.py:101
   │     │     │        │           ├─ 0.272 [self]  
   │     │     │        │           └─ 0.161 parse_yaml  dvc/utils/serialize/_yaml.py:26
   │     │     │        │              └─ 0.136 load  ruamel/yaml/main.py:328
   │     │     │        │                    [96 frames hidden]  ruamel, .., re, sre_compile, sre_pars...
   │     │     │        └─ 0.226 walk  dvc/tree/local.py:98
   │     │     │           └─ 0.165 __call__  dvc/ignore.py:250
   │     │     │              └─ 0.132 _get_trie_pattern  dvc/ignore.py:261
   │     │     └─ 0.253 build_graph  dvc/repo/graph.py:55
   │     └─ 0.267 <module>  networkx/__init__.py:1
   │           [788 frames hidden]  networkx, numpy, .., collections, fun...
   ├─ 3.926 pager  dvc/utils/pager.py:47
   │  └─ 3.872 _pager  dvc/utils/pager.py:21
   │     └─ 3.828 tempfilepager  pydoc.py:1617
   │           [5 frames hidden]  pydoc, ..
   │              3.826 system  ../scripts/<built-in>:0
   └─ 2.566 _show_ascii  dvc/command/dag.py:10
      └─ 2.513 draw  dvc/dagascii.py:245
         ├─ 1.835 line  dvc/dagascii.py:122
         │  ├─ 0.958 [self]  
         │  ├─ 0.689 point  dvc/dagascii.py:103
         │  │  └─ 0.601 [self]  
         │  └─ 0.188 round  ../scripts/<built-in>:0
         │        [2 frames hidden]  ..
         └─ 0.458 _build_sugiyama_layout  dvc/dagascii.py:204
            ├─ 0.187 __init__  grandalf/graphs.py:619
            │     [34 frames hidden]  grandalf, ..
            └─ 0.164 draw  grandalf/layouts.py:406
                  [130 frames hidden]  grandalf, ..
```

</details>


- Also refactored/moved debugging related utils to a separate
module.
- There's `--instrument-open` that'll open the report in the browser instead of the CLI.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
