### PR TITLE
exp show: customize rich table rendering behavior

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -302,7 +302,7 @@ def _parse_filter_list(param_list):
 
 
 def _experiments_table(all_experiments, **kwargs):
-    from rich.table import Table
+    from dvc.utils.table import Table
 
     include_metrics = _parse_filter_list(kwargs.pop("include_metrics", []))
     exclude_metrics = _parse_filter_list(kwargs.pop("exclude_metrics", []))
@@ -347,10 +347,13 @@ def _add_data_columns(table, names, **kwargs):
     count = Counter(
         name for path in names for name in names[path] for path in names
     )
+    first = True
     for path in names:
         for name in names[path]:
             col_name = name if count[name] == 1 else f"{path}:{name}"
+            kwargs["collapse"] = False if first else True
             table.add_column(col_name, **kwargs)
+            first = False
 
 
 def _format_json(item):

--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -318,11 +318,21 @@ def _experiments_table(all_experiments, **kwargs):
     )
 
     table = Table()
-    table.add_column("Experiment", no_wrap=True)
+    table.add_column(
+        "Experiment", no_wrap=True, header_style="black on grey93"
+    )
     if not kwargs.get("no_timestamp", False):
-        table.add_column("Created")
-    _add_data_col(table, metric_names, justify="right", no_wrap=True)
-    _add_data_col(table, param_names, justify="left")
+        table.add_column("Created", header_style="black on grey93")
+    _add_data_columns(
+        table,
+        metric_names,
+        justify="right",
+        no_wrap=True,
+        header_style="black on cornsilk1",
+    )
+    _add_data_columns(
+        table, param_names, justify="left", header_style="black on light_cyan1"
+    )
 
     for base_rev, experiments in all_experiments.items():
         for row, _, in _collect_rows(
@@ -333,7 +343,7 @@ def _experiments_table(all_experiments, **kwargs):
     return table
 
 
-def _add_data_col(table, names, **kwargs):
+def _add_data_columns(table, names, **kwargs):
     count = Counter(
         name for path in names for name in names[path] for path in names
     )

--- a/dvc/utils/pager.py
+++ b/dvc/utils/pager.py
@@ -5,6 +5,8 @@ import os
 import pydoc
 import sys
 
+from rich.pager import Pager
+
 from dvc.env import DVC_PAGER
 from dvc.utils import format_link
 
@@ -46,3 +48,8 @@ def find_pager():
 
 def pager(text):
     find_pager()(text)
+
+
+class DvcPager(Pager):
+    def show(self, content: str) -> None:
+        pager(content)

--- a/dvc/utils/table.py
+++ b/dvc/utils/table.py
@@ -1,0 +1,102 @@
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, List
+
+from rich.style import StyleType
+from rich.table import Column as RichColumn
+from rich.table import Table as RichTable
+
+if TYPE_CHECKING:
+    from rich.console import (
+        Console,
+        JustifyMethod,
+        OverflowMethod,
+        RenderableType,
+    )
+
+
+@dataclass
+class Column(RichColumn):
+    collapse: bool = False
+
+
+class Table(RichTable):
+    def add_column(  # pylint: disable=arguments-differ
+        self,
+        header: "RenderableType" = "",
+        footer: "RenderableType" = "",
+        *,
+        header_style: StyleType = None,
+        footer_style: StyleType = None,
+        style: StyleType = None,
+        justify: "JustifyMethod" = "left",
+        overflow: "OverflowMethod" = "ellipsis",
+        width: int = None,
+        min_width: int = None,
+        max_width: int = None,
+        ratio: int = None,
+        no_wrap: bool = False,
+        collapse: bool = False,
+    ) -> None:
+        column = Column(  # type: ignore[call-arg]
+            _index=len(self.columns),
+            header=header,
+            footer=footer,
+            header_style=header_style or "",
+            footer_style=footer_style or "",
+            style=style or "",
+            justify=justify,
+            overflow=overflow,
+            width=width,
+            min_width=min_width,
+            max_width=max_width,
+            ratio=ratio,
+            no_wrap=no_wrap,
+            collapse=collapse,
+        )
+        self.columns.append(column)
+
+    def _calculate_column_widths(
+        self, console: "Console", max_width: int
+    ) -> List[int]:
+        """Calculate the widths of each column, including padding, not
+        including borders.
+
+        Adjacent collapsed columns will be removed until there is only a single
+        truncated column remaining.
+        """
+        widths = super()._calculate_column_widths(console, max_width)
+        collapsed = False
+        for i in range(len(self.columns) - 1, -1, -1):
+            if widths[i] == 1 and self.columns[i].collapse:
+                if collapsed:
+                    del widths[i]
+                    del self.columns[i]
+                    for column in self.columns[i:]:
+                        column._index -= 1
+                    continue
+                collapsed = True
+            else:
+                collapsed = False
+        return widths
+
+    def _collapse_widths(
+        self, widths: List[int], wrapable: List[bool], max_width: int,
+    ) -> List[int]:
+        """Collapse columns right-to-left if possible to fit table into
+        max_width.
+
+        If table is still too wide after collapsing, rich's automatic overflow
+        handling will be used.
+        """
+        collapsible = [column.collapse for column in self.columns]
+        total_width = sum(widths)
+        excess_width = total_width - max_width
+        if any(collapsible):
+            for i in range(len(widths) - 1, -1, -1):
+                if collapsible[i]:
+                    total_width -= widths[i]
+                    excess_width -= widths[i]
+                    widths[i] = 0
+                    if excess_width <= 0:
+                        break
+        return super()._collapse_widths(widths, wrapable, max_width)

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ install_requires = [
     "pygtrie==2.3.2",
     "dpath>=2.0.1,<3",
     "shtab>=1.3.4,<2",
-    "rich>=3.0.5",
+    "rich>=9.0.0",
     "dictdiffer>=0.8.1",
     "python-benedict>=0.21.1",
     "pyparsing==2.4.7",


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will close #5247

* Updates rich version to 9.x, uses native rich pager support
* Re-enables color/styling in exp show table
* When using `--no-pager`, columns will be collapsed in right-to-left order if the table cannot fit into the console
    * At least one metric column and one params column will always be displayed whenever possible.
    * Params will be collapsed before metrics
    * If the table still does not fit after collapsing all but one metric and param column, will fallback to rich's folding behavior for the remaining columns

TODO

* [x] Wrap rich column/table classes to collapse/merge metrics & params columns which can't be displayed due to terminal width