### PR TITLE
add: prevent crash while getting relpath

### DIFF
--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -325,8 +325,8 @@ def relpath(path, start=os.curdir):
         # we need to resolve to UNC path first. We resolve only the drive
         # name so that we don't follow any 'real' symlinks on the path
         def resolve_network_drive_windows(path_to_resolve):
-            drive, upper_path = os.path.splitdrive(path_to_resolve)
-            return os.path.join(os.path.realpath(drive), upper_path)
+            drive, tail = os.path.splitdrive(path_to_resolve)
+            return os.path.join(os.path.realpath(drive), tail)
 
         path = resolve_network_drive_windows(os.path.abspath(path))
         start = resolve_network_drive_windows(start)

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -319,10 +319,19 @@ def relpath(path, start=os.curdir):
     start = os.path.abspath(os.fspath(start))
 
     # Windows path on different drive than curdir doesn't have relpath
-    if os.name == "nt" and not os.path.commonprefix(
-        [start, os.path.abspath(path)]
-    ):
-        return path
+    if os.name == "nt":
+        # Since python 3.8 os.realpath resolves network shares to their UNC
+        # path. So, to be certain that relative paths correctly captured,
+        # we need to resolve to UNC path first. We resolve only the drive
+        # name so that we don't follow any 'real' symlinks on the path
+        def resolve_network_drive_windows(path_to_resolve):
+            drive, upper_path = os.path.splitdrive(path_to_resolve)
+            return os.path.join(os.path.realpath(drive), upper_path)
+
+        path = resolve_network_drive_windows(os.path.abspath(path))
+        start = resolve_network_drive_windows(start)
+        if not os.path.commonprefix([start, path]):
+            return path
     return os.path.relpath(path, start)
 
 

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -112,7 +112,7 @@ def test_relpath():
 
     assert relpath(path) == relpath(path_info)
 
-
+@pytest.mark.skipif(os.name != "nt", reason="Windows specific")
 def test_relpath_windows(monkeypatch):
     """test that relpath correctly generated when run on a
     windows network share. The drive mapped path is mapped
@@ -121,12 +121,11 @@ def test_relpath_windows(monkeypatch):
     def dummy_realpath(path):
         return path.replace("x:", "\\\\server\\share")
 
-    if os.name == "nt":
-        monkeypatch.setattr(os.path, "realpath", dummy_realpath)
-        assert (
-            relpath("x:\\dir1\\dir2\\file.txt", "\\\\server\\share\\dir1")
-            == "dir2\\file.txt"
-        )
+    monkeypatch.setattr(os.path, "realpath", dummy_realpath)
+    assert (
+        relpath("x:\\dir1\\dir2\\file.txt", "\\\\server\\share\\dir1")
+        == "dir2\\file.txt"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -112,6 +112,7 @@ def test_relpath():
 
     assert relpath(path) == relpath(path_info)
 
+
 @pytest.mark.skipif(os.name != "nt", reason="Windows specific")
 def test_relpath_windows(monkeypatch):
     """test that relpath correctly generated when run on a
@@ -125,6 +126,11 @@ def test_relpath_windows(monkeypatch):
     assert (
         relpath("x:\\dir1\\dir2\\file.txt", "\\\\server\\share\\dir1")
         == "dir2\\file.txt"
+    )
+
+    assert (
+        relpath("y:\\dir1\\dir2\\file.txt", "\\\\server\\share\\dir1")
+        == "y:\\dir1\\dir2\\file.txt"
     )
 
 

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -113,6 +113,22 @@ def test_relpath():
     assert relpath(path) == relpath(path_info)
 
 
+def test_relpath_windows(monkeypatch):
+    """test that relpath correctly generated when run on a
+    windows network share. The drive mapped path is mapped
+    to a UNC path by os.path.realpath"""
+
+    def dummy_realpath(path):
+        return path.replace("x:", "\\\\server\\share")
+
+    if os.name == "nt":
+        monkeypatch.setattr(os.path, "realpath", dummy_realpath)
+        assert (
+            relpath("x:\\dir1\\dir2\\file.txt", "\\\\server\\share\\dir1")
+            == "dir2\\file.txt"
+        )
+
+
 @pytest.mark.parametrize(
     "inp,out,is_dir,expected",
     [


### PR DESCRIPTION
Since python 3.8 os.path.realpath has resolved windows network shares
to UNC paths. This breaks the logic for relpath as the UNC and mapped
drive paths don't have an obvious common prefix. As it is not easy to go
back to the mapped drive path from UNC path, this is resolved by always
using the UNC paths for calculating relative paths in windows.

Fixes #5832

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
