### PR TITLE
parametrization: do not load parser on import

### DIFF
--- a/dvc/parsing/interpolate.py
+++ b/dvc/parsing/interpolate.py
@@ -3,20 +3,15 @@ import typing
 from collections.abc import Mapping
 from functools import singledispatch
 
-from funcy import rpartial
-from pyparsing import (
-    CharsNotIn,
-    ParseException,
-    ParserElement,
-    Suppress,
-    ZeroOrMore,
-)
+from funcy import memoize, rpartial
 
 from dvc.exceptions import DvcException
 from dvc.utils import colorize
 
 if typing.TYPE_CHECKING:
     from typing import List, Match
+
+    from pyparsing import ParseException
 
     from .context import Context
 
@@ -36,14 +31,20 @@ KEYCRE = re.compile(
     re.VERBOSE,
 )
 
-ParserElement.enablePackrat()
 
+@memoize
+def get_parser():
+    from pyparsing import CharsNotIn, ParserElement, Suppress, ZeroOrMore
 
-word = CharsNotIn(f"{PERIOD}{LBRACK}{RBRACK}")
-idx = Suppress(LBRACK) + word + Suppress(RBRACK)
-attr = Suppress(PERIOD) + word
-parser = word + ZeroOrMore(attr ^ idx)
-parser.setParseAction(PERIOD.join)
+    ParserElement.enablePackrat()
+
+    word = CharsNotIn(f"{PERIOD}{LBRACK}{RBRACK}")
+    idx = Suppress(LBRACK) + word + Suppress(RBRACK)
+    attr = Suppress(PERIOD) + word
+    parser = word + ZeroOrMore(attr ^ idx)
+    parser.setParseAction(PERIOD.join)
+
+    return parser
 
 
 class ParseError(DvcException):
@@ -80,7 +81,9 @@ def _(obj: bool):
     return "true" if obj else "false"
 
 
-def _format_exc_msg(exc: ParseException):
+def _format_exc_msg(exc: "ParseException"):
+    from pyparsing import ParseException
+
     exc.loc += 2  # 2 because we append `${` at the start of expr below
 
     expr = exc.pstr
@@ -126,8 +129,10 @@ def check_expression(s: str):
 
 
 def parse_expr(s: str):
+    from pyparsing import ParseException
+
     try:
-        result = parser.parseString(s, parseAll=True)
+        result = get_parser().parseString(s, parseAll=True)
     except ParseException as exc:
         format_and_raise_parse_error(exc)
 


### PR DESCRIPTION
A great benefit to this is that, if the dvc.yaml file
is never interpolated, the parser is never built, which
reduces the gap even further between 1.0 and 2.0 files (except the `context` :( ).

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
