### PR TITLE
metrics/params: fix bug preventing usage from being displayed

### DIFF
--- a/dvc/command/metrics.py
+++ b/dvc/command/metrics.py
@@ -284,7 +284,7 @@ def add_parser(subparsers, parent_parser):
             "(even if not found as `metrics` in `dvc.yaml`). "
             "Using -R, directories to search metrics files in "
             "can also be given."
-            "Shows all tracked metrics by default.",
+            "Shows all tracked metrics by default."
         ),
         metavar="<paths>",
     ).complete = completion.FILE

--- a/dvc/command/params.py
+++ b/dvc/command/params.py
@@ -101,7 +101,7 @@ def add_parser(subparsers, parent_parser):
         help=(
             "Specific params file(s) to compare "
             "(even if not found as `params` in `dvc.yaml`). "
-            "Shows all tracked params by default.",
+            "Shows all tracked params by default."
         ),
         metavar="<paths>",
     ).complete = completion.FILE


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Fix typo from #5193 that broke displaying usage for params & metrics commands

```
$ dvc params diff -v --help
ERROR: unexpected error - unsupported operand type(s) for %: 'tuple' and 'dict'
```