### PR TITLE
exp run: `dvc commit` DVC-tracked data deps when stashing an experiment

### DIFF
--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -251,10 +251,10 @@ class Experiments:
             targets = args[0]
         else:
             targets = kwargs.get("targets")
-        if targets is None:
-            targets = [None]
-        elif isinstance(targets, str):
+        if isinstance(targets, str):
             targets = [targets]
+        elif not targets:
+            targets = [None]
         for target in targets:
             self.repo.commit(
                 target,

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -433,15 +433,21 @@ class Stage(params.StageParams):
         return m
 
     def save(self, allow_missing=False):
-        self.save_deps()
+        self.save_deps(allow_missing=allow_missing)
         self.save_outs(allow_missing=allow_missing)
         self.md5 = self.compute_md5()
 
         self.repo.stage_cache.save(self)
 
-    def save_deps(self):
+    def save_deps(self, allow_missing=False):
+        from dvc.dependency.base import DependencyDoesNotExistError
+
         for dep in self.deps:
-            dep.save()
+            try:
+                dep.save()
+            except DependencyDoesNotExistError:
+                if not allow_missing:
+                    raise
 
     def save_outs(self, allow_missing=False):
         from dvc.output.base import OutputDoesNotExistError

--- a/tests/func/experiments/test_experiments.py
+++ b/tests/func/experiments/test_experiments.py
@@ -1,3 +1,4 @@
+import itertools
 import logging
 import os
 import stat
@@ -627,10 +628,10 @@ def test_fix_exp_head(tmp_dir, scm, tail):
 
 
 @pytest.mark.parametrize(
-    "workspace, params",
-    [(True, "foo: 1"), (True, "foo: 2"), (False, "foo: 1"), (False, "foo: 2")],
+    "workspace, params, target",
+    itertools.product((True, False), ("foo: 1", "foo: 2"), (True, False)),
 )
-def test_modified_data_dep(tmp_dir, scm, dvc, workspace, params):
+def test_modified_data_dep(tmp_dir, scm, dvc, workspace, params, target):
     tmp_dir.dvc_gen("data", "data")
     tmp_dir.gen("copy.py", COPY_SCRIPT)
     tmp_dir.gen("params.yaml", "foo: 1")
@@ -657,7 +658,9 @@ def test_modified_data_dep(tmp_dir, scm, dvc, workspace, params):
     tmp_dir.gen("params.yaml", params)
     tmp_dir.gen("data", "modified")
 
-    results = dvc.experiments.run(exp_stage.addressing, tmp_dir=not workspace)
+    results = dvc.experiments.run(
+        exp_stage.addressing if target else None, tmp_dir=not workspace
+    )
     exp = first(results)
 
     for rev in dvc.brancher(revs=[exp]):


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will close #5593

- Data dependencies are now `dvc commit`ed internally when stashing an experiment so that any modifications to that data dep are preserved in both workspace and tempdir runs (previously the changes were dropped entirely by the `exp run` `dvc checkout` step).