### PR TITLE
dvc: get rid of can_be_skipped logic

### DIFF
--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -255,12 +255,9 @@ def _create_stages(
             external=external,
         )
         restore_meta(stage)
-        if stage.can_be_skipped:
-            stage = None
-        else:
-            Dvcfile(repo, stage.path).remove()
-            if desc:
-                stage.outs[0].desc = desc
+        Dvcfile(repo, stage.path).remove()
+        if desc:
+            stage.outs[0].desc = desc
 
         repo._reset()  # pylint: disable=protected-access
 

--- a/dvc/repo/imp_url.py
+++ b/dvc/repo/imp_url.py
@@ -57,8 +57,6 @@ def imp_url(
         erepo=erepo,
     )
     restore_meta(stage)
-    if stage.can_be_skipped:
-        return None
 
     if desc:
         stage.outs[0].desc = desc

--- a/dvc/repo/run.py
+++ b/dvc/repo/run.py
@@ -22,8 +22,6 @@ def run(
     from dvc.stage.utils import validate_state
 
     stage = self.stage.create_from_cli(**kwargs)
-    if run_cache and stage.can_be_skipped:
-        return None
 
     validate_state(self, stage, force=force)
 

--- a/tests/func/test_run_multistage.py
+++ b/tests/func/test_run_multistage.py
@@ -73,13 +73,15 @@ def test_run_multi_stage_repeat(tmp_dir, dvc, run_copy):
     }
 
 
-def test_multi_stage_run_cached(tmp_dir, dvc, run_copy):
+def test_multi_stage_run_cached(tmp_dir, dvc, run_copy, mocker):
+    from dvc.stage.run import subprocess
+
     tmp_dir.dvc_gen("foo", "foo")
 
     run_copy("foo", "foo2", name="copy-foo1-foo2")
-    stage2 = run_copy("foo", "foo2", name="copy-foo1-foo2")
-
-    assert stage2 is None
+    spy = mocker.spy(subprocess, "Popen")
+    run_copy("foo", "foo2", name="copy-foo1-foo2")
+    assert not spy.called
 
 
 def test_multistage_dump_on_non_cached_outputs(tmp_dir, dvc):

--- a/tests/func/test_run_single_stage.py
+++ b/tests/func/test_run_single_stage.py
@@ -527,32 +527,6 @@ class TestCmdRunOverwrite(TestDvc):
                 self.FOO,
                 "-d",
                 self.CODE,
-                "-o",
-                "out",
-                "--file",
-                "out.dvc",
-                "--single-stage",
-                "python",
-                self.CODE,
-                self.FOO,
-                "out",
-            ]
-        )
-        self.assertEqual(ret, 0)
-
-        # NOTE: check that dvcfile was NOT overwritten
-        self.assertEqual(stage_mtime, os.path.getmtime("out.dvc"))
-        stage_mtime = os.path.getmtime("out.dvc")
-
-        time.sleep(1)
-
-        ret = main(
-            [
-                "run",
-                "-d",
-                self.FOO,
-                "-d",
-                self.CODE,
                 "--force",
                 "--no-run-cache",
                 "--single-stage",
@@ -660,20 +634,34 @@ class TestCmdRunWorkingDirectory(TestDvc):
         self.assertEqual(d[Stage.PARAM_WDIR], "..")
 
 
-def test_rerun_deterministic(tmp_dir, run_copy):
+def test_rerun_deterministic(tmp_dir, run_copy, mocker):
+    from dvc.stage.run import subprocess
+
     tmp_dir.gen("foo", "foo content")
 
-    assert run_copy("foo", "out", single_stage=True) is not None
-    assert run_copy("foo", "out", single_stage=True) is None
+    spy = mocker.spy(subprocess, "Popen")
+
+    run_copy("foo", "out", single_stage=True)
+    assert spy.called
+
+    spy.reset_mock()
+    run_copy("foo", "out", single_stage=True)
+    assert not spy.called
 
 
-def test_rerun_deterministic_ignore_cache(tmp_dir, run_copy):
+def test_rerun_deterministic_ignore_cache(tmp_dir, run_copy, mocker):
+    from dvc.stage.run import subprocess
+
     tmp_dir.gen("foo", "foo content")
 
-    assert run_copy("foo", "out", single_stage=True) is not None
-    assert (
-        run_copy("foo", "out", run_cache=False, single_stage=True) is not None
-    )
+    spy = mocker.spy(subprocess, "Popen")
+
+    run_copy("foo", "out", single_stage=True)
+    assert spy.called
+
+    spy.reset_mock()
+    run_copy("foo", "out", run_cache=False, single_stage=True)
+    assert spy.called
 
 
 def test_rerun_callback(dvc):
@@ -934,37 +922,6 @@ class TestShouldNotCheckoutUponCorruptedLocalHardlinkCache(TestDvc):
 
                     mock_run.assert_called_once()
                     mock_checkout.assert_not_called()
-
-
-class TestPersistentOutput(TestDvc):
-    def test_ignore_run_cache(self):
-        warning = "Build cache is ignored when persisting outputs."
-
-        with open("immutable", "w") as fobj:
-            fobj.write("1")
-
-        cmd = [
-            "run",
-            "--force",
-            "--single-stage",
-            "--deps",
-            "immutable",
-            "--outs-persist",
-            "greetings",
-            "echo hello>>greetings",
-        ]
-
-        with self._caplog.at_level(logging.WARNING, logger="dvc"):
-            assert main(cmd) == 0
-            assert warning not in self._caplog.text
-
-            assert main(cmd) == 0
-            assert warning in self._caplog.text
-
-        # Even if the "immutable" dependency didn't change
-        # it should run the command again, as it is "ignoring build cache"
-        with open("greetings") as fobj:
-            assert "hello\nhello\n" == fobj.read()
 
 
 def test_bad_stage_fname(tmp_dir, dvc, run_copy):


### PR DESCRIPTION
This is a legacy logic that we used to have before run-cache. At this point it is not needed and is broken in some scenarios.

Part of https://github.com/iterative/dvc/issues/4841
Related to #5368
Fixes https://github.com/iterative/dvc/issues/4529

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
