### PR TITLE
Revert "utils/fs: checking files ownership in 'move' (#4348) (#4832)"

### DIFF
--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -227,11 +227,6 @@ class FileMissingError(DvcException):
         )
 
 
-class FileOwnershipError(DvcException):
-    def __init__(self, path):
-        super().__init__(f"file '{path}' not owned by user! ")
-
-
 class DvcIgnoreInCollectedDirError(DvcException):
     def __init__(self, ignore_dirname):
         super().__init__(

--- a/dvc/utils/fs.py
+++ b/dvc/utils/fs.py
@@ -8,7 +8,7 @@ import sys
 import nanotime
 from shortuuid import uuid
 
-from dvc.exceptions import DvcException, FileOwnershipError
+from dvc.exceptions import DvcException
 from dvc.system import System
 from dvc.utils import dict_md5
 
@@ -95,20 +95,14 @@ def move(src, dst, mode=None):
     dst = os.path.abspath(dst)
     tmp = f"{dst}.{uuid()}"
 
-    try:
-        if mode is not None:
-            os.chmod(src, mode)
-    except OSError as e:
-        if e.errno not in [errno.EACCES, errno.EPERM]:
-            raise
-        else:
-            raise FileOwnershipError(src)
-
     if os.path.islink(src):
         shutil.copy(src, tmp)
-        _unlink(src, _chmod)
+        os.unlink(src)
     else:
         shutil.move(src, tmp)
+
+    if mode is not None:
+        os.chmod(tmp, mode)
 
     shutil.move(tmp, dst)
 


### PR DESCRIPTION
Fixes #5255

We need a proper solution for #4832, will introduce later.

This reverts commit 8e738262adf78f081473d32419c2fbc07811da4b.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
