### PR TITLE
fs: ssh: pass timeout to paramiko's connect()

### DIFF
--- a/dvc/fs/ssh/connection.py
+++ b/dvc/fs/ssh/connection.py
@@ -40,7 +40,9 @@ class SSHConnection:
                 host=host, **kwargs
             )
         )
-        self.timeout = kwargs.get("timeout", 1800)
+
+        kwargs.setdefault("timeout", 1800)
+        self.timeout = kwargs["timeout"]
 
         self._ssh = paramiko.SSHClient()
 


### PR DESCRIPTION
DVC did not always pass a timeout to Paramiko's `connect()`. This could cause DVC to hang indefinitely when e.g. fetching files from an SSH remote FS.

With this patch we pass a timeout to Paramiko, which should prevent this behavior.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

