### PR TITLE
ui: merge --to-remote and --remote for add and import-url

### DIFF
--- a/dvc/command/add.py
+++ b/dvc/command/add.py
@@ -27,7 +27,6 @@ class CmdAdd(CmdBase):
                 glob=self.args.glob,
                 desc=self.args.desc,
                 out=self.args.out,
-                remote=self.args.remote,
                 to_remote=self.args.to_remote,
                 jobs=self.args.jobs,
             )
@@ -86,14 +85,10 @@ def add_parser(subparsers, parent_parser):
     )
     parser.add_argument(
         "--to-remote",
-        action="store_true",
+        nargs="?",
         default=False,
+        const=True,
         help="Download it directly to the remote",
-    )
-    parser.add_argument(
-        "-r",
-        "--remote",
-        help="Remote storage to download to",
         metavar="<name>",
     )
     parser.add_argument(

--- a/dvc/command/imp_url.py
+++ b/dvc/command/imp_url.py
@@ -16,7 +16,6 @@ class CmdImportUrl(CmdBase):
                 out=self.args.out,
                 fname=self.args.file,
                 no_exec=self.args.no_exec,
-                remote=self.args.remote,
                 to_remote=self.args.to_remote,
                 desc=self.args.desc,
                 jobs=self.args.jobs,
@@ -73,14 +72,10 @@ def add_parser(subparsers, parent_parser):
     )
     import_parser.add_argument(
         "--to-remote",
-        action="store_true",
+        nargs="?",
         default=False,
+        const=True,
         help="Download it directly to the remote",
-    )
-    import_parser.add_argument(
-        "-r",
-        "--remote",
-        help="Remote storage to download to",
         metavar="<name>",
     )
     import_parser.add_argument(

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -56,9 +56,7 @@ def add(  # noqa: C901
             invalid_opt = "--external option"
     else:
         message = "{option} can't be used without --to-remote"
-        if kwargs.get("remote"):
-            invalid_opt = "--remote"
-        elif kwargs.get("jobs"):
+        if kwargs.get("jobs"):
             invalid_opt = "--jobs"
 
     if invalid_opt is not None:
@@ -165,11 +163,9 @@ def _process_stages(
         (out,) = stage.outs
 
         if to_remote:
+            remote = None if to_remote is True else to_remote
             out.hash_info = repo.cloud.transfer(
-                target,
-                jobs=kwargs.get("jobs"),
-                remote=kwargs.get("remote"),
-                command="add",
+                target, jobs=kwargs.get("jobs"), remote=remote, command="add",
             )
         else:
             from dvc.fs import get_cloud_fs

--- a/dvc/repo/imp_url.py
+++ b/dvc/repo/imp_url.py
@@ -18,7 +18,6 @@ def imp_url(
     erepo=None,
     frozen=True,
     no_exec=False,
-    remote=None,
     to_remote=False,
     desc=None,
     jobs=None,
@@ -28,17 +27,12 @@ def imp_url(
 
     out = resolve_output(url, out)
     path, wdir, out = resolve_paths(
-        self, out, always_local=to_remote and not out
+        self, out, always_local=to_remote is not False and not out
     )
 
     if to_remote and no_exec:
         raise InvalidArgumentError(
             "--no-exec can't be combined with --to-remote"
-        )
-
-    if not to_remote and remote:
-        raise InvalidArgumentError(
-            "--remote can't be used without --to-remote"
         )
 
     # NOTE: when user is importing something from within their own repository
@@ -74,6 +68,7 @@ def imp_url(
     if no_exec:
         stage.ignore_outs()
     elif to_remote:
+        remote = None if to_remote is True else to_remote
         stage.outs[0].hash_info = self.cloud.transfer(
             url, jobs=jobs, remote=remote, command="import-url"
         )

--- a/tests/unit/command/test_add.py
+++ b/tests/unit/command/test_add.py
@@ -65,6 +65,29 @@ def test_add_to_remote(mocker):
     )
 
 
+def test_add_target_after_to_remote_takes_default_remote(mocker):
+    cli_args = parse_args(["add", "--to-remote", "s3://bucket/foo"])
+    assert cli_args.func == CmdAdd
+
+    cmd = cli_args.func(cli_args)
+    m = mocker.patch.object(cmd.repo, "add", autospec=True)
+
+    assert cmd.run() == 0
+
+    m.assert_called_once_with(
+        ["s3://bucket/foo"],
+        recursive=False,
+        no_commit=False,
+        glob=False,
+        fname=None,
+        external=False,
+        out=None,
+        to_remote=True,
+        desc=None,
+        jobs=None,
+    )
+
+
 def test_add_to_remote_invalid_combinations(mocker, caplog):
     cli_args = parse_args(
         ["add", "s3://bucket/foo", "s3://bucket/bar", "--to-remote"]

--- a/tests/unit/command/test_add.py
+++ b/tests/unit/command/test_add.py
@@ -34,7 +34,6 @@ def test_add(mocker, dvc):
         fname="file",
         external=True,
         out=None,
-        remote=None,
         to_remote=False,
         desc="stage description",
         jobs=None,
@@ -43,15 +42,7 @@ def test_add(mocker, dvc):
 
 def test_add_to_remote(mocker):
     cli_args = parse_args(
-        [
-            "add",
-            "s3://bucket/foo",
-            "--to-remote",
-            "--out",
-            "bar",
-            "--remote",
-            "remote",
-        ]
+        ["add", "s3://bucket/foo", "--to-remote", "remote", "--out", "bar"]
     )
     assert cli_args.func == CmdAdd
 
@@ -68,8 +59,7 @@ def test_add_to_remote(mocker):
         fname=None,
         external=False,
         out="bar",
-        remote="remote",
-        to_remote=True,
+        to_remote="remote",
         desc=None,
         jobs=None,
     )
@@ -87,14 +77,14 @@ def test_add_to_remote_invalid_combinations(mocker, caplog):
         expected_msg = "multiple targets can't be used with --to-remote"
         assert expected_msg in caplog.text
 
-    for option, value in (("--remote", "remote"), ("--jobs", "4")):
-        cli_args = parse_args(["add", "foo", option, value])
+    option, value = "--jobs", "4"
+    cli_args = parse_args(["add", "foo", option, value])
 
-        cmd = cli_args.func(cli_args)
-        with caplog.at_level(logging.ERROR, logger="dvc"):
-            assert cmd.run() == 1
-            expected_msg = f"{option} can't be used without --to-remote"
-            assert expected_msg in caplog.text
+    cmd = cli_args.func(cli_args)
+    with caplog.at_level(logging.ERROR, logger="dvc"):
+        assert cmd.run() == 1
+        expected_msg = f"{option} can't be used without --to-remote"
+        assert expected_msg in caplog.text
 
 
 def test_add_to_cache_invalid_combinations(mocker, caplog):

--- a/tests/unit/command/test_imp_url.py
+++ b/tests/unit/command/test_imp_url.py
@@ -31,7 +31,6 @@ def test_import_url(mocker):
         out="out",
         fname="file",
         no_exec=False,
-        remote=None,
         to_remote=False,
         desc="description",
         jobs=4,
@@ -78,7 +77,6 @@ def test_import_url_no_exec(mocker):
         out="out",
         fname="file",
         no_exec=True,
-        remote=None,
         to_remote=False,
         desc="description",
         jobs=None,
@@ -92,7 +90,6 @@ def test_import_url_to_remote(mocker):
             "s3://bucket/foo",
             "bar",
             "--to-remote",
-            "--remote",
             "remote",
             "--desc",
             "description",
@@ -110,8 +107,7 @@ def test_import_url_to_remote(mocker):
         out="bar",
         fname=None,
         no_exec=False,
-        remote="remote",
-        to_remote=True,
+        to_remote="remote",
         desc="description",
         jobs=None,
     )
@@ -124,7 +120,6 @@ def test_import_url_to_remote_invalid_combination(mocker, caplog):
             "s3://bucket/foo",
             "bar",
             "--to-remote",
-            "--remote",
             "remote",
             "--no-exec",
         ]
@@ -135,14 +130,4 @@ def test_import_url_to_remote_invalid_combination(mocker, caplog):
     with caplog.at_level(logging.ERROR, logger="dvc"):
         assert cmd.run() == 1
         expected_msg = "--no-exec can't be combined with --to-remote"
-        assert expected_msg in caplog.text
-
-    cli_args = parse_args(
-        ["import-url", "s3://bucket/foo", "bar", "--remote", "remote"]
-    )
-
-    cmd = cli_args.func(cli_args)
-    with caplog.at_level(logging.ERROR, logger="dvc"):
-        assert cmd.run() == 1
-        expected_msg = "--remote can't be used without --to-remote"
         assert expected_msg in caplog.text


### PR DESCRIPTION
Fixes #5719

* [X] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

I removed `--remote` altogether; I'm not sure if this is the way to go or if there is any sort of deprecation policy in which case I'd restore it and make the appropriate changes.

It looks to me like the execution path where a remote other than the default is used is not covered by the tests; if you think it'd be valuable, I can try to add a couple of test cases covering that.

I'll update the docs once I get some feedback.
