### PR TITLE
parsing: resolve relative paths when loading parameters

### DIFF
--- a/dvc/parsing/context.py
+++ b/dvc/parsing/context.py
@@ -401,9 +401,9 @@ class Context(CtxDict):
     ):
         path, _, keys_str = item.partition(":")
         select_keys = lfilter(bool, keys_str.split(",")) if keys_str else None
-        path_info = wdir / path
 
-        abspath = os.path.abspath(path_info)
+        abspath = os.path.abspath(wdir / path)
+        path_info = PathInfo(abspath)
         if abspath in self.imports:
             if not select_keys and self.imports[abspath] is None:
                 return  # allow specifying complete filepath multiple times

--- a/tests/func/parsing/test_resolver.py
+++ b/tests/func/parsing/test_resolver.py
@@ -1,3 +1,4 @@
+import os
 from copy import deepcopy
 
 import pytest
@@ -65,6 +66,16 @@ def test_load_vars_from_file(tmp_dir, dvc):
     expected = deepcopy(DATA)
     expected.update(datasets)
     assert resolver.context == expected
+
+
+def test_load_vars_with_relpath(tmp_dir, dvc):
+    dump_yaml(DEFAULT_PARAMS_FILE, DATA)
+
+    subdir = tmp_dir / "subdir"
+    d = {"vars": [os.path.relpath(tmp_dir / DEFAULT_PARAMS_FILE, subdir)]}
+    resolver = DataResolver(dvc, subdir, d)
+
+    assert resolver.context == deepcopy(DATA)
 
 
 def test_partial_vars_doesnot_exist(tmp_dir, dvc):


### PR DESCRIPTION
We were joining the paths in the following way: 

https://github.com/iterative/dvc/blob/09cb49542364694f2eec84f61b63e40ae8dcd05f/dvc/parsing/context.py#L404

This created the path such as `PosixPath: dir/../params.yaml`, which broke on GitFS when trying to get the key of the GitTrie,
as it is now changed to `('dir', '..', 'params.yaml')` parts instead of just `(params.yaml,)`.


Similarly, LocalFS.exists was also failing because of the unresolved path.

This is fixed by changing it to abspath first, removing those relative paths and then converted into `PathInfo`.

Closes https://github.com/iterative/dvc/issues/5731

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
