### PR TITLE
exp run: jobs should default to 1

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -1213,6 +1213,7 @@ def _add_run_common(parser):
         "-j",
         "--jobs",
         type=int,
+        default=1,
         help="Run the specified number of experiments at a time in parallel.",
         metavar="<number>",
     )

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -93,7 +93,7 @@ def test_experiments_run(dvc, scm, mocker):
         "name": None,
         "queue": False,
         "run_all": False,
-        "jobs": None,
+        "jobs": 1,
         "tmp_dir": False,
         "checkpoint_resume": None,
         "reset": False,


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will fix #5780