### PR TITLE
pylint: don't use astroid 2.5.7

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -32,6 +32,7 @@ jaraco.windows==5.5.0
 
 # pylint requirements
 pylint==2.8.2
+astroid==2.5.6
 # we use this to suppress pytest-related false positives in our tests.
 pylint-pytest==1.0.3
 # we use this to suppress some messages in tests, eg: foo/bar naming,

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -32,7 +32,8 @@ jaraco.windows==5.5.0
 
 # pylint requirements
 pylint==2.8.2
-astroid==2.5.6
+# suppress pylint false positives
+astroid<2.5.7
 # we use this to suppress pytest-related false positives in our tests.
 pylint-pytest==1.0.3
 # we use this to suppress some messages in tests, eg: foo/bar naming,


### PR DESCRIPTION
2.5.7 has caused sudden pylint false-positives:
```
************* Module tests.remotes.gdrive
tests/remotes/gdrive.py:40:11: E1120: No value for argument 'tries' in function call (no-value-for-parameter)
************* Module dvc.stage.serialize
dvc/stage/serialize.py:38:1: E1120: No value for argument 'func' in function call (no-value-for-parameter)
************* Module dvc.logger
dvc/logger.py:192:33: E1101: Instance of 'RootLogger' has no 'loggerDict' member (no-member)
************* Module dvc.fs.http
dvc/fs/http.py:19:1: E1120: No value for argument 'ctx' in function call (no-value-for-parameter)
************* Module dvc.fs.gdrive
dvc/fs/gdrive.py:66:11: E1120: No value for argument 'tries' in function call (no-value-for-parameter)
dvc/fs/gdrive.py:459:5: E1120: No value for argument 'ctx' in function call (no-value-for-parameter)

-----------------------------------
Your code has been rated at 9.98/10

Registered custom plugin. Some checks will be disabled for tests.
************* Module dvc.path_info
dvc/path_info.py:204:4: E0202: An attribute defined in dvc.path_info line 152 hides this method (method-hidden)
************* Module tests.unit.command.test_repro
tests/unit/command/test_repro.py:26:4: E1101: Function 'reproduce' has no 'assert_called_with' member (no-member)
tests/unit/command/test_repro.py:35:4: E1101: Function 'reproduce' has no 'assert_called_with' member (no-member)
************* Module dvc.fs.pool
dvc/fs/pool.py:21:1: E1120: No value for argument 'ctx' in function call (no-value-for-parameter)
************* Module dvc.fs.repo
dvc/fs/repo.py:89:5: E1120: No value for argument 'ctx' in function call (no-value-for-parameter)
************* Module dvc.external_repo
dvc/external_repo.py:94:1: E1120: No value for argument 'ctx' in function call (no-value-for-parameter)
dvc/external_repo.py:166:1: E1120: No value for argument 'ctx' in function call (no-value-for-parameter)
dvc/external_repo.py:251:19: E1120: No value for argument 'tries' in function call (no-value-for-parameter)
************* Module dvc.fs.ssh
dvc/fs/ssh/__init__.py:22:1: E1120: No value for argument 'ctx' in function call (no-value-for-parameter)
************* Module tests.unit.command.test_experiments
tests/unit/command/test_experiments.py:110:4: E1101: Method 'run' has no 'assert_called_with' member (no-member)
```

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
