### PR TITLE
exp run: error out when trying to resume from intermediate checkpoint w/no modifications

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -172,7 +172,10 @@ def _collect_rows(
                 else:
                     tree = "└──"
                 new_checkpoint = True
-            name = exp.get("name", rev[:7])
+            if "name" in exp:
+                name = f"{rev[:7]} [[bold]{exp['name']}[/]]"
+            else:
+                name = rev[:7]
 
         row = [
             name,

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -206,12 +206,35 @@ class Experiments:
                             not branch
                             or self.scm.get_ref(branch) != resume_rev
                         ):
-                            raise DvcException(
-                                f"Nothing to do for unchanged checkpoint "
-                                f"'{resume_rev[:7]}'. To resume from the head "
-                                "of this experiment, use "
-                                f"'dvc exp apply {branch_name}'."
-                            )
+                            msg = [
+                                (
+                                    "Nothing to do for unchanged checkpoint "
+                                    f"'{resume_rev[:7]}'. "
+                                )
+                            ]
+                            if branch:
+                                msg.append(
+                                    "To resume from the head of this "
+                                    "experiment, use "
+                                    f"'dvc exp apply {branch_name}'."
+                                )
+                            else:
+                                names = [
+                                    ref_info.name
+                                    for ref_info in exp_refs_by_rev(
+                                        self.scm, resume_rev
+                                    )
+                                ]
+                                if len(names) > 3:
+                                    names[3:] = [
+                                        f"... ({len(names) - 3} more)"
+                                    ]
+                                msg.append(
+                                    "To resume an experiment containing this "
+                                    "checkpoint, apply one of these heads:\n"
+                                    "\t{}".format(", ".join(names))
+                                )
+                            raise DvcException("".join(msg))
                         else:
                             logger.info(
                                 "Existing checkpoint experiment '%s' will be "

--- a/dvc/repo/experiments/apply.py
+++ b/dvc/repo/experiments/apply.py
@@ -32,7 +32,9 @@ def apply(repo, rev, force=True, **kwargs):
         raise InvalidExpRevError(rev) from exc
 
     stash_rev = exp_rev in exps.stash_revs
-    if not stash_rev and not exps.get_branch_by_rev(exp_rev):
+    if not stash_rev and not exps.get_branch_by_rev(
+        exp_rev, allow_multiple=True
+    ):
         raise InvalidExpRevError(exp_rev)
 
     # Note that we don't use stash_workspace() here since we need finer control

--- a/dvc/repo/experiments/base.py
+++ b/dvc/repo/experiments/base.py
@@ -74,12 +74,13 @@ class InvalidExpRevError(InvalidArgumentError):
 
 
 class MultipleBranchError(DvcException):
-    def __init__(self, rev):
+    def __init__(self, rev, ref_infos):
         super().__init__(
             f"Ambiguous commit '{rev[:7]}' belongs to multiple experiment "
             "branches."
         )
         self.rev = rev
+        self.ref_infos = ref_infos
 
 
 class ApplyConflictError(InvalidArgumentError):

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -426,7 +426,7 @@ class Git(Base):
             commit = self.resolve_commit(parent)
 
     @contextmanager
-    def detach_head(self, rev: Optional[str] = None):
+    def detach_head(self, rev: Optional[str] = None, force: bool = False):
         """Context manager for performing detached HEAD SCM operations.
 
         Detaches and restores HEAD similar to interactive git rebase.
@@ -440,7 +440,7 @@ class Git(Base):
             rev = "HEAD"
         orig_head = self.get_ref("HEAD", follow=False)
         logger.debug("Detaching HEAD at '%s'", rev)
-        self.checkout(rev, detach=True)
+        self.checkout(rev, detach=True, force=force)
         try:
             yield self.get_ref("HEAD")
         finally:

--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -111,6 +111,7 @@ def test_show_checkpoint(
     for i, rev in enumerate(checkpoints):
         if i == 0:
             name = dvc.experiments.get_exact_name(rev)
+            name = f"{rev[:7]} [{name}]"
             fs = "╓"
         elif i == len(checkpoints) - 1:
             name = rev[:7]
@@ -155,7 +156,7 @@ def test_show_checkpoint_branch(
     for rev in (checkpoint_a, checkpoint_b):
         ref = dvc.experiments.get_branch_by_rev(rev)
         ref_info = ExpRefInfo.from_ref(ref)
-        name = ref_info.name
+        name = f"{rev[:7]} [{ref_info.name}]"
         assert f"╓ {name}" in cap.out
     assert f"({branch_rev[:7]})" in cap.out
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will close #5737, see original issue for full discussion of changes

After this PR

- Checkpoints can only be resumed (with no modifications) from the head of a checkpoint run. (New checkpoint branches with modifications can still be created from any intermediate or head checkpoint)

See example:
1. apply ambiguous commit and run with no modifications (error with no modifications)
2. apply ambiguous commit that is an exact match for a head and run with no modifications (resume from the exact matching head)
3. apply non-ambiguous commit and run with no modifications (error with no modifications)
[![asciicast](https://asciinema.org/a/BsdI6cf78qTYhlNTKsoApSm52.svg)](https://asciinema.org/a/BsdI6cf78qTYhlNTKsoApSm52)