### PR TITLE
[WIP] tests build: cancel previous builds for given branch

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,6 +18,7 @@ env:
   GS_CREDS_JSON: ${{ secrets.GS_CREDS_JSON }}
 
 jobs:
+  
   pretest:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,9 +18,13 @@ env:
   GS_CREDS_JSON: ${{ secrets.GS_CREDS_JSON }}
 
 jobs:
-  lint:
+  pretest:
     runs-on: ubuntu-latest
     steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.7.0
+      with:
+        access_token: ${{ github.token }}
     - uses: actions/checkout@v2.3.2
     - name: Set up Python 3.8
       uses: actions/setup-python@v2.1.4


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Add an action that will cancel previous builds for the same branch, in case of `tests` workflow.

[EDIT]

Regretfully, the action that I tried to use requires write permissions to cancel previous runs. So it would work only for PR's created from withing the `dvc` repo. Pull requests from forks won't be canceled. 

Take a look at Cancel previous workflows actions from sample PR:
https://github.com/iterative/dvc/runs/1822233058?check_suite_focus=true

```
{
  eventName: 'pull_request',
  sha: 'a65cb012d39cf1e770b1d3a8d0b91fca1561c784',
  headSha: 'ac1d219fd2db151c84de54e9d345747509b756b8',
  branch: 'cancel_previous_workflows',
  owner: 'iterative',
  repo: 'dvc',
  GITHUB_RUN_ID: '533784846'
}
Found token: yes
Found workflow_id: ["2442271"]
Found 2 runs for workflow 2442271 on branch cancel_previous_workflows
- https://github.com/iterative/dvc/actions/runs/533784846
- https://github.com/iterative/dvc/actions/runs/533783788
with 1 runs to cancel.
Canceling run:  {
  id: 533783788,
  head_sha: '9c2cb5a949c19c4f84587e88f040744ddd707b58',
  status: 'queued',
  html_url: 'https://github.com/iterative/dvc/actions/runs/533783788'
}
Error while canceling workflow_id 2442271: Resource not accessible by integration
```
Closing.
