### PR TITLE
diff: clear calculated renamed files from inverted hashmap

### DIFF
--- a/dvc/repo/diff.py
+++ b/dvc/repo/diff.py
@@ -199,7 +199,7 @@ def _calculate_renamed(new, old, added, deleted):
         old_inverted[path_hash].append(path)
 
     renamed = []
-    for path in sorted(added, key=len):
+    for path in added:
         path_hash = new[path]
         old_paths = old_inverted[path_hash]
         try:

--- a/dvc/repo/diff.py
+++ b/dvc/repo/diff.py
@@ -201,18 +201,19 @@ def _calculate_renamed(new, old, added, deleted):
             bucket.append(path)
 
     renamed = []
-    for path in added:
+    for path in sorted(added, key=len):
         path_hash = new[path]
         old_paths = old_inverted.get(path_hash, None)
         if not old_paths:
             continue
-        old_path = None
-        for tmp_old_path in old_paths:
-            if tmp_old_path in deleted:
-                old_path = tmp_old_path
-                break
-        if not old_path:
+
+        try:
+            iterator = enumerate(old_paths)
+            index = next((idx for idx, path in iterator if path in deleted))
+        except StopIteration:
             continue
+
+        old_path = old_paths.pop(index)
         renamed.append(
             {"path": {"old": old_path, "new": path}, "hash": path_hash}
         )


### PR DESCRIPTION
We were trying to reuse the first encounter of the file from the inverted hashmap again and again, which was throwing ValueError.

Fixes #5597
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
