### PR TITLE
dvc: refactor cache saving

### DIFF
--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -239,11 +239,6 @@ class FileMissingError(DvcException):
         )
 
 
-class FileOwnershipError(DvcException):
-    def __init__(self, path):
-        super().__init__(f"file '{path}' not owned by user! ")
-
-
 class DvcIgnoreInCollectedDirError(DvcException):
     def __init__(self, ignore_dirname):
         super().__init__(

--- a/dvc/stage/cache.py
+++ b/dvc/stage/cache.py
@@ -60,10 +60,6 @@ class StageCache:
     def cache_dir(self):
         return os.path.join(self.repo.cache.local.cache_dir, "runs")
 
-    @property
-    def tree(self):
-        return self.repo.cache.local.tree
-
     def _get_cache_dir(self, key):
         return os.path.join(self.cache_dir, key[:2], key)
 
@@ -170,12 +166,12 @@ class StageCache:
         COMPILED_LOCK_FILE_STAGE_SCHEMA(cache)
 
         path = PathInfo(self._get_cache_path(cache_key, cache_value))
-        self.tree.makedirs(path.parent)
+        self.repo.cache.local.makedirs(path.parent)
         tmp = tempfile.NamedTemporaryFile(delete=False, dir=path.parent).name
         assert os.path.exists(path.parent)
         assert os.path.isdir(path.parent)
         dump_yaml(tmp, cache)
-        self.tree.move(PathInfo(tmp), path)
+        self.repo.cache.local.move(PathInfo(tmp), path)
 
     def restore(self, stage, run_cache=True, pull=False):
         from .serialize import to_single_stage_lockfile

--- a/dvc/tree/ssh/__init__.py
+++ b/dvc/tree/ssh/__init__.py
@@ -187,8 +187,7 @@ class SSHTree(BaseTree):
         with self.ssh(path_info) as ssh:
             ssh.makedirs(path_info.path)
 
-    def move(self, from_info, to_info, mode=None):
-        assert mode is None
+    def move(self, from_info, to_info):
         if from_info.scheme != self.scheme or to_info.scheme != self.scheme:
             raise NotImplementedError
 

--- a/dvc/tree/webdav.py
+++ b/dvc/tree/webdav.py
@@ -188,7 +188,7 @@ class WebDAVTree(BaseTree):  # pylint:disable=abstract-method
         self._client.mkdir(path_info.path)
 
     # Moves file/directory at remote
-    def move(self, from_info, to_info, mode=None):
+    def move(self, from_info, to_info):
         # Webdav client move
         self._client.move(from_info.path, to_info.path)
 

--- a/dvc/tree/webhdfs.py
+++ b/dvc/tree/webhdfs.py
@@ -139,7 +139,7 @@ class WebHDFSTree(BaseTree):
             with self.hdfs_client.write(to_info.path) as writer:
                 shutil.copyfileobj(reader, writer)
 
-    def move(self, from_info, to_info, mode=None):
+    def move(self, from_info, to_info):
         self.hdfs_client.makedirs(to_info.parent.path)
         self.hdfs_client.rename(from_info.path, to_info.path)
 

--- a/tests/unit/stage/test_cache.py
+++ b/tests/unit/stage/test_cache.py
@@ -174,6 +174,8 @@ def test_shared_stage_cache(tmp_dir, dvc, run_copy):
 
     dvc.cache = Cache(dvc)
 
+    assert not os.path.exists(dvc.cache.local.cache_dir)
+
     run_copy("foo", "bar", name="copy-foo-bar")
 
     parent_cache_dir = os.path.join(dvc.stage_cache.cache_dir, "88",)
@@ -198,7 +200,7 @@ def test_shared_stage_cache(tmp_dir, dvc, run_copy):
         dir_mode = 0o777
         file_mode = 0o666
     else:
-        dir_mode = 0o775
+        dir_mode = 0o2775
         file_mode = 0o664
 
     assert _mode(dvc.cache.local.cache_dir) == dir_mode

--- a/tests/unit/tree/test_tree.py
+++ b/tests/unit/tree/test_tree.py
@@ -1,11 +1,8 @@
-import os
-import stat
-
 import pytest
 
 from dvc.config import ConfigError
-from dvc.path_info import CloudURLInfo, PathInfo
-from dvc.tree import LocalTree, get_cloud_tree
+from dvc.path_info import CloudURLInfo
+from dvc.tree import get_cloud_tree
 
 
 def test_get_cloud_tree(tmp_dir, dvc):
@@ -49,22 +46,3 @@ def test_get_cloud_tree_validate(tmp_dir, dvc):
 
     with pytest.raises(ConfigError):
         get_cloud_tree(dvc, name="second")
-
-
-@pytest.mark.skipif(os.name == "nt", reason="Not supported for Windows.")
-@pytest.mark.parametrize(
-    "mode, expected", [(None, None), (0o777, 0o777)],
-)
-def test_upload_file_mode(tmp_dir, mode, expected):
-    tmp_dir.gen("src", "foo")
-    src = PathInfo(tmp_dir / "src")
-
-    if not expected:
-        expected = stat.S_IMODE((tmp_dir / "src").stat().st_mode)
-
-    dest = PathInfo(tmp_dir / "dest")
-    tree = LocalTree(None, {"url": os.fspath(tmp_dir)})
-    tree.upload(src, dest, file_mode=mode)
-    assert (tmp_dir / "dest").exists()
-    assert (tmp_dir / "dest").read_text() == "foo"
-    assert stat.S_IMODE(os.stat(dest).st_mode) == expected


### PR DESCRIPTION
Moving cache-related modes from the tree to the cache itself. On our way to unify transfer/push/pull/save functionality into one, so that we could use them in the 3.0 cache format.

Pre-requisite for #5255 

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
