### PR TITLE
collect: unify message for no file in workspace

### DIFF
--- a/dvc/repo/collect.py
+++ b/dvc/repo/collect.py
@@ -47,9 +47,14 @@ def _collect_paths(
 
         if not tree.exists(path_info):
             if not recursive:
-                logger.warning(
-                    "'%s' was not found at: '%s'.", path_info, rev,
-                )
+                if rev == "workspace" or rev == "":
+                    logger.warning(
+                        "'%s' was not found in current workspace.", path_info,
+                    )
+                else:
+                    logger.warning(
+                        "'%s' was not found at: '%s'.", path_info, rev,
+                    )
             continue
         target_infos.append(path_info)
     return target_infos


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Closes #4446 

Related https://github.com/iterative/dvc/issues/3943

I tried playing around with branches and unifying the `workspace/''` issue in its source, but it is material for the whole issue - simple replace won't fix it. So for now I unified the warning message when collecting.