### PR TITLE
system: prevent mypy from checking windows-related method

### DIFF
--- a/dvc/system.py
+++ b/dvc/system.py
@@ -10,9 +10,9 @@ from dvc.exceptions import DvcException
 logger = logging.getLogger(__name__)
 
 if (
-    platform.system() == "Windows"
+    sys.platform == "win32"
     and sys.version_info < (3, 8)
-    and sys.getwindowsversion() >= (6, 2)  # type: ignore
+    and sys.getwindowsversion() >= (6, 2)
 ):
     try:
         import speedcopy

--- a/dvc/system.py
+++ b/dvc/system.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 if (
     platform.system() == "Windows"
     and sys.version_info < (3, 8)
-    and sys.getwindowsversion() >= (6, 2)
+    and sys.getwindowsversion() >= (6, 2)  # type: ignore
 ):
     try:
         import speedcopy


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

mypy fails on non-windows machines because the `sys` module does not have `getwindowsversion`.