### PR TITLE
tests: temporarily exclude gdrivefs from extras

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,7 +27,7 @@ jobs:
       with:
         python-version: 3.8
     - name: Install requirements
-      run: pip install ".[all,tests]" Pygments collective.checkdocs pre-commit
+      run: pip install ".[all,tests]" Pygments collective.checkdocs pre-commit git+https://github.com/intake/gdrivefs.git
     - name: Check README
       run: python setup.py checkdocs
     - uses: pre-commit/action@v2.0.0

--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,8 @@ tests_requirements = [
     "mypy",
     "wsgidav",
     "crc32c",
-    "gdrivefs @ git+https://github.com/intake/gdrivefs.git",
+    # pypi doesn't allow for direct dependencies
+    #    "gdrivefs @ git+https://github.com/intake/gdrivefs.git",
 ]
 
 setup(

--- a/tests/remotes/gdrive.py
+++ b/tests/remotes/gdrive.py
@@ -46,7 +46,11 @@ class GDrive(Base, CloudURLInfo):
     @cached_property
     def client(self):
         import pydata_google_auth
-        from gdrivefs import GoogleDriveFileSystem
+
+        try:
+            from gdrivefs import GoogleDriveFileSystem
+        except ImportError:
+            pytest.skip("gdrivefs is not installed")
 
         tmp_path = tmp_fname()
         with open(tmp_path, "w") as stream:


### PR DESCRIPTION
When trying to publish to pypi, we get:

```
Invalid value for requires_dist. Error: Can't have direct dependency:
"gdrivefs @ git+https://github.com/intake/gdrivefs.git ; extra ==
'tests'"
```

Related to https://github.com/intake/gdrivefs/issues/21

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
