### PR TITLE
fsspec: update to 0.9 (including remotes)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,17 +88,17 @@ install_requires = [
     "python-benedict>=0.21.1",
     "pyparsing==2.4.7",
     "typing_extensions>=3.7.4",
-    "fsspec==0.8.7",
+    "fsspec==0.9.0",
     "diskcache>=5.2.1",
 ]
 
 
 # Extra dependencies for remote integrations
 
-gs = ["gcsfs==0.7.2"]
+gs = ["gcsfs==0.8.0"]
 gdrive = ["pydrive2>=1.8.1", "six >= 1.13.0"]
 s3 = ["boto3>=1.9.201"]
-azure = ["adlfs==0.7.0", "azure-identity>=1.4.0", "knack"]
+azure = ["adlfs==0.7.1", "azure-identity>=1.4.0", "knack"]
 # https://github.com/Legrandin/pycryptodome/issues/465
 oss = ["oss2==2.6.1", "pycryptodome>=3.10"]
 ssh = ["paramiko[invoke]>=2.7.0"]


### PR DESCRIPTION
With the adlfs's 0.7.1 release, we should be fine to update fsspec to 0.9 which would allow us to use newer versions of s3fs and gcsfs at the same time with adlfs.