### PR TITLE
exp run: clean untracked lockfiles before running

### DIFF
--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -258,8 +258,21 @@ class Experiments:
             if is_lock_file(fname)
         ]
         if lock_files:
+
             self.scm.reset(paths=lock_files)
             self.scm.checkout_index(paths=lock_files, force=True)
+
+    def _prune_untracked_lockfiles(self):
+        from dvc.dvcfile import is_lock_file
+        from dvc.utils.fs import remove
+
+        untracked = [
+            fname
+            for fname in self.scm.untracked_files()
+            if is_lock_file(fname)
+        ]
+        for fname in untracked:
+            remove(fname)
 
     def _stash_msg(
         self,
@@ -698,6 +711,7 @@ class Experiments:
         # result in conflict between workspace params and stashed CLI params).
         self.scm.reset(hard=True)
         with self.scm.detach_head(entry.rev):
+            self._prune_untracked_lockfiles()
             rev = self.stash.pop()
             self.scm.set_ref(EXEC_BASELINE, entry.baseline_rev)
             if entry.branch:

--- a/dvc/repo/experiments/executor/base.py
+++ b/dvc/repo/experiments/executor/base.py
@@ -250,6 +250,9 @@ class BaseExecutor(ABC):
             args, kwargs = cls._repro_args(dvc)
 
             repro_force = kwargs.get("force", False)
+            logger.trace(  # type: ignore[attr-defined]
+                "Executor repro with force = '%s'", str(repro_force)
+            )
 
             # NOTE: for checkpoint experiments we handle persist outs slightly
             # differently than normal:

--- a/dvc/repo/experiments/executor/base.py
+++ b/dvc/repo/experiments/executor/base.py
@@ -250,7 +250,6 @@ class BaseExecutor(ABC):
             args, kwargs = cls._repro_args(dvc)
 
             repro_force = kwargs.get("force", False)
-            logger.debug("force = %s", str(repro_force))
 
             # NOTE: for checkpoint experiments we handle persist outs slightly
             # differently than normal:


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will fix #5404

* Untracked (new) `dvc.lock` files will be ignored entirely with regard to experiment runs. This is essentially an extension of the existing `git reset` behavior for tracked lock files during `exp run`.