### PR TITLE
use `repo.stage.create_from_cli` to create stages

### DIFF
--- a/dvc/command/stage.py
+++ b/dvc/command/stage.py
@@ -8,19 +8,12 @@ logger = logging.getLogger(__name__)
 
 
 class CmdStageAdd(CmdBase):
-    @staticmethod
-    def create(repo, force, **kwargs):
-        from dvc.stage.utils import check_graphs, create_stage_from_cli
-
-        stage = create_stage_from_cli(repo, **kwargs)
-        check_graphs(repo, stage, force=force)
-        return stage
-
     def run(self):
-        stage = self.create(self.repo, self.args.force, **vars(self.args))
+        kwargs = vars(self.args)
+        stage = self.repo.stage.create_from_cli(validate=True, **kwargs)
+
         stage.ignore_outs()
         stage.dump()
-
         return 0
 
 

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -280,7 +280,7 @@ class Repo:
 
         self.scm.ignore_list(flist)
 
-    def check_modified_graph(self, new_stages):
+    def check_modified_graph(self, new_stages, old_stages=None):
         """Generate graph including the new stage to check for errors"""
         # Building graph might be costly for the ones with many DVC-files,
         # so we provide this undocumented hack to skip it. See [1] for
@@ -295,7 +295,8 @@ class Repo:
         #
         # [1] https://github.com/iterative/dvc/issues/2671
         if not getattr(self, "_skip_graph_checks", False):
-            build_graph(self.stages + new_stages)
+            existing_stages = self.stages if old_stages is None else old_stages
+            build_graph(existing_stages + new_stages)
 
     def used_cache(
         self,

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -85,7 +85,7 @@ def add(
                 )
             except OutputDuplicationError as exc:
                 raise OutputDuplicationError(
-                    exc.output, set(exc.stages) - set(stages)
+                    exc.output, list(set(exc.stages) - set(stages))
                 )
 
             link_failures.extend(

--- a/dvc/repo/stage.py
+++ b/dvc/repo/stage.py
@@ -3,7 +3,7 @@ import logging
 import os
 import typing
 from contextlib import suppress
-from typing import Iterable, List, NamedTuple, Optional, Set, Tuple
+from typing import Iterable, List, NamedTuple, Optional, Set, Tuple, Union
 
 from dvc.exceptions import (
     DvcException,
@@ -19,7 +19,7 @@ if typing.TYPE_CHECKING:
     from networkx import DiGraph
 
     from dvc.repo import Repo
-    from dvc.stage import Stage
+    from dvc.stage import PipelineStage, Stage
     from dvc.stage.loader import StageLoader
     from dvc.types import OptStr
 
@@ -92,6 +92,21 @@ def _collect_specific_target(
 class StageLoad:
     def __init__(self, repo: "Repo") -> None:
         self.repo = repo
+
+    def create_from_cli(
+        self, validate: bool = False, **kwargs
+    ) -> Union["Stage", "PipelineStage"]:
+        """Creates a stage from CLI args passed as kwargs.
+
+        Args:
+            validate: if true, the new created stage is checked against the
+                stages in the repo. Eg: graph correctness,
+                potential overwrites in dvc.yaml file (unless `force=True`).
+        """
+        from dvc.stage.utils import create_stage_from_cli
+
+        kwargs.update(validate=validate)
+        return create_stage_from_cli(self.repo, **kwargs)
 
     def from_target(
         self, target: str, accept_group: bool = False, glob: bool = False,

--- a/tests/unit/command/test_stage.py
+++ b/tests/unit/command/test_stage.py
@@ -57,13 +57,11 @@ def test_stage_add(mocker, dvc, extra_args, expected_extra):
         ]
     )
     assert cli_args.func == CmdStageAdd
-    m = mocker.patch.object(CmdStageAdd, "create")
 
     cmd = cli_args.func(cli_args)
+    m = mocker.patch.object(cmd.repo.stage, "create_from_cli")
 
     assert cmd.run() == 0
-    assert m.call_args[0] == (cmd.repo, True)
-
     expected = dict(
         name="name",
         deps=["deps"],


### PR DESCRIPTION
Refactoring and introducing `repo.stage.create_from_cli` instead of using ugly `utils` (directly).

Also clarified API names, docstring and code, especially around `validate_state`/`check_graphs`.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
