### PR TITLE
exp run: if target is provided, only checkout target and dependencies

### DIFF
--- a/dvc/repo/experiments/executor/base.py
+++ b/dvc/repo/experiments/executor/base.py
@@ -248,6 +248,10 @@ class BaseExecutor(ABC):
 
         with cls._repro_dvc(dvc_dir, rel_cwd) as dvc:
             args, kwargs = cls._repro_args(dvc)
+            if args:
+                targets: Optional[Union[list, str]] = args[0]
+            else:
+                targets = kwargs.get("targets")
 
             repro_force = kwargs.get("force", False)
             logger.trace(  # type: ignore[attr-defined]
@@ -265,7 +269,14 @@ class BaseExecutor(ABC):
             #   be removed/does not yet exist) so that our executor workspace
             #   is not polluted with the (persistent) out from an unrelated
             #   experiment run
-            dvc_checkout(dvc, force=True, quiet=True, allow_missing=True)
+            dvc_checkout(
+                dvc,
+                targets=targets,
+                with_deps=targets is not None,
+                force=True,
+                quiet=True,
+                allow_missing=True,
+            )
 
             checkpoint_func = partial(
                 cls.checkpoint_callback, dvc.scm, name, repro_force


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will close #5472

If experiment is run with a specific target, only its dependencies (and outputs for earlier pipeline stages) will be checked out before reproducing the target, rather than checking out the entire repo/pipeline.