### PR TITLE
exp show: cleanup data column handling

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -18,6 +18,42 @@ from dvc.utils.flatten import flatten
 logger = logging.getLogger(__name__)
 
 
+def _filter_name(names, label, filter_strs):
+    ret = defaultdict(dict)
+    path_filters = defaultdict(list)
+
+    for filter_s in filter_strs:
+        path, _, name = filter_s.rpartition(":")
+        path_filters[path].append(tuple(name.split(".")))
+
+    for path, filters in path_filters.items():
+        if path:
+            match_paths = [path]
+        else:
+            match_paths = names.keys()
+        for length, groups in groupby(filters, len):
+            for group in groups:
+                for match_path in match_paths:
+                    possible_names = [
+                        tuple(name.split(".")) for name in names[match_path]
+                    ]
+                    matches = [
+                        name
+                        for name in possible_names
+                        if name[:length] == group
+                    ]
+                    if not matches:
+                        name = ".".join(group)
+                        raise InvalidArgumentError(
+                            f"'{name}' does not match any known {label}"
+                        )
+                    ret[match_path].update(
+                        {".".join(match): None for match in matches}
+                    )
+
+    return ret
+
+
 def _filter_names(
     names: Dict[str, Dict[str, None]],
     label: str,
@@ -33,34 +69,20 @@ def _filter_names(
                 f" --exclude-{label}"
             )
 
-    names = [tuple(name.split(".")) for name in names]
-
-    def _filter(filters, update_func):
-        filters = [tuple(name.split(".")) for name in filters]
-        for length, groups in groupby(filters, len):
-            for group in groups:
-                matches = [name for name in names if name[:length] == group]
-                if not matches:
-                    name = ".".join(group)
-                    raise InvalidArgumentError(
-                        f"'{name}' does not match any known {label}"
-                    )
-                update_func({match: None for match in matches})
-
     if include:
-        ret: OrderedDict = OrderedDict()
-        _filter(include, ret.update)
+        ret = _filter_name(names, label, include)
     else:
-        ret = OrderedDict({name: None for name in names})
+        ret = names
 
     if exclude:
-        to_remove: Dict[str, Optional[str]] = {}
-        _filter(exclude, to_remove.update)
-        for key in to_remove:
-            if key in ret:
-                del ret[key]
+        to_remove = _filter_name(names, label, exclude)
+        for path in to_remove:
+            if path in ret:
+                for key in to_remove[path]:
+                    if key in ret[path]:
+                        del ret[path][key]
 
-    return [".".join(name) for name in ret]
+    return ret
 
 
 def _update_names(names, items):
@@ -78,6 +100,19 @@ def _collect_names(all_experiments, **kwargs):
         for exp in experiments.values():
             _update_names(metric_names, exp.get("metrics", {}).items())
             _update_names(param_names, exp.get("params", {}).items())
+
+    metric_names = _filter_names(
+        metric_names,
+        "metrics",
+        kwargs.get("include_metrics"),
+        kwargs.get("exclude_metrics"),
+    )
+    param_names = _filter_names(
+        (param_names),
+        "params",
+        kwargs.get("include_params"),
+        kwargs.get("exclude_params"),
+    )
 
     return metric_names, param_names
 
@@ -231,24 +266,24 @@ def _extend_row(row, names, items, precision):
                 row.append("-")
 
 
-def _parse_list(param_list):
+def _parse_filter_list(param_list):
     ret = []
     for param_str in param_list:
-        # we don't care about filename prefixes for show, silently
-        # ignore it if provided to keep usage consistent with other
-        # metric/param list command options
-        _, _, param_str = param_str.rpartition(":")
-        ret.extend(param_str.split(","))
+        path, _, param_str = param_str.rpartition(":")
+        if path:
+            ret.extend(f"{path}:{param}" for param in param_str.split(","))
+        else:
+            ret.extend(param_str.split(","))
     return ret
 
 
 def _show_experiments(all_experiments, console, **kwargs):
     from rich.table import Table
 
-    include_metrics = _parse_list(kwargs.pop("include_metrics", []))
-    exclude_metrics = _parse_list(kwargs.pop("exclude_metrics", []))
-    include_params = _parse_list(kwargs.pop("include_params", []))
-    exclude_params = _parse_list(kwargs.pop("exclude_params", []))
+    include_metrics = _parse_filter_list(kwargs.pop("include_metrics", []))
+    exclude_metrics = _parse_filter_list(kwargs.pop("exclude_metrics", []))
+    include_params = _parse_filter_list(kwargs.pop("include_params", []))
+    exclude_params = _parse_filter_list(kwargs.pop("exclude_params", []))
 
     metric_names, param_names = _collect_names(
         all_experiments,


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will fix #5266
Will close #5009

* User column order is now respected
    * defaults to order within params/metrics file (same as other dvc metrics/params commands)
    * if `--include-...` is used, order used in `--include...` will take precedence over the params/metrics file
* If multiple params/metrics files contain an identical key, filename will be prepended in the column name