### PR TITLE
setup: freeze aiobotocore/botocore/boto3 versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ install_requires = [
 
 gs = ["gcsfs==2021.4.0"]
 gdrive = ["pydrive2>=1.8.1", "six >= 1.13.0"]
-s3 = ["s3fs==2021.4.0", "boto3==1.16.52"]
+s3 = ["s3fs==2021.4.0", "aiobotocore[boto3]==1.3.0"]
 azure = ["adlfs==0.7.1", "azure-identity>=1.4.0", "knack"]
 # https://github.com/Legrandin/pycryptodome/issues/465
 oss = ["oss2==2.6.1", "pycryptodome>=3.10"]


### PR DESCRIPTION
Since `aiobotocore` already hosts an extra with it's own pinned boto package, there is no need for us to also maintain versioning for boto too. This might also create conflicts since aiobotocore's version might not be always pinned, and different aiobotocore versions might depend on different botocore versions (which @shcheklein reported). 