### PR TITLE
output: resolve path for path_isin checks

### DIFF
--- a/dvc/output/local.py
+++ b/dvc/output/local.py
@@ -73,9 +73,9 @@ class LocalOutput(BaseOutput):
         if os.path.isabs(self.def_path):
             return False
 
-        if self.repo and not self.path_info.isin(self.repo.root_dir):
-            return False
-        return True
+        return self.repo and path_isin(
+            os.path.realpath(self.path_info), self.repo.root_dir
+        )
 
     def dumpd(self):
         ret = super().dumpd()


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

We need to resolve path_info to compare with `path_isin` with the `Repo`'s root. This is because we use a resolved path for the repo's root whereas for the output, it is just abspath. We could change the output's path_info, but to really make a change, we'd need to fix all of Stage, Output and Dependencies. This seem to be easiest to me.

Motivation: Test failures in https://github.com/iterative/dvc/runs/2498067350#step:10:10248.
