### PR TITLE
ui.table: accept dict for header styling

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -362,31 +362,9 @@ def show_experiments(
         kwargs.get("sort_order"),
         kwargs.get("precision"),
     )
-    styles = [
-        {"no_wrap": True, "header_style": "black on grey93"},
-        {"header_style": "black on grey93"},
-        *[
-            {
-                "justify": "right",
-                "header_style": "black on cornsilk1",
-                "no_wrap": True,
-                "collapse": idx != 0,
-            }
-            for idx, _ in enumerate(metric_headers)
-        ],
-        *[
-            {
-                "justify": "left",
-                "header_style": "black on light_cyan1",
-                "collapse": idx != 0,
-            }
-            for idx, _ in enumerate(param_headers)
-        ],
-    ]
 
     if no_timestamp:
         td.drop("Created")
-        styles.pop(1)
 
     baseline_styler = iffy(constantly({"style": "bold"}), default={})
     row_styles = lmap(baseline_styler, td.column("is_baseline"))
@@ -395,6 +373,25 @@ def show_experiments(
     merge_headers = ["Experiment", "queued", "ident_guide", "parent"]
     td.column("Experiment")[:] = map(prepare_exp_id, td.as_dict(merge_headers))
     td.drop(*merge_headers[1:])
+
+    headers = {"metrics": metric_headers, "params": param_headers}
+    styles = {
+        "Experiment": {"no_wrap": True, "header_style": "black on grey93"},
+        "Created": {"header_style": "black on grey93"},
+    }
+    header_bg_colors = {"metrics": "cornsilk1", "params": "light_cyan1"}
+    styles.update(
+        {
+            header: {
+                "justify": "left" if typ == "metrics" else "params",
+                "header_style": f"black on {header_bg_colors[typ]}",
+                "collapse": idx != 0,
+                "no_wrap": typ == "metrics",
+            }
+            for typ, hs in headers.items()
+            for idx, header in enumerate(hs)
+        }
+    )
 
     td.render(
         pager=pager,

--- a/dvc/ui/__init__.py
+++ b/dvc/ui/__init__.py
@@ -155,7 +155,7 @@ class Console:
         rich_table: bool = False,
         force: bool = True,
         pager: bool = False,
-        header_styles: Sequence["Styles"] = None,
+        header_styles: Union[Dict[str, "Styles"], Sequence["Styles"]] = None,
         row_styles: Sequence["Styles"] = None,
         borders: Union[bool, str] = False,
     ) -> None:

--- a/dvc/ui/table.py
+++ b/dvc/ui/table.py
@@ -1,6 +1,7 @@
+from collections import abc
 from contextlib import contextmanager
 from itertools import zip_longest
-from typing import TYPE_CHECKING, Iterator, Sequence, Union
+from typing import TYPE_CHECKING, Dict, Iterator, Sequence, Union
 
 from dvc.types import DictStrAny
 
@@ -81,7 +82,7 @@ def rich_table(
     data: TableData,
     headers: Headers = None,
     pager: bool = False,
-    header_styles: Sequence[Styles] = None,
+    header_styles: Union[Dict[str, Styles], Sequence[Styles]] = None,
     row_styles: Sequence[Styles] = None,
     borders: Union[bool, str] = False,
 ) -> None:
@@ -97,12 +98,16 @@ def rich_table(
     }
 
     table = Table(box=border_style[borders])
-    hs: Sequence[Styles] = header_styles or []
+
+    if isinstance(header_styles, abc.Sequence):
+        hs: Dict[str, Styles] = dict(zip(headers or [], header_styles))
+    else:
+        hs = header_styles or {}
+
+    for header in headers or []:
+        table.add_column(header, **hs.get(header, {}))
+
     rs: Sequence[Styles] = row_styles or []
-
-    for header, style in zip_longest(headers or [], hs):
-        table.add_column(header, **(style or {}))
-
     for row, style in zip_longest(data, rs):
         table.add_row(*row, **(style or {}))
 

--- a/tests/unit/ui/test_table.py
+++ b/tests/unit/ui/test_table.py
@@ -119,6 +119,7 @@ def test_rich_border(capsys: CaptureFixture[str]):
     "extra_opts",
     [
         {"header_styles": [{"style": Style(bold=True)}]},
+        {"header_styles": {"first": {"style": Style(bold=True)}}},
         {"row_styles": [{"style": Style(bold=True)}]},
     ],
 )


### PR DESCRIPTION
I found that it's harder to style a header with the list using the index,
they are to be applied by header name. Otherwise, we might end up using
a different header for coloring, or worse throw some error because the
header name and style don't match.
Row does have its property of index, so it makes sense there.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
