### PR TITLE
exp show: separate ui representation of exp names and identifiers

### DIFF
--- a/dvc/compare.py
+++ b/dvc/compare.py
@@ -165,9 +165,11 @@ class TabularData(MutableSequence[Sequence["CellT"]]):
 
         ui.table(self, headers=self.keys(), **kwargs)
 
-    def as_dict(self):
-        keys = self.keys()
-        return [dict(zip(keys, row)) for row in self]
+    def as_dict(self, cols: Iterable[str] = None) -> Iterable[Dict[str, str]]:
+        keys = self.keys() if cols is None else set(cols)
+        return [
+            {k: self._columns[k][i] for k in keys} for i in range(len(self))
+        ]
 
 
 def _format_field(val: Any, precision: int = None) -> str:

--- a/tests/unit/test_tabular_data.py
+++ b/tests/unit/test_tabular_data.py
@@ -107,6 +107,7 @@ def test_dict_like_interfaces():
         {"col-1": "foo", "col-2": "bar"},
         {"col-1": "foobar", "col-2": "foobar"},
     ]
+    assert td.as_dict(["col-1"]) == [{"col-1": "foo"}, {"col-1": "foobar"}]
 
 
 def test_fill_value():


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

It might not be apparent from the PR on why I am doing this. Basically, I am trying to separate the presentation logic with the other business logics. The indent guide seems to be a `rich-table` only thing. For example, if we have a `--show-md`, it might not make much sense to have that tree (but it can be there if we want to on a separate presentation logic). 

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
