### PR TITLE
deps: limit rich version to <10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ install_requires = [
     "pygtrie==2.3.2",
     "dpath>=2.0.1,<3",
     "shtab>=1.3.4,<2",
-    "rich>=9.0.0",
+    "rich>=9.0.0,<10",
     "dictdiffer>=0.8.1",
     "python-benedict>=0.21.1",
     "pyparsing==2.4.7",


### PR DESCRIPTION
The recent release of rich-10 broke the internal API that we were depending on
for `exp show`. See https://github.com/iterative/dvc/issues/5722

Limiting it to `<10` till it gets fixed.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
