### PR TITLE
repo: Add repro from given out names functionality

### DIFF
--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -11,10 +11,6 @@ logger = logging.getLogger(__name__)
 
 class CmdRepro(CmdBase):
     def run(self):
-        if self.args.glob and self.args.glob_stages:
-            raise ValueError(
-                "--glob and --glob-stages options are mutually exclusive."
-            )
         stages = self.repo.reproduce(**self._repro_kwargs)
         if len(stages) == 0:
             logger.info(CmdDataStatus.UP_TO_DATE_MSG)
@@ -151,22 +147,23 @@ def add_arguments(repro_parser):
             "from the run-cache."
         ),
     )
-    repro_parser.add_argument(
+    glob_group = repro_parser.add_mutually_exclusive_group()
+    glob_group.add_argument(
         "--glob",
         action="store_true",
         default=False,
         help=(
             "Allows targets containing shell-style wildcards to match out "
-            "files.",
+            "files."
         ),
     )
-    repro_parser.add_argument(
+    glob_group.add_argument(
         "--glob-stages",
         action="store_true",
         default=False,
         help=(
             "Allows targets containing shell-style wildcards to match stage "
-            "names.",
+            "names."
         ),
     )
 

--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -50,7 +50,7 @@ def add_arguments(repro_parser):
     repro_parser.add_argument(
         "targets",
         nargs="*",
-        help="Stages to reproduce. 'dvc.yaml' by default.",
+        help="Stages or output files to reproduce. 'dvc.yaml' by default.",
     ).complete = completion.DVCFILES_AND_STAGE
     repro_parser.add_argument(
         "-f",

--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -50,7 +50,7 @@ def add_arguments(repro_parser):
     repro_parser.add_argument(
         "targets",
         nargs="*",
-        help="Stages or output files to reproduce. 'dvc.yaml' by default.",
+        help="Stage names or stage outputs to reproduce. 'dvc.yaml' by default.",
     ).complete = completion.DVCFILES_AND_STAGE
     repro_parser.add_argument(
         "-f",

--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -50,7 +50,8 @@ def add_arguments(repro_parser):
     repro_parser.add_argument(
         "targets",
         nargs="*",
-        help="Stage names or stage outputs to reproduce. 'dvc.yaml' by default.",
+        help="Stage names or stage outputs to reproduce. 'dvc.yaml' by "
+        "default.",
     ).complete = completion.DVCFILES_AND_STAGE
     repro_parser.add_argument(
         "-f",

--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -11,6 +11,10 @@ logger = logging.getLogger(__name__)
 
 class CmdRepro(CmdBase):
     def run(self):
+        if self.args.glob and self.args.glob_stages:
+            raise ValueError(
+                "--glob and --glob-stages options are mutually exclusive."
+            )
         stages = self.repo.reproduce(**self._repro_kwargs)
         if len(stages) == 0:
             logger.info(CmdDataStatus.UP_TO_DATE_MSG)
@@ -42,6 +46,7 @@ class CmdRepro(CmdBase):
             "force_downstream": self.args.force_downstream,
             "pull": self.args.pull,
             "glob": self.args.glob,
+            "glob_stages": self.args.glob_stages,
         }
 
 
@@ -150,7 +155,19 @@ def add_arguments(repro_parser):
         "--glob",
         action="store_true",
         default=False,
-        help="Allows targets containing shell-style wildcards.",
+        help=(
+            "Allows targets containing shell-style wildcards to match out "
+            "files.",
+        ),
+    )
+    repro_parser.add_argument(
+        "--glob-stages",
+        action="store_true",
+        default=False,
+        help=(
+            "Allows targets containing shell-style wildcards to match stage "
+            "names.",
+        ),
     )
 
 

--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -153,8 +153,8 @@ def add_arguments(repro_parser):
         action="store_true",
         default=False,
         help=(
-            "Allows targets containing shell-style wildcards to match out "
-            "files."
+            "Allows targets containing shell-style wildcards to match stage "
+            "outputs."
         ),
     )
     glob_group.add_argument(

--- a/dvc/command/repro.py
+++ b/dvc/command/repro.py
@@ -50,8 +50,8 @@ def add_arguments(repro_parser):
     repro_parser.add_argument(
         "targets",
         nargs="*",
-        help="Stage names or stage outputs to reproduce. 'dvc.yaml' by "
-        "default.",
+        help="Stage names or stage outputs to reproduce. './dvc.yaml' "
+        "by default.",
     ).complete = completion.DVCFILES_AND_STAGE
     repro_parser.add_argument(
         "-f",

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -455,7 +455,7 @@ class Repo:
                 return True
 
             if glob:
-                return fnmatch.fnmatch(out.path_info.name, path)
+                return fnmatch.fnmatch(str(out.path_info), path)
 
             return False
 

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -1,3 +1,4 @@
+import fnmatch
 import logging
 import os
 from contextlib import contextmanager
@@ -436,7 +437,9 @@ class Repo:
         error_handler = self.stage_collection_error_handler
         return self.stage.collect_repo(onerror=error_handler)
 
-    def find_outs_by_path(self, path, outs=None, recursive=False, strict=True):
+    def find_outs_by_path(
+        self, path, outs=None, recursive=False, strict=True, glob=False
+    ):
         # using `outs_graph` to ensure graph checks are run
         outs = outs or self.outs_graph
 
@@ -450,6 +453,9 @@ class Repo:
 
             if recursive and out.path_info.isin(path_info):
                 return True
+
+            if glob:
+                return fnmatch.fnmatch(out.path_info.name, path)
 
             return False
 

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -124,7 +124,10 @@ def reproduce(
     else:
         for target in targets:
             granular_stages = self.stage.collect_granular(
-                target, recursive=recursive, accept_group=accept_group
+                target,
+                recursive=recursive,
+                accept_group=accept_group,
+                glob=glob,
             )
             stages.update([stage_info.stage for stage_info in granular_stages])
 

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -92,7 +92,8 @@ def reproduce(
     from .graph import get_pipeline, get_pipelines
 
     glob = kwargs.pop("glob", False)
-    accept_group = not glob
+    glob_stages = kwargs.pop("glob_stages", False) and not glob
+    accept_group = not glob and not glob_stages
 
     if isinstance(targets, str):
         targets = [targets]
@@ -128,6 +129,7 @@ def reproduce(
                 recursive=recursive,
                 accept_group=accept_group,
                 glob=glob,
+                glob_stages=glob_stages,
             )
             stages.update([stage_info.stage for stage_info in granular_stages])
 

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -92,7 +92,7 @@ def reproduce(
     from .graph import get_pipeline, get_pipelines
 
     glob = kwargs.pop("glob", False)
-    glob_stages = kwargs.pop("glob_stages", False) and not glob
+    glob_stages = kwargs.pop("glob_stages", False)
     accept_group = not glob and not glob_stages
 
     if isinstance(targets, str):

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -123,14 +123,10 @@ def reproduce(
                     stages.add(stage)
     else:
         for target in targets:
-            stages.update(
-                self.stage.collect(
-                    target,
-                    recursive=recursive,
-                    accept_group=accept_group,
-                    glob=glob,
-                )
+            granular_stages = self.stage.collect_granular(
+                target, recursive=recursive, accept_group=accept_group
             )
+            stages.update([stage_info.stage for stage_info in granular_stages])
 
     return _reproduce_stages(self.graph, list(stages), **kwargs)
 

--- a/dvc/repo/stage.py
+++ b/dvc/repo/stage.py
@@ -17,6 +17,7 @@ from typing import (
 
 from dvc.exceptions import (
     DvcException,
+    InvalidArgumentError,
     NoOutputOrStageError,
     OutputNotFoundError,
 )
@@ -396,6 +397,11 @@ class StageLoad:
 
             (see `collect()` for other arguments)
         """
+        if glob and glob_stages:
+            raise InvalidArgumentError(
+                "--glob and --glob-stages options are mutually exclusive."
+            )
+
         if not target:
             return [StageInfo(stage) for stage in self.repo.stages]
 

--- a/dvc/repo/stage.py
+++ b/dvc/repo/stage.py
@@ -376,6 +376,7 @@ class StageLoad:
         graph: "DiGraph" = None,
         accept_group: bool = False,
         glob: bool = False,
+        glob_stages: bool = False,
     ) -> List[StageInfo]:
         """Collects a list of (stage, filter_info) from the given target.
 
@@ -399,7 +400,7 @@ class StageLoad:
             return [StageInfo(stage) for stage in self.repo.stages]
 
         stages, file, _ = _collect_specific_target(
-            self, target, with_deps, recursive, accept_group, glob=glob
+            self, target, with_deps, recursive, accept_group, glob=glob_stages
         )
         if not stages:
             if not (recursive and self.fs.isdir(target)):

--- a/dvc/repo/stage.py
+++ b/dvc/repo/stage.py
@@ -404,9 +404,11 @@ class StageLoad:
         if not stages:
             if not (recursive and self.fs.isdir(target)):
                 try:
-                    (out,) = self.repo.find_outs_by_path(target, strict=False)
+                    outs = self.repo.find_outs_by_path(
+                        target, strict=False, glob=glob
+                    )
                     filter_info = PathInfo(os.path.abspath(target))
-                    return [StageInfo(out.stage, filter_info)]
+                    return [StageInfo(out.stage, filter_info) for out in outs]
                 except OutputNotFoundError:
                     pass
 

--- a/dvc/repo/stage.py
+++ b/dvc/repo/stage.py
@@ -399,7 +399,7 @@ class StageLoad:
         """
         if glob and glob_stages:
             raise InvalidArgumentError(
-                "--glob and --glob-stages options are mutually exclusive."
+                "The --glob and --glob-stages options are mutually exclusive."
             )
 
         if not target:

--- a/tests/func/test_repro.py
+++ b/tests/func/test_repro.py
@@ -96,6 +96,17 @@ def test_repro_glob_by_outs(tmp_dir, dvc, run_copy):
     assert dvc.stage.from_target("copy_stage")[0] in res
 
 
+def test_repro_glob_by_outs_multiple_match(tmp_dir, dvc, run_copy):
+    tmp_dir.gen("input", "file content")
+    run_copy("input", "copy_output", name="copy_stage")
+    run_copy("input", "copy_output2", name="copy_stage2")
+    os.remove("copy_output")
+    os.remove("copy_output2")
+    res = dvc.reproduce(targets=["copy_o*"], glob=True)
+    assert dvc.stage.from_target("copy_stage")[0] in res
+    assert dvc.stage.from_target("copy_stage2")[0] in res
+
+
 class TestReproFail(TestRepro):
     def test(self):
         os.unlink(self.CODE)

--- a/tests/func/test_repro.py
+++ b/tests/func/test_repro.py
@@ -57,24 +57,10 @@ class TestRepro(SingleStageRun, TestDvc):
         )
 
 
-class TestReproByOuts(TestRepro):
-    def test(self):
-        with open(self.FOO, "a") as dep_file:
-            dep_file.write("hello")
-
-        res = self.dvc.reproduce(targets=[self.file1])
-        self.assertIn(self.dvc.stage.get_target(self.file1_stage), res)
-
-
 def test_repro_glob(tmp_dir, dvc, run_copy):
     tmp_dir.gen("input", "file content")
     run_copy("input", "copy_output", name="copy_stage")
     os.remove("copy_output")
-
-    print(dvc.stage.collect())
-    print(type(dvc.stage.collect()))
-    print(dvc.stage.collect_granular())
-    print(type(dvc.stage.collect_granular()))
 
     res = dvc.reproduce(targets=["copy_*"], glob=True)
     assert dvc.stage.from_target("copy_stage")[0] in res

--- a/tests/func/test_repro.py
+++ b/tests/func/test_repro.py
@@ -10,6 +10,7 @@ from mock import patch
 from dvc.dvcfile import DVC_FILE, Dvcfile
 from dvc.exceptions import (
     CyclicGraphError,
+    NoOutputOrStageError,
     ReproductionError,
     StagePathAsOutputError,
 )
@@ -1092,7 +1093,7 @@ def test_recursive_repro_recursive_missing_file(dvc):
     """
     with pytest.raises(StageFileDoesNotExistError):
         dvc.reproduce("notExistingStage.dvc", recursive=True)
-    with pytest.raises(StageFileDoesNotExistError):
+    with pytest.raises(NoOutputOrStageError):
         dvc.reproduce("notExistingDir/", recursive=True)
 
 

--- a/tests/func/test_repro.py
+++ b/tests/func/test_repro.py
@@ -66,6 +66,36 @@ class TestReproByOuts(TestRepro):
         self.assertIn(self.dvc.stage.get_target(self.file1_stage), res)
 
 
+def test_repro_glob(tmp_dir, dvc, run_copy):
+    tmp_dir.gen("input", "file content")
+    run_copy("input", "copy_output", name="copy_stage")
+    os.remove("copy_output")
+
+    print(dvc.stage.collect())
+    print(type(dvc.stage.collect()))
+    print(dvc.stage.collect_granular())
+    print(type(dvc.stage.collect_granular()))
+
+    res = dvc.reproduce(targets=["copy_*"], glob=True)
+    assert dvc.stage.from_target("copy_stage")[0] in res
+
+
+def test_repro_by_outs(tmp_dir, dvc, run_copy):
+    tmp_dir.gen("input", "file content")
+    run_copy("input", "copy_output", name="copy_stage")
+    os.remove("copy_output")
+    res = dvc.reproduce(targets=["copy_output"])
+    assert dvc.stage.from_target("copy_stage")[0] in res
+
+
+def test_repro_glob_by_outs(tmp_dir, dvc, run_copy):
+    tmp_dir.gen("input", "file content")
+    run_copy("input", "copy_output", name="copy_stage")
+    os.remove("copy_output")
+    res = dvc.reproduce(targets=["copy_o*"], glob=True)
+    assert dvc.stage.from_target("copy_stage")[0] in res
+
+
 class TestReproFail(TestRepro):
     def test(self):
         os.unlink(self.CODE)

--- a/tests/func/test_repro.py
+++ b/tests/func/test_repro.py
@@ -62,7 +62,7 @@ def test_repro_glob(tmp_dir, dvc, run_copy):
     run_copy("input", "copy_output", name="copy_stage")
     os.remove("copy_output")
 
-    res = dvc.reproduce(targets=["copy_*"], glob=True)
+    res = dvc.reproduce(targets=["copy_s*"], glob_stages=True)
     assert dvc.stage.from_target("copy_stage")[0] in res
 
 
@@ -74,11 +74,24 @@ def test_repro_by_outs(tmp_dir, dvc, run_copy):
     assert dvc.stage.from_target("copy_stage")[0] in res
 
 
-def test_repro_glob_by_outs(tmp_dir, dvc, run_copy):
+def test_repro_glob_by_out_name(tmp_dir, dvc, run_copy):
     tmp_dir.gen("input", "file content")
     run_copy("input", "copy_output", name="copy_stage")
     os.remove("copy_output")
-    res = dvc.reproduce(targets=["copy_o*"], glob=True)
+    res = dvc.reproduce(targets=["copy*"], glob=True)
+    assert dvc.stage.from_target("copy_stage")[0] in res
+
+
+def test_repro_glob_by_out_path(tmp_dir, dvc, run_copy):
+    tmp_dir.gen("data/input", "file content")
+    run_copy("data/input", "data/copy_output", name="copy_stage")
+
+    os.remove("data/copy_output")
+    res = dvc.reproduce(targets=["**/copy_o*"], glob=True)
+    assert dvc.stage.from_target("copy_stage")[0] in res
+
+    os.remove("data/copy_output")
+    res = dvc.reproduce(targets=["data/*"], glob=True)
     assert dvc.stage.from_target("copy_stage")[0] in res
 
 

--- a/tests/func/test_repro.py
+++ b/tests/func/test_repro.py
@@ -57,6 +57,15 @@ class TestRepro(SingleStageRun, TestDvc):
         )
 
 
+class TestReproByOuts(TestRepro):
+    def test(self):
+        with open(self.FOO, "a") as dep_file:
+            dep_file.write("hello")
+
+        res = self.dvc.reproduce(targets=[self.file1])
+        self.assertIn(self.dvc.stage.get_target(self.file1_stage), res)
+
+
 class TestReproFail(TestRepro):
     def test(self):
         os.unlink(self.CODE)

--- a/tests/unit/command/test_repro.py
+++ b/tests/unit/command/test_repro.py
@@ -15,6 +15,7 @@ default_arguments = {
     "force_downstream": False,
     "pull": False,
     "glob": False,
+    "glob_stages": False,
     "targets": [],
 }
 


### PR DESCRIPTION
I'm not sure if I should have added special test for this functionality.

Should the `--glob` functionality be preserved? If so, should handling for it be added to `collect_granular(...)`?

Fixes #3875

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

@pared 