### PR TITLE
dvc: move protect from tree to cache

### DIFF
--- a/dvc/cache/base.py
+++ b/dvc/cache/base.py
@@ -221,7 +221,7 @@ class CloudCache:
                 path_info
             ):
                 # Default relink procedure involves unneeded copy
-                self.tree.unprotect(path_info)
+                self.unprotect(path_info)
             else:
                 self.tree.remove(path_info)
                 self.link(cache_info, path_info)
@@ -281,7 +281,9 @@ class CloudCache:
 
         from_info = PathInfo(tmp)
         to_info = self.tree.path_info / tmp_fname("")
-        self.tree.upload(from_info, to_info, no_progress_bar=True)
+        self.tree.upload(
+            from_info, to_info, no_progress_bar=True, file_mode=self.CACHE_MODE
+        )
 
         hash_info = self.tree.get_file_hash(to_info)
         hash_info.value += self.tree.CHECKSUM_DIR_SUFFIX
@@ -373,6 +375,15 @@ class CloudCache:
     def hash_to_path(self, hash_):
         return self.tree.hash_to_path_info(hash_)
 
+    def protect(self, path_info):  # pylint: disable=unused-argument
+        pass
+
+    def is_protected(self, path_info):  # pylint: disable=unused-argument
+        return False
+
+    def unprotect(self, path_info):  # pylint: disable=unused-argument
+        pass
+
     def changed_cache_file(self, hash_info):
         """Compare the given hash with the (corresponding) actual one.
 
@@ -387,7 +398,7 @@ class CloudCache:
         """
         # Prefer string path over PathInfo when possible due to performance
         cache_info = self.hash_to_path(hash_info.value)
-        if self.tree.is_protected(cache_info):
+        if self.is_protected(cache_info):
             logger.trace(
                 "Assuming '%s' is unchanged since it is read-only", cache_info
             )
@@ -408,7 +419,7 @@ class CloudCache:
         if actual.value.split(".")[0] == hash_info.value.split(".")[0]:
             # making cache file read-only so we don't need to check it
             # next time
-            self.tree.protect(cache_info)
+            self.protect(cache_info)
             return False
 
         if self.tree.exists(cache_info):

--- a/dvc/output/base.py
+++ b/dvc/output/base.py
@@ -430,7 +430,7 @@ class BaseOutput:
 
     def unprotect(self):
         if self.exists:
-            self.tree.unprotect(self.path_info)
+            self.cache.unprotect(self.path_info)
 
     def get_dir_cache(self, **kwargs):
         if not self.is_dir_checksum:

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -309,15 +309,24 @@ class Remote:
         )
 
         if download:
+            # NOTE: don't set CACHE_MODE if we don't trust the remote, so that
+            # cache could verify these files by-hand later.
+            if self.tree.verify:
+                mode = self.tree.file_mode
+            else:
+                mode = cache.CACHE_MODE
             func = partial(
                 _log_exceptions(self.tree.download, "download"),
                 dir_mode=cache.tree.dir_mode,
-                file_mode=cache.tree.file_mode,
+                file_mode=mode,
             )
             status = STATUS_DELETED
             desc = "Downloading"
         else:
-            func = _log_exceptions(self.tree.upload, "upload")
+            func = partial(
+                _log_exceptions(self.tree.upload, "upload"),
+                file_mode=self.cache.CACHE_MODE,
+            )
             status = STATUS_NEW
             desc = "Uploading"
 

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -267,7 +267,7 @@ class Repo:
         return Repo(root_dir)
 
     def unprotect(self, target):
-        return self.cache.local.tree.unprotect(PathInfo(target))
+        return self.cache.local.unprotect(PathInfo(target))
 
     def _ignore(self):
         flist = [

--- a/dvc/tree/base.py
+++ b/dvc/tree/base.py
@@ -60,7 +60,6 @@ class BaseTree:
     TRAVERSE_THRESHOLD_SIZE = 500000
     CAN_TRAVERSE = True
 
-    CACHE_MODE: Optional[int] = None
     SHARED_MODE_MAP = {None: (None, None), "group": (None, None)}
     PARAM_CHECKSUM: ClassVar[Optional[str]] = None
 
@@ -251,18 +250,7 @@ class BaseTree:
     def reflink(self, from_info, to_info):
         raise RemoteActionNotImplemented("reflink", self.scheme)
 
-    @staticmethod
-    def protect(path_info):
-        pass
-
-    def is_protected(self, path_info):
-        return False
-
     # pylint: enable=unused-argument
-
-    @staticmethod
-    def unprotect(path_info):
-        pass
 
     @classmethod
     def is_dir_hash(cls, hash_):

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -714,7 +714,7 @@ def test_readding_dir_should_not_unprotect_all(tmp_dir, dvc, mocker):
     dvc.add("dir")
     tmp_dir.gen("dir/new_file", "new_file_content")
 
-    unprotect_spy = mocker.spy(LocalTree, "unprotect")
+    unprotect_spy = mocker.spy(dvc.cache.local, "unprotect")
     dvc.add("dir")
 
     assert not unprotect_spy.mock.called

--- a/tests/unit/tree/test_tree.py
+++ b/tests/unit/tree/test_tree.py
@@ -53,11 +53,15 @@ def test_get_cloud_tree_validate(tmp_dir, dvc):
 
 @pytest.mark.skipif(os.name == "nt", reason="Not supported for Windows.")
 @pytest.mark.parametrize(
-    "mode, expected", [(None, LocalTree.CACHE_MODE), (0o777, 0o777)],
+    "mode, expected", [(None, None), (0o777, 0o777)],
 )
 def test_upload_file_mode(tmp_dir, mode, expected):
     tmp_dir.gen("src", "foo")
     src = PathInfo(tmp_dir / "src")
+
+    if not expected:
+        expected = stat.S_IMODE((tmp_dir / "src").stat().st_mode)
+
     dest = PathInfo(tmp_dir / "dest")
     tree = LocalTree(None, {"url": os.fspath(tmp_dir)})
     tree.upload(src, dest, file_mode=mode)


### PR DESCRIPTION
Trees shouldn't have anything to do with protect/unprotect logic, as it is a purely cache-related thing.

This PR does a naive move, without generalizing it for all cache types.

Pre-requisite for #5255 

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
