### PR TITLE
exp: subclass tempfile.TemporaryDirectory to handle cleanup

### DIFF
--- a/dvc/repo/experiments/executor/local.py
+++ b/dvc/repo/experiments/executor/local.py
@@ -3,11 +3,21 @@ import os
 from tempfile import TemporaryDirectory
 from typing import Optional
 
-from dvc.utils.fs import remove
-
 from .base import BaseExecutor
 
 logger = logging.getLogger(__name__)
+
+
+class ExpTemporaryDirectory(TemporaryDirectory):
+    # Python's TemporaryDirectory cleanup shutil.rmtree wrapper does not handle
+    # git read-only dirs cleanly in Windows, so we use our own remove()
+    # see: https://github.com/iterative/dvc/pull/5425
+
+    @classmethod
+    def _rmtree(cls, name):
+        from dvc.utils.fs import remove
+
+        remove(name)
 
 
 class BaseLocalExecutor(BaseExecutor):
@@ -37,7 +47,7 @@ class TempDirExecutor(BaseLocalExecutor):
         cache_dir: Optional[str] = None,
         **kwargs,
     ):
-        self._tmp_dir = TemporaryDirectory(dir=tmp_dir)
+        self._tmp_dir = ExpTemporaryDirectory(dir=tmp_dir)
         kwargs["root_dir"] = self._tmp_dir.name
         super().__init__(*args, **kwargs)
         if cache_dir:
@@ -55,4 +65,4 @@ class TempDirExecutor(BaseLocalExecutor):
     def cleanup(self):
         super().cleanup()
         logger.debug("Removing tmpdir '%s'", self._tmp_dir)
-        remove(self._tmp_dir.name)
+        self._tmp_dir.cleanup()

--- a/dvc/repo/experiments/executor/local.py
+++ b/dvc/repo/experiments/executor/local.py
@@ -10,14 +10,20 @@ logger = logging.getLogger(__name__)
 
 class ExpTemporaryDirectory(TemporaryDirectory):
     # Python's TemporaryDirectory cleanup shutil.rmtree wrapper does not handle
-    # git read-only dirs cleanly in Windows, so we use our own remove()
-    # see: https://github.com/iterative/dvc/pull/5425
+    # git read-only dirs cleanly in Windows on Python <3.8, so we use our own
+    # remove(). See:
+    # https://github.com/iterative/dvc/pull/5425
+    # https://bugs.python.org/issue26660
 
     @classmethod
     def _rmtree(cls, name):
         from dvc.utils.fs import remove
 
         remove(name)
+
+    def cleanup(self):
+        if self._finalizer.detach():
+            self._rmtree(self.name)
 
 
 class BaseLocalExecutor(BaseExecutor):


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will close https://github.com/iterative/dvc/issues/5595
Will close https://github.com/iterative/dvc/issues/5478

After the changes to use `dvc.utils.fs.remove` instead of `TemporaryDirectory.cleanup()` in https://github.com/iterative/dvc/pull/5425, on Python <3.8 on Linux, a skipped/ignored exception message would be logged and visible during DVC runs (with or without `-v`). This happened when `cleanup()` was called on deletion of the tempdir object - the directory itself had already been manually removed by DVC, and `FileNotFoundError` is logged (but not re-raised) to note that `cleanup()` expected to remove a directory which no longer exists. In other python versions, the ignored exception is just silently handled (since it's not actually an error condition).

After this PR we just subclass `TemporaryDirectory` to use our `remove` so that `cleanup()` works as expected (without logging ignored exceptions) whether it is called manually or on object deletion.