### PR TITLE
plots: support opening plots file directly in the browser

### DIFF
--- a/dvc/command/plots.py
+++ b/dvc/command/plots.py
@@ -45,12 +45,19 @@ class CmdPlots(CmdBase):
             path = os.path.join(os.getcwd(), path)
 
             write(path, plots)
-
-            logger.info(f"file://{path}")
-
+            url = f"file://{path}"
         except DvcException:
             logger.exception("")
             return 1
+
+        logger.info(url)
+        if self.args.open:
+            import webbrowser
+
+            opened = webbrowser.open(url)
+            if not opened:
+                logger.error("Failed to open. Please try opening it manually.")
+                return 1
 
         return 0
 
@@ -228,4 +235,10 @@ def _add_output_arguments(parser):
         action="store_true",
         default=False,
         help="Show output in Vega format.",
+    )
+    parser.add_argument(
+        "--open",
+        action="store_true",
+        default=False,
+        help="Open plot file directly in the browser.",
     )

--- a/tests/unit/command/test_plots.py
+++ b/tests/unit/command/test_plots.py
@@ -117,7 +117,7 @@ def test_plots_diff_open(tmp_dir, dvc, mocker, caplog):
 
     assert cmd.run() == 0
 
-    expected_url = f"file://{tmp_dir}/plots.html"
+    expected_url = f"file://{tmp_dir / 'plots.html'}"
     assert expected_url in caplog.text
 
     mocked_open.assert_called_once_with(expected_url)
@@ -133,7 +133,7 @@ def test_plots_diff_open_failed(tmp_dir, dvc, mocker, caplog):
 
     assert cmd.run() == 1
 
-    expected_url = f"file://{tmp_dir}/plots.html"
+    expected_url = f"file://{tmp_dir / 'plots.html'}"
     mocked_open.assert_called_once_with(expected_url)
 
     error_message = "Failed to open. Please try opening it manually."


### PR DESCRIPTION
Closes https://github.com/iterative/dvc/issues/4179
```
$ dvc plots show --open
```
I don't know if this is that useful, but I think this does save some time (I was feeling the need when I was going through `example-get-started`).

### Alternative:
No way to be compatible across different platforms. For me on Linux, it's following:
```
$ dvc plots show | xargs xdg-open
```

Working on macOS and on Windows (cc @jorgeorpinel?) confirmation would be great. 

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
