### PR TITLE
[WIP] cache/remote: drop dos2unix MD5 by default

### DIFF
--- a/dvc/cache/base.py
+++ b/dvc/cache/base.py
@@ -53,7 +53,7 @@ class CloudCache:
 
         self.tree = tree
         self.repo = tree.repo
-        self.odb = BaseODB(self.tree, path=self.cache_path)
+        self.odb = BaseODB(self.tree, path=self.cache_dir)
 
         self.cache_types = tree.config.get("type") or copy(
             self.DEFAULT_CACHE_TYPES
@@ -62,8 +62,8 @@ class CloudCache:
         self._dir_info = {}
 
     @property
-    def cache_path(self):
-        return self.tree.path_info
+    def cache_dir(self):
+        return None
 
     def get_dir_cache(self, hash_info):
         assert hash_info

--- a/dvc/cache/base.py
+++ b/dvc/cache/base.py
@@ -53,13 +53,17 @@ class CloudCache:
 
         self.tree = tree
         self.repo = tree.repo
-        self.odb = BaseODB(self.tree)
+        self.odb = BaseODB(self.tree, path=self.cache_path)
 
         self.cache_types = tree.config.get("type") or copy(
             self.DEFAULT_CACHE_TYPES
         )
         self.cache_type_confirmed = False
         self._dir_info = {}
+
+    @property
+    def cache_path(self):
+        return self.tree.path_info
 
     def get_dir_cache(self, hash_info):
         assert hash_info

--- a/dvc/cache/base.py
+++ b/dvc/cache/base.py
@@ -49,8 +49,11 @@ class CloudCache:
     CACHE_MODE: Optional[int] = None
 
     def __init__(self, tree):
+        from dvc.odb.base import BaseODB
+
         self.tree = tree
         self.repo = tree.repo
+        self.odb = BaseODB(self.tree)
 
         self.cache_types = tree.config.get("type") or copy(
             self.DEFAULT_CACHE_TYPES

--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -117,6 +117,7 @@ SCHEMA = {
         Optional("autostage", default=False): Bool,
         Optional("experiments"): Bool,  # obsoleted
         Optional("check_update", default=True): Bool,
+        Optional("dos2unix", default=False): Bool,
     },
     "cache": {
         "local": str,

--- a/dvc/hash_info.py
+++ b/dvc/hash_info.py
@@ -1,3 +1,4 @@
+import enum
 from collections import OrderedDict
 from dataclasses import dataclass, field
 from typing import Dict, Optional
@@ -5,6 +6,17 @@ from typing import Dict, Optional
 HASH_DIR_SUFFIX = ".dir"
 
 DirInfo = Dict[str, str]
+
+
+class HashType(str, enum.Enum):
+
+    ETAG = "etag"
+    HDFS_CHECKSUM = "checksum"
+    MD5 = "md5"
+
+    @classmethod
+    def all_types(cls):
+        return [typ.value for typ in cls]
 
 
 @dataclass

--- a/dvc/odb/base.py
+++ b/dvc/odb/base.py
@@ -42,7 +42,7 @@ class BaseODB:
             data = load_yaml(self.CONFIG_FILE, tree=self.tree)
             try:
                 self._validate_version(data)
-                return ODB_VERSION.from_dict(data)
+                return data
             except MultipleInvalid:
                 pass
         return {}

--- a/dvc/odb/base.py
+++ b/dvc/odb/base.py
@@ -1,0 +1,74 @@
+import logging
+from typing import TYPE_CHECKING
+
+from voluptuous import MultipleInvalid
+
+from dvc.exceptions import DvcException
+from dvc.parsing.versions import SCHEMA_KWD
+
+from .versions import ODB_VERSION
+
+if TYPE_CHECKING:
+    from dvc.tree.base import BaseTree
+
+logger = logging.getLogger(__name__)
+
+
+class ODBConfigFormatError(DvcException):
+    pass
+
+
+def get_odb_schema(d):
+    from dvc.schema import COMPILED_ODB_CONFIG_V2_SCHEMA
+
+    schema = {ODB_VERSION.V2: COMPILED_ODB_CONFIG_V2_SCHEMA}
+    version = ODB_VERSION.from_dict(d)
+    return schema[version]
+
+
+class BaseODB:
+
+    CONFIG_FILE = "dvc.odb.yaml"
+
+    def __init__(self, tree: "BaseTree"):
+        self.tree = tree
+        self.config = self.load_config()
+
+    def load_config(self):
+        from dvc.utils.serialize import load_yaml
+
+        if self.tree.exists(self.CONFIG_FILE):
+            data = load_yaml(self.CONFIG_FILE, tree=self.tree)
+            try:
+                self._validate_version(data)
+                return ODB_VERSION.from_dict(data)
+            except MultipleInvalid:
+                pass
+        return {}
+
+    @classmethod
+    def _validate_version(cls, d):
+        schema = get_odb_schema(d)
+        try:
+            return schema(d)
+        except MultipleInvalid as exc:
+            raise ODBConfigFormatError(
+                f"'{cls.CONFIG_FILE}' format error: {exc}"
+            )
+
+    @property
+    def version(self):
+        return ODB_VERSION.from_dict(self.config)
+
+    @property
+    def latest_version_info(self):
+        version = ODB_VERSION.V2.value  # pylint:disable=no-member
+        return {SCHEMA_KWD: version}
+
+    def dump_config(self):
+        from dvc.utils.serialize import modify_yaml
+
+        if self.version == ODB_VERSION.V1:
+            logger.info("Migrating ODB config '%s' to v2", self.CONFIG_FILE)
+            with modify_yaml(self.CONFIG_FILE, tree=self.tree) as data:
+                data.update(self.latest_version_info)

--- a/dvc/odb/base.py
+++ b/dvc/odb/base.py
@@ -81,6 +81,8 @@ class BaseODB:
         from dvc.utils.serialize import modify_yaml
 
         logger.debug("Writing ODB config '%s'", self.config_path)
+        if not self.tree.exists(self.config_path.parent):
+            self.tree.makedirs(self.config_path.parent)
         with modify_yaml(self.config_path, tree=self.tree) as data:
             data.update(self.config)
 

--- a/dvc/odb/versions.py
+++ b/dvc/odb/versions.py
@@ -1,0 +1,40 @@
+import enum
+from collections.abc import Mapping
+
+from voluptuous import validators
+
+from dvc.parsing.versions import SCHEMA_KWD
+
+
+def odb_version_schema(value):
+    expected = [ODB_VERSION.V2.value]  # pylint: disable=no-member
+    msg = "invalid schema version {}, expected one of {}".format(
+        value, expected
+    )
+    return validators.Any(*expected, msg=msg)(value)
+
+
+class VersionEnum(str, enum.Enum):
+    @classmethod
+    def all_versions(cls):
+        return [v.value for v in cls]
+
+
+class ODB_VERSION(VersionEnum):
+    V1 = "1.0"  # DVC <2.0 (dos2unix MD5)
+    V2 = "2.0"  # DVC 2.x (standard MD5)
+
+    @classmethod
+    def from_dict(cls, data):
+        # 1) if it's empty or or is not a dict, use the oldest one (V1).
+        # 2) use the `schema` identifier if it exists and is a supported
+        # version
+        # 3) if it's not in any of the supported version, use the latest one
+        # 4) if there's no identifier, it's a V1
+        if not data or not isinstance(data, Mapping):
+            return cls(cls.V1)
+
+        version = data.get(SCHEMA_KWD)
+        if version:
+            return cls(version if version in cls.all_versions() else cls.V2)
+        return cls(cls.V1)

--- a/dvc/output/__init__.py
+++ b/dvc/output/__init__.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse
 from funcy import collecting, project
 from voluptuous import And, Any, Coerce, Length, Lower, Required, SetTo
 
-from dvc.hash_info import HashInfo
+from dvc.hash_info import HashInfo, HashType
 from dvc.output.base import BaseOutput
 from dvc.output.gs import GSOutput
 from dvc.output.hdfs import HDFSOutput
@@ -15,10 +15,6 @@ from dvc.output.webhdfs import WebHDFSOutput
 from dvc.scheme import Schemes
 
 from ..tree import get_cloud_tree
-from ..tree.hdfs import HDFSTree
-from ..tree.local import LocalTree
-from ..tree.s3 import S3Tree
-from ..tree.webhdfs import WebHDFSTree
 
 OUTS = [
     HDFSOutput,
@@ -52,12 +48,7 @@ CHECKSUM_SCHEMA = Any(
 #
 # so when a few types of outputs share the same name, we only need
 # specify it once.
-CHECKSUMS_SCHEMA = {
-    LocalTree.PARAM_CHECKSUM: CHECKSUM_SCHEMA,
-    S3Tree.PARAM_CHECKSUM: CHECKSUM_SCHEMA,
-    HDFSTree.PARAM_CHECKSUM: CHECKSUM_SCHEMA,
-    WebHDFSTree.PARAM_CHECKSUM: CHECKSUM_SCHEMA,
-}
+CHECKSUMS_SCHEMA = {typ: CHECKSUM_SCHEMA for typ in HashType.all_types()}
 
 SCHEMA = CHECKSUMS_SCHEMA.copy()
 SCHEMA[Required(BaseOutput.PARAM_PATH)] = str

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -69,10 +69,12 @@ class Remote:
 
     def __init__(self, tree):
         from dvc.cache import get_cloud_cache
+        from dvc.odb.base import BaseODB
 
         self.tree = tree
         self.repo = tree.repo
         self.cache = get_cloud_cache(self.tree)
+        self.odb = BaseODB(self.tree)
 
         config = tree.config
         url = config.get("url")

--- a/dvc/remote/base.py
+++ b/dvc/remote/base.py
@@ -452,6 +452,7 @@ class Remote:
 
     @index_locked
     def push(self, cache, named_cache, jobs=None, show_checksums=False):
+        self.odb.migrate_config()
         ret = self._process(
             cache,
             named_cache,

--- a/dvc/schema.py
+++ b/dvc/schema.py
@@ -2,6 +2,7 @@ from voluptuous import Any, Optional, Required, Schema
 
 from dvc import dependency, output
 from dvc.hash_info import HashInfo
+from dvc.odb.versions import odb_version_schema
 from dvc.output import CHECKSUMS_SCHEMA, BaseOutput
 from dvc.parsing import DO_KWD, FOREACH_KWD, VARS_KWD
 from dvc.parsing.versions import SCHEMA_KWD, lockfile_version_schema
@@ -111,3 +112,8 @@ COMPILED_MULTI_STAGE_SCHEMA = Schema(MULTI_STAGE_SCHEMA)
 COMPILED_LOCK_FILE_STAGE_SCHEMA = Schema(LOCK_FILE_STAGE_SCHEMA)
 COMPILED_LOCKFILE_V1_SCHEMA = Schema(LOCKFILE_V1_SCHEMA)
 COMPILED_LOCKFILE_V2_SCHEMA = Schema(LOCKFILE_V2_SCHEMA)
+
+ODB_VERSION_SCHEMA = {
+    Required(SCHEMA_KWD): odb_version_schema,
+}
+COMPILED_ODB_CONFIG_V2_SCHEMA = Schema(ODB_VERSION_SCHEMA)

--- a/dvc/tree/azure.py
+++ b/dvc/tree/azure.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 
 from funcy import cached_property, wrap_prop
 
-from dvc.hash_info import HashInfo
+from dvc.hash_info import HashInfo, HashType
 from dvc.path_info import CloudURLInfo
 from dvc.progress import Tqdm
 from dvc.scheme import Schemes
@@ -22,7 +22,7 @@ class AzureTree(BaseTree):
         "azure-storage-blob": "azure.storage.blob",
         "knack": "knack",
     }
-    PARAM_CHECKSUM = "etag"
+    PARAM_CHECKSUM = HashType.ETAG.value
     COPY_POLL_SECONDS = 5
     LIST_OBJECT_PAGE_SIZE = 5000
 

--- a/dvc/tree/base.py
+++ b/dvc/tree/base.py
@@ -90,6 +90,10 @@ class BaseTree:
             or self.HASH_JOBS
         )
 
+    @cached_property
+    def enable_dos2unix(self):
+        return self.repo and self.repo.config["core"].get("dos2unix")
+
     @classmethod
     def get_missing_deps(cls):
         import importlib

--- a/dvc/tree/gs.py
+++ b/dvc/tree/gs.py
@@ -7,7 +7,7 @@ from functools import wraps
 from funcy import cached_property, wrap_prop
 
 from dvc.exceptions import DvcException
-from dvc.hash_info import HashInfo
+from dvc.hash_info import HashInfo, HashType
 from dvc.path_info import CloudURLInfo
 from dvc.progress import Tqdm
 from dvc.scheme import Schemes
@@ -70,7 +70,7 @@ class GSTree(BaseTree):
     scheme = Schemes.GS
     PATH_CLS = CloudURLInfo
     REQUIRES = {"google-cloud-storage": "google.cloud.storage"}
-    PARAM_CHECKSUM = "md5"
+    PARAM_CHECKSUM = HashType.MD5.value
 
     def __init__(self, repo, config):
         super().__init__(repo, config)

--- a/dvc/tree/hdfs.py
+++ b/dvc/tree/hdfs.py
@@ -8,7 +8,7 @@ from collections import deque
 from contextlib import closing, contextmanager
 from urllib.parse import urlparse
 
-from dvc.hash_info import HashInfo
+from dvc.hash_info import HashInfo, HashType
 from dvc.progress import Tqdm
 from dvc.scheme import Schemes
 from dvc.utils import fix_env, tmp_fname
@@ -62,7 +62,7 @@ class HDFSTree(BaseTree):
     scheme = Schemes.HDFS
     REQUIRES = {"pyarrow": "pyarrow"}
     REGEX = r"^hdfs://((?P<user>.*)@)?.*$"
-    PARAM_CHECKSUM = "checksum"
+    PARAM_CHECKSUM = HashType.HDFS_CHECKSUM.value
     TRAVERSE_PREFIX_LEN = 2
 
     def __init__(self, repo, config):

--- a/dvc/tree/http.py
+++ b/dvc/tree/http.py
@@ -6,7 +6,7 @@ from funcy import cached_property, memoize, wrap_prop, wrap_with
 
 import dvc.prompt as prompt
 from dvc.exceptions import DvcException, HTTPError
-from dvc.hash_info import HashInfo
+from dvc.hash_info import HashInfo, HashType
 from dvc.path_info import HTTPURLInfo
 from dvc.progress import Tqdm
 from dvc.scheme import Schemes
@@ -28,7 +28,7 @@ def ask_password(host, user):
 class HTTPTree(BaseTree):  # pylint:disable=abstract-method
     scheme = Schemes.HTTP
     PATH_CLS = HTTPURLInfo
-    PARAM_CHECKSUM = "etag"
+    PARAM_CHECKSUM = HashType.ETAG.value
     CAN_TRAVERSE = False
 
     SESSION_RETRIES = 5

--- a/dvc/tree/local.py
+++ b/dvc/tree/local.py
@@ -5,7 +5,7 @@ import stat
 
 from funcy import cached_property
 
-from dvc.hash_info import HashInfo
+from dvc.hash_info import HashInfo, HashType
 from dvc.path_info import PathInfo
 from dvc.scheme import Schemes
 from dvc.system import System
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 class LocalTree(BaseTree):
     scheme = Schemes.LOCAL
     PATH_CLS = PathInfo
-    PARAM_CHECKSUM = "md5"
+    PARAM_CHECKSUM = HashType.MD5.value
     PARAM_PATH = "path"
     TRAVERSE_PREFIX_LEN = 2
 

--- a/dvc/tree/local.py
+++ b/dvc/tree/local.py
@@ -231,7 +231,10 @@ class LocalTree(BaseTree):
                 raise
 
     def get_file_hash(self, path_info):
-        hash_info = HashInfo(self.PARAM_CHECKSUM, file_md5(path_info)[0],)
+        hash_info = HashInfo(
+            self.PARAM_CHECKSUM,
+            file_md5(path_info, enable_dos2unix=self.enable_dos2unix)[0],
+        )
 
         if hash_info:
             hash_info.size = os.path.getsize(path_info)

--- a/dvc/tree/oss.py
+++ b/dvc/tree/oss.py
@@ -4,6 +4,7 @@ import threading
 
 from funcy import cached_property, wrap_prop
 
+from dvc.hash_info import HashType
 from dvc.path_info import CloudURLInfo
 from dvc.progress import Tqdm
 from dvc.scheme import Schemes
@@ -35,7 +36,7 @@ class OSSTree(BaseTree):  # pylint:disable=abstract-method
     scheme = Schemes.OSS
     PATH_CLS = CloudURLInfo
     REQUIRES = {"oss2": "oss2"}
-    PARAM_CHECKSUM = "etag"
+    PARAM_CHECKSUM = HashType.ETAG.value
     COPY_POLL_SECONDS = 5
     LIST_OBJECT_PAGE_SIZE = 100
 

--- a/dvc/tree/repo.py
+++ b/dvc/tree/repo.py
@@ -413,7 +413,12 @@ class RepoTree(BaseTree):  # pylint:disable=abstract-method
                 return dvc_tree.get_file_hash(path_info)
             except FileNotFoundError:
                 pass
-        return HashInfo(self.PARAM_CHECKSUM, file_md5(path_info, self)[0])
+        return HashInfo(
+            self.PARAM_CHECKSUM,
+            file_md5(
+                path_info, tree=self, enable_dos2unix=self.enable_dos2unix
+            )[0],
+        )
 
     def _download(
         self, from_info, to_file, name=None, no_progress_bar=False, **kwargs

--- a/dvc/tree/s3.py
+++ b/dvc/tree/s3.py
@@ -7,7 +7,7 @@ from funcy import cached_property, wrap_prop
 
 from dvc.config import ConfigError
 from dvc.exceptions import DvcException, ETagMismatchError
-from dvc.hash_info import HashInfo
+from dvc.hash_info import HashInfo, HashType
 from dvc.path_info import CloudURLInfo
 from dvc.progress import Tqdm
 from dvc.scheme import Schemes
@@ -22,7 +22,7 @@ class S3Tree(BaseTree):
     scheme = Schemes.S3
     PATH_CLS = CloudURLInfo
     REQUIRES = {"boto3": "boto3"}
-    PARAM_CHECKSUM = "etag"
+    PARAM_CHECKSUM = HashType.ETAG.value
 
     def __init__(self, repo, config):
         super().__init__(repo, config)

--- a/dvc/tree/webdav.py
+++ b/dvc/tree/webdav.py
@@ -7,7 +7,7 @@ from funcy import cached_property, nullcontext, wrap_prop
 
 from dvc.config import ConfigError
 from dvc.exceptions import DvcException
-from dvc.hash_info import HashInfo
+from dvc.hash_info import HashInfo, HashType
 from dvc.path_info import HTTPURLInfo, WebDAVURLInfo
 from dvc.progress import Tqdm
 from dvc.scheme import Schemes
@@ -42,7 +42,7 @@ class WebDAVTree(BaseTree):  # pylint:disable=abstract-method
     # Chunk size for buffered upload/download with progress bar
     CHUNK_SIZE = 2 ** 16
 
-    PARAM_CHECKSUM = "etag"
+    PARAM_CHECKSUM = HashType.ETAG.value
 
     # Constructor
     def __init__(self, repo, config):

--- a/dvc/tree/webhdfs.py
+++ b/dvc/tree/webhdfs.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse
 
 from funcy import cached_property, wrap_prop
 
-from dvc.hash_info import HashInfo
+from dvc.hash_info import HashInfo, HashType
 from dvc.path_info import CloudURLInfo
 from dvc.progress import Tqdm
 from dvc.scheme import Schemes
@@ -34,7 +34,7 @@ class WebHDFSTree(BaseTree):
     scheme = Schemes.WEBHDFS
     PATH_CLS = CloudURLInfo
     REQUIRES = {"hdfs": "hdfs"}
-    PARAM_CHECKSUM = "checksum"
+    PARAM_CHECKSUM = HashType.HDFS_CHECKSUM.value
     TRAVERSE_PREFIX_LEN = 2
 
     def __init__(self, repo, config):

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -65,7 +65,7 @@ def file_md5(
 
     if exists_func(fname):
         hash_md5 = hashlib.md5()
-        binary = enable_dos2unix and not istextfile(fname, tree=tree)
+        binary = not (enable_dos2unix and istextfile(fname, tree=tree))
         size = stat_func(fname).st_size
         no_progress_bar = True
         if size >= LARGE_FILE_SIZE:

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -1021,3 +1021,16 @@ def test_add_to_remote(tmp_dir, dvc, local_cloud, local_remote):
 def test_add_to_remote_invalid_combinations(dvc, invalid_opt, kwargs):
     with pytest.raises(InvalidArgumentError, match=invalid_opt):
         dvc.add(to_remote=True, **kwargs)
+
+
+@pytest.mark.parametrize(
+    "dos2unix, expected",
+    [
+        (True, "d3b07384d113edec49eaa6238ad5ff00"),
+        (False, "2145971cf82058b108229a3a2e3bff35"),
+    ],
+)
+def test_add_dos2unix(tmp_dir, dvc, dos2unix, expected):
+    dvc.config["core"]["dos2unix"] = dos2unix
+    (stage,) = tmp_dir.dvc_gen({"foo": "foo\r\n"})
+    assert stage.outs[0].hash_info == HashInfo("md5", expected)

--- a/tests/func/test_odb.py
+++ b/tests/func/test_odb.py
@@ -1,0 +1,29 @@
+import pytest
+
+from dvc.odb.base import BaseODB
+
+
+@pytest.mark.parametrize("dos2unix", [True, False])
+def test_migrates_config_during_push(
+    tmp_dir, dvc, local_remote, mocker, dos2unix
+):
+    dvc.config["core"]["dos2unix"] = dos2unix
+    tmp_dir.dvc_gen("foo", "foo")
+
+    migrate_spy = mocker.spy(BaseODB, "migrate_config")
+    dump_spy = mocker.spy(BaseODB, "_dump_config")
+
+    dvc.push()
+
+    assert migrate_spy.mock.called
+    assert dump_spy.mock.called != dos2unix
+
+
+@pytest.mark.parametrize(
+    "config", [{"schema": "1.1"}, {"schema": "2.1"}, {"schema": "3.0"}],
+)
+def test_config_invalid_versions(tmp_dir, dvc, config):
+    from dvc.odb.base import ODBConfigFormatError
+
+    with pytest.raises(ODBConfigFormatError):
+        BaseODB._validate_version(config)

--- a/tests/func/test_utils.py
+++ b/tests/func/test_utils.py
@@ -1,10 +1,16 @@
+import pytest
+
 from dvc import utils
 
 
-def test_file_md5_crlf(tmp_dir):
+@pytest.mark.parametrize("dos2unix", [True, False])
+def test_file_md5_crlf(tmp_dir, dos2unix):
     tmp_dir.gen("cr", b"a\nb\nc")
     tmp_dir.gen("crlf", b"a\r\nb\r\nc")
-    assert utils.file_md5("cr")[0] == utils.file_md5("crlf")[0]
+    eq = utils.file_md5("cr", enable_dos2unix=dos2unix) == utils.file_md5(
+        "crlf", enable_dos2unix=dos2unix
+    )
+    assert eq == dos2unix
 
 
 def test_dict_md5():

--- a/tests/unit/test_info.py
+++ b/tests/unit/test_info.py
@@ -53,7 +53,10 @@ def test_info_in_broken_git_repo(tmp_dir, dvc, scm, caplog):
     assert "Repo: dvc, git (broken)" in dvc_info
 
 
-def test_caches(tmp_dir, dvc, caplog):
+def test_caches(tmp_dir, dvc, caplog, mocker):
+    from dvc.tree.ssh import SSHTree
+
+    mocker.patch.object(SSHTree, "exists", return_value=False)
     tmp_dir.add_remote(
         name="sshcache", url="ssh://example.com/path", default=False
     )


### PR DESCRIPTION
* [ ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

* Adds stubs for cache/remote ODB class/refactor
    * currently only supports reading/writing a single yaml config file containing schema version
* Disables dos2unix conversion by default when computing MD5 hashes for new files
    * Can be explicitly re-enabled by configuring `core.dos2unix` to be true 
* MD5 hashes for existing files will not be re-computed. Any files previously tracked in DVC will still be referred to using their dos2unix-MD5.
    *  When pushing a new file with a "true" MD5 that matches an existing dos2unix-MD5 contained in a remote, the old file will not be replaced
 * By default any remotes will be "migrated" to the new `2.0` ODB schema version (the only migration step taken at this time is to write the config/version file)

Will close #4658.
Related to #829.