### PR TITLE
gs: Use rm() instead of delete() calls

### DIFF
--- a/dvc/fs/fsspec_wrapper.py
+++ b/dvc/fs/fsspec_wrapper.py
@@ -71,7 +71,7 @@ class FSSpecWrapper(BaseFileSystem):
             yield path_info.replace(path=file)
 
     def remove(self, path_info):
-        self.fs.delete(self._with_bucket(path_info))
+        self.fs.rm(self._with_bucket(path_info))
 
     def info(self, path_info):
         info = self.fs.info(self._with_bucket(path_info)).copy()

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ install_requires = [
 
 # Extra dependencies for remote integrations
 
-gs = ["gcsfs @ git+https://github.com/isidentical/gcsfs@support-delete"]
+gs = ["gcsfs>=0.7.2"]
 gdrive = ["pydrive2>=1.7.3", "six >= 1.13.0"]
 s3 = ["boto3>=1.9.201"]
 azure = ["adlfs>=0.6.3", "azure.identity>=1.4.0", "knack"]


### PR DESCRIPTION
delete is a direct alias to rm(), though apparently it is kind of
broken on the latest release of gcsfs. This doesn't change any behavior
but only uses rm() directly instead of the given alias.

