### PR TITLE
azure: add account key to the config schema

### DIFF
--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -183,6 +183,7 @@ SCHEMA = {
                     "connection_string": str,
                     "sas_token": str,
                     "account_name": str,
+                    "account_key": str,
                     "tenant_id": str,
                     "client_id": str,
                     "client_secret": str,


### PR DESCRIPTION
This is something I noticed while writing docs for config vars. We support it in the tree though the config var isn't on the schema. 