### PR TITLE
metrics: pass --precision to _show_metrics

### DIFF
--- a/dvc/command/metrics.py
+++ b/dvc/command/metrics.py
@@ -95,6 +95,7 @@ class CmdMetricsShow(CmdMetricsBase):
                     self.args.all_branches,
                     self.args.all_tags,
                     self.args.all_commits,
+                    self.args.precision,
                 )
                 if table:
                     logger.info(table)

--- a/tests/unit/command/test_metrics.py
+++ b/tests/unit/command/test_metrics.py
@@ -111,22 +111,37 @@ def test_metrics_show(dvc, mocker):
             "--all-commits",
             "target1",
             "target2",
+            "--precision",
+            "8",
         ]
     )
     assert cli_args.func == CmdMetricsShow
 
     cmd = cli_args.func(cli_args)
-    m = mocker.patch("dvc.repo.metrics.show.show", return_value={})
+    m1 = mocker.patch("dvc.repo.metrics.show.show", return_value={})
+    m2 = mocker.patch(
+        "dvc.command.metrics._show_metrics",
+        spec=_show_metrics,
+        return_value={},
+    )
 
     assert cmd.run() == 0
 
-    m.assert_called_once_with(
+    m1.assert_called_once_with(
         cmd.repo,
         ["target1", "target2"],
         recursive=True,
         all_tags=True,
         all_branches=True,
         all_commits=True,
+    )
+    m2.assert_called_once_with(
+        {},
+        markdown=False,
+        all_tags=True,
+        all_branches=True,
+        all_commits=True,
+        precision=8,
     )
 
 

--- a/tests/unit/command/test_metrics.py
+++ b/tests/unit/command/test_metrics.py
@@ -122,7 +122,7 @@ def test_metrics_show(dvc, mocker):
     m2 = mocker.patch(
         "dvc.command.metrics._show_metrics",
         spec=_show_metrics,
-        return_value={},
+        return_value="",
     )
 
     assert cmd.run() == 0


### PR DESCRIPTION
`metrics show --precision <value>` was ignored due to it is never passed the underlying `_show_metrics` function.  Resolves #5840