### PR TITLE
don't allow loading stages without `cmd`

### DIFF
--- a/dvc/schema.py
+++ b/dvc/schema.py
@@ -1,4 +1,4 @@
-from voluptuous import Any, Exclusive, Optional, Required, Schema
+from voluptuous import Any, Optional, Required, Schema
 
 from dvc import dependency, output
 from dvc.hash_info import HashInfo
@@ -100,7 +100,7 @@ FOREACH_IN = {
     Required(FOREACH_KWD): Any(dict, list, str),
     Required(DO_KWD): STAGE_DEFINITION,
 }
-SINGLE_PIPELINE_STAGE_SCHEMA = {str: Exclusive(FOREACH_IN, STAGE_DEFINITION)}
+SINGLE_PIPELINE_STAGE_SCHEMA = {str: Any(FOREACH_IN, STAGE_DEFINITION)}
 MULTI_STAGE_SCHEMA = {
     STAGES: SINGLE_PIPELINE_STAGE_SCHEMA,
     VARS_KWD: VARS_SCHEMA,

--- a/dvc/schema.py
+++ b/dvc/schema.py
@@ -1,4 +1,4 @@
-from voluptuous import Any, Optional, Required, Schema
+from voluptuous import Any, Exclusive, Optional, Required, Schema
 
 from dvc import dependency, output
 from dvc.hash_info import HashInfo
@@ -79,7 +79,7 @@ PARAM_PSTAGE_NON_DEFAULT_SCHEMA = {str: [str]}
 VARS_SCHEMA = [str, dict]
 
 STAGE_DEFINITION = {
-    StageParams.PARAM_CMD: Any(str, list),
+    Required(StageParams.PARAM_CMD): Any(str, list),
     Optional(StageParams.PARAM_WDIR): str,
     Optional(StageParams.PARAM_DEPS): [str],
     Optional(StageParams.PARAM_PARAMS): [Any(str, dict)],
@@ -100,7 +100,7 @@ FOREACH_IN = {
     Required(FOREACH_KWD): Any(dict, list, str),
     Required(DO_KWD): STAGE_DEFINITION,
 }
-SINGLE_PIPELINE_STAGE_SCHEMA = {str: Any(STAGE_DEFINITION, FOREACH_IN)}
+SINGLE_PIPELINE_STAGE_SCHEMA = {str: Exclusive(FOREACH_IN, STAGE_DEFINITION)}
 MULTI_STAGE_SCHEMA = {
     STAGES: SINGLE_PIPELINE_STAGE_SCHEMA,
     VARS_KWD: VARS_SCHEMA,

--- a/dvc/stage/serialize.py
+++ b/dvc/stage/serialize.py
@@ -129,6 +129,12 @@ def to_pipeline_file(stage: "PipelineStage"):
     params = _serialize_params_keys(params)
 
     outs, metrics, plots, live = _serialize_outs(stage.outs)
+
+    cmd = stage.cmd
+    assert cmd, (
+        f"'{stage.PARAM_CMD}' cannot be empty for stage '{stage.name}', "
+        f"got: '{cmd}'(type: '{type(cmd).__name__}')"
+    )
     res = [
         (stage.PARAM_DESC, stage.desc),
         (stage.PARAM_CMD, stage.cmd),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,8 +145,9 @@ def dummy_stage(tmp_dir, dvc):
     def make(path="dvc.yaml", name="dummy_stage", **kwargs):
         from dvc.stage import PipelineStage, create_stage
 
+        cmd = kwargs.get("cmd", "command")
         stage = create_stage(
-            PipelineStage, dvc, path, name=name, cmd="", **kwargs
+            PipelineStage, dvc, path, name=name, cmd=cmd, **kwargs
         )
         stage.dump()
         return stage

--- a/tests/unit/command/test_status.py
+++ b/tests/unit/command/test_status.py
@@ -6,7 +6,7 @@ from dvc.cli import parse_args
 from dvc.command.status import CmdDataStatus
 
 
-def test_cloud_status(mocker):
+def test_cloud_status(tmp_dir, dvc, mocker):
     cli_args = parse_args(
         [
             "status",


### PR DESCRIPTION
This was loosened when introducing parametrization.
But, `foreach`..`do` should be considered first
before the stage's regular structure. And, cmd is made
required (as it should have been)

Related: #5371, #5370, #5312

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
