### PR TITLE
Fix test assertion with environment when using pyenv

### DIFF
--- a/tests/unit/fs/test_hdfs.py
+++ b/tests/unit/fs/test_hdfs.py
@@ -2,6 +2,7 @@ import os
 
 from dvc.fs.hdfs import _hadoop_fs_checksum
 from dvc.path_info import URLInfo
+from dvc.utils import fix_env
 
 
 def test_hadoop_fs_checksum(mocker):
@@ -22,7 +23,7 @@ def test_hadoop_fs_checksum(mocker):
         shell=True,
         close_fds=os.name != "nt",
         executable=os.getenv("SHELL") if os.name != "nt" else None,
-        env=os.environ,
+        env=fix_env(os.environ),
         stdin=-1,
         stdout=-1,
         stderr=-1,


### PR DESCRIPTION
We modify the environment when passing env through the subprocess which changes some environment variables when pyenv is detected. 
https://github.com/iterative/dvc/blob/19d0b2af56633886f9272732b14195cd4ee322f8/dvc/fs/hdfs.py#L37

In the assertion of the test, we should also check this with the modified expected env vars (not to the real envvars).

This was making the tests fail when using pyenv.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
