### PR TITLE
package: Increment shtab's version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ install_requires = [
     "tabulate>=0.8.7",
     "pygtrie==2.3.2",
     "dpath>=2.0.1,<3",
-    "shtab>=1.3.2,<2",
+    "shtab>=1.3.4,<2",
     "rich>=3.0.5",
     "dictdiffer>=0.8.1",
     "python-benedict>=0.21.1",


### PR DESCRIPTION
Looks like new version does not depend on `pkg_resources`, thus it should make dvc's startup faster.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
