### PR TITLE
plots: quote and resolve paths properly

### DIFF
--- a/tests/func/plots/test_show.py
+++ b/tests/func/plots/test_show.py
@@ -708,7 +708,7 @@ def test_show_from_subdir(tmp_dir, dvc, caplog):
     with subdir.chdir(), caplog.at_level(logging.INFO, "dvc"):
         assert main(["plots", "show", "metric.json"]) == 0
 
-    assert f"file://{str(subdir)}" in caplog.text
+    assert subdir.as_uri() in caplog.text
     assert (subdir / "plots.html").exists()
 
 


### PR DESCRIPTION
This commit fixes 3 things:
1. The path printed on the terminal is properly is quoted.  This was
problematic when the output is piped to `xdg-open` if the path contained
spaces or quotes or special characters.
```console
$ dvc plots show -o 'plots with spaces.html' | xargs xdg-open
xdg-open: unexpected argument 'with'
Try 'xdg-open --help' for more information.
```

2. The path is resolved. This is not an issue at all but makes the
output look nicer.
```console
$ dvc plots show -o '../plots.html' --open
file:///home/saugat/repos/iterative/example-get-started/../plots.html
```

3. The path with which the browser is opened with uses relative path.
This is done to solve issue in WSL, that the absolute path is not
accessible outside the WSL for host programs as the linux filesystem
is available on `/wsl$` path.
```console
$ dvc plots show --open
file:///home/saugat/example-get-started/plots.html
Start : This command cannot be run due to the error: The system cannot find the file specified.
At line:1 char:1
+ Start "/home/saugat/example-get-started/plots.html"
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [Start-Process], InvalidOperationException
    + FullyQualifiedErrorId : InvalidOperationException,Microsoft.PowerShell.Commands.StartProcessCommand
```

4. On Windows, the file-uri was being constructed using platform-dependent `os.path.join`. This has been changed to use `as_uri()` from `pathlib.Path`.

With the fix to use relative path as argument to `webbrowser.open`, I expect WSL to be able to work from outside (tested) as well as within inside if needed (didnot test at all). This does work on Linux.

See https://github.com/iterative/dvc/pull/5584#issuecomment-801325773

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
