### PR TITLE
add, import-url: always resolve the output in the local path for --to-remote

### DIFF
--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -52,6 +52,8 @@ def add(  # noqa: C901
             invalid_opt = "--no-commit option"
         elif recursive:
             invalid_opt = "--recursive option"
+        elif kwargs.get("external"):
+            invalid_opt = "--external option"
     else:
         message = "{option} can't be used without --to-remote"
         if kwargs.get("remote"):
@@ -88,7 +90,12 @@ def add(  # noqa: C901
                 )
 
             stages = _create_stages(
-                repo, sub_targets, fname, pbar=pbar, **kwargs,
+                repo,
+                sub_targets,
+                fname,
+                pbar=pbar,
+                transfer=to_remote or to_cache,
+                **kwargs,
             )
 
             try:
@@ -230,6 +237,7 @@ def _create_stages(
     external=False,
     glob=False,
     desc=None,
+    transfer=False,
     **kwargs,
 ):
     from dvc.dvcfile import Dvcfile
@@ -246,7 +254,9 @@ def _create_stages(
     ):
         if kwargs.get("out"):
             out = resolve_output(out, kwargs["out"])
-        path, wdir, out = resolve_paths(repo, out)
+        path, wdir, out = resolve_paths(
+            repo, out, always_local=transfer and not kwargs.get("out")
+        )
         stage = create_stage(
             Stage,
             repo,

--- a/dvc/repo/imp_url.py
+++ b/dvc/repo/imp_url.py
@@ -27,7 +27,9 @@ def imp_url(
     from dvc.stage import Stage, create_stage, restore_meta
 
     out = resolve_output(url, out)
-    path, wdir, out = resolve_paths(self, out)
+    path, wdir, out = resolve_paths(
+        self, out, always_local=to_remote and not out
+    )
 
     if to_remote and no_exec:
         raise InvalidArgumentError(

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -357,7 +357,7 @@ def resolve_output(inp, out):
     return ret
 
 
-def resolve_paths(repo, out):
+def resolve_paths(repo, out, always_local=False):
     from urllib.parse import urlparse
 
     from ..dvcfile import DVC_FILE_SUFFIX
@@ -391,6 +391,9 @@ def resolve_paths(repo, out):
         raise DvcException(msg)
     else:
         wdir = dirname
+        out = base
+
+    if always_local:
         out = base
 
     path = os.path.join(wdir, base + DVC_FILE_SUFFIX)

--- a/tests/func/test_import_url.py
+++ b/tests/func/test_import_url.py
@@ -1,7 +1,6 @@
 import json
 import os
 import textwrap
-from tempfile import gettempdir
 from uuid import uuid4
 
 import pytest
@@ -341,18 +340,17 @@ def test_import_url_to_remote_directory(tmp_dir, dvc, workspace, local_remote):
         )
 
 
-def test_import_url_to_remote_absolute(tmp_dir, dvc, local_remote):
-    from shortuuid import uuid
+def test_import_url_to_remote_absolute(
+    tmp_dir, make_tmp_dir, dvc, local_remote
+):
+    tmp_abs_dir = make_tmp_dir("abs")
+    tmp_foo = tmp_abs_dir / "foo"
+    tmp_foo.write_text("foo")
 
-    temp_name = uuid()
-    temp_file = os.path.join(gettempdir(), temp_name)
-    with open(temp_file, "w") as stream:
-        stream.write("foo")
+    stage = dvc.imp_url(str(tmp_foo), to_remote=True)
 
-    stage = dvc.imp_url(temp_file, to_remote=True)
-
-    foo = tmp_dir / temp_name
-    assert stage.deps[0].fspath == temp_file
+    foo = tmp_dir / "foo"
+    assert stage.deps[0].fspath == str(tmp_foo)
     assert stage.outs[0].fspath == os.fspath(foo)
     assert foo.with_suffix(".dvc").exists()
 


### PR DESCRIPTION
During the discussions on #5445, it seemed `--external` is redundantly needed when trying to add an absolute path in the local system without `-o`. This wasn't the case for remote locations, such as `s3://` or `azure://`. So this PR forbids the usage of `--external` with `to-remote`/`to-cache` and normalizes absolute system paths just like other remote providers.

- [ ] dvc.org docs PR 🙂 