### PR TITLE
tests: add basic [web]hdfs mockers

### DIFF
--- a/dvc/tree/webhdfs.py
+++ b/dvc/tree/webhdfs.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import posixpath
 import shutil
 import threading
 from contextlib import contextmanager
@@ -34,6 +35,7 @@ class WebHDFSTree(BaseTree):
     PATH_CLS = CloudURLInfo
     REQUIRES = {"hdfs": "hdfs"}
     PARAM_CHECKSUM = "checksum"
+    TRAVERSE_PREFIX_LEN = 2
 
     def __init__(self, repo, config):
         super().__init__(repo, config)
@@ -105,10 +107,9 @@ class WebHDFSTree(BaseTree):
             return
 
         root = path_info.path
-        for path, _, files in self.hdfs_client.walk(root):
-            for file_ in files:
-                path = os.path.join(path, file_)
-                yield path_info.replace(path=path)
+        for path, _, fnames in self.hdfs_client.walk(root):
+            for fname in fnames:
+                yield path_info.replace(path=posixpath.join(path, fname))
 
     def remove(self, path_info):
         if path_info.scheme != self.scheme:

--- a/setup.py
+++ b/setup.py
@@ -151,6 +151,7 @@ tests_requirements = [
     "filelock",
     "mypy",
     "wsgidav",
+    "crc32c",
 ]
 
 setup(

--- a/tests/remotes/__init__.py
+++ b/tests/remotes/__init__.py
@@ -14,7 +14,7 @@ from .gs import (  # noqa: F401; noqa: F401
     TEST_GCP_REPO_BUCKET,
     gs,
 )
-from .hdfs import HDFS, hadoop, hdfs, hdfs_server, webhdfs  # noqa: F401
+from .hdfs import HDFS, hadoop, hdfs, hdfs_server, real_hdfs  # noqa: F401
 from .http import HTTP, http, http_server  # noqa: F401
 from .local import Local, local_cloud, local_remote  # noqa: F401
 from .oss import (  # noqa: F401
@@ -32,6 +32,7 @@ from .ssh import (  # noqa: F401; noqa: F401
     ssh_server,
 )
 from .webdav import Webdav, webdav, webdav_server  # noqa: F401
+from .webhdfs import WebHDFS, real_webhdfs, webhdfs  # noqa: F401
 
 TEST_REMOTE = "upstream"
 TEST_CONFIG = {

--- a/tests/remotes/webhdfs.py
+++ b/tests/remotes/webhdfs.py
@@ -1,0 +1,223 @@
+import locale
+import os
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from dvc.path_info import URLInfo
+
+from .base import Base
+from .hdfs import _hdfs_root, md5md5crc32c
+
+
+class WebHDFS(Base, URLInfo):  # pylint: disable=abstract-method
+    @contextmanager
+    def _webhdfs(self):
+        from hdfs import InsecureClient
+
+        client = InsecureClient(f"http://{self.host}:{self.port}", self.user)
+        yield client
+
+    def is_file(self):
+        with self._webhdfs() as _hdfs:
+            return _hdfs.status(self.path)["type"] == "FILE"
+
+    def is_dir(self):
+        with self._webhdfs() as _hdfs:
+            return _hdfs.status(self.path)["type"] == "DIRECTORY"
+
+    def exists(self):
+        with self._webhdfs() as _hdfs:
+            return _hdfs.status(self.path, strict=False) is not None
+
+    def mkdir(self, mode=0o777, parents=False, exist_ok=False):
+        assert mode == 0o777
+        assert parents
+        assert not exist_ok
+
+        with self._webhdfs() as _hdfs:
+            # NOTE: hdfs.makekdirs always creates parents
+            _hdfs.makedirs(self.path, permission=mode)
+
+    def write_bytes(self, contents):
+        with self._webhdfs() as _hdfs:
+            with _hdfs.write(self.path, overwrite=True) as writer:
+                writer.write(contents)
+
+    def write_text(self, contents, encoding=None, errors=None):
+        if not encoding:
+            encoding = locale.getpreferredencoding(False)
+        assert errors is None
+        self.write_bytes(contents.encode(encoding))
+
+    def read_bytes(self):
+        with self._webhdfs() as _hdfs:
+            with _hdfs.read(self.path) as reader:
+                return reader.read()
+
+    def read_text(self, encoding=None, errors=None):
+        if not encoding:
+            encoding = locale.getpreferredencoding(False)
+        assert errors is None
+        return self.read_bytes().decode(encoding)
+
+
+@pytest.fixture
+def real_webhdfs(hdfs_server):
+    port = hdfs_server["webhdfs"]
+    url = f"webhdfs://127.0.0.1:{port}/{uuid.uuid4()}"
+    yield WebHDFS(url)
+
+
+class FakeClient:
+    def __init__(self, *args, **kwargs):
+        self._root = Path(_hdfs_root.name)
+
+    def _path(self, path):
+        return self._root / path.lstrip("/")
+
+    def makedirs(self, path, permission=None):
+        self._path(path).mkdir(
+            mode=permission or 0o777, exist_ok=True, parents=True
+        )
+
+    def write(self, hdfs_path, overwrite=False):
+        from hdfs.util import HdfsError
+
+        path = self._path(hdfs_path)
+
+        if not overwrite and path.exists():
+            raise HdfsError(f"Remote path {hdfs_path} already exists.")
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path.open("wb")
+
+    @contextmanager
+    def read(
+        self,
+        hdfs_path,
+        encoding=None,
+        chunk_size=0,
+        delimiter=None,
+        progress=None,
+    ):
+        pobj = self._path(hdfs_path)
+        if not chunk_size and not delimiter:
+            if encoding:
+                yield pobj.open("r", encoding=encoding)
+            else:
+                yield pobj.open("rb")
+        else:
+            if delimiter:
+                data = pobj.open("r", encoding=encoding, newline=delimiter)
+            else:
+
+                def read_chunks(fobj, _chunk_size):
+                    while True:
+                        chunk = fobj.read(_chunk_size)
+                        if not chunk:
+                            break
+                        yield chunk
+
+                data = read_chunks(
+                    pobj.open("rb", encoding=encoding), chunk_size
+                )
+
+            if progress:
+
+                def reader(_hdfs_path, _progress):
+                    nbytes = 0
+                    for chunk in data:
+                        nbytes += len(chunk)
+                        _progress(_hdfs_path, nbytes)
+                        yield chunk
+                    _progress(_hdfs_path, -1)
+
+                yield reader(hdfs_path, progress)
+            else:
+                yield data
+
+    def walk(self, hdfs_path):
+        import posixpath
+
+        local_path = self._path(hdfs_path)
+        for local_root, dnames, fnames in os.walk(local_path):
+            if local_root == os.fspath(local_path):
+                root = hdfs_path
+            else:
+                root = posixpath.join(
+                    hdfs_path, os.path.relpath(local_root, local_path)
+                )
+            yield (
+                root,
+                dnames,
+                fnames,
+            )
+
+    def delete(self, hdfs_path):
+        return self._path(hdfs_path).unlink()
+
+    def status(self, hdfs_path, strict=True):
+        from hdfs.util import HdfsError
+
+        try:
+            return {"length": self._path(hdfs_path).stat().st_size}
+        except FileNotFoundError:
+            if not strict:
+                return None
+            raise HdfsError(
+                f"File does not exist: {hdfs_path}",
+                exception="FileNotFoundException",
+            )
+
+    def checksum(self, hdfs_path):
+        return {
+            "algorithm": "MD5-of-0MD5-of-512CRC32",
+            "bytes": md5md5crc32c(self._path(hdfs_path)) + "00000000",
+            "size": 28,
+        }
+
+    def rename(self, from_path, to_path):
+        from dvc.utils.fs import move
+
+        move(self._path(from_path), self._path(to_path))
+
+    def upload(
+        self,
+        hdfs_path,
+        local_path,
+        chunk_size=2 ** 16,
+        progress=None,
+        **kwargs,
+    ):
+        with open(local_path, "rb") as from_fobj:
+            with self.write(hdfs_path, **kwargs) as to_fobj:
+                nbytes = 0
+                while True:
+                    chunk = from_fobj.read(chunk_size)
+                    if not chunk:
+                        break
+                    if progress:
+                        nbytes += len(chunk)
+                        progress(local_path, nbytes)
+                    to_fobj.write(chunk)
+
+    def download(self, hdfs_path, local_path, **kwargs):
+        from dvc.utils.fs import makedirs
+
+        kwargs.setdefault("chunk_size", 2 ** 16)
+
+        makedirs(os.path.dirname(local_path), exist_ok=True)
+        with open(local_path, "wb") as writer:
+            with self.read(hdfs_path, **kwargs) as reader:
+                for chunk in reader:
+                    writer.write(chunk)
+
+
+@pytest.fixture
+def webhdfs(mocker):
+    mocker.patch("hdfs.InsecureClient", FakeClient)
+    url = f"webhdfs://example.com:12345/{uuid.uuid4()}"
+    yield WebHDFS(url)

--- a/tests/unit/tree/test_hdfs.py
+++ b/tests/unit/tree/test_hdfs.py
@@ -1,0 +1,30 @@
+import os
+
+from dvc.path_info import URLInfo
+from dvc.tree.hdfs import _hadoop_fs_checksum
+
+
+def test_hadoop_fs_checksum(mocker):
+    mock_proc = mocker.Mock()
+
+    out = b"/path/to/file\tMD5-of-0MD5-of-512CRC32C\t123456789"
+    err = b""
+    mock_proc.configure_mock(
+        **{"communicate.return_value": (out, err), "returncode": 0}
+    )
+    mock_popen = mocker.patch("subprocess.Popen", return_value=mock_proc)
+
+    path_info = URLInfo("hdfs://example.com:1234/path/to/file")
+
+    assert _hadoop_fs_checksum(path_info) == "123456789"
+    mock_popen.assert_called_once_with(
+        "hadoop fs -checksum hdfs://example.com:1234/path/to/file",
+        shell=True,
+        close_fds=os.name != "nt",
+        executable=os.getenv("SHELL") if os.name != "nt" else None,
+        env=os.environ,
+        stdin=-1,
+        stdout=-1,
+        stderr=-1,
+    )
+    assert mock_proc.communicate.called


### PR DESCRIPTION
Raw POC for hdfs and webhdfs. Both mockers are library-level, not emulating real hdfs protocol or http.

Now all [web]hdfs tests run on all operating systems (previously only linux).

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
