### PR TITLE
experiments: bug fixes

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -472,10 +472,12 @@ class CmdExperimentsDiff(CmdBase):
 
 class CmdExperimentsRun(CmdRepro):
     def run(self):
+        from dvc.command.metrics import _show_metrics
+
         if self.args.reset:
             logger.info("Any existing checkpoints will be reset and re-run.")
 
-        self.repo.experiments.run(
+        results = self.repo.experiments.run(
             name=self.args.name,
             queue=self.args.queue,
             run_all=self.args.run_all,
@@ -486,6 +488,11 @@ class CmdExperimentsRun(CmdRepro):
             tmp_dir=self.args.tmp_dir,
             **self._repro_kwargs,
         )
+
+        if self.args.metrics and results:
+            metrics = self.repo.metrics.show(revs=list(results))
+            metrics.pop("workspace", None)
+            logger.info(_show_metrics(metrics))
 
         return 0
 

--- a/tests/func/experiments/test_experiments.py
+++ b/tests/func/experiments/test_experiments.py
@@ -581,3 +581,15 @@ def test_queue(tmp_dir, scm, dvc, exp_stage, mocker):
         with tree.open(tmp_dir / "metrics.yaml") as fobj:
             metrics.add(fobj.read().strip())
     assert expected == metrics
+
+
+def test_run_metrics(tmp_dir, scm, dvc, exp_stage, mocker):
+    from dvc.main import main
+
+    mocker.patch.object(
+        dvc.experiments, "run", return_value={"abc123": "abc123"}
+    )
+    show_mock = mocker.patch.object(dvc.metrics, "show", return_value={})
+
+    main(["exp", "run", "-m"])
+    assert show_mock.called_once()

--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from datetime import datetime
 
@@ -214,3 +215,21 @@ def test_show_multiple_commits(tmp_dir, scm, dvc, exp_stage):
 
     results = dvc.experiments.show(num=100)
     assert set(results.keys()) == expected
+
+
+def test_show_sort(tmp_dir, scm, dvc, exp_stage, caplog):
+    with caplog.at_level(logging.ERROR):
+        assert main(["exp", "show", "--no-pager", "--sort-by=bar"]) != 0
+        assert "Unknown sort column" in caplog.text
+
+    with caplog.at_level(logging.ERROR):
+        assert main(["exp", "show", "--no-pager", "--sort-by=foo"]) != 0
+        assert "Ambiguous sort column" in caplog.text
+
+    assert (
+        main(["exp", "show", "--no-pager", "--sort-by=params.yaml:foo"]) == 0
+    )
+
+    assert (
+        main(["exp", "show", "--no-pager", "--sort-by=metrics.yaml:foo"]) == 0
+    )


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will fix #5402 
Will fix #5406

* `exp run` now displays metrics as expected with `-m`
* `exp show --sort-by ...` now handles metrics/params file names as needed (i.e. `--sort-by path/to/params.yaml:my_param`)
    * If no path name is provided, will attempt to match against any metric/params file, if multiple possible matches are found an error will be returned