### PR TITLE
tests: mark test_stash_pop as xfail on linux

### DIFF
--- a/tests/func/test_scm.py
+++ b/tests/func/test_scm.py
@@ -1,7 +1,7 @@
 import os
+import sys
 
 import pytest
-from flaky.flaky_decorator import flaky
 from git import Repo
 
 from dvc.scm import SCM, Git, NoSCM
@@ -243,10 +243,22 @@ def test_git_stash_drop(tmp_dir, scm, ref):
     assert len(stash) == 1
 
 
-# libgit2 stash_save() is flaky on linux when run inside pytest, see:
-# https://github.com/iterative/dvc/pull/5286#issuecomment-792574294
-@flaky(max_runs=5, min_passes=1)
-@pytest.mark.parametrize("ref", [None, "refs/foo/stash"])
+reason = """libgit2 stash_save() is flaky on linux when run inside pytest
+    https://github.com/iterative/dvc/pull/5286#issuecomment-792574294"""
+
+
+@pytest.mark.parametrize(
+    "ref",
+    [
+        pytest.param(
+            None,
+            marks=pytest.mark.xfail(
+                sys.platform == "linux", raises=AssertionError, reason=reason,
+            ),
+        ),
+        "refs/foo/stash",
+    ],
+)
 def test_git_stash_pop(tmp_dir, scm, ref):
     from dvc.scm.git import Stash
 


### PR DESCRIPTION
I experimented increasing max_run number, even to a very high number: 1000. Even in that case, it failed 947 times. So I don't really see a reason to mark it as flaky. Anyway, we are treating it as xfail by keeping it failing in the CI, so this PR does not change anything for us. :)

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
