### PR TITLE
S3Tree._list_paths now recognizes the max_items limit

### DIFF
--- a/dvc/tree/s3.py
+++ b/dvc/tree/s3.py
@@ -202,6 +202,7 @@ class S3Tree(BaseTree):
         kwargs = {"Prefix": path_info.path}
         if max_items is not None:
             kwargs["MaxKeys"] = max_items
+            kwargs["limit"] = max_items
 
         with self._get_bucket(path_info.bucket) as bucket:
             for obj_summary in bucket.objects.filter(**kwargs):

--- a/dvc/tree/s3.py
+++ b/dvc/tree/s3.py
@@ -199,13 +199,13 @@ class S3Tree(BaseTree):
         return path_info.path in self._list_paths(path_info)
 
     def _list_paths(self, path_info, max_items=None):
-        kwargs = {"Prefix": path_info.path}
-        if max_items is not None:
-            kwargs["MaxKeys"] = max_items
-            kwargs["limit"] = max_items
-
         with self._get_bucket(path_info.bucket) as bucket:
-            for obj_summary in bucket.objects.filter(**kwargs):
+            obj_summaries = bucket.objects.filter(Prefix=path_info.path)
+            if max_items is not None:
+                obj_summaries = obj_summaries.page_size(max_items).limit(
+                    max_items
+                )
+            for obj_summary in obj_summaries:
                 yield obj_summary.key
 
     def walk_files(self, path_info, **kwargs):

--- a/tests/func/test_s3.py
+++ b/tests/func/test_s3.py
@@ -116,6 +116,6 @@ def test_copy_multipart_preserve_etag():
 def test_s3_isdir(tmp_dir, dvc, s3):
     s3.gen({"data": {"foo": "foo"}})
     tree = S3Tree(dvc, s3.config)
-    
+
     assert not tree.isdir(s3 / "data" / "foo")
     assert tree.isdir(s3 / "data")

--- a/tests/func/test_s3.py
+++ b/tests/func/test_s3.py
@@ -111,3 +111,17 @@ def test_copy_multipart_preserve_etag():
     s3.create_bucket(Bucket=from_info.bucket)
     _upload_multipart(s3, from_info.bucket, from_info.path)
     S3Tree._copy(s3, from_info, to_info, {})
+
+
+@mock_s3
+def test_s3_isdir(tmp_dir, dvc, scm):
+    path_info = S3Tree.PATH_CLS("s3://bucket/data/foo")
+    tree = S3Tree(dvc, {"url": str(path_info.parent)})
+
+    s3 = tree.s3.meta.client
+    s3.create_bucket(Bucket=path_info.bucket)
+    s3.put_object(Bucket=path_info.bucket, Key=path_info.path, Body="data")
+
+    tree.makedirs(path_info.parent)
+    assert not tree.isdir(path_info)
+    assert tree.isdir(path_info.parent)

--- a/tests/func/test_s3.py
+++ b/tests/func/test_s3.py
@@ -113,15 +113,9 @@ def test_copy_multipart_preserve_etag():
     S3Tree._copy(s3, from_info, to_info, {})
 
 
-@mock_s3
-def test_s3_isdir(tmp_dir, dvc, scm):
-    path_info = S3Tree.PATH_CLS("s3://bucket/data/foo")
-    tree = S3Tree(dvc, {"url": str(path_info.parent)})
-
-    s3 = tree.s3.meta.client
-    s3.create_bucket(Bucket=path_info.bucket)
-    s3.put_object(Bucket=path_info.bucket, Key=path_info.path, Body="data")
-
-    tree.makedirs(path_info.parent)
-    assert not tree.isdir(path_info)
-    assert tree.isdir(path_info.parent)
+def test_s3_isdir(tmp_dir, dvc, s3):
+    s3.gen({"data": {"foo": "foo"}})
+    tree = S3Tree(dvc, s3.config)
+    
+    assert not tree.isdir(s3 / "data" / "foo")
+    assert tree.isdir(s3 / "data")


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

The `MaxKeys` represents the number of items to fetch in one request, if `limit` is not supplied this takes forever and potentially creates tons of requests (I found out about this because my code literally stuck on `from_tree.isdir()` for a very long time on a massive dataset). This is what `limit` is for. We could have also potentially fixed this in the client code by changing `list()` into a `next(<test>, False)` call but fixing this makes it redundant and just a fix of a code smell so not going to bother with it.

```
from dvc.repo import Repo
from dvc.tree import get_cloud_tree

URL = "remote://private/dataset-registry-private"
repo = Repo()

from_tree = get_cloud_tree(repo, url=URL)
from_info = from_tree.path_info
import time
start = time.perf_counter()
print(from_tree.isdir(from_info))
print("Took: ", time.perf_counter() - start)
```
This now results within a second

https://github.com/boto/boto3/issues/631