### PR TITLE
fix empty string parsing for the command

### DIFF
--- a/dvc/command/stage.py
+++ b/dvc/command/stage.py
@@ -113,8 +113,11 @@ def parse_cmd(commands: List[str]) -> str:
     """
 
     def quote_argument(arg: str):
-        should_quote = " " in arg and '"' not in arg
-        return f'"{arg}"' if should_quote else arg
+        if not arg:
+            return '""'
+        if " " in arg and '"' not in arg:
+            return f'"{arg}"'
+        return arg
 
     if len(commands) < 2:
         return " ".join(commands)

--- a/tests/unit/command/test_stage.py
+++ b/tests/unit/command/test_stage.py
@@ -10,6 +10,7 @@ from dvc.command.stage import CmdStageAdd
         (["echo", "foo", "bar"], "echo foo bar"),
         (["echo", '"foo bar"'], 'echo "foo bar"'),
         (["echo", "foo bar"], 'echo "foo bar"'),
+        (["cmd", "--flag", ""], 'cmd --flag ""'),
     ],
 )
 def test_stage_add(mocker, dvc, command, parsed_command):


### PR DESCRIPTION
We get the `cmd --flag ""` as `["cmd", "--flag", ""]`, so we have to parse the empty string back to the. double quotes.


Fixes #6072
