### PR TITLE
Pass missing `glob` flag to `pull` command

### DIFF
--- a/dvc/command/data_sync.py
+++ b/dvc/command/data_sync.py
@@ -37,6 +37,7 @@ class CmdDataPull(CmdDataBase):
                 force=self.args.force,
                 recursive=self.args.recursive,
                 run_cache=self.args.run_cache,
+                glob=self.args.glob,
             )
             self.log_summary(stats)
         except (CheckoutError, DvcException) as exc:

--- a/tests/unit/command/test_data_sync.py
+++ b/tests/unit/command/test_data_sync.py
@@ -57,6 +57,7 @@ def test_pull(mocker):
             "--force",
             "--recursive",
             "--run-cache",
+            "--glob",
         ]
     )
     assert cli_args.func == CmdDataPull
@@ -77,6 +78,7 @@ def test_pull(mocker):
         force=True,
         recursive=True,
         run_cache=True,
+        glob=True,
     )
 
 


### PR DESCRIPTION
The `--glob` flag is parsed from the command line, but in the
`CmdDataPull` class in the invocation the parameter (`self.args.glob`)
is not passed to the `pull` method implementation. Hence, always the
default value (False) is used. This commit fixes this issue and sets the
`glob` parameter properly.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Related to #5353

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
