### PR TITLE
cli: remove: Show traceback on verbose

### DIFF
--- a/dvc/command/remove.py
+++ b/dvc/command/remove.py
@@ -13,8 +13,8 @@ class CmdRemove(CmdBase):
         for target in self.args.targets:
             try:
                 self.repo.remove(target, outs=self.args.outs)
-            except DvcException as exc:
-                logger.error(exc)
+            except DvcException:
+                logger.exception("")
                 return 1
         return 0
 


### PR DESCRIPTION
During `-v`, we need to be able to see the traceback and the cause/context of the recent exception.
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
