### PR TITLE
checkout: don't filter hash if it is a file

### DIFF
--- a/dvc/cache/base.py
+++ b/dvc/cache/base.py
@@ -92,7 +92,7 @@ class CloudCache:
         return DirInfo.from_list(d)
 
     def _filter_hash_info(self, hash_info, path_info, filter_info):
-        if not filter_info:
+        if not filter_info or path_info == filter_info:
             return hash_info
 
         dir_info = self.get_dir_cache(hash_info)

--- a/tests/func/test_checkout.py
+++ b/tests/func/test_checkout.py
@@ -974,3 +974,14 @@ def test_checkout_partial_subdir(tmp_dir, dvc):
         "foo": "foo",
         "sub_dir": {"bar": "bar", "baz": "baz"},
     }
+
+
+def test_checkout_file(tmp_dir, dvc):
+    tmp_dir.dvc_gen("foo", "foo")
+
+    stats = dvc.checkout("foo")
+    assert not any(stats.values())
+
+    os.unlink("foo")
+    stats = dvc.checkout("foo")
+    assert stats["added"] == ["foo"]


### PR DESCRIPTION
- One some cases (like `dvc checkout foo` where the `foo/` is the whole tracked directory) the `filter_info` is going to be equal to `path_info`, which we don't actually need to filter
- Also, if the origin is a file, then there is no literal need to filter the hash_info