### PR TITLE
objects: don't recompute hash on odb.add() if verify is False

### DIFF
--- a/dvc/objects/db/base.py
+++ b/dvc/objects/db/base.py
@@ -45,7 +45,7 @@ class ObjectDB:
 
     def add(self, path_info, fs, hash_info, move=True, **kwargs):
         try:
-            self.check(hash_info)
+            self.check(hash_info, check_hash=self.verify)
             return
         except (ObjectFormatError, FileNotFoundError):
             pass
@@ -106,8 +106,10 @@ class ObjectDB:
     def set_exec(self, path_info):  # pylint: disable=unused-argument
         pass
 
-    def check(self, hash_info):
-        """Compare the given hash with the (corresponding) actual one.
+    def check(self, hash_info, check_hash=True):
+        """Compare the given hash with the (corresponding) actual one if
+        check_hash is specified, or just verify the existence of the cache
+        files on the filesystem.
 
         - Use `State` as a cache for computed hashes
             + The entries are invalidated by taking into account the following:
@@ -128,7 +130,7 @@ class ObjectDB:
             return
 
         try:
-            obj.check(self)
+            obj.check(self, check_hash=check_hash)
         except ObjectFormatError:
             logger.warning("corrupted cache file '%s'.", obj.path_info)
             self.fs.remove(obj.path_info)

--- a/dvc/objects/file.py
+++ b/dvc/objects/file.py
@@ -1,4 +1,6 @@
+import errno
 import logging
+import os
 
 from .errors import ObjectFormatError
 
@@ -35,8 +37,16 @@ class HashFile:
             and self.hash_info == other.hash_info
         )
 
-    def check(self, odb):
+    def check(self, odb, check_hash=True):
         from .stage import get_file_hash
+
+        if not check_hash:
+            if not self.fs.exists(self.path_info):
+                raise FileNotFoundError(
+                    errno.ENOENT, os.strerror(errno.ENOENT), self.path_info
+                )
+            else:
+                return None
 
         actual = get_file_hash(
             self.path_info, self.fs, self.hash_info.name, odb.repo.state


### PR DESCRIPTION
When adding new objects with `odb.add()` when the `odb.verify` is set to False (or defaulted to False, which happens on almost all remotes except GDrive), instead of recomputing the hash again we'll simply check the existence of the cache file and not verify the contents. This speeds up the `dvc update --to-remote` by  %15 (from `2.49 minutes` to `2.24 minutes`). Part of #5768