### PR TITLE
tree: stop using self.path_info outside of __init__

### DIFF
--- a/dvc/tree/azure.py
+++ b/dvc/tree/azure.py
@@ -31,10 +31,12 @@ class AzureTree(BaseTree):
 
         url = config.get("url", "azure://")
         self.path_info = self.PATH_CLS(url)
+        self.bucket = self.path_info.bucket
 
-        if not self.path_info.bucket:
+        if not self.bucket:
             container = self._az_config.get("storage", "container_name", None)
             self.path_info = self.PATH_CLS(f"azure://{container}")
+            self.bucket = self.path_info.bucket
 
         self._conn_str = config.get(
             "connection_string"
@@ -73,8 +75,6 @@ class AzureTree(BaseTree):
         )
         from azure.storage.blob import BlobServiceClient
 
-        logger.debug(f"URL {self.path_info}")
-
         if self._conn_str:
             logger.debug(f"Using connection string '{self._conn_str}'")
             blob_service = BlobServiceClient.from_connection_string(
@@ -86,10 +86,8 @@ class AzureTree(BaseTree):
                 self._account_url, credential=self._credential
             )
 
-        logger.debug(f"Container name {self.path_info.bucket}")
-        container_client = blob_service.get_container_client(
-            self.path_info.bucket
-        )
+        logger.debug(f"Container name {self.bucket}")
+        container_client = blob_service.get_container_client(self.bucket)
 
         try:  # verify that container exists
             container_client.get_container_properties()

--- a/dvc/tree/gdrive.py
+++ b/dvc/tree/gdrive.py
@@ -113,6 +113,7 @@ class GDriveTree(BaseTree):
             )
 
         self._bucket = self.path_info.bucket
+        self._path = self.path_info.path
         self._trash_only = config.get("gdrive_trash_only")
         self._use_service_account = config.get("gdrive_use_service_account")
         self._service_account_email = config.get(
@@ -284,7 +285,7 @@ class GDriveTree(BaseTree):
             ),
         }
 
-        self._cache_path_id(self.path_info.path, cache["root_id"], cache)
+        self._cache_path_id(self._path, cache["root_id"], cache)
 
         for item in self._gdrive_list(
             "'{}' in parents and trashed=false".format(cache["root_id"])

--- a/dvc/tree/http.py
+++ b/dvc/tree/http.py
@@ -42,9 +42,8 @@ class HTTPTree(BaseTree):  # pylint:disable=abstract-method
         url = config.get("url")
         if url:
             self.path_info = self.PATH_CLS(url)
-            user = config.get("user", None)
-            if user:
-                self.path_info.user = user
+            self.user = config.get("user", None)
+            self.host = self.path_info.host
         else:
             self.path_info = None
 
@@ -56,20 +55,16 @@ class HTTPTree(BaseTree):  # pylint:disable=abstract-method
         self.ssl_verify = config.get("ssl_verify", True)
         self.method = config.get("method", "POST")
 
-    def _auth_method(self, path_info=None):
+    def _auth_method(self):
         from requests.auth import HTTPBasicAuth, HTTPDigestAuth
-
-        if path_info is None:
-            path_info = self.path_info
 
         if self.auth:
             if self.ask_password and self.password is None:
-                host, user = path_info.host, path_info.user
-                self.password = ask_password(host, user)
+                self.password = ask_password(self.host, self.user)
             if self.auth == "basic":
-                return HTTPBasicAuth(path_info.user, self.password)
+                return HTTPBasicAuth(self.user, self.password)
             if self.auth == "digest":
-                return HTTPDigestAuth(path_info.user, self.password)
+                return HTTPDigestAuth(self.user, self.password)
             if self.auth == "custom" and self.custom_auth_header:
                 self.headers.update({self.custom_auth_header: self.password})
         return None

--- a/dvc/tree/oss.py
+++ b/dvc/tree/oss.py
@@ -45,6 +45,7 @@ class OSSTree(BaseTree):  # pylint:disable=abstract-method
         url = config.get("url")
         self.path_info = self.PATH_CLS(url) if url else None
 
+        self.bucket = self.path_info.bucket
         self.endpoint = config.get("oss_endpoint") or os.getenv("OSS_ENDPOINT")
 
         self.key_id = (
@@ -64,12 +65,11 @@ class OSSTree(BaseTree):  # pylint:disable=abstract-method
     def oss_service(self):
         import oss2
 
-        logger.debug(f"URL: {self.path_info}")
         logger.debug(f"key id: {self.key_id}")
         logger.debug(f"key secret: {self.key_secret}")
 
         auth = oss2.Auth(self.key_id, self.key_secret)
-        bucket = oss2.Bucket(auth, self.endpoint, self.path_info.bucket)
+        bucket = oss2.Bucket(auth, self.endpoint, self.bucket)
 
         # Ensure bucket exists
         try:
@@ -84,7 +84,7 @@ class OSSTree(BaseTree):  # pylint:disable=abstract-method
         return bucket
 
     def _generate_download_url(self, path_info, expires=3600):
-        assert path_info.bucket == self.path_info.bucket
+        assert path_info.bucket == self.bucket
 
         return self.oss_service.sign_url("GET", path_info.path, expires)
 


### PR DESCRIPTION
The fact that our trees have `self.path_info` is really confusing and some cloud implementations sometimes accidentally use it instead of the explicitly provided `path_info`. As an endgoal, we should completely separate `self.path_info` and the tree (aka filesystem) itself. So the tree should accept itsown options during initialization instead of the whole config section with the url.

We've been doing things this way because long ago we only had remotes that acted as both remotes, caches and trees at the same time. `self.path_info` is used as a `cache` location, so it has nothing to do with the tree(aka filesystem).

We are already following that isolation nicely in the most places, but this PR tries to cleanup a few leftovers outside `__init__`, so we could get rid of `self.path_info` in the upcoming PRs.

This also makes us 1 step closer to complying with fsspec.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
