### PR TITLE
tests: temporarily skip dvclive tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,6 @@ install_requires = [
     "pyparsing==2.4.7",
     "typing_extensions>=3.7.4",
     "fsspec>=0.8.5",
-    "dvclive>=0.0.1a0",
     "diskcache>=5.2.1",
 ]
 

--- a/tests/func/test_live.py
+++ b/tests/func/test_live.py
@@ -54,6 +54,11 @@ LIVE_CHECKPOINT_SCRIPT = dedent(
 
 @pytest.fixture
 def live_stage(tmp_dir, scm, dvc):
+    try:
+        import dvclive  # noqa, pylint:disable=unused-import
+    except ImportError:
+        pytest.skip("no dvclive")
+
     def make(summary=True, html=True, live=None, live_no_cache=None):
         assert bool(live) != bool(live_no_cache)
         tmp_dir.gen("train.py", LIVE_SCRITP)
@@ -167,6 +172,11 @@ def test_live_html(tmp_dir, dvc, live_stage, html):
 
 @pytest.fixture
 def live_checkpoint_stage(tmp_dir, scm, dvc):
+    try:
+        import dvclive  # noqa, pylint:disable=unused-import
+    except ImportError:
+        pytest.skip("no dvclive")
+
     def make(live=None, live_no_cache=None):
         assert bool(live) != bool(live_no_cache)
 


### PR DESCRIPTION
Our builds are timing out because pip is confused by

> dvclive 0.0.1a1 requires dvc==2.0.0a0, but you'll have dvc 2.0.0a1+e61136 which is incompatible.

and tries really hard to resolve conflicts.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
