### PR TITLE
repro/exp run: revert use git status when reminding to git-track files

### DIFF
--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -272,19 +272,10 @@ class Git(Base):
         self.files_to_track = set()
 
     def remind_to_track(self):
-        def _filter(files):
-            if not files:
-                return set()
-            staged, unstaged, untracked = self.status()
-            return files.intersection(
-                staged.get("modify", []) + unstaged + untracked
-            )
-
-        files_to_track = _filter(self.files_to_track)
-        if self.quiet or not files_to_track:
+        if self.quiet or not self.files_to_track:
             return
 
-        files = " ".join(shlex.quote(path) for path in sorted(files_to_track))
+        files = " ".join(shlex.quote(path) for path in self.files_to_track)
 
         logger.info(
             "\n"

--- a/tests/unit/scm/test_git.py
+++ b/tests/unit/scm/test_git.py
@@ -528,20 +528,10 @@ def test_reset(tmp_dir, scm, git):
     assert len(unstaged) == 2
 
 
-def test_remind_to_track(tmp_dir, scm, caplog):
-    files = ["fname with spaces.txt", "тест", "foo"]
-    tmp_dir.gen({name: "foo" for name in files})
-    scm.files_to_track.update(files)
-
+def test_remind_to_track(scm, caplog):
+    scm.files_to_track = ["fname with spaces.txt", "тест", "foo"]
     scm.remind_to_track()
-    assert "git add 'fname with spaces.txt' foo 'тест'" in caplog.text
-
-    scm.add(["foo"])
-    caplog.clear()
-
-    scm.remind_to_track()
-    assert "git add 'fname with spaces.txt' 'тест'" in caplog.text
-    assert "foo" not in caplog.text
+    assert "git add 'fname with spaces.txt' 'тест' foo" in caplog.text
 
 
 def test_add(tmp_dir, scm, git):


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Related to https://github.com/iterative/dvc/issues/5594

Reverts git status reminder change from #5544