### PR TITLE
gs: process etag when it is available

### DIFF
--- a/dvc/fs/gs.py
+++ b/dvc/fs/gs.py
@@ -31,7 +31,8 @@ class GSFileSystem(FSSpecWrapper):
         return login_info
 
     def _entry_hook(self, entry):
-        entry["etag"] = base64.b64decode(entry["etag"]).hex()
+        if "etag" in entry:
+            entry["etag"] = base64.b64decode(entry["etag"]).hex()
         return entry
 
     @wrap_prop(threading.Lock())


### PR DESCRIPTION
Directories doesn't have etag entries, so we need to skip processing them on _entry_hook