### PR TITLE
checkpoints/live: move execution env to stage

### DIFF
--- a/dvc/output/base.py
+++ b/dvc/output/base.py
@@ -1,15 +1,13 @@
 import logging
 import os
 from copy import copy
-from typing import Dict, Type
+from typing import Type
 from urllib.parse import urlparse
 
-from funcy import cached_property, project
 from voluptuous import Any
 
 import dvc.prompt as prompt
 from dvc.cache import NamedCache
-from dvc.env import DVCLIVE_PATH, DVCLIVE_REPORT, DVCLIVE_SUMMARY
 from dvc.exceptions import (
     CheckoutError,
     CollectCacheError,
@@ -607,22 +605,3 @@ class BaseOutput:
         self.hash_info = self.cache.merge(
             ancestor_info, self.hash_info, other.hash_info
         )
-
-    @cached_property
-    def env(self) -> Dict[str, str]:
-        if self.live:
-            from dvc.schema import LIVE_PROPS
-
-            env = {DVCLIVE_PATH: str(self.path_info)}
-            if isinstance(self.live, dict):
-
-                config = project(self.live, LIVE_PROPS)
-
-                env[DVCLIVE_SUMMARY] = str(
-                    int(config.get(BaseOutput.PARAM_LIVE_SUMMARY, True))
-                )
-                env[DVCLIVE_REPORT] = str(
-                    int(config.get(BaseOutput.PARAM_LIVE_REPORT, True))
-                )
-            return env
-        return {}

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -273,16 +273,21 @@ class Stage(params.StageParams):
                     int(config.get(BaseOutput.PARAM_LIVE_REPORT, True))
                 )
         elif out.checkpoint and checkpoint_func:
-            from dvc.env import DVC_CHECKPOINT, DVC_ROOT
+            from dvc.env import DVC_CHECKPOINT
 
-            env.update({DVC_CHECKPOINT: "1", DVC_ROOT: self.repo.root_dir})
+            env.update({DVC_CHECKPOINT: "1"})
         return env
 
     def env(self, checkpoint_func=None) -> Env:
+        from dvc.env import DVC_ROOT
+
         env: Env = {}
+        if self.repo:
+            env.update({DVC_ROOT: self.repo.root_dir})
+
         for out in self.outs:
             current = self._read_env(out, checkpoint_func=checkpoint_func)
-            if any(current.keys() and env.keys()):
+            if set(env.keys()).intersection(set(current.keys())):
                 raise DvcException("Duplicated env variable")
             env.update(current)
         return env

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -255,13 +255,36 @@ class Stage(params.StageParams):
         """
         return any(out.checkpoint for out in self.outs)
 
-    @property
-    def env(self) -> Env:
+    def _read_env(self, out, checkpoint_func=None) -> Env:
+        env: Env = {}
+        if out.live:
+            from dvc.env import DVCLIVE_PATH, DVCLIVE_REPORT, DVCLIVE_SUMMARY
+            from dvc.output import BaseOutput
+            from dvc.schema import LIVE_PROPS
+
+            env[DVCLIVE_PATH] = str(out.path_info)
+            if isinstance(out.live, dict):
+                config = project(out.live, LIVE_PROPS)
+
+                env[DVCLIVE_SUMMARY] = str(
+                    int(config.get(BaseOutput.PARAM_LIVE_SUMMARY, True))
+                )
+                env[DVCLIVE_REPORT] = str(
+                    int(config.get(BaseOutput.PARAM_LIVE_REPORT, True))
+                )
+        elif out.checkpoint and checkpoint_func:
+            from dvc.env import DVC_CHECKPOINT, DVC_ROOT
+
+            env.update({DVC_CHECKPOINT: "1", DVC_ROOT: self.repo.root_dir})
+        return env
+
+    def env(self, checkpoint_func=None) -> Env:
         env: Env = {}
         for out in self.outs:
-            if any(out.env.keys() and env.keys()):
+            current = self._read_env(out, checkpoint_func=checkpoint_func)
+            if any(current.keys() and env.keys()):
                 raise DvcException("Duplicated env variable")
-            env.update(out.env)
+            env.update(current)
         return env
 
     def changed_deps(self):


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

This PR aims to make `Output` source of the execution environment for `Stage.run`. It seems that outputs are the cause of `env.`
Related: https://github.com/iterative/dvc/pull/4902#discussion_r542551178
