### PR TITLE
dependabot: use "maintenance" label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,12 @@ updates:
     package-ecosystem: "pip"
     schedule:
       interval: "daily"
+    labels:
+      - "maintenance"
 
   - directory: "/"
     package-ecosystem: "github-actions"
     schedule:
       interval: "daily"
+    labels:
+      - "maintenance"


### PR DESCRIPTION
Seems to fit better into our current labels and makes release drafter generate proper changelogs.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
