### PR TITLE
refactor run; move to stage.utils

### DIFF
--- a/dvc/repo/experiments/run.py
+++ b/dvc/repo/experiments/run.py
@@ -2,7 +2,7 @@ import logging
 from typing import Iterable, Optional
 
 from dvc.repo import locked
-from dvc.utils.cli_parse import loads_params_from_cli
+from dvc.utils.cli_parse import loads_params
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +28,7 @@ def run(
         return repo.experiments.reproduce_queued(jobs=jobs)
 
     if params:
-        params = loads_params_from_cli(params)
+        params = loads_params(params)
     return repo.experiments.reproduce_one(
         targets=targets, params=params, tmp_dir=tmp_dir, **kwargs
     )

--- a/dvc/repo/run.py
+++ b/dvc/repo/run.py
@@ -1,82 +1,29 @@
-import os
-from contextlib import suppress
+from typing import TYPE_CHECKING
 
-from funcy import concat, first, without
-
-from dvc.utils.cli_parse import parse_params_from_cli
-from dvc.utils.collections import chunk_dict
+from dvc.exceptions import InvalidArgumentError
 
 from . import locked
 from .scm_context import scm_context
 
-
-def is_valid_name(name: str):
-    from ..stage import INVALID_STAGENAME_CHARS
-
-    return not INVALID_STAGENAME_CHARS & set(name)
-
-
-def _get_file_path(kwargs):
-    from dvc.dvcfile import DVC_FILE, DVC_FILE_SUFFIX
-
-    out = first(
-        concat(
-            kwargs.get("outs", []),
-            kwargs.get("outs_no_cache", []),
-            kwargs.get("metrics", []),
-            kwargs.get("metrics_no_cache", []),
-            kwargs.get("plots", []),
-            kwargs.get("plots_no_cache", []),
-            kwargs.get("outs_persist", []),
-            kwargs.get("outs_persist_no_cache", []),
-            kwargs.get("checkpoints", []),
-            without([kwargs.get("live", None)], None),
-        )
-    )
-
-    return (
-        os.path.basename(os.path.normpath(out)) + DVC_FILE_SUFFIX
-        if out
-        else DVC_FILE
-    )
-
-
-def _check_stage_exists(dvcfile, stage):
-    from dvc.stage import PipelineStage
-    from dvc.stage.exceptions import (
-        DuplicateStageName,
-        StageFileAlreadyExistsError,
-    )
-
-    if not dvcfile.exists():
-        return
-
-    hint = "Use '--force' to overwrite."
-    if stage.__class__ != PipelineStage:
-        raise StageFileAlreadyExistsError(
-            f"'{stage.relpath}' already exists. {hint}"
-        )
-    elif stage.name and stage.name in dvcfile.stages:
-        raise DuplicateStageName(
-            f"Stage '{stage.name}' already exists in '{stage.relpath}'. {hint}"
-        )
+if TYPE_CHECKING:
+    from . import Repo
 
 
 @locked
 @scm_context
-def run(self, fname=None, no_exec=False, single_stage=False, **kwargs):
-    from dvc.dvcfile import PIPELINE_FILE, Dvcfile
-    from dvc.exceptions import InvalidArgumentError, OutputDuplicationError
-    from dvc.stage import PipelineStage, Stage, create_stage, restore_meta
-    from dvc.stage.exceptions import InvalidStageName
+def run(
+    self: "Repo",
+    fname: str = None,
+    no_exec=False,
+    single_stage: bool = False,
+    **kwargs
+):
+    from dvc.stage.utils import create_stage_from_cli
 
     if not kwargs.get("cmd"):
         raise InvalidArgumentError("command is not specified")
 
-    stage_cls = PipelineStage
-    path = PIPELINE_FILE
     stage_name = kwargs.get("name")
-
     if stage_name and single_stage:
         raise InvalidArgumentError(
             "`-n|--name` is incompatible with `--single-stage`"
@@ -91,33 +38,9 @@ def run(self, fname=None, no_exec=False, single_stage=False, **kwargs):
     if not stage_name and not single_stage:
         raise InvalidArgumentError("`-n|--name` is required")
 
-    if single_stage:
-        kwargs.pop("name", None)
-        stage_cls = Stage
-        path = fname or _get_file_path(kwargs)
-    else:
-        if not is_valid_name(stage_name):
-            raise InvalidStageName
-
-    params = chunk_dict(parse_params_from_cli(kwargs.pop("params", [])))
-    stage = create_stage(
-        stage_cls, repo=self, path=path, params=params, **kwargs
+    stage = create_stage_from_cli(
+        self, single_stage=single_stage, fname=fname, **kwargs
     )
-    restore_meta(stage)
-    if kwargs.get("run_cache", True) and stage.can_be_skipped:
-        return None
-
-    dvcfile = Dvcfile(self, stage.path)
-    try:
-        if kwargs.get("force", True):
-            with suppress(ValueError):
-                self.stages.remove(stage)
-        else:
-            _check_stage_exists(dvcfile, stage)
-        self.check_modified_graph([stage])
-    except OutputDuplicationError as exc:
-        raise OutputDuplicationError(exc.output, set(exc.stages) - {stage})
-
     if no_exec:
         stage.ignore_outs()
     else:
@@ -126,5 +49,5 @@ def run(self, fname=None, no_exec=False, single_stage=False, **kwargs):
             run_cache=kwargs.get("run_cache", True),
         )
 
-    dvcfile.dump(stage, update_lock=not no_exec)
+    stage.dump(update_lock=not no_exec)
     return stage

--- a/dvc/repo/run.py
+++ b/dvc/repo/run.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 def run(
     self: "Repo",
     fname: str = None,
-    no_exec=False,
+    no_exec: bool = False,
     single_stage: bool = False,
     **kwargs
 ):

--- a/dvc/repo/run.py
+++ b/dvc/repo/run.py
@@ -18,7 +18,7 @@ def run(
     single_stage: bool = False,
     **kwargs
 ):
-    from dvc.stage.utils import create_stage_from_cli
+    from dvc.stage.utils import check_graphs, create_stage_from_cli
 
     if not kwargs.get("cmd"):
         raise InvalidArgumentError("command is not specified")
@@ -41,6 +41,11 @@ def run(
     stage = create_stage_from_cli(
         self, single_stage=single_stage, fname=fname, **kwargs
     )
+    if kwargs.get("run_cache", True) and stage.can_be_skipped:
+        return None
+
+    check_graphs(self, stage, force=kwargs.get("force", True))
+
     if no_exec:
         stage.ignore_outs()
     else:

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -3,7 +3,7 @@ import os
 import string
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import TYPE_CHECKING, Dict, Optional
 
 from funcy import cached_property, project
 
@@ -33,6 +33,9 @@ from .utils import (
     get_dump,
     stage_dump_eq,
 )
+
+if TYPE_CHECKING:
+    from dvc.dvcfile import DVCFile
 
 logger = logging.getLogger(__name__)
 # Disallow all punctuation characters except hyphen and underscore
@@ -166,7 +169,7 @@ class Stage(params.StageParams):
         self.__dict__.pop("relpath", None)
 
     @property
-    def dvcfile(self):
+    def dvcfile(self) -> "DVCFile":
         if self.path and self._dvcfile and self.path == self._dvcfile.path:
             return self._dvcfile
 
@@ -176,13 +179,13 @@ class Stage(params.StageParams):
                 "and is detached from dvcfile."
             )
 
-        from dvc.dvcfile import Dvcfile
+        from dvc.dvcfile import make_dvcfile
 
-        self._dvcfile = Dvcfile(self.repo, self.path)
+        self._dvcfile = make_dvcfile(self.repo, self.path)
         return self._dvcfile
 
     @dvcfile.setter
-    def dvcfile(self, dvcfile):
+    def dvcfile(self, dvcfile: "DVCFile") -> None:
         self._dvcfile = dvcfile
 
     def __repr__(self):
@@ -665,6 +668,9 @@ class Stage(params.StageParams):
         self._check_can_merge(other, ancestor_out)
 
         self.outs[0].merge(ancestor_out, other.outs[0])
+
+    def dump(self, update_lock: bool = False):
+        self.dvcfile.dump(self, update_lock=update_lock)
 
 
 class PipelineStage(Stage):

--- a/dvc/stage/utils.py
+++ b/dvc/stage/utils.py
@@ -264,7 +264,7 @@ def split_params_deps(stage):
     return lsplit(rpartial(isinstance, ParamsDependency), stage.deps)
 
 
-def _is_valid_name(name: str):
+def is_valid_name(name: str):
     from . import INVALID_STAGENAME_CHARS
 
     return not INVALID_STAGENAME_CHARS & set(name)
@@ -336,7 +336,7 @@ def create_stage_from_cli(
         stage_name = kwargs.get("name", None)
         path = PIPELINE_FILE
         stage_cls = PipelineStage
-        if not (stage_name and _is_valid_name(stage_name)):
+        if not (stage_name and is_valid_name(stage_name)):
             raise InvalidStageName
 
     params = chunk_dict(parse_params(kwargs.pop("params", [])))

--- a/dvc/stage/utils.py
+++ b/dvc/stage/utils.py
@@ -1,17 +1,28 @@
 import os
 import pathlib
+from contextlib import suppress
 from itertools import product
+from typing import TYPE_CHECKING, Any
 
-from funcy import lsplit, rpartial
+from funcy import concat, first, lsplit, rpartial, without
+
+from dvc.utils.cli_parse import parse_params
+from dvc.utils.collections import chunk_dict
 
 from ..hash_info import HashInfo
 from .exceptions import (
+    InvalidStageName,
     MissingDataSource,
     StageExternalOutputsError,
     StagePathNotDirectoryError,
     StagePathNotFoundError,
     StagePathOutsideError,
 )
+
+if TYPE_CHECKING:
+    from dvc.repo import Repo
+
+    from . import Stage
 
 
 def check_stage_path(repo, path, is_wdir=False):
@@ -251,3 +262,98 @@ def split_params_deps(stage):
     from ..dependency import ParamsDependency
 
     return lsplit(rpartial(isinstance, ParamsDependency), stage.deps)
+
+
+def _is_valid_name(name: str):
+    from . import INVALID_STAGENAME_CHARS
+
+    return not INVALID_STAGENAME_CHARS & set(name)
+
+
+def _get_file_path(kwargs):
+    """Determine file path from the first output name.
+
+    Used in creating .dvc files.
+    """
+    from dvc.dvcfile import DVC_FILE, DVC_FILE_SUFFIX
+
+    out = first(
+        concat(
+            kwargs.get("outs", []),
+            kwargs.get("outs_no_cache", []),
+            kwargs.get("metrics", []),
+            kwargs.get("metrics_no_cache", []),
+            kwargs.get("plots", []),
+            kwargs.get("plots_no_cache", []),
+            kwargs.get("outs_persist", []),
+            kwargs.get("outs_persist_no_cache", []),
+            kwargs.get("checkpoints", []),
+            without([kwargs.get("live", None)], None),
+        )
+    )
+
+    return (
+        os.path.basename(os.path.normpath(out)) + DVC_FILE_SUFFIX
+        if out
+        else DVC_FILE
+    )
+
+
+def _check_stage_exists(dvcfile, stage):
+    from dvc.stage import PipelineStage
+    from dvc.stage.exceptions import (
+        DuplicateStageName,
+        StageFileAlreadyExistsError,
+    )
+
+    if not dvcfile.exists():
+        return
+
+    hint = "Use '--force' to overwrite."
+    if stage.__class__ != PipelineStage:
+        raise StageFileAlreadyExistsError(
+            f"'{stage.relpath}' already exists. {hint}"
+        )
+    elif stage.name and stage.name in dvcfile.stages:
+        raise DuplicateStageName(
+            f"Stage '{stage.name}' already exists in '{stage.relpath}'. {hint}"
+        )
+
+
+def create_stage_from_cli(
+    repo: "Repo", single_stage: bool = False, fname: str = None, **kwargs: Any
+) -> "Stage":
+    from dvc.dvcfile import PIPELINE_FILE, Dvcfile
+    from dvc.exceptions import OutputDuplicationError
+
+    from . import PipelineStage, Stage, create_stage, restore_meta
+
+    if single_stage:
+        kwargs.pop("name", None)
+        stage_cls = Stage
+        path = fname or _get_file_path(kwargs)
+    else:
+        stage_name = kwargs.get("name", None)
+        path = PIPELINE_FILE
+        stage_cls = PipelineStage
+        if not (stage_name and _is_valid_name(stage_name)):
+            raise InvalidStageName
+
+    params = chunk_dict(parse_params(kwargs.pop("params", [])))
+    stage = create_stage(
+        stage_cls, repo=repo, path=path, params=params, **kwargs
+    )
+    restore_meta(stage)
+
+    try:
+        if kwargs.get("force", True):
+            with suppress(ValueError):
+                repo.stages.remove(stage)
+        else:
+            dvcfile = Dvcfile(repo, stage.path)
+            _check_stage_exists(dvcfile, stage)
+        repo.check_modified_graph([stage])
+    except OutputDuplicationError as exc:
+        raise OutputDuplicationError(exc.output, set(exc.stages) - {stage})
+
+    return stage

--- a/dvc/utils/cli_parse.py
+++ b/dvc/utils/cli_parse.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from typing import Any, Dict, Iterable, List
 
 
-def parse_params_from_cli(path_params: Iterable[str]) -> Dict[str, List[str]]:
+def parse_params(path_params: Iterable[str]) -> Dict[str, List[str]]:
     """Normalizes the shape of params from the CLI to dict."""
     from dvc.dependency.param import ParamsDependency
 
@@ -17,9 +17,7 @@ def parse_params_from_cli(path_params: Iterable[str]) -> Dict[str, List[str]]:
     return ret
 
 
-def loads_params_from_cli(
-    path_params: Iterable[str],
-) -> Dict[str, Dict[str, Any]]:
+def loads_params(path_params: Iterable[str],) -> Dict[str, Dict[str, Any]]:
 
     """Loads the content of params from the cli as Python object."""
     from ruamel.yaml import YAMLError
@@ -28,7 +26,7 @@ def loads_params_from_cli(
 
     from .serialize import loads_yaml
 
-    normalized_params = parse_params_from_cli(path_params)
+    normalized_params = parse_params(path_params)
     ret: Dict[str, Dict[str, Any]] = defaultdict(dict)
 
     for path, param_keys in normalized_params.items():

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dvc.repo.run import is_valid_name
+from dvc.stage.utils import is_valid_name
 
 
 @pytest.mark.parametrize("name", ["copy_name", "copy-name", "copyName", "12"])

--- a/tests/unit/utils/test_cli_parse.py
+++ b/tests/unit/utils/test_cli_parse.py
@@ -1,8 +1,8 @@
-from dvc.utils.cli_parse import parse_params_from_cli
+from dvc.utils.cli_parse import parse_params
 
 
 def test_parse_params():
-    assert parse_params_from_cli(
+    assert parse_params(
         [
             "param1",
             "file1:param1,param2",


### PR DESCRIPTION
Pre-requisite PR for #5253. Moving some code to `stage.utils` to reduce duplications, that might be there when we introduce `stage add/create`.

Also changed `loads_params_from_cli` and `parse_params_from_cli` to `loads_params` and `parse_params` respectively.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
