### PR TITLE
exp run: Separate exp param parsing from other commands

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -521,7 +521,7 @@ class CmdExperimentsRun(CmdRepro):
             queue=self.args.queue,
             run_all=self.args.run_all,
             jobs=self.args.jobs,
-            params=self.args.params,
+            params=self.args.set_param,
             checkpoint_resume=self.args.checkpoint_resume,
             reset=self.args.reset,
             tmp_dir=self.args.tmp_dir,
@@ -1184,10 +1184,11 @@ def _add_run_common(parser):
         metavar="<name>",
     )
     parser.add_argument(
-        "--params",
+        "-S",
+        "--set-param",
         action="append",
         default=[],
-        help="Use the specified param values when reproducing pipelines.",
+        help="Use the specified param value when reproducing pipelines.",
         metavar="[<filename>:]<param_name>=<param_value>",
     )
     parser.add_argument(

--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -1188,7 +1188,7 @@ def _add_run_common(parser):
         action="append",
         default=[],
         help="Use the specified param values when reproducing pipelines.",
-        metavar="[<filename>:]<params_list>",
+        metavar="[<filename>:]<param_name>=<param_value>",
     )
     parser.add_argument(
         "--queue",

--- a/dvc/repo/experiments/run.py
+++ b/dvc/repo/experiments/run.py
@@ -2,7 +2,7 @@ import logging
 from typing import Iterable, Optional
 
 from dvc.repo import locked
-from dvc.utils.cli_parse import loads_params
+from dvc.utils.cli_parse import loads_param_overrides
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ def run(
         return repo.experiments.reproduce_queued(jobs=jobs)
 
     if params:
-        params = loads_params(params)
+        params = loads_param_overrides(params)
     return repo.experiments.reproduce_one(
         targets=targets, params=params, tmp_dir=tmp_dir, **kwargs
     )

--- a/tests/func/experiments/test_experiments.py
+++ b/tests/func/experiments/test_experiments.py
@@ -103,7 +103,7 @@ def test_failed_exp(tmp_dir, scm, dvc, exp_stage, mocker, caplog):
     "changes, expected",
     [
         [["foo=baz"], "{foo: baz, goo: {bag: 3}, lorem: false}"],
-        [["foo=baz,goo=bar"], "{foo: baz, goo: bar, lorem: false}"],
+        [["foo=baz", "goo=bar"], "{foo: baz, goo: bar, lorem: false}"],
         [
             ["goo.bag=4"],
             "{foo: [bar: 1, baz: 2], goo: {bag: 4}, lorem: false}",
@@ -114,7 +114,7 @@ def test_failed_exp(tmp_dir, scm, dvc, exp_stage, mocker, caplog):
             "{foo: [bar: 1, baz: 3], goo: {bag: 3}, lorem: false}",
         ],
         [
-            ["foo[1]=- baz\n- goo"],
+            ["foo[1]=[baz, goo]"],
             "{foo: [bar: 1, [baz, goo]], goo: {bag: 3}, lorem: false}",
         ],
         [
@@ -261,7 +261,11 @@ def test_update_py_params(tmp_dir, scm, dvc):
 
     results = dvc.experiments.run(
         stage.addressing,
-        params=["params.py:FLOAT=0.1,Train.seed=2121,Klass.a=222"],
+        params=[
+            "params.py:FLOAT=0.1",
+            "params.py:Train.seed=2121",
+            "params.py:Klass.a=222",
+        ],
         tmp_dir=True,
     )
     exp_a = first(results)


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

# Purpose
Will close #5302

# Approach
Since `dvc exp run` is the only command that uses parameter _overrides_ (as compared with `dvc run`, where you are simply specifying a list of parameters), it makes sense for it have a separate parsing function. Conveniently, `dvc.utils.cli_parse.loads_params` is only being used by `dvc.repo.experiments.run.run`. So I renamed this function to `loads_param_overrides` for clarity and updated it to use the logic described in the source issue. I also updated the test to reflect the new possibilities.

I didn't see anywhere in the docs where `dvc experiments` is documented, otherwise I would open a PR there as well.