### PR TITLE
plots: fix bug preventing usage from being displayed

### DIFF
--- a/dvc/command/plots.py
+++ b/dvc/command/plots.py
@@ -138,7 +138,7 @@ def add_parser(subparsers, parent_parser):
         help=(
             "Specific plots file(s) to visualize "
             "(even if not found as `plots` in `dvc.yaml`). "
-            "Shows all tracked plots by default.",
+            "Shows all tracked plots by default."
         ),
         metavar="<paths>",
     ).complete = completion.FILE


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Related to #5453 

Reason: running `dvc plots diff --help` resulted in error:
```
ERROR: unexpected error - unsupported operand type(s) for %: 'tuple' and 'dict'
```