### PR TITLE
RepoTree: get rid if implicit fetching

### DIFF
--- a/dvc/cache/base.py
+++ b/dvc/cache/base.py
@@ -246,12 +246,7 @@ class CloudCache:
         else:
             if self.changed_cache(hash_info):
                 with tree.open(path_info, mode="rb") as fobj:
-                    # if tree has fetch enabled, DVC out will be fetched on
-                    # open and we do not need to read/copy any data
-                    if not (
-                        tree.isdvc(path_info, strict=False) and tree.fetch
-                    ):
-                        self.tree.upload_fobj(fobj, cache_info)
+                    self.tree.upload_fobj(fobj, cache_info)
                 callback = kwargs.get("download_callback")
                 if callback:
                     callback(1)
@@ -444,7 +439,9 @@ class CloudCache:
             )
 
         if not hash_info:
-            hash_info = tree.get_hash(path_info, **kwargs)
+            kw = kwargs.copy()
+            kw.pop("download_callback", None)
+            hash_info = tree.get_hash(path_info, **kw)
             if not hash_info:
                 raise FileNotFoundError(
                     errno.ENOENT, os.strerror(errno.ENOENT), path_info

--- a/dvc/dependency/repo.py
+++ b/dvc/dependency/repo.py
@@ -47,9 +47,7 @@ class RepoDependency(LocalDependency):
         return external_repo(d["url"], rev=rev, **kwargs)
 
     def _get_hash(self, locked=True):
-        # we want stream but not fetch, so DVC out directories are
-        # walked, but dir contents is not fetched
-        with self._make_repo(locked=locked, fetch=False, stream=True) as repo:
+        with self._make_repo(locked=locked) as repo:
             path_info = PathInfo(repo.root_dir) / self.def_path
             return repo.repo_tree.get_hash(path_info, follow_subrepos=False)
 

--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -66,9 +66,6 @@ def external_repo(
         **kwargs,
     )
 
-    if "fetch" not in repo_kwargs:
-        repo_kwargs["fetch"] = True
-
     repo = Repo(**repo_kwargs)
 
     try:

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -130,8 +130,6 @@ class Repo:
         config=None,
         url=None,
         repo_factory=None,
-        fetch=None,
-        stream=None,
     ):
         from dvc.cache import Cache
         from dvc.config import Config
@@ -148,8 +146,6 @@ class Repo:
 
         self.url = url
         self._tree_conf = {
-            "stream": stream,
-            "fetch": fetch,
             "repo_factory": repo_factory,
         }
 
@@ -458,7 +454,7 @@ class Repo:
         """Opens a specified resource as a file descriptor"""
         from dvc.tree.repo import RepoTree
 
-        tree = RepoTree(self, stream=True, subrepos=True)
+        tree = RepoTree(self, subrepos=True)
         path = PathInfo(self.root_dir) / path
         try:
             with self.state:

--- a/dvc/repo/diff.py
+++ b/dvc/repo/diff.py
@@ -22,7 +22,7 @@ def diff(self, a_rev="HEAD", b_rev=None, targets=None):
 
     from dvc.tree.repo import RepoTree
 
-    repo_tree = RepoTree(self, stream=True)
+    repo_tree = RepoTree(self)
 
     b_rev = b_rev if b_rev else "workspace"
     results = {}

--- a/dvc/repo/ls.py
+++ b/dvc/repo/ls.py
@@ -30,9 +30,7 @@ def ls(
     """
     from dvc.external_repo import external_repo
 
-    # use our own RepoTree instance instead of repo.repo_tree since we want to
-    # fetch directory listings, but don't want to fetch file contents.
-    with external_repo(url, rev, fetch=False, stream=True) as repo:
+    with external_repo(url, rev) as repo:
         path_info = PathInfo(repo.root_dir)
         if path:
             path_info /= path

--- a/dvc/tree/repo.py
+++ b/dvc/tree/repo.py
@@ -36,7 +36,7 @@ class RepoTree(BaseTree):  # pylint:disable=abstract-method
     PARAM_CHECKSUM = "md5"
 
     def __init__(
-        self, repo, subrepos=False, repo_factory: RepoFactory = None, **kwargs
+        self, repo, subrepos=False, repo_factory: RepoFactory = None,
     ):
         super().__init__(repo, {"url": repo.root_dir})
 
@@ -61,10 +61,8 @@ class RepoTree(BaseTree):  # pylint:disable=abstract-method
         self._dvctrees = {}
         """Keep a dvctree instance of each repo."""
 
-        self._dvctree_configs = kwargs
-
         if hasattr(repo, "dvc_dir"):
-            self._dvctrees[repo.root_dir] = DvcTree(repo, **kwargs)
+            self._dvctrees[repo.root_dir] = DvcTree(repo)
 
     def _get_repo(self, path) -> Optional["Repo"]:
         """Returns repo that the path falls in, using prefix.
@@ -99,12 +97,8 @@ class RepoTree(BaseTree):  # pylint:disable=abstract-method
                     scm=self.repo.scm,
                     rev=self.repo.get_rev(),
                     repo_factory=self.repo_factory,
-                    fetch=self.fetch,
-                    stream=self.stream,
                 )
-                self._dvctrees[repo.root_dir] = DvcTree(
-                    repo, **self._dvctree_configs
-                )
+                self._dvctrees[repo.root_dir] = DvcTree(repo)
             self._subrepos_trie[d] = repo
 
     def _is_dvc_repo(self, dir_path):
@@ -130,14 +124,6 @@ class RepoTree(BaseTree):  # pylint:disable=abstract-method
 
         dvc_tree = self._dvctrees.get(repo.root_dir)
         return repo.tree, dvc_tree
-
-    @property
-    def fetch(self):
-        return self._dvctree_configs.get("fetch")
-
-    @property
-    def stream(self):
-        return self._dvctree_configs.get("stream")
 
     def open(
         self, path, mode="r", encoding="utf-8", **kwargs

--- a/tests/func/test_import.py
+++ b/tests/func/test_import.py
@@ -9,7 +9,7 @@ import dvc.data_cloud as cloud
 from dvc.cache import Cache
 from dvc.config import NoRemoteError
 from dvc.dvcfile import Dvcfile
-from dvc.exceptions import CollectCacheError, DownloadError
+from dvc.exceptions import DownloadError
 from dvc.stage.exceptions import StagePathNotFoundError
 from dvc.system import System
 from dvc.utils.fs import makedirs, remove
@@ -289,7 +289,7 @@ def test_push_wildcard_from_bare_git_repo(
     dvc_repo = make_tmp_dir("dvc-repo", scm=True, dvc=True)
     with dvc_repo.chdir():
         dvc_repo.dvc.imp(os.fspath(tmp_dir), "dirextra")
-        with pytest.raises(CollectCacheError):
+        with pytest.raises(FileNotFoundError):
             dvc_repo.dvc.imp(os.fspath(tmp_dir), "dir123")
 
 

--- a/tests/func/test_tree.py
+++ b/tests/func/test_tree.py
@@ -9,8 +9,6 @@ from dvc.repo import Repo
 from dvc.scm import SCM
 from dvc.tree import get_cloud_tree
 from dvc.tree.local import LocalTree
-from dvc.tree.repo import RepoTree
-from dvc.utils.fs import remove
 from tests.basic_env import TestDir, TestGit, TestGitSubmodule
 
 
@@ -187,50 +185,6 @@ class TestWalkInGit(AssertWalkEqualMixin, TestGit):
                 )
             ],
         )
-
-
-def test_repotree_walk_fetch(tmp_dir, dvc, scm, local_remote):
-    out = tmp_dir.dvc_gen({"dir": {"foo": "foo"}}, commit="init")[0].outs[0]
-    dvc.push()
-    remove(dvc.cache.local.cache_dir)
-    remove(tmp_dir / "dir")
-
-    tree = RepoTree(dvc, fetch=True)
-    for _, _, _ in tree.walk("dir"):
-        pass
-
-    assert os.path.exists(out.cache_path)
-    for _, hi in out.dir_cache.items():
-        assert hi.name == out.tree.PARAM_CHECKSUM
-        assert os.path.exists(dvc.cache.local.tree.hash_to_path_info(hi.value))
-
-
-def test_repotree_cache_save(tmp_dir, dvc, scm, erepo_dir, local_cloud):
-    with erepo_dir.chdir():
-        erepo_dir.gen({"dir": {"subdir": {"foo": "foo"}, "bar": "bar"}})
-        erepo_dir.dvc_add("dir/subdir", commit="subdir")
-        erepo_dir.scm_add("dir", commit="dir")
-        erepo_dir.add_remote(config=local_cloud.config)
-        erepo_dir.dvc.push()
-
-    # test only cares that either fetch or stream are set so that DVC dirs are
-    # walked.
-    #
-    # for this test, all file objects are being opened() and copied from tree
-    # into dvc.cache, not fetched or streamed from a remote
-    tree = RepoTree(erepo_dir.dvc, stream=True)
-    expected = [
-        tree.get_file_hash(PathInfo(erepo_dir / path)).value
-        for path in ("dir/bar", "dir/subdir/foo")
-    ]
-
-    cache = dvc.cache.local
-    path_info = PathInfo(erepo_dir / "dir")
-    hash_info = cache.tree.get_hash(path_info)
-    cache.save(path_info, tree, hash_info)
-
-    for hash_ in expected:
-        assert os.path.exists(cache.tree.hash_to_path_info(hash_))
 
 
 def test_cleantree_subrepo(tmp_dir, dvc, scm, monkeypatch):

--- a/tests/unit/test_external_repo.py
+++ b/tests/unit/test_external_repo.py
@@ -39,8 +39,6 @@ def test_hook_is_called(tmp_dir, erepo_dir, mocker):
                     path,
                     scm=repo.scm,
                     rev=repo.get_rev(),
-                    fetch=True,
-                    stream=None,
                     repo_factory=repo.repo_tree.repo_factory,
                 )
                 for path in paths

--- a/tests/unit/tree/test_dvc.py
+++ b/tests/unit/tree/test_dvc.py
@@ -133,25 +133,7 @@ def test_walk(tmp_dir, dvc):
     assert len(actual) == len(expected)
 
 
-@pytest.mark.parametrize(
-    "fetch,expected",
-    [
-        (False, []),
-        (
-            True,
-            [
-                PathInfo("dir") / "subdir1",
-                PathInfo("dir") / "subdir2",
-                PathInfo("dir") / "subdir1" / "foo1",
-                PathInfo("dir") / "subdir1" / "bar1",
-                PathInfo("dir") / "subdir2" / "foo2",
-                PathInfo("dir") / "foo",
-                PathInfo("dir") / "bar",
-            ],
-        ),
-    ],
-)
-def test_walk_dir(tmp_dir, dvc, fetch, expected):
+def test_walk_dir(tmp_dir, dvc):
     tmp_dir.gen(
         {
             "dir": {
@@ -164,9 +146,17 @@ def test_walk_dir(tmp_dir, dvc, fetch, expected):
     )
 
     dvc.add("dir")
-    tree = DvcTree(dvc, fetch=fetch)
+    tree = DvcTree(dvc)
 
-    expected = [str(tmp_dir / path) for path in expected]
+    expected = [
+        str(tmp_dir / "dir" / "subdir1"),
+        str(tmp_dir / "dir" / "subdir2"),
+        str(tmp_dir / "dir" / "subdir1" / "foo1"),
+        str(tmp_dir / "dir" / "subdir1" / "bar1"),
+        str(tmp_dir / "dir" / "subdir2" / "foo2"),
+        str(tmp_dir / "dir" / "foo"),
+        str(tmp_dir / "dir" / "bar"),
+    ]
 
     actual = []
     for root, dirs, files in tree.walk("dir"):
@@ -231,7 +221,7 @@ def test_get_hash_granular(tmp_dir, dvc):
     tmp_dir.dvc_gen(
         {"dir": {"foo": "foo", "bar": "bar", "subdir": {"data": "data"}}}
     )
-    tree = DvcTree(dvc, fetch=True)
+    tree = DvcTree(dvc)
     subdir = PathInfo(tmp_dir) / "dir" / "subdir"
     assert tree.get_hash(subdir) == HashInfo(
         "md5", "af314506f1622d107e0ed3f14ec1a3b5.dir",

--- a/tests/unit/tree/test_repo.py
+++ b/tests/unit/tree/test_repo.py
@@ -94,7 +94,7 @@ def test_exists_isdir_isfile_dirty(tmp_dir, dvc):
         {"datafile": "data", "datadir": {"foo": "foo", "bar": "bar"}}
     )
 
-    tree = RepoTree(dvc, stream=True)
+    tree = RepoTree(dvc)
     shutil.rmtree(tmp_dir / "datadir")
     (tmp_dir / "datafile").unlink()
 
@@ -324,7 +324,7 @@ def test_subrepos(tmp_dir, scm, dvc):
     )
 
     dvc.tree._reset()
-    tree = RepoTree(dvc, subrepos=True, fetch=True)
+    tree = RepoTree(dvc, subrepos=True)
 
     def assert_tree_belongs_to_repo(ret_val):
         method = tree._get_repo
@@ -406,7 +406,7 @@ def test_subrepo_walk(tmp_dir, scm, dvc, dvcfiles, extra_expected):
 
     # using tree that does not have dvcignore
     dvc.tree._reset()
-    tree = RepoTree(dvc, subrepos=True, fetch=True)
+    tree = RepoTree(dvc, subrepos=True)
     expected = [
         PathInfo("dir") / "repo",
         PathInfo("dir") / "repo.txt",
@@ -449,7 +449,7 @@ def test_repo_tree_no_subrepos(tmp_dir, dvc, scm):
 
     # using tree that does not have dvcignore
     dvc.tree._reset()
-    tree = RepoTree(dvc, subrepos=False, fetch=True)
+    tree = RepoTree(dvc, subrepos=False)
     expected = [
         tmp_dir / ".dvcignore",
         tmp_dir / ".gitignore",
@@ -516,7 +516,7 @@ def test_get_hash_cached_granular(tmp_dir, dvc, mocker):
     tmp_dir.dvc_gen(
         {"dir": {"foo": "foo", "bar": "bar", "subdir": {"data": "data"}}}
     )
-    tree = RepoTree(dvc, fetch=True)
+    tree = RepoTree(dvc)
     dvc_tree_spy = mocker.spy(tree._dvctrees[dvc.root_dir], "get_file_hash")
     subdir = PathInfo(tmp_dir) / "dir" / "subdir"
     assert tree.get_hash(subdir) == HashInfo(
@@ -612,7 +612,7 @@ def test_walk_nested_subrepos(tmp_dir, dvc, scm, traverse_subrepos):
         expected[str(tmp_dir / "subrepo1")].add("subrepo3")
 
     actual = {}
-    tree = RepoTree(dvc, subrepos=traverse_subrepos, fetch=True)
+    tree = RepoTree(dvc, subrepos=traverse_subrepos)
     for root, dirs, files in tree.walk(str(tmp_dir)):
         actual[root] = set(dirs + files)
     assert expected == actual

--- a/tests/unit/tree/test_repo_metadata.py
+++ b/tests/unit/tree/test_repo_metadata.py
@@ -37,7 +37,7 @@ def repo_tree(tmp_dir, dvc, scm):
     tmp_dir.scm_gen(fs_structure, commit="repo init")
     tmp_dir.dvc_gen(dvc_structure, commit="use dvc")
 
-    yield RepoTree(dvc, fetch=True, subrepos=True)
+    yield RepoTree(dvc, subrepos=True)
 
 
 def test_metadata_not_existing(repo_tree):


### PR DESCRIPTION
When we collect cache for pull/fetch or run status -c, we implicitly try to fetch the dir cache entry from the remote. And that's the behaviour that is expected from RepoTree too. There have been multiple times where we've tried to use Repo.repo_tree just to realise that it tries to fetch automatically, which is often not needed. 

This PR is more of a POC that tries to get rid of `fetch` flag and the implicit fetching during walk() that it implies in favor of just fetching stuff explicitly where we really need it (repo has `fetch` method just for that already).

Need to check performance and also 2 `webdav` tests fail now because they don't have open() support, and Tree doesn't fetch things automatically, as expected by the api code.

Depends on https://github.com/iterative/dvc/pull/5307

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
