### PR TITLE
exp apply: force apply by default

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -764,10 +764,10 @@ def add_parser(subparsers, parent_parser):
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     experiments_apply_parser.add_argument(
-        "-f",
-        "--force",
-        action="store_true",
-        help="Overwrite any conflicting changes.",
+        "--no-force",
+        action="store_false",
+        dest="force",
+        help="Fail if this command would overwrite conflicting changes.",
     )
     experiments_apply_parser.add_argument(
         "experiment", help="Experiment to be applied.",

--- a/dvc/repo/experiments/apply.py
+++ b/dvc/repo/experiments/apply.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 @locked
 @scm_context
-def apply(repo, rev, force=False, **kwargs):
+def apply(repo, rev, force=True, **kwargs):
     from dvc.repo.checkout import checkout as dvc_checkout
     from dvc.scm.base import MergeConflictError, SCMError
 

--- a/tests/func/experiments/test_checkpoints.py
+++ b/tests/func/experiments/test_checkpoints.py
@@ -129,7 +129,7 @@ def test_resume_branch(tmp_dir, scm, dvc, checkpoint_stage, workspace):
     )
     checkpoint_a = first(results)
 
-    dvc.experiments.apply(branch_rev, force=True)
+    dvc.experiments.apply(branch_rev)
     results = dvc.experiments.run(
         checkpoint_stage.addressing,
         checkpoint_resume=branch_rev,

--- a/tests/func/experiments/test_experiments.py
+++ b/tests/func/experiments/test_experiments.py
@@ -175,7 +175,7 @@ def test_apply(tmp_dir, scm, dvc, exp_stage, queue):
     )
 
     with pytest.raises(ApplyConflictError):
-        dvc.experiments.apply(exp_b)
+        dvc.experiments.apply(exp_b, force=False)
         # failed apply should revert everything to prior state
         assert (tmp_dir / "params.yaml").read_text().strip() == "foo: 2"
         assert (
@@ -184,7 +184,7 @@ def test_apply(tmp_dir, scm, dvc, exp_stage, queue):
             else "foo: 2"
         )
 
-    dvc.experiments.apply(exp_b, force=True)
+    dvc.experiments.apply(exp_b)
     assert (tmp_dir / "params.yaml").read_text().strip() == "foo: 3"
     assert (
         (tmp_dir / "metrics.yaml").read_text().strip() == metrics_original

--- a/tests/func/experiments/test_gc.py
+++ b/tests/func/experiments/test_gc.py
@@ -43,7 +43,7 @@ def test_all_commits(tmp_dir, scm, dvc, queued, expected):
     exp_rev = first(results)
     dvc.experiments.run(stage.addressing, params=["foo=3"], queue=True)
 
-    dvc.experiments.apply(exp_rev, force=True)
+    dvc.experiments.apply(exp_rev)
     scm.add(["dvc.yaml", "dvc.lock", "copy.py", "params.yaml", "metrics.yaml"])
     scm.commit("v2")
 
@@ -72,7 +72,7 @@ def test_all_branches(tmp_dir, scm, dvc, queued, expected):
     exp_rev = first(results)
     dvc.experiments.run(stage.addressing, params=["foo=3"], queue=True)
 
-    dvc.experiments.apply(exp_rev, force=True)
+    dvc.experiments.apply(exp_rev)
     scm.add(["dvc.yaml", "dvc.lock", "copy.py", "params.yaml", "metrics.yaml"])
     scm.commit("v2")
 
@@ -82,7 +82,7 @@ def test_all_branches(tmp_dir, scm, dvc, queued, expected):
     dvc.experiments.run(stage.addressing, params=["foo=5"], queue=True)
     exp_rev = first(results)
 
-    dvc.experiments.apply(exp_rev, force=True)
+    dvc.experiments.apply(exp_rev)
     scm.add(["dvc.yaml", "dvc.lock", "copy.py", "params.yaml", "metrics.yaml"])
     scm.commit("v3")
 
@@ -108,7 +108,7 @@ def test_all_tags(tmp_dir, scm, dvc, queued, expected):
     exp_rev = first(results)
     dvc.experiments.run(stage.addressing, params=["foo=3"], queue=True)
 
-    dvc.experiments.apply(exp_rev, force=True)
+    dvc.experiments.apply(exp_rev)
     scm.add(["dvc.yaml", "dvc.lock", "copy.py", "params.yaml", "metrics.yaml"])
     scm.commit("v2")
     scm.tag("tag-v2")

--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -135,7 +135,7 @@ def test_show_checkpoint_branch(
     )
     checkpoint_a = first(results)
 
-    dvc.experiments.apply(branch_rev, force=True)
+    dvc.experiments.apply(branch_rev)
     results = dvc.experiments.run(
         checkpoint_stage.addressing,
         checkpoint_resume=branch_rev,

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -18,7 +18,7 @@ from .test_repro import default_arguments as repro_arguments
 
 
 def test_experiments_apply(dvc, scm, mocker):
-    cli_args = parse_args(["experiments", "apply", "--force", "exp_rev"])
+    cli_args = parse_args(["experiments", "apply", "--no-force", "exp_rev"])
     assert cli_args.func == CmdExperimentsApply
 
     cmd = cli_args.func(cli_args)
@@ -26,7 +26,7 @@ def test_experiments_apply(dvc, scm, mocker):
 
     assert cmd.run() == 0
 
-    m.assert_called_once_with(cmd.repo, "exp_rev", force=True)
+    m.assert_called_once_with(cmd.repo, "exp_rev", force=False)
 
 
 def test_experiments_diff(dvc, scm, mocker):


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

After discussion with @dmpetrov and @dberenbaum, overwriting any conflicting workspace changes with `--force` should be the default behavior when applying an experiment commit. Due to the nature of how we hide git usage behind experiments, it is not obvious to the user why applying an experiment can cause git conflicts, and in typical use cases for `exp apply`, overwriting conflicting changes is likely the behavior the user was already expecting to begin with.

* `--no-force` can be used to disable overwriting existing changes