### PR TITLE
dvc: move 'verify' property from tree to cache

### DIFF
--- a/dvc/cache/__init__.py
+++ b/dvc/cache/__init__.py
@@ -6,6 +6,7 @@ from ..scheme import Schemes
 
 def get_cloud_cache(tree):
     from .base import CloudCache
+    from .gdrive import GDriveCache
     from .local import LocalCache
     from .ssh import SSHCache
 
@@ -14,6 +15,9 @@ def get_cloud_cache(tree):
 
     if tree.scheme == Schemes.SSH:
         return SSHCache(tree)
+
+    if tree.scheme == Schemes.GDRIVE:
+        return GDriveCache(tree)
 
     return CloudCache(tree)
 

--- a/dvc/cache/base.py
+++ b/dvc/cache/base.py
@@ -45,6 +45,7 @@ def use_state(call):
 
 class CloudCache:
 
+    DEFAULT_VERIFY = False
     DEFAULT_CACHE_TYPES = ["copy"]
     CACHE_MODE: Optional[int] = None
 
@@ -52,6 +53,7 @@ class CloudCache:
         self.tree = tree
         self.repo = tree.repo
 
+        self.verify = tree.config.get("verify", self.DEFAULT_VERIFY)
         self.cache_types = tree.config.get("type") or copy(
             self.DEFAULT_CACHE_TYPES
         )

--- a/dvc/cache/gdrive.py
+++ b/dvc/cache/gdrive.py
@@ -1,0 +1,5 @@
+from .base import CloudCache
+
+
+class GDriveCache(CloudCache):
+    DEFAULT_VERIFY = True

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -481,7 +481,7 @@ class Remote:
             download=True,
         )
 
-        if not self.tree.verify:
+        if not self.cache.verify:
             with cache.tree.state:
                 for checksum in named_cache.scheme_keys("local"):
                     cache_file = cache.tree.hash_to_path_info(checksum)

--- a/dvc/tree/base.py
+++ b/dvc/tree/base.py
@@ -53,7 +53,6 @@ class BaseTree:
 
     CHECKSUM_DIR_SUFFIX = ".dir"
     HASH_JOBS = max(1, min(4, cpu_count() // 2))
-    DEFAULT_VERIFY = False
     LIST_OBJECT_PAGE_SIZE = 1000
     TRAVERSE_WEIGHT_MULTIPLIER = 5
     TRAVERSE_PREFIX_LEN = 3
@@ -71,7 +70,6 @@ class BaseTree:
 
         self._check_requires()
 
-        self.verify = config.get("verify", self.DEFAULT_VERIFY)
         self.path_info = None
 
     @cached_property

--- a/dvc/tree/gdrive.py
+++ b/dvc/tree/gdrive.py
@@ -89,7 +89,6 @@ class GDriveTree(BaseTree):
     scheme = Schemes.GDRIVE
     PATH_CLS = GDriveURLInfo
     REQUIRES = {"pydrive2": "pydrive2"}
-    DEFAULT_VERIFY = True
     # Always prefer traverse for GDrive since API usage quotas are a concern.
     TRAVERSE_WEIGHT_MULTIPLIER = 1
     TRAVERSE_PREFIX_LEN = 2


### PR DESCRIPTION
`verify` property is used to tell dvc if it should trust the cache files that come from that particular cache and it has nothing to do with the fs tree.

Pre-requisite for #5255

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
