### PR TITLE
Implement optional dos2unix feature

### DIFF
--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -117,6 +117,7 @@ SCHEMA = {
         Optional("autostage", default=False): Bool,
         Optional("experiments"): Bool,  # obsoleted
         Optional("check_update", default=True): Bool,
+        Optional("dos2unix", default=True): Bool,
     },
     "cache": {
         "local": str,

--- a/dvc/tree/local.py
+++ b/dvc/tree/local.py
@@ -303,7 +303,8 @@ class LocalTree(BaseTree):
         return stat.S_IMODE(mode) == self.CACHE_MODE
 
     def get_file_hash(self, path_info):
-        hash_info = HashInfo(self.PARAM_CHECKSUM, file_md5(path_info)[0],)
+        to_unix=self.repo.config["core"].get("dos2unix")
+        hash_info = HashInfo(self.PARAM_CHECKSUM, file_md5(path_info, to_unix=to_unix)[0],)
 
         if hash_info:
             hash_info.size = os.path.getsize(path_info)

--- a/dvc/tree/local.py
+++ b/dvc/tree/local.py
@@ -303,8 +303,10 @@ class LocalTree(BaseTree):
         return stat.S_IMODE(mode) == self.CACHE_MODE
 
     def get_file_hash(self, path_info):
-        to_unix=self.repo.config["core"].get("dos2unix")
-        hash_info = HashInfo(self.PARAM_CHECKSUM, file_md5(path_info, to_unix=to_unix)[0],)
+        to_unix = self.repo.config["core"].get("dos2unix")
+        hash_info = HashInfo(
+            self.PARAM_CHECKSUM, file_md5(path_info, to_unix=to_unix)[0],
+        )
 
         if hash_info:
             hash_info.size = os.path.getsize(path_info)

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -95,10 +95,11 @@ def test_file_md5_to_unix(tmp_dir):
     tmp_dir.gen("unix", b"foo content\n")
     tmp_dir.gen("dos", b"foo content\r\n")
 
-    assert file_md5("dos")[0]  == unixmd5
+    assert file_md5("dos")[0] == unixmd5
     assert file_md5("unix")[0] == unixmd5
     assert file_md5("dos", to_unix=False)[0] == dosmd5
     assert file_md5("unix", to_unix=False)[0] == unixmd5
+
 
 def test_tmp_fname():
     file_path = os.path.join("path", "to", "file")

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -89,6 +89,17 @@ def test_file_md5(tmp_dir):
     assert file_md5("foo") == file_md5(PathInfo("foo"))
 
 
+def test_file_md5_to_unix(tmp_dir):
+    unixmd5 = "fe7297fc04aa54f76ac9537f1a22aa15"
+    dosmd5 = "3060ccb598fd503335eae431903f1ef1"
+    tmp_dir.gen("unix", b"foo content\n")
+    tmp_dir.gen("dos", b"foo content\r\n")
+
+    assert file_md5("dos")[0]  == unixmd5
+    assert file_md5("unix")[0] == unixmd5
+    assert file_md5("dos", to_unix=False)[0] == dosmd5
+    assert file_md5("unix", to_unix=False)[0] == unixmd5
+
 def test_tmp_fname():
     file_path = os.path.join("path", "to", "file")
     file_path_info = PathInfo(file_path)


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Hi again =)

Related to #4658, I've implemented the [option to disable](https://github.com/iterative/dvc/issues/4658#issuecomment-703790216) dos2unix fron the dvc configuration file.

We are starting to use dvc internally, but we are facing issues with pdf or image/tiff formats because they are accidentally identified as text. This means that every /r/n is replaced to /n and the md5 hash calculation no longer matches the file content.

We rolled out our own version of dvc internally with this patch, but it is hard to explain to people that they have to install it from another source. For that reason, I've invested a little bit more time to properly add the parameter and submit this PR. Hopefully, someone else will be able to enjoy this feature.

By default, the parameter dos2unix under **core** configuration will be True. So dvc will behave as usual for everyone. In case someone notices errors due to the dos2unix feature, they can simply set dos2unix to False. 

I know that changing this value in an already existing repo may have weird issues, like dvc detecting changes on unchanged files. I think this won't be a usual case because either you have problems and disable it, or you never notice that this option exists. Usually, this value will be set at project creation and never modified again.

I will write the documentation page, but first, I would like to have your feedback.

Thanks for your support!