### PR TITLE
tests: reduce checkpoint experiment iterations

### DIFF
--- a/dvc/api/__init__.py
+++ b/dvc/api/__init__.py
@@ -139,4 +139,4 @@ def make_checkpoint():
         fobj.flush()
         os.fsync(fobj.fileno())
     while os.path.exists(signal_file):
-        sleep(1)
+        sleep(0.1)

--- a/tests/func/experiments/conftest.py
+++ b/tests/func/experiments/conftest.py
@@ -4,6 +4,7 @@ import pytest
 
 from tests.func.test_repro_multistage import COPY_SCRIPT
 
+DEFAULT_ITERATIONS = 2
 CHECKPOINT_SCRIPT_FORMAT = dedent(
     """\
     import os
@@ -70,7 +71,10 @@ def checkpoint_stage(tmp_dir, scm, dvc):
     tmp_dir.gen("checkpoint.py", CHECKPOINT_SCRIPT)
     tmp_dir.gen("params.yaml", "foo: 1")
     stage = dvc.run(
-        cmd="python checkpoint.py foo 5 params.yaml metrics.yaml",
+        cmd=(
+            f"python checkpoint.py foo {DEFAULT_ITERATIONS} "
+            "params.yaml metrics.yaml"
+        ),
         metrics_no_cache=["metrics.yaml"],
         params=["foo"],
         checkpoints=["foo"],
@@ -80,4 +84,5 @@ def checkpoint_stage(tmp_dir, scm, dvc):
     )
     scm.add(["dvc.yaml", "checkpoint.py", "params.yaml", ".gitignore"])
     scm.commit("init")
+    stage.iterations = DEFAULT_ITERATIONS
     return stage

--- a/tests/func/experiments/test_checkpoints.py
+++ b/tests/func/experiments/test_checkpoints.py
@@ -22,7 +22,7 @@ def test_new_checkpoint(
             continue
         tree = dvc.repo_tree
         with tree.open(tmp_dir / "foo") as fobj:
-            assert fobj.read().strip() == "5"
+            assert fobj.read().strip() == str(checkpoint_stage.iterations)
         with tree.open(tmp_dir / "metrics.yaml") as fobj:
             assert fobj.read().strip() == "foo: 2"
 
@@ -30,7 +30,9 @@ def test_new_checkpoint(
         assert scm.get_ref(EXEC_APPLY) == exp
     assert scm.get_ref(EXEC_CHECKPOINT) == exp
     if workspace:
-        assert (tmp_dir / "foo").read_text().strip() == "5"
+        assert (tmp_dir / "foo").read_text().strip() == str(
+            checkpoint_stage.iterations
+        )
         assert (tmp_dir / "metrics.yaml").read_text().strip() == "foo: 2"
 
 
@@ -69,7 +71,7 @@ def test_resume_checkpoint(
             continue
         tree = dvc.repo_tree
         with tree.open(tmp_dir / "foo") as fobj:
-            assert fobj.read().strip() == "10"
+            assert fobj.read().strip() == str(2 * checkpoint_stage.iterations)
         with tree.open(tmp_dir / "metrics.yaml") as fobj:
             assert fobj.read().strip() == "foo: 2"
 
@@ -104,7 +106,7 @@ def test_reset_checkpoint(
             continue
         tree = dvc.repo_tree
         with tree.open(tmp_dir / "foo") as fobj:
-            assert fobj.read().strip() == "5"
+            assert fobj.read().strip() == str(checkpoint_stage.iterations)
         with tree.open(tmp_dir / "metrics.yaml") as fobj:
             assert fobj.read().strip() == "foo: 2"
 
@@ -143,7 +145,7 @@ def test_resume_branch(tmp_dir, scm, dvc, checkpoint_stage, workspace):
             continue
         tree = dvc.repo_tree
         with tree.open(tmp_dir / "foo") as fobj:
-            assert fobj.read().strip() == "10"
+            assert fobj.read().strip() == str(2 * checkpoint_stage.iterations)
         with tree.open(tmp_dir / "metrics.yaml") as fobj:
             assert fobj.read().strip() == "foo: 2"
 
@@ -152,7 +154,7 @@ def test_resume_branch(tmp_dir, scm, dvc, checkpoint_stage, workspace):
             continue
         tree = dvc.repo_tree
         with tree.open(tmp_dir / "foo") as fobj:
-            assert fobj.read().strip() == "10"
+            assert fobj.read().strip() == str(2 * checkpoint_stage.iterations)
         with tree.open(tmp_dir / "metrics.yaml") as fobj:
             assert fobj.read().strip() == "foo: 100"
 

--- a/tests/func/experiments/test_remote.py
+++ b/tests/func/experiments/test_remote.py
@@ -256,7 +256,7 @@ def test_push_pull_cache(
     ref_info = first(exp_refs_by_rev(scm, exp))
 
     dvc.experiments.push(remote, ref_info.name, push_cache=True)
-    for x in range(2, 6):
+    for x in range(2, checkpoint_stage.iterations + 1):
         hash_ = digest(str(x))
         path = os.path.join(local_remote.url, hash_[:2], hash_[2:])
         assert os.path.exists(path)
@@ -265,7 +265,7 @@ def test_push_pull_cache(
     remove(dvc.cache.local.cache_dir)
 
     dvc.experiments.pull(remote, ref_info.name, pull_cache=True)
-    for x in range(2, 6):
+    for x in range(2, checkpoint_stage.iterations + 1):
         hash_ = digest(str(x))
         path = os.path.join(dvc.cache.local.cache_dir, hash_[:2], hash_[2:])
         assert os.path.exists(path)

--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -92,7 +92,7 @@ def test_show_checkpoint(
     exp_rev = first(results)
 
     results = dvc.experiments.show()[baseline_rev]
-    assert len(results) == 6
+    assert len(results) == checkpoint_stage.iterations + 1
 
     checkpoints = []
     for rev, exp in results.items():


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Cuts `tests/func/experiments` from 137s to 84s on my machine