### PR TITLE
Make few imports lazy on dvc.main

### DIFF
--- a/dvc/main.py
+++ b/dvc/main.py
@@ -1,17 +1,11 @@
 """Main entry point for dvc CLI."""
-
-import errno
 import logging
 
-from dvc import analytics
 from dvc._debug import debugtools
 from dvc.cli import parse_args
 from dvc.config import ConfigError
 from dvc.exceptions import DvcException, DvcParserError, NotDvcRepoError
-from dvc.external_repo import clean_repos
 from dvc.logger import FOOTER, disable_other_loggers
-from dvc.tree.pool import close_pools
-from dvc.utils import error_link
 
 # Workaround for CPython bug. See [1] and [2] for more info.
 # [1] https://github.com/aws/aws-cli/blob/1.16.277/awscli/clidriver.py#L55
@@ -70,7 +64,11 @@ def main(argv=None):  # noqa: C901
         logger.exception("")
     except Exception as exc:  # noqa, pylint: disable=broad-except
         # pylint: disable=no-member
+        import errno
+
         if isinstance(exc, OSError) and exc.errno == errno.EMFILE:
+            from dvc.utils import error_link
+
             logger.exception(
                 "too many open files, please visit "
                 "{} to see how to handle this "
@@ -89,6 +87,8 @@ def main(argv=None):  # noqa: C901
         ret = 255
 
     try:
+        from dvc import analytics
+
         if analytics.is_enabled():
             analytics.collect_and_send_report(args, ret)
 
@@ -96,10 +96,14 @@ def main(argv=None):  # noqa: C901
     finally:
         logger.setLevel(outerLogLevel)
 
+        from dvc.tree.pool import close_pools
+
         # Closing pools by-hand to prevent weird messages when closing SSH
         # connections. See https://github.com/iterative/dvc/issues/3248 for
         # more info.
         close_pools()
+
+        from dvc.external_repo import clean_repos
 
         # Remove cached repos in the end of the call, these are anonymous
         # so won't be reused by any other subsequent run anyway.


### PR DESCRIPTION
* Moved exception handling imports wherever they occur
* Move dvc.tree and dvc.external_repo imports to it's
  nearest use, as it is expensive for `--version`.
* Move analytics import to when it's used
* Move format_link to place where error occurs

This reduces ~0.02s consistently for me, which puts me @ 0.15s for `dvc --version`.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
