### PR TITLE
tests: upgrade azurite and enable loose mode

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -2,7 +2,8 @@
 version: '3.2'
 services:
   azurite:
-    image: mcr.microsoft.com/azure-storage/azurite:3.9.0
+    image: mcr.microsoft.com/azure-storage/azurite:3.10.0
+    command: azurite -L -l /data --blobHost 0.0.0.0 --queueHost 0.0.0.0
     ports:
       - "10000"
   oss:

--- a/tests/func/test_tree.py
+++ b/tests/func/test_tree.py
@@ -279,20 +279,18 @@ def test_walk_dont_ignore_subrepos(tmp_dir, scm, dvc):
 
 
 @pytest.mark.parametrize(
-    "workspace",
+    "cloud",
     [
         pytest.lazy_fixture("local_cloud"),
         pytest.lazy_fixture("s3"),
         pytest.lazy_fixture("gs"),
-        pytest.lazy_fixture("gdrive"),
         pytest.lazy_fixture("hdfs"),
         pytest.lazy_fixture("http"),
     ],
-    indirect=True,
 )
-def test_tree_getsize(dvc, workspace):
-    workspace.gen({"data": {"foo": "foo"}, "baz": "baz baz"})
-    tree = get_cloud_tree(dvc, url=workspace.url)
+def test_tree_getsize(dvc, cloud):
+    cloud.gen({"data": {"foo": "foo"}, "baz": "baz baz"})
+    tree = get_cloud_tree(dvc, **cloud.config)
     path_info = tree.path_info
 
     assert tree.getsize(path_info / "baz") == 7


### PR DESCRIPTION
Azure tests started failing today with the release of azure-storage-blog 2.7.0 .
They still work with real azure, so this is on azurite's side.

```
2021-01-14T16:09:43.1140570Z     return client.upload(
2021-01-14T16:09:43.1141820Z   File "/opt/hostedtoolcache/Python/3.8.7/x64/lib/python3.8/site-packages/azure/storage/blob/_generated/operations/_block_blob_operations.py", line 233, in upload
2021-01-14T16:09:43.1142819Z     raise HttpResponseError(response=response, model=error)
2021-01-14T16:09:43.1145036Z azure.core.exceptions.HttpResponseError: Operation returned an invalid status 'x-ms-encryption-algorithm header or parameter is not supported in Azurite strict mode. Switch to loose model by Azurite command line parameter "--loose" or Visual Studio Code configuration "Loose". Please vote your wanted features to https://github.com/azure/azurite/issues'
```

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
