### PR TITLE
exp show: fix column collapse behavior

### DIFF
--- a/dvc/utils/table.py
+++ b/dvc/utils/table.py
@@ -69,7 +69,7 @@ class Table(RichTable):
         last_collapsed = -1
         columns = cast(List[Column], self.columns)
         for i in range(len(columns) - 1, -1, -1):
-            if widths[i] == 1 and columns[i].collapse:
+            if widths[i] == 0 and columns[i].collapse:
                 if last_collapsed >= 0:
                     del widths[last_collapsed]
                     del columns[last_collapsed]


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

In `exp show` we merge adjacent collapsed (minimum width) columns into a single column containing `…`. Prior to https://github.com/willmcgugan/rich/commit/2f752afaa931d67664967100bc990de3c6f6abbc rich assigned collapsed columns a minimum width of 1, after that commit the minimum width became 0.

Will close #5722