### PR TITLE
build: add pyinstaller hook for googleapiclient

### DIFF
--- a/scripts/hooks/hook-googleapiclient.model.py
+++ b/scripts/hooks/hook-googleapiclient.model.py
@@ -1,0 +1,5 @@
+"""Temporary fix for https://github.com/iterative/dvc/issues/5618."""
+from PyInstaller.utils.hooks import collect_data_files, copy_metadata
+
+datas = collect_data_files("googleapiclient.discovery")
+datas += copy_metadata("google_api_python_client")

--- a/scripts/hooks/hook-googleapiclient.model.py
+++ b/scripts/hooks/hook-googleapiclient.model.py
@@ -1,5 +1,7 @@
 """Temporary fix for https://github.com/iterative/dvc/issues/5618."""
-from PyInstaller.utils.hooks import collect_data_files, copy_metadata
+from PyInstaller.utils.hooks import (    # pylint:disable=import-error
+    collect_data_files, copy_metadata
+)
 
 datas = collect_data_files("googleapiclient.discovery")
 datas += copy_metadata("google_api_python_client")

--- a/scripts/hooks/hook-googleapiclient.model.py
+++ b/scripts/hooks/hook-googleapiclient.model.py
@@ -1,6 +1,7 @@
 """Temporary fix for https://github.com/iterative/dvc/issues/5618."""
-from PyInstaller.utils.hooks import (    # pylint:disable=import-error
-    collect_data_files, copy_metadata
+from PyInstaller.utils.hooks import (  # pylint:disable=import-error
+    collect_data_files,
+    copy_metadata,
 )
 
 datas = collect_data_files("googleapiclient.discovery")


### PR DESCRIPTION
> _The Google API Discovery Service JSON files from [googleapiclient/discovery_cache/documents](https://github.com/googleapis/google-api-python-client/tree/6970659a84d0eec6ff72f59e906716036516922e/googleapiclient/discovery_cache/documents) were being excluded due to a bug and, particularly, [`drive.v2.json`](https://github.com/googleapis/google-api-python-client/blob/6970659a84d0eec6ff72f59e906716036516922e/googleapiclient/discovery_cache/documents/drive.v2.json) is essential for our gdrive backend. Now we're explicitly asking PyInstaller to embed these files on the generated packages._ **(Fixes #5618)**

* [X] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.