### PR TITLE
Override __str__ implementation for StageNotFound

### DIFF
--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -7,6 +7,7 @@ class DvcException(Exception):
 
     def __init__(self, msg, *args):
         assert msg
+        self.msg = msg
         super().__init__(msg, *args)
 
 

--- a/dvc/stage/exceptions.py
+++ b/dvc/stage/exceptions.py
@@ -80,15 +80,18 @@ class MissingDataSource(DvcException):
         super().__init__(msg)
 
 
-class StageNotFound(KeyError, DvcException):
-    __str__ = DvcException.__str__
-
+class StageNotFound(DvcException, KeyError):
     def __init__(self, file, name):
         self.file = file.relpath
         self.name = name
         super().__init__(
             f"Stage '{self.name}' not found inside '{self.file}' file"
         )
+
+    def __str__(self):
+        # `KeyError` quotes the message
+        # see: https://bugs.python.org/issue2651
+        return self.msg
 
 
 class StageNameUnspecified(DvcException):


### PR DESCRIPTION
This happens because KeyError quotes the error message.
We'd still like to keep StageNotFound being a KeyError
semantics, but workaround the __str__ implementation.

Mypy was having some problem with the previous `__str__`
override.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
