### PR TITLE
repro/exp run: use git status when reminding to git-track files

### DIFF
--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -61,7 +61,11 @@ def _track_stage(stage):
 
     stage.repo.scm.track_file(stage.dvcfile.relpath)
     for dep in stage.deps:
-        if not dep.use_scm_ignore and dep.is_in_repo:
+        if (
+            not dep.use_scm_ignore
+            and dep.is_in_repo
+            and not stage.repo.repo_fs.isdvc(dep.path_info)
+        ):
             stage.repo.scm.track_file(relpath(dep.path_info))
     for out in stage.outs:
         if not out.use_scm_ignore and out.is_in_repo:

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -272,10 +272,19 @@ class Git(Base):
         self.files_to_track = set()
 
     def remind_to_track(self):
-        if self.quiet or not self.files_to_track:
+        def _filter(files):
+            if not files:
+                return set()
+            staged, unstaged, untracked = self.status()
+            return files.intersection(
+                staged.get("modify", []) + unstaged + untracked
+            )
+
+        files_to_track = _filter(self.files_to_track)
+        if self.quiet or not files_to_track:
             return
 
-        files = " ".join(shlex.quote(path) for path in self.files_to_track)
+        files = " ".join(shlex.quote(path) for path in files_to_track)
 
         logger.info(
             "\n"

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -284,7 +284,7 @@ class Git(Base):
         if self.quiet or not files_to_track:
             return
 
-        files = " ".join(shlex.quote(path) for path in files_to_track)
+        files = " ".join(shlex.quote(path) for path in sorted(files_to_track))
 
         logger.info(
             "\n"

--- a/tests/unit/scm/test_git.py
+++ b/tests/unit/scm/test_git.py
@@ -509,10 +509,20 @@ def test_reset(tmp_dir, scm, git):
     assert len(unstaged) == 2
 
 
-def test_remind_to_track(scm, caplog):
-    scm.files_to_track = ["fname with spaces.txt", "тест", "foo"]
+def test_remind_to_track(tmp_dir, scm, caplog):
+    files = ["fname with spaces.txt", "тест", "foo"]
+    tmp_dir.gen({name: "foo" for name in files})
+    scm.files_to_track.update(files)
+
     scm.remind_to_track()
-    assert "git add 'fname with spaces.txt' 'тест' foo" in caplog.text
+    assert "git add 'fname with spaces.txt' foo 'тест'" in caplog.text
+
+    scm.add(["foo"])
+    caplog.clear()
+
+    scm.remind_to_track()
+    assert "git add 'fname with spaces.txt' 'тест'" in caplog.text
+    assert "foo" not in caplog.text
 
 
 def test_add(tmp_dir, scm, git):


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

discord context: https://discord.com/channels/485586884165107732/565759186693128202/816602671967764490

* `To track the changes with git, run: ...` reminder now only suggests `git add` for files which actually need to be tracked by the user rather than all possible files.
* If nothing needs to be tracked (because nothing was modified or the changes are already staged in git) the reminder will now be suppressed entirely
* Reminder output should now be consistent between `dvc repro` and `dvc exp run`

Previously, `exp run` reminder would include a list of files which are aggressively git-added to ensure that full repo state was included in experiment commits. The reminder for `repro` only included the user-expected list of files, but would still suggest git-adding files which were unmodified or already staged in the user's workspace.

old behavior (suggests adding unchanged `data/data.xml.dvc`):
```
$ git reset --hard
HEAD is now at 9e0cd8a Evaluate bigrams model
$ dvc repro prepare -f
Verifying outputs in frozen stage: 'data/data.xml.dvc'

Running stage 'prepare':
...

To track the changes with git, run:

        git add data/data.xml.dvc dvc.lock
Use `dvc push` to send your updates to remote storage.
$ git status
HEAD detached at 9e0cd8a
Changes not staged for commit:
        modified:   dvc.lock

no changes added to commit
```

new (only suggests adding the modified `dvc.lock`):
```
$ git reset --hard
HEAD is now at 9e0cd8a Evaluate bigrams model
$ dvc repro prepare -f
Verifying outputs in frozen stage: 'data/data.xml.dvc'

Running stage 'prepare':
...

To track the changes with git, run:

        git add dvc.lock
Use `dvc push` to send your updates to remote storage.
$ git status
HEAD detached at 9e0cd8a
Changes not staged for commit:
        modified:   dvc.lock

no changes added to commit
```