### PR TITLE
exp run: remove `exp reset` in favor of `exp run --reset`

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -914,35 +914,11 @@ def add_parser(subparsers, parent_parser):
         metavar="<experiment_rev>",
     )
     experiments_run_parser.add_argument(
-        "--reset", action="store_true", help=argparse.SUPPRESS,
+        "--reset",
+        action="store_true",
+        help="Reset existing checkpoints and restart the experiment.",
     )
     experiments_run_parser.set_defaults(func=CmdExperimentsRun)
-
-    EXPERIMENTS_RESET_HELP = "Reset and restart checkpoint experiments."
-    experiments_reset_parser = experiments_subparsers.add_parser(
-        "reset",
-        parents=[parent_parser],
-        description=append_doc_link(EXPERIMENTS_RESET_HELP, "exp/reset"),
-        help=EXPERIMENTS_RESET_HELP,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
-    experiments_reset_parser.add_argument(
-        "-r",
-        "--rev",
-        type=str,
-        default=None,
-        dest="checkpoint_resume",
-        help=argparse.SUPPRESS,
-    )
-    _add_run_common(experiments_reset_parser)
-    experiments_reset_parser.add_argument(
-        "--reset",
-        action="store_const",
-        const=True,
-        default=True,
-        help=argparse.SUPPRESS,
-    )
-    experiments_reset_parser.set_defaults(func=CmdExperimentsRun)
 
     EXPERIMENTS_GC_HELP = "Garbage collect unneeded experiments."
     EXPERIMENTS_GC_DESCRIPTION = (

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -86,10 +86,7 @@ def test_experiments_show(dvc, scm, mocker):
     )
 
 
-@pytest.mark.parametrize(
-    "args, reset", [(["exp", "run"], False), (["exp", "reset"], True)],
-)
-def test_experiments_run(dvc, scm, mocker, args, reset):
+def test_experiments_run(dvc, scm, mocker, args):
     default_arguments = {
         "params": [],
         "name": None,
@@ -98,7 +95,7 @@ def test_experiments_run(dvc, scm, mocker, args, reset):
         "jobs": None,
         "tmp_dir": False,
         "checkpoint_resume": None,
-        "reset": reset,
+        "reset": False,
     }
     default_arguments.update(repro_arguments)
 

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -86,7 +86,7 @@ def test_experiments_show(dvc, scm, mocker):
     )
 
 
-def test_experiments_run(dvc, scm, mocker, args):
+def test_experiments_run(dvc, scm, mocker):
     default_arguments = {
         "params": [],
         "name": None,
@@ -99,7 +99,7 @@ def test_experiments_run(dvc, scm, mocker, args):
     }
     default_arguments.update(repro_arguments)
 
-    cmd = CmdExperimentsRun(parse_args(args))
+    cmd = CmdExperimentsRun(parse_args(["exp", "run"]))
     mocker.patch.object(cmd.repo, "reproduce")
     mocker.patch.object(cmd.repo.experiments, "run")
     cmd.run()


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Related to https://github.com/iterative/dvc/issues/5413

* `dvc exp reset` command is removed
* `dvc exp run --reset` option can be used to reset/restart checkpoints