### PR TITLE
scm: implement pygit2 resolve rev and native checkout

### DIFF
--- a/dvc/scm/git/backend/base.py
+++ b/dvc/scm/git/backend/base.py
@@ -151,9 +151,7 @@ class BaseGitBackend(ABC):
         """
 
     @abstractmethod
-    def get_ref(
-        self, name: str, follow: Optional[bool] = True
-    ) -> Optional[str]:
+    def get_ref(self, name: str, follow: bool = True) -> Optional[str]:
         """Return the value of specified ref.
 
         If follow is false, symbolic refs will not be dereferenced.

--- a/dvc/scm/git/backend/dulwich.py
+++ b/dvc/scm/git/backend/dulwich.py
@@ -262,7 +262,7 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
         ):
             raise SCMError(f"Failed to set '{name}'")
 
-    def get_ref(self, name, follow: Optional[bool] = True) -> Optional[str]:
+    def get_ref(self, name, follow: bool = True) -> Optional[str]:
         from dulwich.refs import parse_symref_value
 
         name_b = os.fsencode(name)

--- a/dvc/scm/git/backend/gitpython.py
+++ b/dvc/scm/git/backend/gitpython.py
@@ -375,7 +375,10 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
 
         if name == "HEAD":
             try:
-                return self.repo.head.commit.hexsha
+                if follow or self.repo.head.is_detached:
+                    return self.repo.head.commit.hexsha
+                else:
+                    return f"refs/heads/{self.repo.active_branch}"
             except (GitCommandError, ValueError):
                 return None
         elif name.startswith("refs/heads/"):

--- a/dvc/scm/git/backend/gitpython.py
+++ b/dvc/scm/git/backend/gitpython.py
@@ -370,9 +370,7 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
         except GitCommandError as exc:
             raise SCMError(f"Failed to set ref '{name}'") from exc
 
-    def get_ref(
-        self, name: str, follow: Optional[bool] = True
-    ) -> Optional[str]:
+    def get_ref(self, name: str, follow: bool = True) -> Optional[str]:
         from git.exc import GitCommandError
 
         if name == "HEAD":

--- a/dvc/scm/git/backend/gitpython.py
+++ b/dvc/scm/git/backend/gitpython.py
@@ -496,7 +496,8 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
         try:
             self.git.stash("apply", rev)
         except GitCommandError as exc:
-            if "CONFLICT" in str(exc):
+            out = str(exc)
+            if "CONFLICT" in out or "already exists" in out:
                 raise MergeConflictError(
                     "Stash apply resulted in merge conflicts"
                 ) from exc

--- a/dvc/scm/git/backend/pygit2.py
+++ b/dvc/scm/git/backend/pygit2.py
@@ -282,18 +282,18 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
     def reset(self, hard: bool = False, paths: Iterable[str] = None):
         from pygit2 import GIT_RESET_HARD, GIT_RESET_MIXED, IndexEntry
 
-        self.repo.index.read()
         if paths is not None:
+            self.repo.index.read()
             tree = self.repo.revparse_single("HEAD").tree
             for path in paths:
                 rel = relpath(path, self.root_dir)
                 obj = tree[relpath(rel, self.root_dir)]
                 self.repo.index.add(IndexEntry(rel, obj.oid, obj.filemode))
+            self.repo.index.write()
         elif hard:
             self.repo.reset(self.repo.head.target, GIT_RESET_HARD)
         else:
             self.repo.reset(self.repo.head.target, GIT_RESET_MIXED)
-        self.repo.index.write()
 
     def checkout_index(
         self,
@@ -319,7 +319,6 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
         if ours or theirs:
             strategy |= GIT_CHECKOUT_ALLOW_CONFLICTS
 
-        self.repo.index.read()
         index = self.repo.index
         if paths:
             path_list: Optional[List[str]] = [
@@ -374,7 +373,6 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
         except GitError as exc:
             raise SCMError("Merge failed") from exc
 
-        self.repo.index.read()
         if self.repo.index.conflicts:
             raise MergeConflictError("Merge contained conflicts")
 

--- a/dvc/scm/git/backend/pygit2.py
+++ b/dvc/scm/git/backend/pygit2.py
@@ -93,7 +93,7 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
     def checkout(
         self, branch: str, create_new: Optional[bool] = False, **kwargs,
     ):
-        from pygit2 import GIT_RESET_MIXED, GitError
+        from pygit2 import GitError
 
         if create_new:
             commit = self.repo.revparse_single("HEAD")
@@ -110,7 +110,6 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
                 self.repo.set_head(ref.name)
             else:
                 self.repo.set_head(commit.id)
-            self.repo.reset(commit.id, GIT_RESET_MIXED)
 
     def pull(self, **kwargs):
         raise NotImplementedError

--- a/dvc/scm/git/backend/pygit2.py
+++ b/dvc/scm/git/backend/pygit2.py
@@ -282,8 +282,8 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
     def reset(self, hard: bool = False, paths: Iterable[str] = None):
         from pygit2 import GIT_RESET_HARD, GIT_RESET_MIXED, IndexEntry
 
+        self.repo.index.read(False)
         if paths is not None:
-            self.repo.index.read()
             tree = self.repo.revparse_single("HEAD").tree
             for path in paths:
                 rel = relpath(path, self.root_dir)
@@ -369,7 +369,9 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
             raise SCMError("Merge commit message is required")
 
         try:
+            self.repo.index.read(False)
             self.repo.merge(rev)
+            self.repo.index.write()
         except GitError as exc:
             raise SCMError("Merge failed") from exc
 
@@ -386,4 +388,5 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
         if squash:
             self.repo.reset(self.repo.head.target, GIT_RESET_MIXED)
             self.repo.state_cleanup()
+            self.repo.index.write()
         return None

--- a/dvc/scm/git/backend/pygit2.py
+++ b/dvc/scm/git/backend/pygit2.py
@@ -187,7 +187,9 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
         ref.delete()
 
     def iter_refs(self, base: Optional[str] = None):
-        raise NotImplementedError
+        for ref in self.repo.references:
+            if ref.startswith(base):
+                yield ref
 
     def get_refs_containing(self, rev: str, pattern: Optional[str] = None):
         raise NotImplementedError

--- a/dvc/scm/git/backend/pygit2.py
+++ b/dvc/scm/git/backend/pygit2.py
@@ -100,6 +100,8 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
             new_branch = self.repo.branches.local.create(branch, commit)
             self.repo.checkout(new_branch)
         else:
+            if branch == "-":
+                branch = "@{-1}"
             try:
                 commit, ref = self.repo.resolve_refish(branch)
             except (KeyError, GitError):

--- a/tests/func/test_install.py
+++ b/tests/func/test_install.py
@@ -50,7 +50,7 @@ class TestInstall:
         os.unlink("file")
         scm.install()
 
-        scm.checkout("new_branch", create_new=True)
+        scm.gitpython.git.checkout("-b", "new_branch")
 
         assert os.path.isfile("file")
 

--- a/tests/unit/scm/test_git.py
+++ b/tests/unit/scm/test_git.py
@@ -141,9 +141,6 @@ def test_branch_revs(tmp_dir, scm):
 
 
 def test_set_ref(tmp_dir, git):
-    if git.test_backend == "pygit2":
-        pytest.skip()
-
     tmp_dir.scm_gen({"file": "0"}, commit="init")
     init_rev = tmp_dir.scm.get_rev()
     tmp_dir.scm_gen({"file": "1"}, commit="commit")
@@ -171,9 +168,6 @@ def test_set_ref(tmp_dir, git):
 
 
 def test_get_ref(tmp_dir, git):
-    if git.test_backend == "pygit2":
-        pytest.skip()
-
     tmp_dir.scm_gen({"file": "0"}, commit="init")
     init_rev = tmp_dir.scm.get_rev()
     tmp_dir.gen(
@@ -192,9 +186,6 @@ def test_get_ref(tmp_dir, git):
 
 
 def test_remove_ref(tmp_dir, git):
-    if git.test_backend == "pygit2":
-        pytest.skip()
-
     tmp_dir.scm_gen({"file": "0"}, commit="init")
     init_rev = tmp_dir.scm.get_rev()
     tmp_dir.gen(os.path.join(".git", "refs", "foo", "bar"), init_rev)


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Implements required functionality for workspace `git checkout` and `git checkout -b` (`get_ref/set_ref/iter_refs`, `resolve_rev`, `reset`) in pygit2 backend.
Related to #2215