### PR TITLE
dvc: bump to 2.0.0a0

### DIFF
--- a/dvc/version.py
+++ b/dvc/version.py
@@ -6,7 +6,7 @@
 import os
 import subprocess
 
-_BASE_VERSION = "1.11.0"
+_BASE_VERSION = "2.0.0a0"
 
 
 def _generate_version(base_version):


### PR DESCRIPTION
Looking at the log is confusing, as the version is stuck in `1.11.0` whereas the recent one is `1.11.10`.

As the updater is also dependent on that version, it prints an ugly update message while running too.
https://github.com/iterative/dvc/issues/5023#issuecomment-758450519

Even though we are not releasing right now, it'd be better to bump the version as it can be no longer considered as 1.X.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
