### PR TITLE
keep stage.dump() and dvcfile.dump() in sync

### DIFF
--- a/dvc/command/stage.py
+++ b/dvc/command/stage.py
@@ -135,7 +135,7 @@ class CmdStageAdd(CmdBase):
 
         with repo.scm.track_file_changes(config=repo.config):
             stage.ignore_outs()
-            stage.dump()
+            stage.dump(update_lock=False)
         return 0
 
 

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -701,8 +701,8 @@ class Stage(params.StageParams):
 
         self.outs[0].merge(ancestor_out, other.outs[0])
 
-    def dump(self, update_lock: bool = False):
-        self.dvcfile.dump(self, update_lock=update_lock)
+    def dump(self, **kwargs):
+        self.dvcfile.dump(self, **kwargs)
 
 
 class PipelineStage(Stage):

--- a/tests/unit/test_params.py
+++ b/tests/unit/test_params.py
@@ -27,7 +27,7 @@ def test_repro_unicode(tmp_dir, dvc, dummy_stage):
     dummy_stage(params=[{"settings.json": ["Ω_value"]}])
     (stage,) = dvc.reproduce(dry=True)
     stage.cmd = "foo"
-    stage.dvcfile._lockfile.dump(stage)
+    stage.dump()
 
     dvc.remove(stage.name)
     assert not (tmp_dir / "dvc.yaml").exists()


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
