### PR TITLE
refactor webdav to use client; extract write_text to base remote fixture

### DIFF
--- a/tests/remotes/azure.py
+++ b/tests/remotes/azure.py
@@ -53,12 +53,6 @@ class Azure(Base, CloudURLInfo):
     def write_bytes(self, contents):
         self.blob_client.upload_blob(contents, overwrite=True)
 
-    def write_text(self, contents, encoding=None, errors=None):
-        if not encoding:
-            encoding = locale.getpreferredencoding(False)
-        assert errors is None
-        self.write_bytes(contents.encode(encoding))
-
     def read_bytes(self):
         stream = self.blob_client.download_blob()
         return stream.readall()

--- a/tests/remotes/base.py
+++ b/tests/remotes/base.py
@@ -1,3 +1,4 @@
+import locale
 import pathlib
 
 from funcy import cached_property
@@ -19,7 +20,10 @@ class Base(URLInfo):
         raise NotImplementedError
 
     def write_text(self, contents, encoding=None, errors=None):
-        raise NotImplementedError
+        if not encoding:
+            encoding = locale.getpreferredencoding(False)
+        assert errors is None
+        self.write_bytes(contents.encode(encoding))
 
     def write_bytes(self, contents):
         raise NotImplementedError

--- a/tests/remotes/gs.py
+++ b/tests/remotes/gs.py
@@ -84,12 +84,6 @@ class GCP(Base, CloudURLInfo):
         assert isinstance(contents, bytes)
         self._blob.upload_from_string(contents)
 
-    def write_text(self, contents, encoding=None, errors=None):
-        if not encoding:
-            encoding = locale.getpreferredencoding(False)
-        assert errors is None
-        self.write_bytes(contents.encode(encoding))
-
     def read_bytes(self):
         return self._blob.download_as_string()
 

--- a/tests/remotes/hdfs.py
+++ b/tests/remotes/hdfs.py
@@ -58,12 +58,6 @@ class HDFS(Base, URLInfo):  # pylint: disable=abstract-method
             with _hdfs.open_output_stream(self.path) as fobj:
                 fobj.write(contents)
 
-    def write_text(self, contents, encoding=None, errors=None):
-        if not encoding:
-            encoding = locale.getpreferredencoding(False)
-        assert errors is None
-        self.write_bytes(contents.encode(encoding))
-
     def read_bytes(self):
         with self._hdfs() as _hdfs:
             with _hdfs.open_input_stream(self.path) as fobj:

--- a/tests/remotes/http.py
+++ b/tests/remotes/http.py
@@ -1,5 +1,4 @@
 # pylint:disable=abstract-method
-import locale
 import os
 import uuid
 
@@ -25,12 +24,6 @@ class HTTP(Base, HTTPURLInfo):
         assert isinstance(contents, bytes)
         response = requests.post(self.url, data=contents)
         assert response.status_code == 200
-
-    def write_text(self, contents, encoding=None, errors=None):
-        if not encoding:
-            encoding = locale.getpreferredencoding(False)
-        assert errors is None
-        self.write_bytes(contents.encode(encoding))
 
 
 @pytest.fixture(scope="session")

--- a/tests/remotes/s3.py
+++ b/tests/remotes/s3.py
@@ -80,12 +80,6 @@ class S3(Base, CloudURLInfo):
             Bucket=self.bucket, Key=self.path, Body=contents,
         )
 
-    def write_text(self, contents, encoding=None, errors=None):
-        if not encoding:
-            encoding = locale.getpreferredencoding(False)
-        assert errors is None
-        self.write_bytes(contents.encode(encoding))
-
     def read_bytes(self):
         data = self._s3.get_object(Bucket=self.bucket, Key=self.path)
         return data["Body"].read()

--- a/tests/remotes/ssh.py
+++ b/tests/remotes/ssh.py
@@ -92,12 +92,6 @@ class SSHMocked(Base, URLInfo):
                 # NOTE: accepts both str and bytes
                 fobj.write(contents)
 
-    def write_text(self, contents, encoding=None, errors=None):
-        if not encoding:
-            encoding = locale.getpreferredencoding(False)
-        assert errors is None
-        self.write_bytes(contents.encode(encoding))
-
     def read_bytes(self):
         with self._ssh() as _ssh:
             # NOTE: sftp always reads in binary format

--- a/tests/remotes/webhdfs.py
+++ b/tests/remotes/webhdfs.py
@@ -45,12 +45,6 @@ class WebHDFS(Base, URLInfo):  # pylint: disable=abstract-method
             with _hdfs.write(self.path, overwrite=True) as writer:
                 writer.write(contents)
 
-    def write_text(self, contents, encoding=None, errors=None):
-        if not encoding:
-            encoding = locale.getpreferredencoding(False)
-        assert errors is None
-        self.write_bytes(contents.encode(encoding))
-
     def read_bytes(self):
         with self._webhdfs() as _hdfs:
             with _hdfs.read(self.path) as reader:


### PR DESCRIPTION
- Moves `write_text` to `Base` to reduce duplications
- Move `Webdav` fixture to use `webdav` client rather than creating files/directories in the workspace.
  This was done before to speed up tests, but we found out that they never worked before as they were never used.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

From https://github.com/iterative/dvc/pull/5275#discussion_r569483334

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
