### PR TITLE
repo.tree: make imports lazy

### DIFF
--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -11,15 +11,14 @@ from dvc.exceptions import FileMissingError
 from dvc.exceptions import IsADirectoryError as DvcIsADirectoryError
 from dvc.exceptions import NotDvcRepoError, OutputNotFoundError
 from dvc.path_info import PathInfo
-from dvc.scm import Base
 from dvc.scm.base import SCMError
-from dvc.tree.repo import RepoTree
 from dvc.utils.fs import path_isin
 
 from .graph import build_graph, build_outs_graph, get_pipelines
 from .trie import build_outs_trie
 
 if TYPE_CHECKING:
+    from dvc.scm import Base
     from dvc.tree.base import BaseTree
 
 
@@ -88,7 +87,7 @@ class Repo:
     def _get_repo_dirs(
         self,
         root_dir: str = None,
-        scm: Base = None,
+        scm: "Base" = None,
         rev: str = None,
         uninitialized: bool = False,
     ):
@@ -114,6 +113,8 @@ class Repo:
                 scm = SCM(root_dir or os.curdir)
             except SCMError:
                 scm = SCM(os.curdir, no_scm=True)
+
+            from dvc.scm import Base
 
             assert isinstance(scm, Base)
             root_dir = scm.root_dir
@@ -415,11 +416,14 @@ class Repo:
 
     @cached_property
     def repo_tree(self):
+        from dvc.tree.repo import RepoTree
+
         return RepoTree(self, subrepos=self.subrepos, fetch=True)
 
     @contextmanager
     def open_by_relpath(self, path, remote=None, mode="r", encoding=None):
         """Opens a specified resource as a file descriptor"""
+        from dvc.tree.repo import RepoTree
 
         tree = RepoTree(self, stream=True, subrepos=True)
         path = PathInfo(self.root_dir) / path

--- a/dvc/repo/diff.py
+++ b/dvc/repo/diff.py
@@ -3,8 +3,6 @@ import os
 
 from dvc.exceptions import PathMissingError
 from dvc.repo import locked
-from dvc.tree.local import LocalTree
-from dvc.tree.repo import RepoTree
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +20,10 @@ def diff(self, a_rev="HEAD", b_rev=None, targets=None):
     if self.scm.no_commits:
         return {}
 
+    from dvc.tree.repo import RepoTree
+
+    repo_tree = RepoTree(self, stream=True)
+
     b_rev = b_rev if b_rev else "workspace"
     results = {}
     missing_targets = {}
@@ -35,10 +37,10 @@ def diff(self, a_rev="HEAD", b_rev=None, targets=None):
         if targets is not None:
             # convert targets to path_infos, and capture any missing targets
             targets_path_infos, missing_targets[rev] = _targets_to_path_infos(
-                self, targets
+                repo_tree, targets
             )
 
-        results[rev] = _paths_checksums(self, targets_path_infos)
+        results[rev] = _paths_checksums(self, repo_tree, targets_path_infos)
 
     if targets is not None:
         # check for overlapping missing targets between a_rev and b_rev
@@ -57,7 +59,7 @@ def diff(self, a_rev="HEAD", b_rev=None, targets=None):
     if b_rev == "workspace":
         # missing status is only applicable when diffing local workspace
         # against a commit
-        missing = sorted(_filter_missing(self, deleted_or_missing))
+        missing = sorted(_filter_missing(repo_tree, deleted_or_missing))
     else:
         missing = []
     deleted = sorted(deleted_or_missing - set(missing))
@@ -79,7 +81,7 @@ def diff(self, a_rev="HEAD", b_rev=None, targets=None):
     return ret if any(ret.values()) else {}
 
 
-def _paths_checksums(repo, targets):
+def _paths_checksums(repo, repo_tree, targets):
     """
     A dictionary of checksums addressed by relpaths collected from
     the current tree outputs.
@@ -91,11 +93,12 @@ def _paths_checksums(repo, targets):
         file:      "data"
     """
 
-    return dict(_output_paths(repo, targets))
+    return dict(_output_paths(repo, repo_tree, targets))
 
 
-def _output_paths(repo, targets):
-    repo_tree = RepoTree(repo, stream=True)
+def _output_paths(repo, repo_tree, targets):
+    from dvc.tree.local import LocalTree
+
     on_working_tree = isinstance(repo.tree, LocalTree)
 
     def _exists(output):
@@ -145,8 +148,7 @@ def _dir_output_paths(repo_tree, output, targets=None):
         logger.warning("dir cache entry for '%s' is missing", output)
 
 
-def _filter_missing(repo, paths):
-    repo_tree = RepoTree(repo, stream=True)
+def _filter_missing(repo_tree, paths):
     for path in paths:
         try:
             metadata = repo_tree.metadata(path)
@@ -158,11 +160,9 @@ def _filter_missing(repo, paths):
             pass
 
 
-def _targets_to_path_infos(repo, targets):
+def _targets_to_path_infos(repo_tree, targets):
     path_infos = []
     missing = []
-
-    repo_tree = RepoTree(repo, stream=True)
 
     for target in targets:
         if repo_tree.exists(target):


### PR DESCRIPTION
* Also removed dvcfile related imports on `dvc.tree.repo`. This was making imports slower on `dvc.main`.
* `repo.diff` uses only a single pre-initialized repo tree instance.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
