### PR TITLE
fs: get rid of fs_root

### DIFF
--- a/dvc/fs/git.py
+++ b/dvc/fs/git.py
@@ -13,25 +13,21 @@ class GitFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
 
     def __init__(self, root_dir, trie):
         super().__init__()
-        self._fs_root = root_dir
+        self._root = root_dir
         self.trie = trie
 
     @property
     def rev(self):
         return self.trie.rev
 
-    @property
-    def fs_root(self):
-        return self._fs_root
-
     def _get_key(self, path):
         if isinstance(path, str):
             if not os.path.isabs(path):
                 relparts = path.split(os.sep)
             else:
-                relparts = relpath(path, self.fs_root).split(os.sep)
+                relparts = relpath(path, self._root).split(os.sep)
         else:
-            relparts = path.relative_to(self.fs_root).parts
+            relparts = path.relative_to(self._root).parts
         if relparts == ["."]:
             return ()
         return tuple(relparts)
@@ -88,9 +84,9 @@ class GitFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
         key = self._get_key(top)
         for prefix, dirs, files in self.trie.walk(key, topdown=topdown):
             if prefix:
-                root = os.path.join(self.fs_root, os.sep.join(prefix))
+                root = os.path.join(self._root, os.sep.join(prefix))
             else:
-                root = self.fs_root
+                root = self._root
             yield root, dirs, files
 
     def isexec(self, path_info):

--- a/dvc/fs/local.py
+++ b/dvc/fs/local.py
@@ -27,7 +27,6 @@ class LocalFileSystem(BaseFileSystem):
         self.fs = LocalFS()
         url = config.get("url")
         self.path_info = self.PATH_CLS(url) if url else None
-        self.fs_root = url
 
     @staticmethod
     def open(path_info, mode="r", encoding=None, **kwargs):

--- a/dvc/ignore.py
+++ b/dvc/ignore.py
@@ -52,10 +52,10 @@ class DvcIgnorePatterns(DvcIgnore):
         ]
 
     @classmethod
-    def from_files(cls, ignore_file_path, fs):
+    def from_files(cls, ignore_file_path, fs, root):
         assert os.path.isabs(ignore_file_path)
         dirname = os.path.normpath(os.path.dirname(ignore_file_path))
-        ignore_file_rel_path = os.path.relpath(ignore_file_path, fs.fs_root)
+        ignore_file_rel_path = os.path.relpath(ignore_file_path, root)
         with fs.open(ignore_file_path, encoding="utf-8") as fobj:
             path_spec_lines = [
                 PatternInfo(
@@ -201,7 +201,7 @@ class DvcIgnoreFilter:
         ignore_file_path = os.path.join(dirname, DvcIgnore.DVCIGNORE_FILE)
         if not matches and self.fs.exists(ignore_file_path):
             new_pattern = DvcIgnorePatterns.from_files(
-                ignore_file_path, self.fs
+                ignore_file_path, self.fs, self.root_dir,
             )
             if old_pattern:
                 trie[dirname] = DvcIgnorePatterns(

--- a/tests/unit/test_ignore.py
+++ b/tests/unit/test_ignore.py
@@ -9,7 +9,9 @@ from dvc.ignore import DvcIgnorePatterns
 def mock_dvcignore(dvcignore_path, patterns):
     fs = MagicMock()
     with patch.object(fs, "open", mock_open(read_data="\n".join(patterns))):
-        ignore_patterns = DvcIgnorePatterns.from_files(dvcignore_path, fs)
+        ignore_patterns = DvcIgnorePatterns.from_files(
+            dvcignore_path, fs, None
+        )
 
     return ignore_patterns
 


### PR DESCRIPTION
`fs_root` no longer makes sense after decoupling `fs` and `dvcignore` and needs to go for fsspec migration.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
