### PR TITLE
stage collection: do not collect .gitignored dvcfiles

### DIFF
--- a/dvc/dvcfile.py
+++ b/dvc/dvcfile.py
@@ -39,7 +39,7 @@ PIPELINE_LOCK = "dvc.lock"
 
 class FileIsGitIgnored(DvcException):
     def __init__(self, path):
-        super().__init__(f"{path} is git-ignored.")
+        super().__init__(f"'{path}' is git-ignored.")
 
 
 class LockfileCorruptedError(DvcException):

--- a/dvc/dvcfile.py
+++ b/dvc/dvcfile.py
@@ -122,10 +122,8 @@ class FileMixin:
         # 3. path doesn't represent a regular file
         # 4. when the file is git ignored
         if not self.exists():
-            dvc_ignored = self.repo.tree.dvcignore.is_ignored_file(self.path)
-            raise StageFileDoesNotExistError(
-                self.path, dvc_ignored=dvc_ignored
-            )
+            is_ignored = self.repo.tree.exists(self.path, use_dvcignore=False)
+            raise StageFileDoesNotExistError(self.path, dvc_ignored=is_ignored)
 
         if self.verify:
             check_dvc_filename(self.path)

--- a/dvc/repo/stage.py
+++ b/dvc/repo/stage.py
@@ -13,6 +13,7 @@ from typing import (
     Tuple,
     Union,
 )
+from functools import partial
 
 from dvc.exceptions import (
     DvcException,
@@ -371,13 +372,33 @@ class StageLoad:
                 the collection.
         """
         from dvc.dvcfile import is_valid_filename
+        from dvc.tree.local import LocalTree
+
+        scm = self.repo.scm
+        sep = os.sep
+        outs: Set[str] = set()
+
+        is_local_tree = isinstance(self.tree, LocalTree)
+
+        def is_ignored(path):
+            # apply only for the local tree
+            return is_local_tree and scm.is_ignored(path)
+
+        def is_dvcfile_and_not_ignored(root, file):
+            return is_valid_filename(file) and not is_ignored(
+                f"{root}{sep}{file}"
+            )
+
+        def is_out_or_ignored(root, directory):
+            dir_path = f"{root}{sep}{directory}"
+            return dir_path in outs or is_ignored(dir_path)
 
         stages = []
-        outs: Set[str] = set()
         for root, dirs, files in self.tree.walk(self.repo.root_dir):
-            for file_name in filter(is_valid_filename, files):
-                file_path = os.path.join(root, file_name)
+            dvcfile_filter = partial(is_dvcfile_and_not_ignored, root)
 
+            for file in filter(dvcfile_filter, files):
+                file_path = os.path.join(root, file)
                 try:
                     new_stages = self.load_file(file_path)
                 except DvcException as exc:
@@ -393,5 +414,5 @@ class StageLoad:
                     for out in stage.outs
                     if out.scheme == "local"
                 )
-            dirs[:] = [d for d in dirs if os.path.join(root, d) not in outs]
+            dirs[:] = [d for d in dirs if not is_out_or_ignored(root, d)]
         return stages

--- a/dvc/repo/stage.py
+++ b/dvc/repo/stage.py
@@ -3,6 +3,7 @@ import logging
 import os
 import typing
 from contextlib import suppress
+from functools import partial
 from typing import (
     Callable,
     Iterable,
@@ -13,7 +14,6 @@ from typing import (
     Tuple,
     Union,
 )
-from functools import partial
 
 from dvc.exceptions import (
     DvcException,

--- a/dvc/stage/exceptions.py
+++ b/dvc/stage/exceptions.py
@@ -14,7 +14,7 @@ class StageFileFormatError(DvcException):
 
 
 class StageFileDoesNotExistError(DvcException):
-    DVC_IGNORED = "is dvc-ignored."
+    DVC_IGNORED = "is dvc-ignored"
     DOES_NOT_EXIST = "does not exist"
 
     def __init__(self, fname, dvc_ignored=False):

--- a/dvc/stage/exceptions.py
+++ b/dvc/stage/exceptions.py
@@ -14,9 +14,13 @@ class StageFileFormatError(DvcException):
 
 
 class StageFileDoesNotExistError(DvcException):
-    def __init__(self, fname):
+    DVC_IGNORED = "is dvc-ignored."
+    DOES_NOT_EXIST = "does not exist"
+
+    def __init__(self, fname, dvc_ignored=False):
         self.file = fname
-        super().__init__(f"'{self.file}' does not exist.")
+        message = self.DVC_IGNORED if dvc_ignored else self.DOES_NOT_EXIST
+        super().__init__(f"'{self.file}' " + message)
 
 
 class StageFileAlreadyExistsError(DvcException):

--- a/dvc/stage/exceptions.py
+++ b/dvc/stage/exceptions.py
@@ -20,7 +20,7 @@ class StageFileDoesNotExistError(DvcException):
     def __init__(self, fname, dvc_ignored=False):
         self.file = fname
         message = self.DVC_IGNORED if dvc_ignored else self.DOES_NOT_EXIST
-        super().__init__(f"'{self.file}' " + message)
+        super().__init__(f"'{self.file}' {message}")
 
 
 class StageFileAlreadyExistsError(DvcException):

--- a/tests/unit/test_dvcfile.py
+++ b/tests/unit/test_dvcfile.py
@@ -4,6 +4,7 @@ from dvc.dvcfile import (
     PIPELINE_FILE,
     PIPELINE_LOCK,
     Dvcfile,
+    FileIsGitIgnored,
     PipelineFile,
     SingleStageFile,
 )
@@ -41,12 +42,23 @@ def test_pipelines_single_stage_file(path):
 
 
 @pytest.mark.parametrize("file", ["stage.dvc", "dvc.yaml"])
-def test_stage_load_on_not_existing_file(tmp_dir, dvc, file):
+@pytest.mark.parametrize("is_dvcignored", [True, False])
+def test_stage_load_on_not_existing_file(tmp_dir, dvc, file, is_dvcignored):
     dvcfile = Dvcfile(dvc, file)
+    if is_dvcignored:
+        (tmp_dir / ".dvcignore").write_text(file)
+
     assert not dvcfile.exists()
-    with pytest.raises(StageFileDoesNotExistError):
+    with pytest.raises(StageFileDoesNotExistError) as exc_info:
         assert dvcfile.stages.values()
+
+    assert str(exc_info.value) == f"'{file}' does not exist"
+
+
+@pytest.mark.parametrize("file", ["stage.dvc", "dvc.yaml"])
+def test_stage_load_on_non_file(tmp_dir, dvc, file):
     (tmp_dir / file).mkdir()
+    dvcfile = Dvcfile(dvc, file)
     with pytest.raises(StageFileIsNotDvcFileError):
         assert dvcfile.stages.values()
 
@@ -83,3 +95,31 @@ def test_dump_stage(tmp_dir, dvc):
     assert (tmp_dir / PIPELINE_FILE).exists()
     assert (tmp_dir / PIPELINE_LOCK).exists()
     assert list(dvcfile.stages.values()) == [stage]
+
+
+@pytest.mark.parametrize("file", ["stage.dvc", "dvc.yaml"])
+def test_stage_load_file_exists_but_dvcignored(tmp_dir, dvc, scm, file):
+    (tmp_dir / file).write_text("")
+    (tmp_dir / ".dvcignore").write_text(file)
+
+    dvcfile = Dvcfile(dvc, file)
+    with pytest.raises(StageFileDoesNotExistError) as exc_info:
+        assert dvcfile.stages.values()
+
+    assert str(exc_info.value) == f"'{file}' is dvc-ignored"
+
+
+@pytest.mark.parametrize("file", ["foo.dvc", "dvc.yaml"])
+def test_try_loading_dvcfile_that_is_gitignored(tmp_dir, dvc, scm, file):
+    with open(tmp_dir / ".gitignore", "a+") as fd:
+        fd.write(file)
+
+    # create a file just to avoid other checks
+    (tmp_dir / file).write_text("")
+    scm._reset()
+
+    dvcfile = Dvcfile(dvc, file)
+    with pytest.raises(FileIsGitIgnored) as exc_info:
+        dvcfile._load()
+
+    assert str(exc_info.value) == f"'{file}' is git-ignored."


### PR DESCRIPTION
Closes #5244 

A few fixes has been made along the way, including:
* better error message if the dvc.yaml and .dvc files are dvc-ignored.
  ```console
  $ echo "dvc.yaml" >> .dvcignore
  $ dvc repro
  ERROR: 'dvc.yaml' is dvc-ignored. 
  ```
* better error message if the dvc.yaml and .dvc files are git-ignored.
  ```console
  $ echo "dvc.yaml" >> .gitignore
  $ dvc repro
  ERROR: 'dvc.yaml' is git-ignored.
  ```

An open question is, what should we do about lockfiles if they are git-ignored or dvc-ignored?
Right now, we assume the lockfile as empty if they are dvc-ignored and we don't care about git-ignores
for the lockfiles. I feel that this behaviour is good, but if we want them to be consistent, please do tell me.

Another thing to keep in mind is, since the implementation depends on `isinstance(repo.tree, LocalTree)`, if we start using LocalTree for `get/list/import`, it'll break, though I don't think it should as we better apply it to only the user's workspace (IIRC `dvcx` uses this mode).
Though, this might be handled by a state (eg: `repo.is_external_repo` or something like that).

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
