### PR TITLE
git: implement merge/checkout via pygit2

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -3,7 +3,7 @@
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code.
-extension-pkg-whitelist=
+extension-pkg-whitelist=pygit2
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -251,7 +251,7 @@ class Experiments:
         ]
         if lock_files:
             self.scm.reset(paths=lock_files)
-            self.scm.checkout_paths(lock_files, force=True)
+            self.scm.checkout_index(paths=lock_files, force=True)
 
     def _stash_msg(
         self,

--- a/dvc/repo/experiments/executor/base.py
+++ b/dvc/repo/experiments/executor/base.py
@@ -106,9 +106,8 @@ class BaseExecutor(ABC):
             # committing
             head = EXEC_BRANCH if branch else EXEC_HEAD
             self.scm.checkout(head, detach=True)
-            self.scm.gitpython.repo.git.merge(
-                EXEC_MERGE, squash=True, no_commit=True
-            )
+            merge_rev = self.scm.get_ref(EXEC_MERGE)
+            self.scm.merge(merge_rev, squash=True, commit=False)
         finally:
             os.chdir(cwd)
 
@@ -400,7 +399,7 @@ class BaseExecutor(ABC):
                 raise ExperimentExistsError(ref_info.name)
             logger.debug("Commit to new experiment branch '%s'", branch)
 
-        scm.gitpython.repo.git.add(update=True)
+        scm.add([], update=True)
         scm.commit(f"dvc: commit experiment {exp_hash}", no_verify=True)
         new_rev = scm.get_rev()
         scm.set_ref(branch, new_rev, old_ref=old_ref)

--- a/dvc/scm/base.py
+++ b/dvc/scm/base.py
@@ -34,6 +34,10 @@ class NoSCMError(SCMError):
         super().__init__(msg)
 
 
+class MergeConflictError(SCMError):
+    pass
+
+
 class Base:
     """Base class for source control management driver implementations."""
 

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -387,6 +387,7 @@ class Git(Base):
     reset = partialmethod(_backend_func, "reset")
     checkout_paths = partialmethod(_backend_func, "checkout_paths")
     status = partialmethod(_backend_func, "status")
+    merge = partialmethod(_backend_func, "merge")
 
     def resolve_rev(self, rev: str) -> str:
         from dvc.repo.experiments.utils import exp_refs_by_name

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -385,7 +385,7 @@ class Git(Base):
     describe = partialmethod(_backend_func, "describe")
     diff = partialmethod(_backend_func, "diff")
     reset = partialmethod(_backend_func, "reset")
-    checkout_paths = partialmethod(_backend_func, "checkout_paths")
+    checkout_index = partialmethod(_backend_func, "checkout_index")
     status = partialmethod(_backend_func, "status")
     merge = partialmethod(_backend_func, "merge")
 

--- a/dvc/scm/git/backend/base.py
+++ b/dvc/scm/git/backend/base.py
@@ -291,7 +291,11 @@ class BaseGitBackend(ABC):
 
     @abstractmethod
     def checkout_index(
-        self, paths: Optional[Iterable[str]] = None, force: bool = False,
+        self,
+        paths: Optional[Iterable[str]] = None,
+        force: bool = False,
+        ours: bool = False,
+        theirs: bool = False,
     ):
         """Checkout the specified paths from index."""
 

--- a/dvc/scm/git/backend/base.py
+++ b/dvc/scm/git/backend/base.py
@@ -308,3 +308,30 @@ class BaseGitBackend(ABC):
 
     def _reset(self) -> None:
         pass
+
+    @abstractmethod
+    def merge(
+        self,
+        rev: str,
+        commit: bool = True,
+        msg: Optional[str] = None,
+        squash: bool = False,
+    ) -> Optional[str]:
+        """Merge specified commit into the current (working copy) branch.
+
+        Args:
+            rev: Git revision to merge.
+            commit: If True, merge will be committed using `msg` as the commit
+                message. If False, the merge changes will be staged but not
+                committed.
+            msg: Merge commit message, required if `commit` is True.
+            squash: If True, working tree state will be updated with merge
+                results, but no commit will be made and no changes will be
+                staged. `commit` must be False when `squash` is True.
+
+        If conflicts are present after merging, MergeConflictError will be
+        raised. The caller is responsible for either resolving the conflicts
+        or resetting the repository state.
+
+        Returns revision of the merge commit or None if no commit was made.
+        """

--- a/dvc/scm/git/backend/base.py
+++ b/dvc/scm/git/backend/base.py
@@ -52,7 +52,7 @@ class BaseGitBackend(ABC):
         pass
 
     @abstractmethod
-    def add(self, paths: Iterable[str]):
+    def add(self, paths: Iterable[str], update=False):
         pass
 
     @abstractmethod

--- a/dvc/scm/git/backend/base.py
+++ b/dvc/scm/git/backend/base.py
@@ -290,8 +290,10 @@ class BaseGitBackend(ABC):
         """Reset current git HEAD."""
 
     @abstractmethod
-    def checkout_paths(self, paths: Iterable[str], force: bool = False):
-        """Checkout the specified paths from HEAD index."""
+    def checkout_index(
+        self, paths: Optional[Iterable[str]] = None, force: bool = False,
+    ):
+        """Checkout the specified paths from index."""
 
     @abstractmethod
     def status(

--- a/dvc/scm/git/backend/dulwich.py
+++ b/dvc/scm/git/backend/dulwich.py
@@ -562,3 +562,12 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
 
     def _reset(self) -> None:
         self.__dict__.pop("ignore_manager", None)
+
+    def merge(
+        self,
+        rev: str,
+        commit: bool = True,
+        msg: Optional[str] = None,
+        squash: bool = False,
+    ) -> Optional[str]:
+        raise NotImplementedError

--- a/dvc/scm/git/backend/dulwich.py
+++ b/dvc/scm/git/backend/dulwich.py
@@ -117,8 +117,11 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
     def dir(self) -> str:
         return self.repo.commondir()
 
-    def add(self, paths: Iterable[str]):
+    def add(self, paths: Iterable[str], update=False):
         from dvc.utils.fs import walk_files
+
+        if update:
+            raise NotImplementedError
 
         if isinstance(paths, str):
             paths = [paths]

--- a/dvc/scm/git/backend/dulwich.py
+++ b/dvc/scm/git/backend/dulwich.py
@@ -539,7 +539,9 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
     def reset(self, hard: bool = False, paths: Iterable[str] = None):
         raise NotImplementedError
 
-    def checkout_paths(self, paths: Iterable[str], force: bool = False):
+    def checkout_index(
+        self, paths: Optional[Iterable[str]] = None, force: bool = False,
+    ):
         raise NotImplementedError
 
     def status(

--- a/dvc/scm/git/backend/dulwich.py
+++ b/dvc/scm/git/backend/dulwich.py
@@ -540,7 +540,11 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
         raise NotImplementedError
 
     def checkout_index(
-        self, paths: Optional[Iterable[str]] = None, force: bool = False,
+        self,
+        paths: Optional[Iterable[str]] = None,
+        force: bool = False,
+        ours: bool = False,
+        theirs: bool = False,
     ):
         raise NotImplementedError
 

--- a/dvc/scm/git/backend/gitpython.py
+++ b/dvc/scm/git/backend/gitpython.py
@@ -188,11 +188,14 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
     def dir(self) -> str:
         return self.repo.git_dir
 
-    def add(self, paths: Iterable[str]):
+    def add(self, paths: Iterable[str], update=False):
         # NOTE: GitPython is not currently able to handle index version >= 3.
         # See https://github.com/iterative/dvc/issues/610 for more details.
         try:
-            self.repo.index.add(paths)
+            if update:
+                self.git.add(*paths, update=True)
+            else:
+                self.repo.index.add(paths)
         except AssertionError:
             msg = (
                 "failed to add '{}' to git. You can add those files "

--- a/dvc/scm/git/backend/gitpython.py
+++ b/dvc/scm/git/backend/gitpython.py
@@ -515,10 +515,11 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
     def reset(self, hard: bool = False, paths: Iterable[str] = None):
         self.repo.head.reset(index=True, working_tree=hard, paths=paths)
 
-    def checkout_paths(self, paths: Iterable[str], force: bool = False):
+    def checkout_index(
+        self, paths: Optional[Iterable[str]] = None, force: bool = False,
+    ):
         """Checkout the specified paths from HEAD index."""
-        if paths:
-            self.repo.index.checkout(paths=paths, force=force)
+        self.repo.index.checkout(paths=paths, force=force)
 
     def status(
         self, ignored: bool = False

--- a/dvc/scm/git/backend/pygit2.py
+++ b/dvc/scm/git/backend/pygit2.py
@@ -84,7 +84,7 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
     def dir(self) -> str:
         raise NotImplementedError
 
-    def add(self, paths: Iterable[str]):
+    def add(self, paths: Iterable[str], update=False):
         raise NotImplementedError
 
     def commit(self, msg: str, no_verify: bool = False):

--- a/dvc/scm/git/backend/pygit2.py
+++ b/dvc/scm/git/backend/pygit2.py
@@ -243,7 +243,6 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
         msg: Optional[str] = None,
         squash: bool = False,
     ) -> Optional[str]:
-        # pylint: disable=no-name-in-module
         from pygit2 import GIT_RESET_MIXED, GitError
 
         if commit and squash:

--- a/dvc/scm/git/backend/pygit2.py
+++ b/dvc/scm/git/backend/pygit2.py
@@ -225,8 +225,25 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
     def reset(self, hard: bool = False, paths: Iterable[str] = None):
         raise NotImplementedError
 
-    def checkout_paths(self, paths: Iterable[str], force: bool = False):
-        raise NotImplementedError
+    def checkout_index(
+        self, paths: Optional[Iterable[str]] = None, force: bool = False,
+    ):
+        from pygit2 import (
+            GIT_CHECKOUT_FORCE,
+            GIT_CHECKOUT_RECREATE_MISSING,
+            GIT_CHECKOUT_SAFE,
+        )
+
+        strategy = GIT_CHECKOUT_RECREATE_MISSING
+        if force:
+            strategy |= GIT_CHECKOUT_FORCE
+        else:
+            strategy |= GIT_CHECKOUT_SAFE
+        self.repo.checkout_index(
+            self.repo.index,
+            paths=list(paths) if paths else None,
+            strategy=strategy,
+        )
 
     def iter_remote_refs(self, url: str, base: Optional[str] = None):
         raise NotImplementedError

--- a/tests/unit/scm/test_git.py
+++ b/tests/unit/scm/test_git.py
@@ -8,11 +8,12 @@ from tests.basic_env import TestDvcGit
 
 # Behaves the same as SCM but will test against all suported Git backends.
 # tmp_dir.scm will still contain a default SCM instance.
-@pytest.fixture(params=["gitpython", "dulwich"])
+@pytest.fixture(params=["gitpython", "dulwich", "pygit2"])
 def git(tmp_dir, scm, request):
     from dvc.scm.git import Git
 
     git_ = Git(os.fspath(tmp_dir), backends=[request.param])
+    git_.test_backend = request.param
     yield git_
     git_.close()
 
@@ -140,6 +141,9 @@ def test_branch_revs(tmp_dir, scm):
 
 
 def test_set_ref(tmp_dir, git):
+    if git.test_backend == "pygit2":
+        pytest.skip()
+
     tmp_dir.scm_gen({"file": "0"}, commit="init")
     init_rev = tmp_dir.scm.get_rev()
     tmp_dir.scm_gen({"file": "1"}, commit="commit")
@@ -167,6 +171,9 @@ def test_set_ref(tmp_dir, git):
 
 
 def test_get_ref(tmp_dir, git):
+    if git.test_backend == "pygit2":
+        pytest.skip()
+
     tmp_dir.scm_gen({"file": "0"}, commit="init")
     init_rev = tmp_dir.scm.get_rev()
     tmp_dir.gen(
@@ -185,6 +192,9 @@ def test_get_ref(tmp_dir, git):
 
 
 def test_remove_ref(tmp_dir, git):
+    if git.test_backend == "pygit2":
+        pytest.skip()
+
     tmp_dir.scm_gen({"file": "0"}, commit="init")
     init_rev = tmp_dir.scm.get_rev()
     tmp_dir.gen(os.path.join(".git", "refs", "foo", "bar"), init_rev)
@@ -282,6 +292,8 @@ def test_list_all_commits(tmp_dir, scm):
 
 
 def test_ignore_remove_empty(tmp_dir, scm, git):
+    if git.test_backend == "pygit2":
+        pytest.skip()
 
     test_entries = [
         {"entry": "/foo1", "path": f"{tmp_dir}/foo1"},
@@ -310,6 +322,9 @@ def test_ignore_remove_empty(tmp_dir, scm, git):
 def test_commit_no_verify(tmp_dir, scm, git, hook):
     import stat
 
+    if git.test_backend == "pygit2":
+        pytest.skip()
+
     hook_file = os.path.join(".git", "hooks", hook)
     tmp_dir.gen(
         hook_file, "#!/usr/bin/env python\nimport sys\nsys.exit(1)",
@@ -321,3 +336,35 @@ def test_commit_no_verify(tmp_dir, scm, git, hook):
     with pytest.raises(SCMError):
         git.commit("commit foo")
     git.commit("commit foo", no_verify=True)
+
+
+@pytest.mark.parametrize("squash", [True, False])
+def test_merge(tmp_dir, scm, git, squash):
+    from dvc.scm.base import MergeConflictError
+
+    if git.test_backend == "dulwich":
+        pytest.skip()
+
+    tmp_dir.scm_gen("foo", "foo", commit="init")
+    init_rev = scm.get_rev()
+
+    scm.checkout("branch", create_new=True)
+    tmp_dir.scm_gen("foo", "bar", commit="bar")
+    branch = scm.resolve_rev("branch")
+
+    scm.checkout("master")
+
+    with pytest.raises(MergeConflictError):
+        tmp_dir.scm_gen("foo", "baz", commit="baz")
+        git.merge(branch, commit=not squash, squash=squash, msg="merge")
+
+    scm.gitpython.git.reset(init_rev, hard=True)
+    merge_rev = git.merge(
+        branch, commit=not squash, squash=squash, msg="merge"
+    )
+    assert (tmp_dir / "foo").read_text() == "bar"
+    if squash:
+        assert merge_rev is None
+        assert scm.get_rev() == init_rev
+    else:
+        assert scm.get_rev() == merge_rev

--- a/tests/unit/scm/test_git.py
+++ b/tests/unit/scm/test_git.py
@@ -368,3 +368,19 @@ def test_merge(tmp_dir, scm, git, squash):
         assert scm.get_rev() == init_rev
     else:
         assert scm.get_rev() == merge_rev
+
+
+def test_checkout_index(tmp_dir, scm, git):
+    if git.test_backend == "dulwich":
+        pytest.skip()
+
+    tmp_dir.scm_gen({"foo": "foo", "bar": "bar"}, commit="init")
+    tmp_dir.gen("foo", "baz")
+
+    git.checkout_index(["foo"], force=True)
+    assert (tmp_dir / "foo").read_text() == "foo"
+
+    tmp_dir.gen({"foo": "baz", "bar": "baz"})
+    git.checkout_index(force=True)
+    assert (tmp_dir / "foo").read_text() == "foo"
+    assert (tmp_dir / "bar").read_text() == "bar"


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Finishes moving the remaining direct `gitpython` calls from experiments into `scm` and implements them in both `gitpython` and `pygit2` backends.

Related to #2215