### PR TITLE
dir_info: only build trie when needed

### DIFF
--- a/dvc/checkout.py
+++ b/dvc/checkout.py
@@ -177,7 +177,7 @@ def _checkout_file(
 def _remove_redundant_files(path_info, fs, dir_info, cache, force):
     existing_files = set(fs.walk_files(path_info))
 
-    needed_files = {info for info, _ in dir_info.items(path_info)}
+    needed_files = {path_info.joinpath(*key) for key, _ in dir_info.items()}
     redundant_files = existing_files - needed_files
     for path in redundant_files:
         _remove(path, fs, cache, force)
@@ -197,9 +197,9 @@ def _checkout_dir(
 
     logger.debug("Linking directory '%s'.", path_info)
 
-    for entry_info, entry_hash_info in obj.hash_info.dir_info.items(path_info):
+    for entry_key, entry_hash_info in obj.hash_info.dir_info.items():
         entry_modified = _checkout_file(
-            entry_info,
+            path_info.joinpath(*entry_key),
             fs,
             cache.get(entry_hash_info),
             cache,

--- a/dvc/fs/dvc.py
+++ b/dvc/fs/dvc.py
@@ -48,7 +48,7 @@ class DvcFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
         # NOTE: use string paths here for performance reasons
         key = tuple(relpath(path_info, out.path_info).split(os.sep))
         out.get_dir_cache(remote=remote)
-        file_hash = out.hash_info.dir_info.trie.get(key)
+        file_hash = out.hash_info.dir_info.get(key)
         if file_hash:
             return file_hash
         raise FileNotFoundError
@@ -145,7 +145,7 @@ class DvcFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
         self._fetch_dir(out, **kwargs)
 
         base = out.path_info.parts
-        for key in out.dir_cache.trie.iterkeys():  # noqa: B301
+        for key, _ in out.dir_cache.items():  # noqa: B301
             trie[base + key] = None
 
     def _walk(self, root, trie, topdown=True, **kwargs):

--- a/dvc/objects/stage.py
+++ b/dvc/objects/stage.py
@@ -76,7 +76,7 @@ def _collect_dir(path_info, fs, name, state, **kwargs):
         #
         # Yes, this is a BUG, as long as we permit "/" in
         # filenames on Windows and "\" on Unix
-        dir_info.trie[fi.relative_to(path_info).parts] = hi
+        dir_info.add(fi.relative_to(path_info).parts, hi)
 
     return dir_info
 

--- a/dvc/output/base.py
+++ b/dvc/output/base.py
@@ -551,11 +551,8 @@ class BaseOutput:
 
         path = str(self.path_info)
         filter_path = str(filter_info) if filter_info else None
-        is_win = os.name == "nt"
-        for entry_relpath, entry_hash_info in self.dir_cache.items():
-            if is_win:
-                entry_relpath = entry_relpath.replace("/", os.sep)
-            entry_path = os.path.join(path, entry_relpath)
+        for entry_key, entry_hash_info in self.dir_cache.items():
+            entry_path = os.path.join(path, *entry_key)
             if (
                 not filter_path
                 or entry_path == filter_path

--- a/dvc/path_info.py
+++ b/dvc/path_info.py
@@ -191,6 +191,9 @@ class URLInfo(_BasePath):
     def __div__(self, other):
         return self.replace(path=posixpath.join(self._spath, other))
 
+    def joinpath(self, *args):
+        return self.replace(path=posixpath.join(self._spath, *args))
+
     __truediv__ = __div__
 
     @property


### PR DESCRIPTION
Trie takes quite a bit of time(over 3 sec for 400K dir, so status from 13sec goes down to 10sec) to serialize and deserialize into/from list (that's how we store dirs in .dir cache files). This PR just brings a previously lost optimization, while properly abstracting dir_info building/reading methods.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
