### PR TITLE
Optimaze dvc update

### DIFF
--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -414,7 +414,8 @@ class Stage(params.StageParams):
         if not (self.is_repo_import or self.is_import):
             raise StageUpdateError(self.relpath)
         if (
-            self.deps[0].tree.isdir(self.deps[0].path_info)
+            self.deps[0].path_info
+            and self.deps[0].tree.isdir(self.deps[0].path_info)
             and self.deps[0].tree.PARAM_CHECKSUM
             == self.outs[0].tree.PARAM_CHECKSUM
         ):

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -418,7 +418,7 @@ class Stage(params.StageParams):
             and self.deps[0].tree.PARAM_CHECKSUM
             == self.outs[0].tree.PARAM_CHECKSUM
         ):
-            update_import_dir(self, rev=rev)
+            update_import_dir(self, rev=rev, jobs=jobs)
         else:
             update_import(
                 self, rev=rev, to_remote=to_remote, remote=remote, jobs=jobs

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -418,6 +418,7 @@ class Stage(params.StageParams):
             and self.deps[0].fs.isdir(self.deps[0].path_info)
             and self.deps[0].fs.PARAM_CHECKSUM
             == self.outs[0].fs.PARAM_CHECKSUM
+            and not to_remote
         ):
             update_import_dir(self, rev=rev, jobs=jobs)
         else:

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -415,9 +415,9 @@ class Stage(params.StageParams):
             raise StageUpdateError(self.relpath)
         if (
             self.deps[0].path_info
-            and self.deps[0].tree.isdir(self.deps[0].path_info)
-            and self.deps[0].tree.PARAM_CHECKSUM
-            == self.outs[0].tree.PARAM_CHECKSUM
+            and self.deps[0].fs.isdir(self.deps[0].path_info)
+            and self.deps[0].fs.PARAM_CHECKSUM
+            == self.outs[0].fs.PARAM_CHECKSUM
         ):
             update_import_dir(self, rev=rev, jobs=jobs)
         else:

--- a/dvc/stage/imports.py
+++ b/dvc/stage/imports.py
@@ -31,6 +31,50 @@ def update_import(stage, rev=None, to_remote=False, remote=None, jobs=None):
         stage.frozen = frozen
 
 
+def get_dir_changes(stage):
+    logger.debug(f"Getting changes from {stage.deps[0].path_info}")
+    deps_tree = stage.deps[0].tree
+    deps_path = stage.deps[0].path_info
+    outs_tree = stage.outs[0].tree
+    outs_path = stage.outs[0].path_info
+
+    deps_files_dict = {
+        deps_tree.get_file_hash(file).value: file
+        for file in deps_tree.walk_files(deps_path)
+    }
+    outs_files_dict = {
+        outs_tree.get_file_hash(file).value: file
+        for file in outs_tree.walk_files(outs_path)
+    }
+    deps_files_hashes = set(deps_files_dict.keys())
+    outs_files_hashes = set(outs_files_dict.keys())
+
+    hashes_to_download = deps_files_hashes - outs_files_hashes
+    hashes_to_remove = outs_files_hashes - deps_files_hashes
+
+    files_to_download = [deps_files_dict[i] for i in hashes_to_download]
+    files_to_remove = [outs_files_dict[i] for i in hashes_to_remove]
+    return files_to_download, files_to_remove
+
+
+def update_import_dir(stage, rev=None, jobs=None):
+    stage.deps[0].update(rev=rev)
+    files_to_down, files_to_rem = get_dir_changes(stage)
+    logger.debug(f"Files to download: {list(files_to_down)}")
+    logger.debug(f"Files to remove: {list(files_to_rem)}")
+
+    stage.save_deps()
+
+    for file in files_to_rem:
+        stage.outs[0].tree.remove(file)
+
+    for file in files_to_down:
+        filename = file.relative_to(stage.deps[0].path_info)
+        stage.deps[0].tree.download(
+            file, stage.outs[0].path_info / filename, jobs=jobs
+        )
+
+
 def sync_import(stage, dry=False, force=False, jobs=None):
     """Synchronize import's outs to the workspace."""
     logger.info(

--- a/tests/unit/stage/test_imports.py
+++ b/tests/unit/stage/test_imports.py
@@ -1,67 +1,40 @@
-from collections import namedtuple
-
 from dvc.path_info import PathInfo
 from dvc.stage.imports import get_dir_changes, update_import_dir
 
 
-class MockTree:
-    def __init__(self, files):
-        self.files = files
+def test_get_dir_changes(tmp_dir, dvc):
 
-    def get_file_hash(self, file):
-        result = namedtuple("HashInfo", "value")
-        return result(file)
+    imp = tmp_dir.gen({"datadir": {"foo": "foo", "bar": "bar"}})[0]
 
-    def walk_files(self, *args, **kwargs):
-        return iter(self.files)
+    out = tmp_dir / "out"
 
-    def download(self, *args, **kwargs):
-        pass
+    stage = dvc.imp_url(str(imp), str(out))
 
-    def remove(self, *args, **kwargs):
-        pass
+    (tmp_dir / "datadir" / "foo").write_text("test")
+    (tmp_dir / "datadir" / "foo1").write_text("test_1")
 
-
-class MockStage:
-    class TestOut:
-        def __init__(self, path_info=None, tree=None):
-            self.path_info = path_info
-            self.tree = tree
-
-        def update(self, *args, **kwargs):
-            pass
-
-    def __init__(self, out, dep, dep_path=None, out_path=None):
-        self.outs = [self.TestOut(path_info=out_path, tree=out)]
-        self.deps = [self.TestOut(path_info=dep_path, tree=dep)]
-
-    def save_deps(self, *args, **kwargs):
-        pass
-
-
-def test_get_dir_changes():
-    out_tree = MockTree(["file1", "file2", "file3"])
-    dep_tree = MockTree(["file1", "file2", "file4"])
-    stage = MockStage(out_tree, dep_tree)
     files_to_down, files_to_rem = get_dir_changes(stage)
-    assert files_to_down == ["file4"]
-    assert files_to_rem == ["file3"]
+    assert tmp_dir / "datadir" / "foo" in files_to_down
+    assert tmp_dir / "datadir" / "foo1" in files_to_down
+    assert tmp_dir / "out" / "foo" in files_to_rem
 
 
-def test_update_import_dir(mocker):
-    out_tree = MockTree([])
-    dep_tree = MockTree([])
-    dep_path = PathInfo("dep/")
-    out_path = PathInfo("out/")
-    stage = MockStage(out_tree, dep_tree, dep_path=dep_path, out_path=out_path)
+def test_update_import_dir(tmp_dir, dvc, mocker):
+    imp = tmp_dir.gen({"data": {"file3": "foo", "file4": "bar"}})[0]
+
+    out = tmp_dir / "out"
+
+    stage = dvc.imp_url(str(imp), str(out))
     save_deps = mocker.patch.object(stage, "save_deps")
-    remove = mocker.patch.object(stage.outs[0].tree, "remove")
-    download = mocker.patch.object(stage.deps[0].tree, "download")
+    remove = mocker.patch.object(stage.outs[0].fs, "remove")
+    download = mocker.patch.object(stage.deps[0].fs, "download")
     with mocker.patch(
         "dvc.stage.imports.get_dir_changes",
-        return_value=([PathInfo("data/file3")], ["file4"]),
+        return_value=([PathInfo("data/file3")], [PathInfo("out/file4")]),
     ):
         update_import_dir(stage)
         assert save_deps.called_once_with()
-        assert remove.called_once_with("file4")
-        assert download.called_once_with("data/file3", "data/file3", jobs=None)
+        assert remove.called_once_with(PathInfo("data/file3"))
+        assert download.called_once_with(
+            PathInfo("data/file3"), PathInfo("data/file3"), jobs=None
+        )

--- a/tests/unit/stage/test_imports.py
+++ b/tests/unit/stage/test_imports.py
@@ -19,6 +19,24 @@ def test_get_dir_changes(tmp_dir, dvc):
     assert tmp_dir / "out" / "foo" in files_to_rem
 
 
+def test_get_dir_changes_nested(tmp_dir, dvc):
+
+    imp = tmp_dir.gen(
+        {"data": {"file": "file", "folder": {"file1": "file1"}}}
+    )[0]
+
+    out = tmp_dir / "out"
+
+    stage = dvc.imp_url(str(imp), str(out))
+
+    (tmp_dir / "data" / "folder" / "file1").write_text("test")
+
+    files_to_down, files_to_rem = get_dir_changes(stage)
+
+    assert tmp_dir / "data" / "folder" / "file1" in files_to_down
+    assert tmp_dir / "out" / "folder" / "file1" in files_to_rem
+
+
 def test_update_import_dir(tmp_dir, dvc, mocker):
     imp = tmp_dir.gen({"data": {"file3": "foo", "file4": "bar"}})[0]
 

--- a/tests/unit/stage/test_imports.py
+++ b/tests/unit/stage/test_imports.py
@@ -1,0 +1,67 @@
+from collections import namedtuple
+
+from dvc.path_info import PathInfo
+from dvc.stage.imports import get_dir_changes, update_import_dir
+
+
+class MockTree:
+    def __init__(self, files):
+        self.files = files
+
+    def get_file_hash(self, file):
+        result = namedtuple("HashInfo", "value")
+        return result(file)
+
+    def walk_files(self, *args, **kwargs):
+        return iter(self.files)
+
+    def download(self, *args, **kwargs):
+        pass
+
+    def remove(self, *args, **kwargs):
+        pass
+
+
+class MockStage:
+    class TestOut:
+        def __init__(self, path_info=None, tree=None):
+            self.path_info = path_info
+            self.tree = tree
+
+        def update(self, *args, **kwargs):
+            pass
+
+    def __init__(self, out, dep, dep_path=None, out_path=None):
+        self.outs = [self.TestOut(path_info=out_path, tree=out)]
+        self.deps = [self.TestOut(path_info=dep_path, tree=dep)]
+
+    def save_deps(self, *args, **kwargs):
+        pass
+
+
+def test_get_dir_changes():
+    out_tree = MockTree(["file1", "file2", "file3"])
+    dep_tree = MockTree(["file1", "file2", "file4"])
+    stage = MockStage(out_tree, dep_tree)
+    files_to_down, files_to_rem = get_dir_changes(stage)
+    assert files_to_down == ["file4"]
+    assert files_to_rem == ["file3"]
+
+
+def test_update_import_dir(mocker):
+    out_tree = MockTree([])
+    dep_tree = MockTree([])
+    dep_path = PathInfo("dep/")
+    out_path = PathInfo("out/")
+    stage = MockStage(out_tree, dep_tree, dep_path=dep_path, out_path=out_path)
+    save_deps = mocker.patch.object(stage, "save_deps")
+    remove = mocker.patch.object(stage.outs[0].tree, "remove")
+    download = mocker.patch.object(stage.deps[0].tree, "download")
+    with mocker.patch(
+        "dvc.stage.imports.get_dir_changes",
+        return_value=([PathInfo("data/file3")], ["file4"]),
+    ):
+        update_import_dir(stage)
+        assert save_deps.called_once_with()
+        assert remove.called_once_with("file4")
+        assert download.called_once_with("data/file3", "data/file3", jobs=None)

--- a/tests/unit/stage/test_stage.py
+++ b/tests/unit/stage/test_stage.py
@@ -60,19 +60,7 @@ def test_stage_update(mocker):
     dep = RepoDependency({"url": "example.com"}, None, "dep_path")
     mocker.patch.object(dep, "update", return_value=None)
 
-    class Out:
-        class Tree:
-            PARAM_CHECKSUM = "md5"
-
-        tree = Tree()
-
-    class DepTree:
-        def isdir(self, *args, **kwargs):
-            return False
-
-    mocker.patch.object(dep, "tree", new=DepTree())
-
-    stage = Stage(None, "path", deps=[dep], outs=[Out()])
+    stage = Stage(None, "path", deps=[dep])
     reproduce = mocker.patch.object(stage, "reproduce")
     is_repo_import = mocker.patch(
         __name__ + ".Stage.is_repo_import", new_callable=mocker.PropertyMock
@@ -90,38 +78,6 @@ def test_stage_update(mocker):
     is_import.return_value = False
     with pytest.raises(StageUpdateError):
         stage.update()
-
-
-@mock.patch("dvc.stage.update_import_dir")
-def test_stage_update_dir(patched, mocker):
-    dep = RepoDependency({"url": "example.com"}, None, "dep_path")
-
-    class Out:
-        class Tree:
-            PARAM_CHECKSUM = "md5"
-
-        tree = Tree()
-
-    class DepTree:
-        PARAM_CHECKSUM = "md5"
-
-        def isdir(self, *args, **kwargs):
-            return True
-
-    mocker.patch.object(dep, "tree", new=DepTree())
-
-    stage = Stage(None, "path", deps=[dep], outs=[Out()])
-    is_repo_import = mocker.patch(
-        __name__ + ".Stage.is_repo_import", new_callable=mocker.PropertyMock
-    )
-    is_import = mocker.patch(
-        __name__ + ".Stage.is_import", new_callable=mocker.PropertyMock
-    )
-
-    is_repo_import.return_value = True
-    is_import.return_value = True
-    stage.update()
-    assert patched.called_once_with()
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
It's PR close #4889. If dependensy is a directory, we compare has of individual files in dep and out and download/remove file if differences were founded. Comparison is possible if dep and out use the same hash functions. Otherwise the processing is the same as before. Also I added tests.

There are a few things that raise doubts in my mind:
- in ```tests/unit/stage/test_imports.py``` I wrote mocks for Stage and Tree classes. I think it would be better to use something that already exists instead, but I haven't found anything that is suitable. Maybe I just missed something.
- Do I need to add any changes to the documentation?

I would be grateful for any advice on further improvement.
