### PR TITLE
run: do not compute hash when no_exec is set

### DIFF
--- a/dvc/repo/run.py
+++ b/dvc/repo/run.py
@@ -114,7 +114,7 @@ def run(self, fname=None, no_exec=False, single_stage=False, **kwargs):
         stage_cls, repo=self, path=path, params=params, **kwargs
     )
     restore_meta(stage)
-    if kwargs.get("run_cache", True) and stage.can_be_skipped:
+    if not no_exec and kwargs.get("run_cache", True) and stage.can_be_skipped:
         return None
 
     dvcfile = Dvcfile(self, stage.path)


### PR DESCRIPTION
Prevent computing hashes of dependencies when
no_exec is set.

Fixes #5368

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
