### PR TITLE
exp show: cleanup UI issues

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -337,6 +337,7 @@ class CmdExperimentsShow(CmdBase):
                 all_tags=self.args.all_tags,
                 all_commits=self.args.all_commits,
                 sha_only=self.args.sha,
+                num=self.args.num,
             )
 
             if self.args.show_json:
@@ -674,10 +675,20 @@ def add_parser(subparsers, parent_parser):
         help="Show experiments derived from all Git tags.",
     )
     experiments_show_parser.add_argument(
+        "-A",
         "--all-commits",
         action="store_true",
         default=False,
         help="Show experiments derived from all Git commits.",
+    )
+    experiments_show_parser.add_argument(
+        "-n",
+        "--num",
+        type=int,
+        default=1,
+        dest="num",
+        metavar="<num>",
+        help="Show the last `num` commits from HEAD.",
     )
     experiments_show_parser.add_argument(
         "--no-pager",

--- a/dvc/repo/experiments/executor/base.py
+++ b/dvc/repo/experiments/executor/base.py
@@ -379,7 +379,7 @@ class BaseExecutor(ABC):
     ):
         """Commit stages as an experiment and return the commit SHA."""
         rev = scm.get_rev()
-        if not scm.is_dirty(untracked_files=True):
+        if not scm.is_dirty():
             logger.debug("No changes to commit")
             raise UnchangedExperimentError(rev)
 

--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -7,6 +7,7 @@ from dvc.repo import locked
 from dvc.repo.experiments.base import ExpRefInfo
 from dvc.repo.metrics.show import _collect_metrics, _read_metrics
 from dvc.repo.params.show import _collect_configs, _read_params
+from dvc.scm.base import SCMError
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +89,12 @@ def show(
         raise InvalidArgumentError(f"Invalid number of commits '{num}'")
 
     if revs is None:
-        revs = [repo.scm.resolve_rev(f"HEAD~{n}") for n in range(0, num)]
+        revs = []
+        for n in range(num):
+            try:
+                revs.append(repo.scm.resolve_rev(f"HEAD~{n}"))
+            except SCMError:
+                break
 
     revs = OrderedDict(
         (rev, None)

--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -2,6 +2,7 @@ import logging
 from collections import OrderedDict, defaultdict
 from datetime import datetime
 
+from dvc.exceptions import InvalidArgumentError
 from dvc.repo import locked
 from dvc.repo.experiments.base import ExpRefInfo
 from dvc.repo.metrics.show import _collect_metrics, _read_metrics
@@ -79,11 +80,15 @@ def show(
     revs=None,
     all_commits=False,
     sha_only=False,
+    num=1,
 ):
     res = defaultdict(OrderedDict)
 
+    if num < 1:
+        raise InvalidArgumentError(f"Invalid number of commits '{num}'")
+
     if revs is None:
-        revs = [repo.scm.get_rev()]
+        revs = [repo.scm.resolve_rev(f"HEAD~{n}") for n in range(0, num)]
 
     revs = OrderedDict(
         (rev, None)

--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -206,7 +206,7 @@ def test_show_multiple_commits(tmp_dir, scm, dvc, exp_stage):
 
     expected = {"workspace", init_rev, next_rev}
     results = dvc.experiments.show(num=2)
-    assert set(results.keys()) == {"workspace", init_rev, next_rev}
+    assert set(results.keys()) == expected
 
     expected = {"workspace"} | set(scm.branch_revs("master"))
     results = dvc.experiments.show(all_commits=True)

--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -192,3 +192,17 @@ def test_show_filter(tmp_dir, scm, dvc, exp_stage, capsys):
     cap = capsys.readouterr()
 
     assert f"{div} foo {div}" not in cap.out
+
+
+def test_show_multiple_commits(tmp_dir, scm, dvc, exp_stage):
+    init_rev = scm.get_rev()
+    tmp_dir.scm_gen("file", "file", "commit")
+    next_rev = scm.get_rev()
+
+    expected = {"workspace", init_rev, next_rev}
+    results = dvc.experiments.show(num=2)
+    assert set(results.keys()) == {"workspace", init_rev, next_rev}
+
+    expected = {"workspace"} | set(scm.branch_revs("master"))
+    results = dvc.experiments.show(all_commits=True)
+    assert set(results.keys()) == expected

--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -195,9 +195,14 @@ def test_show_filter(tmp_dir, scm, dvc, exp_stage, capsys):
 
 
 def test_show_multiple_commits(tmp_dir, scm, dvc, exp_stage):
+    from dvc.exceptions import InvalidArgumentError
+
     init_rev = scm.get_rev()
     tmp_dir.scm_gen("file", "file", "commit")
     next_rev = scm.get_rev()
+
+    with pytest.raises(InvalidArgumentError):
+        dvc.experiments.show(num=-1)
 
     expected = {"workspace", init_rev, next_rev}
     results = dvc.experiments.show(num=2)
@@ -205,4 +210,7 @@ def test_show_multiple_commits(tmp_dir, scm, dvc, exp_stage):
 
     expected = {"workspace"} | set(scm.branch_revs("master"))
     results = dvc.experiments.show(all_commits=True)
+    assert set(results.keys()) == expected
+
+    results = dvc.experiments.show(num=100)
     assert set(results.keys()) == expected

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -65,6 +65,8 @@ def test_experiments_show(dvc, scm, mocker):
             "--all-branches",
             "--all-commits",
             "--sha",
+            "-n",
+            "1",
         ]
     )
     assert cli_args.func == CmdExperimentsShow
@@ -80,6 +82,7 @@ def test_experiments_show(dvc, scm, mocker):
         all_branches=True,
         all_commits=True,
         sha_only=True,
+        num=1,
     )
 
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Related to #5247

* Adds short form `-A/--all-commits` for `dvc exp show`
* Adds `-n/--num <num>` option for `dvc exp show` to show the last `n` commits from HEAD (defaults to 1)
* Fix issue where duplicate (empty) commit would be created for checkpoint runs with untracked files present in workspace