### PR TITLE
introduce tabview backend for tables

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -339,6 +339,8 @@ def show_experiments(
     include_params = _parse_filter_list(kwargs.pop("include_params", []))
     exclude_params = _parse_filter_list(kwargs.pop("exclude_params", []))
 
+    tabview = kwargs.get("tabview", False)
+
     metric_names, param_names = _collect_names(
         all_experiments,
         include_metrics=include_metrics,
@@ -390,7 +392,11 @@ def show_experiments(
     td.drop("is_baseline")
 
     merge_headers = ["Experiment", "queued", "ident_guide", "parent"]
-    td.column("Experiment")[:] = map(prepare_exp_id, td.as_dict(merge_headers))
+
+    if not tabview:
+        td.column("Experiment")[:] = map(
+            prepare_exp_id, td.as_dict(merge_headers)
+        )
     td.drop(*merge_headers[1:])
 
     td.render(
@@ -399,6 +405,7 @@ def show_experiments(
         rich_table=True,
         header_styles=styles,
         row_styles=row_styles,
+        tabview=tabview,
     )
 
 
@@ -450,6 +457,7 @@ class CmdExperimentsShow(CmdBase):
                 sort_order=self.args.sort_order,
                 precision=self.args.precision or DEFAULT_PRECISION,
                 pager=not self.args.no_pager,
+                tabview=True,
             )
         return 0
 

--- a/dvc/command/metrics.py
+++ b/dvc/command/metrics.py
@@ -50,6 +50,7 @@ class CmdMetricsShow(CmdMetricsBase):
                 all_tags=self.args.all_tags,
                 all_commits=self.args.all_commits,
                 precision=self.args.precision or DEFAULT_PRECISION,
+                tabview=True,
             )
 
         return 0

--- a/dvc/compare.py
+++ b/dvc/compare.py
@@ -291,6 +291,7 @@ def metrics_table(
 def show_metrics(
     metrics,
     markdown: bool = False,
+    tabview: bool = False,
     all_branches: bool = False,
     all_tags: bool = False,
     all_commits: bool = False,
@@ -303,4 +304,4 @@ def show_metrics(
         all_commits=all_commits,
         precision=precision,
     )
-    td.render(markdown=markdown)
+    td.render(markdown=markdown, tabview=tabview)

--- a/dvc/ui/__init__.py
+++ b/dvc/ui/__init__.py
@@ -158,10 +158,15 @@ class Console:
         header_styles: Sequence["Styles"] = None,
         row_styles: Sequence["Styles"] = None,
         borders: Union[bool, str] = False,
+        tabview: bool = False,
     ) -> None:
         from dvc.ui import table as t
 
         if not data and not markdown:
+            return
+
+        if tabview:
+            t.tabview_table(data, headers=headers)
             return
 
         if not markdown and rich_table:

--- a/dvc/ui/table.py
+++ b/dvc/ui/table.py
@@ -117,3 +117,13 @@ def rich_table(
     with console_width(table, console, SHOW_MAX_WIDTH):
         with console.pager(pager=DvcPager(), styles=True):
             console.print(table)
+
+
+def tabview_table(data: TableData, headers: Headers = None) -> None:
+    import tabview
+
+    d = list(data)
+    if headers:
+        d.insert(0, headers)
+
+    tabview.view(d)


### PR DESCRIPTION
* [ ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

0. Checkout to this PR.
1. `pip install tabview`.
2. `dvc exp show` or `dvc metrics show`.

Keeping it as a draft for now. It could also leave as an optional flag, but right now for demonstration, it's on by default.

I'd keep this as one of our backend for the table, but more than that, I am not sure. Let's explore this TUI area, I think as metrics flow sideways, it's the best way to provide a good user experience for metrics/diff show. 


We could further explore this with auto-reloading as experiment runs, sorting, aggregating, highlighting experiments run, and adding keyboard shortcuts and commands. But that's far in the future and iff we decide to go with this.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
