### PR TITLE
tests: mock global config dir for Updater

### DIFF
--- a/dvc/config.py
+++ b/dvc/config.py
@@ -262,7 +262,7 @@ class Config(dict):
         return self.load_one(level)
 
     @contextmanager
-    def edit(self, level=None):
+    def edit(self, level=None, validate=True):
         # NOTE: we write to repo config by default, same as git config
         level = level or "repo"
         if level in {"repo", "local"} and self.dvc_dir is None:
@@ -275,10 +275,12 @@ class Config(dict):
 
         merged_conf = self.load_config_to_level(level)
         merge(merged_conf, conf)
-        self.validate(merged_conf)
+
+        if validate:
+            self.validate(merged_conf)
 
         self._save_config(level, conf)
-        self.load()
+        self.load(validate=validate)
 
     @staticmethod
     def validate(data):

--- a/tests/unit/test_analytics.py
+++ b/tests/unit/test_analytics.py
@@ -82,11 +82,8 @@ def test_send(mock_post, tmp_path):
     ],
 )
 def test_is_enabled(dvc, config, result, monkeypatch, tmp_global_dir):
-    import configobj
-
-    conf = configobj.ConfigObj({"core": config})
-    conf.filename = dvc.config.files["repo"]
-    conf.write()
+    with dvc.config.edit(validate=False) as conf:
+        conf["core"] = config
 
     # reset DVC_TEST env var, which affects `is_enabled()`
     monkeypatch.delenv("DVC_TEST")


### PR DESCRIPTION
So that if you have updater disabled globally, tests don't fail/work as expected. Tests are mocked anyway.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
