### PR TITLE
use sys.executable instead of hardcoded python

### DIFF
--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -14,7 +14,7 @@ os.putenv(
 )
 os.putenv("DVC_HOME", REPO_ROOT)
 
+opts = "-v -n=auto --dist loadscope --cov=dvc --durations=0"
 params = " ".join(sys.argv[1:])
-
-cmd = f"pytest -v -n=auto --dist loadscope --cov=dvc --durations=0 {params}"
+cmd = f"{sys.executable} -m pytest {opts} {params}"
 check_call(cmd, shell=True)

--- a/tests/unit/test_imports.py
+++ b/tests/unit/test_imports.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 
 
 def test_no_remote_imports():
@@ -15,7 +16,7 @@ def test_no_remote_imports():
 
     code = "import dvc.main, sys; print(' '.join(sys.modules))"
     res = subprocess.run(
-        ["python", "-c", code], stdout=subprocess.PIPE, check=True
+        [sys.executable, "-c", code], stdout=subprocess.PIPE, check=True
     )
     modules = res.stdout.decode().split()
     assert not set(modules) & remote_modules


### PR DESCRIPTION
Encountered some issues with python on windows. We should use `sys.executable` instead. 

This does not fix all of the issues, we still use `python` in a lot of our test stages, but they did not fail as they only depend on stdlib. Though we should fix this soon.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
