### PR TITLE
Issue 4042 cmd suggestions

### DIFF
--- a/dvc/cli.py
+++ b/dvc/cli.py
@@ -136,8 +136,14 @@ class DvcParser(argparse.ArgumentParser):
                 0
             ].help
         )
+
+        parent_cmd = self.prog
+        command_text = (
+            "subcommand" if len(parent_cmd.split()) > 1 else "command"
+        )
         multi_line_message = [
-            f"dvc: '{self.last_invalid_command}' is not a valid dvc command. "
+            f"dvc: '{self.last_invalid_command}' is "
+            f"not a valid `{parent_cmd}` {command_text}. "
             f"{help_cmd}"
             "\t",
             "",

--- a/dvc/cli.py
+++ b/dvc/cli.py
@@ -115,7 +115,7 @@ class DvcParser(argparse.ArgumentParser):
         _find_parser(self, cmd_cls)
 
     def _check_and_log_suggestions(self, message):
-        cmd = regex_search(string=message, regex="'(.*?)'")
+        cmd = regex_search(string=message, regex="[?=invalid choice: ]'(.*?)'")
         if not cmd:
             return
 
@@ -124,7 +124,6 @@ class DvcParser(argparse.ArgumentParser):
             return
 
         multi_line_message = [
-            "",
             "",
             "The most similar commands are:",
             f"\t{' '.join(suggestions)}",

--- a/dvc/cli.py
+++ b/dvc/cli.py
@@ -142,7 +142,7 @@ class DvcParser(argparse.ArgumentParser):
         return args
 
     def _get_choices(self) -> list:
-        """ Gets the list of choices for dvc and its sub-commands"""
+        """Gets the list of choices for dvc and its sub-commands"""
         cmd_choices = [
             list(action.choices.keys())
             for action in self._actions

--- a/dvc/utils/string.py
+++ b/dvc/utils/string.py
@@ -1,0 +1,22 @@
+import re
+from difflib import get_close_matches
+
+
+def fuzzy_match(string: str, dictionary: list) -> list:
+    """ Performs fuzzy match of the string with the given dictionary
+    and returns the list of possible best "good enough" matches
+    """
+    if not string or not dictionary:
+        return []
+
+    return get_close_matches(
+        word=string, possibilities=dictionary, n=3, cutoff=0.6
+    )
+
+
+def regex_search(string: str, regex: str) -> str:
+    """ Search using regex on string and return the first match"""
+    match = re.search(regex, string)
+    if not match:
+        return ""
+    return match.group(1)

--- a/dvc/utils/string.py
+++ b/dvc/utils/string.py
@@ -3,7 +3,7 @@ from difflib import get_close_matches
 
 
 def fuzzy_match(string: str, dictionary: list) -> list:
-    """ Performs fuzzy match of the string with the given dictionary
+    """Performs fuzzy match of the string with the given dictionary
     and returns the list of possible best "good enough" matches
     """
     if not string or not dictionary:
@@ -15,7 +15,7 @@ def fuzzy_match(string: str, dictionary: list) -> list:
 
 
 def regex_search(string: str, regex: str) -> str:
-    """ Search using regex on string and return the first match"""
+    """Search using regex on string and return the first match"""
     match = re.search(regex, string)
     if not match:
         return ""

--- a/dvc/utils/string.py
+++ b/dvc/utils/string.py
@@ -1,4 +1,3 @@
-import re
 from difflib import get_close_matches
 
 
@@ -12,11 +11,3 @@ def fuzzy_match(string: str, dictionary: list) -> list:
     return get_close_matches(
         word=string, possibilities=dictionary, n=3, cutoff=0.6
     )
-
-
-def regex_search(string: str, regex: str) -> str:
-    """Search using regex on string and return the first match"""
-    match = re.search(regex, string)
-    if not match:
-        return ""
-    return match.group(1)

--- a/tests/func/test_cli.py
+++ b/tests/func/test_cli.py
@@ -261,3 +261,12 @@ def test_unknown_subcommand_help(capsys):
     captured = capsys.readouterr()
     help_output = captured.out
     assert output == help_output
+
+
+def test_cli_suggestions():
+    try:
+        _ = parse_args(["psh"])
+        _ = parse_args(["fileas"])
+        raise AssertionError
+    except DvcParserError:
+        assert True

--- a/tests/func/test_cli.py
+++ b/tests/func/test_cli.py
@@ -265,7 +265,7 @@ def test_unknown_subcommand_help(capsys):
     assert output == help_output
 
 
-def test_cli_suggestions():
+@pytest.mark.parametrize("cmd", ("psh", "fileas"))
+def test_cli_suggestions(cmd):
     with pytest.raises(DvcParserError):
-        _ = parse_args(["psh"])
-        _ = parse_args(["fileas"])
+        parse_args([cmd])

--- a/tests/func/test_cli.py
+++ b/tests/func/test_cli.py
@@ -1,5 +1,7 @@
 import os
 
+import pytest
+
 from dvc.cli import parse_args
 from dvc.command.add import CmdAdd
 from dvc.command.base import CmdBase
@@ -264,9 +266,6 @@ def test_unknown_subcommand_help(capsys):
 
 
 def test_cli_suggestions():
-    try:
+    with pytest.raises(DvcParserError):
         _ = parse_args(["psh"])
         _ = parse_args(["fileas"])
-        raise AssertionError
-    except DvcParserError:
-        assert True

--- a/tests/unit/utils/test_string.py
+++ b/tests/unit/utils/test_string.py
@@ -2,9 +2,6 @@ from dvc.utils import string
 
 
 def test_fuzzy_match():
-    assert string.fuzzy_match(
-        "param", ["parameter", "argument", "sample", "file"]
-    ) == ["parameter"]
 
     assert string.fuzzy_match(
         "param", ["parameter", "argument", "sample", "file", "params"]
@@ -16,3 +13,12 @@ def test_fuzzy_match():
         )
         == []
     )
+
+    assert (
+        string.fuzzy_match(
+            "", ["parameter", "argument", "sample", "file", "params"]
+        )
+        == []
+    )
+
+    assert string.fuzzy_match("help", []) == []

--- a/tests/unit/utils/test_string.py
+++ b/tests/unit/utils/test_string.py
@@ -1,0 +1,18 @@
+from dvc.utils import string
+
+
+def test_fuzzy_match():
+    assert string.fuzzy_match(
+        "param", ["parameter", "argument", "sample", "file"]
+    ) == ["parameter"]
+
+    assert string.fuzzy_match(
+        "param", ["parameter", "argument", "sample", "file", "params"]
+    ) == ["params", "parameter"]
+
+    assert (
+        string.fuzzy_match(
+            "help", ["parameter", "argument", "sample", "file", "params"]
+        )
+        == []
+    )


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

This PR is for the issue: https://github.com/iterative/dvc/issues/4042

I am using regex to figure which command needs to be picked for suggestions. I have tested the regex most of the error scenarios of the argparse library. It is able to handle all the errors during argparse. Sadly, this regex approach is not very future proof but it was getting very complex to figure out the affected command.

Sample outputs :
```
$ dvc commt
ERROR: argument COMMAND: invalid choice: 'commt' (choose from 'init', 'get', 'get-url', 'destroy', 'add', 'remove', 'move', 'unprotect', 'run', 'repro', 'pull', 'push', 'fetch', 'status', 'gc', 'import', 'import-url', 'config', 'checkout', 'remote', 'cache', 'metrics', 'params', 'install', 'root', 'list', 'freeze', 'unfreeze', 'dag', 'daemon', 'commit', 'completion', 'diff', 'version', 'doctor', 'update', 'git-hook', 'plots', 'stage', 'experiments', 'exp', 'check-ignore', 'live')

The most similar commands are:
        commit

usage: dvc [-q | -v] [-h] [-V] [--cd <path>] COMMAND ...

Data Version Control

optional arguments:
  -q, --quiet        Be quiet.
  -v, --verbose      Be verbose.
  -h, --help         Show this help message and exit.
  -V, --version      Show program's version.
  --cd <path>        Change to directory before executing.

Available Commands:
  COMMAND            Use `dvc COMMAND --help` for command-specific help.
    init             Initialize DVC in the current directory.
    get              Download file or directory tracked by DVC or by Git.
    get-url          Download or copy files from URL.
    destroy          Remove DVC files, local DVC config and data cache.
    add              Track data files or directories with DVC.
    remove           Remove stages from dvc.yaml and/or stop tracking files or directories.
    move             Rename or move a DVC controlled data file or a directory.
    unprotect        Unprotect tracked files or directories (when hardlinks or symlinks have been enabled with `dvc config cache.type`).
    run              Generate a dvc.yaml file from a command and execute the command.
    repro            Reproduce complete or partial pipelines by executing their stages.
    pull             Download tracked files or directories from remote storage.
    push             Upload tracked files or directories to remote storage.
    fetch            Download files or directories from remote storage to the cache.
    status           Show changed stages, compare local cache and a remote storage.
    gc               Garbage collect unused objects from cache or remote storage.
    import           Download file or directory tracked by DVC or by Git into the workspace, and track it.
    import-url       Download or copy file from URL and take it under DVC control.
    config           Get or set config options.
    checkout         Checkout data files from cache.
    remote           Set up and manage data remotes.
    cache            Manage cache settings.
    metrics          Commands to display and compare metrics.
    params           Commands to display params.
    install          Install DVC git hooks into the repository.
    root             Return the relative path to the root of the DVC project.
    list             List repository contents, including files and directories tracked by DVC and by Git.
    freeze           Freeze stages or .dvc files.
    unfreeze         Unfreeze stages or .dvc files.
    dag              Visualize DVC project DAG.
    commit           Record changes to files or directories tracked by DVC by storing the current versions in the cache.
    completion       Generate shell tab completion.
    diff             Show added, modified, or deleted data between commits in the DVC repository, or between a commit and the workspace.
    version (doctor)
                     Display the DVC version and system/environment information.
    update           Update data artifacts imported from other DVC repositories.
    plots            Commands to visualize and compare plot metrics in structured files (JSON, YAML, CSV, TSV).
    stage            Commands to list and create stages.
    experiments (exp)
                     Commands to run and compare experiments.
    check-ignore     Check whether files or directories are excluded due to `.dvcignore`.

```

Another sample:

```
$ dvc remote remoev
ERROR: argument cmd: invalid choice: 'remoev' (choose from 'add', 'default', 'modify', 'list', 'remove', 'rename')

The most similar commands are:
        remove rename

usage: dvc remote [-h] [-q | -v] {add,default,modify,list,remove,rename} ...

Set up and manage data remotes.
Documentation: <https://man.dvc.org/remote>

positional arguments:
  {add,default,modify,list,remove,rename}
                        Use `dvc remote CMD --help` for command-specific help.
    add                 Add a new data remote.
    default             Set/unset the default data remote.
    modify              Modify the configuration of a data remote.
    list                List all available data remotes.
    remove              Remove a data remote.
    rename              Rename a DVC remote

optional arguments:
  -h, --help            show this help message and exit
  -q, --quiet           Be quiet.
  -v, --verbose         Be verbose.

```

I havent added the test cases for the string library yet. Let me know if something like this will be required in the future, then I will implement test cases as well.