### PR TITLE
repo: handle rev without scm

### DIFF
--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -141,6 +141,7 @@ class Repo:
         from dvc.repo.params import Params
         from dvc.repo.plots import Plots
         from dvc.repo.stage import StageLoad
+        from dvc.scm import SCM
         from dvc.stage.cache import StageCache
         from dvc.state import State, StateNoop
 
@@ -148,6 +149,9 @@ class Repo:
         self._fs_conf = {
             "repo_factory": repo_factory,
         }
+
+        if rev and not scm:
+            scm = SCM(root_dir or os.curdir)
 
         self.root_dir, self.dvc_dir, self.tmp_dir = self._get_repo_dirs(
             root_dir=root_dir, scm=scm, rev=rev, uninitialized=uninitialized

--- a/tests/func/test_api.py
+++ b/tests/func/test_api.py
@@ -182,6 +182,15 @@ def test_open_not_cached(dvc):
         api.read(metric_file)
 
 
+def test_open_rev(tmp_dir, scm, dvc):
+    tmp_dir.scm_gen("foo", "foo", commit="foo")
+
+    (tmp_dir / "foo").write_text("bar")
+
+    with api.open("foo", rev="master") as fobj:
+        assert fobj.read() == "foo"
+
+
 @pytest.mark.parametrize("as_external", [True, False])
 @pytest.mark.parametrize("remote", [pytest.lazy_fixture("ssh")], indirect=True)
 @pytest.mark.parametrize(


### PR DESCRIPTION
This part of logic used to be only used by external repo for cloned
repos, but since we now handle local repos without cloning, we don't
always pass scm instance. This PR automatically creates scm instance
for such cases.

Fixes #5590

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
