### PR TITLE
setup: fix all fsspec remote versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,17 +88,17 @@ install_requires = [
     "python-benedict>=0.21.1",
     "pyparsing==2.4.7",
     "typing_extensions>=3.7.4",
-    "fsspec>=0.8.5",
+    "fsspec==0.8.7",
     "diskcache>=5.2.1",
 ]
 
 
 # Extra dependencies for remote integrations
 
-gs = ["gcsfs>=0.7.2"]
+gs = ["gcsfs==0.7.2"]
 gdrive = ["pydrive2>=1.8.1", "six >= 1.13.0"]
 s3 = ["boto3>=1.9.201"]
-azure = ["adlfs>=0.7.0", "azure-identity>=1.4.0", "knack"]
+azure = ["adlfs==0.7.0", "azure-identity>=1.4.0", "knack"]
 # https://github.com/Legrandin/pycryptodome/issues/465
 oss = ["oss2==2.6.1", "pycryptodome>=3.10"]
 ssh = ["paramiko[invoke]>=2.7.0"]


### PR DESCRIPTION
fsspec 0.9 contains a lot of breaking changes, and since it is released yesterday some remote's haven't adapted using (adlfs) it and some others doesn't reference it properly (e.g gcsfs). `gcsfs==0.8` (should) require `fsspec>=0.9` but `adlfs==0.7` require `fsspec<0.9`. Until `adlfs` is updated to support new async system on the `>=0.9`, we can't update our versions. This patch fixes the ambigous dependencies to a certain version in order to not have any conflicts. 