### PR TITLE
gs: disable consistency checker

### DIFF
--- a/dvc/fs/gs.py
+++ b/dvc/fs/gs.py
@@ -39,4 +39,4 @@ class GSFileSystem(FSSpecWrapper):
     def fs(self):
         from gcsfs import GCSFileSystem
 
-        return GCSFileSystem(**self.login_info)
+        return GCSFileSystem(**self.login_info, consistency=None)


### PR DESCRIPTION
GCSFile employs a strategy for checking the success of the save operation by calculating the md5 hash on write and then when the file is closed checking whether the written md5 hash matches with the response from the server. Even though this is the default mechanism, it doesn't work with composite objects. There is also a checker for 'size' (like ensuring the same amount of bytes are written) and 'crc32c' (AFAIK this is supported in composite objects) but I don't think we need any of those since none of the other implementations (like adlfs) directly supports it (they don't implement such checkers). So this patch disables checking and resolves #5604