### PR TITLE
azure: use account_name with default credentials

### DIFF
--- a/dvc/fs/azure.py
+++ b/dvc/fs/azure.py
@@ -69,8 +69,8 @@ class AzureFileSystem(FSSpecWrapper):
         login_info["client_id"] = config.get("client_id")
         login_info["client_secret"] = config.get("client_secret")
 
-        if not any(login_info.values()):
-            login_info["credentials"] = DefaultAzureCredential()
+        if not any([a in login_info and a is not None for a in ["connection_string", "account_key", "sas_token", "client_secret"]]):
+            login_info["credential"] = DefaultAzureCredential(exclude_interactive_browser_credential=False)
 
         for login_method, required_keys in [  # noqa
             ("connection string", ["connection_string"]),

--- a/dvc/fs/azure.py
+++ b/dvc/fs/azure.py
@@ -50,6 +50,8 @@ class AzureFileSystem(FSSpecWrapper):
 
     def _prepare_credentials(self, config):
         from azure.identity.aio import DefaultAzureCredential
+        # Disable spam from failed cred types for DefaultAzureCredential
+        logging.getLogger("azure.identity.aio").setLevel(logging.ERROR)
 
         login_info = {}
         login_info["connection_string"] = config.get(

--- a/dvc/fs/azure.py
+++ b/dvc/fs/azure.py
@@ -69,7 +69,8 @@ class AzureFileSystem(FSSpecWrapper):
         login_info["client_id"] = config.get("client_id")
         login_info["client_secret"] = config.get("client_secret")
 
-        if not any([a in login_info and a is not None for a in ["connection_string", "account_key", "sas_token", "client_secret"]]):
+        non_cred_auth_methods = ["connection_string", "client_secret", "account_key", "sas_token"]
+        if not any([login_info.get(a, None) is not None for a in non_cred_auth_methods]):
             login_info["credential"] = DefaultAzureCredential(exclude_interactive_browser_credential=False)
 
         for login_method, required_keys in [  # noqa
@@ -80,8 +81,8 @@ class AzureFileSystem(FSSpecWrapper):
             ),
             ("account key", ["account_name", "account_key"]),
             ("SAS token", ["account_name", "sas_token"]),
+            (f"default credentials ({_DEFAULT_CREDS_STEPS})", ["account_name", "credential"]),
             ("anonymous login", ["account_name"]),
-            (f"default credentials ({_DEFAULT_CREDS_STEPS})", ["credentials"]),
         ]:
             if all(login_info.get(key) is not None for key in required_keys):
                 break

--- a/dvc/fs/azure.py
+++ b/dvc/fs/azure.py
@@ -50,6 +50,7 @@ class AzureFileSystem(FSSpecWrapper):
 
     def _prepare_credentials(self, config):
         from azure.identity.aio import DefaultAzureCredential
+
         # Disable spam from failed cred types for DefaultAzureCredential
         logging.getLogger("azure.identity.aio").setLevel(logging.ERROR)
 
@@ -71,8 +72,12 @@ class AzureFileSystem(FSSpecWrapper):
         login_info["client_id"] = config.get("client_id")
         login_info["client_secret"] = config.get("client_secret")
 
-        if not any(value for key, value in login_info.items() if key != 'account_name'):
-            login_info["credential"] = DefaultAzureCredential(exclude_interactive_browser_credential=False)
+        if not any(
+            value for key, value in login_info.items() if key != "account_name"
+        ):
+            login_info["credential"] = DefaultAzureCredential(
+                exclude_interactive_browser_credential=False
+            )
 
         for login_method, required_keys in [  # noqa
             ("connection string", ["connection_string"]),
@@ -82,7 +87,10 @@ class AzureFileSystem(FSSpecWrapper):
             ),
             ("account key", ["account_name", "account_key"]),
             ("SAS token", ["account_name", "sas_token"]),
-            (f"default credentials ({_DEFAULT_CREDS_STEPS})", ["account_name", "credential"]),
+            (
+                f"default credentials ({_DEFAULT_CREDS_STEPS})",
+                ["account_name", "credential"],
+            ),
             ("anonymous login", ["account_name"]),
         ]:
             if all(login_info.get(key) is not None for key in required_keys):


### PR DESCRIPTION
This resolves the authentication issues highlighted in #5511. Before I was getting authentication failures with DefaultAzureCredential, now auth seems to succeed but I still face the problems in #5556 which make this hard to test beyond the fact that the error has changed from auth to threading.

EDIT: Hacked azure.identity.aio so that it doesn't complain by disabling asyncio.Lock - with this done I no longer get the treading errors of #5556 and auth works fine! Not really sure what is the cause of the threading issues and this clearly isn't a viable solution though...


* [ ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏