### PR TITLE
fix errors raised by pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -313,6 +313,7 @@ missing-member-hint-distance=1
 # showing a hint for a missing member.
 missing-member-max-choices=1
 
+signature-mutators=funcy.decorators.decorator,
 
 [VARIABLES]
 

--- a/dvc/checkout.py
+++ b/dvc/checkout.py
@@ -2,7 +2,7 @@ import logging
 
 from shortuuid import uuid
 
-import dvc.prompt as prompt
+from dvc import prompt
 from dvc.exceptions import (
     CacheLinkError,
     CheckoutError,

--- a/dvc/command/destroy.py
+++ b/dvc/command/destroy.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 
-import dvc.prompt as prompt
+from dvc import prompt
 from dvc.command.base import CmdBase, append_doc_link
 
 logger = logging.getLogger(__name__)

--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Dict, Iterable, Optional
 
 from funcy import lmap
 
-import dvc.prompt as prompt
+from dvc import prompt
 from dvc.command import completion
 from dvc.command.base import CmdBase, append_doc_link, fix_subparsers
 from dvc.command.metrics import DEFAULT_PRECISION

--- a/dvc/command/gc.py
+++ b/dvc/command/gc.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 import os
 
-import dvc.prompt as prompt
+from dvc import prompt
 from dvc.command.base import CmdBase, append_doc_link
 
 logger = logging.getLogger(__name__)

--- a/dvc/fs/http.py
+++ b/dvc/fs/http.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from funcy import cached_property, memoize, wrap_prop, wrap_with
 
-import dvc.prompt as prompt
+from dvc import prompt
 from dvc.exceptions import DvcException, HTTPError
 from dvc.path_info import HTTPURLInfo
 from dvc.progress import Tqdm

--- a/dvc/fs/ssh/__init__.py
+++ b/dvc/fs/ssh/__init__.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 
 from funcy import first, memoize, silent, wrap_with
 
-import dvc.prompt as prompt
+from dvc import prompt
 from dvc.hash_info import HashInfo
 from dvc.scheme import Schemes
 

--- a/dvc/logger.py
+++ b/dvc/logger.py
@@ -188,8 +188,8 @@ def _stack_trace(exc_info):
 
 def disable_other_loggers():
     logging.captureWarnings(True)
-    root = logging.root
-    for (logger_name, logger) in root.manager.loggerDict.items():
+    loggerDict = logging.root.manager.loggerDict  # pylint: disable=no-member
+    for logger_name, logger in loggerDict.items():
         if logger_name != "dvc" and not logger_name.startswith("dvc."):
             logger.disabled = True
 

--- a/dvc/output.py
+++ b/dvc/output.py
@@ -8,8 +8,7 @@ from urllib.parse import urlparse
 from funcy import collecting, project
 from voluptuous import And, Any, Coerce, Length, Lower, Required, SetTo
 
-import dvc.objects as objects
-import dvc.prompt as prompt
+from dvc import objects, prompt
 from dvc.checkout import checkout
 from dvc.exceptions import (
     CheckoutError,

--- a/dvc/path_info.py
+++ b/dvc/path_info.py
@@ -201,7 +201,7 @@ class URLInfo(_BasePath):
         return self._spath
 
     @cached_property
-    def _path(self):
+    def _path(self):  # false-positive, pylint: disable=method-hidden
         return _URLPathInfo(self._spath)
 
     @property

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -46,7 +46,7 @@ class Tqdm(tqdm):
         desc=None,
         leave=False,
         bar_format=None,
-        bytes=False,  # pylint: disable=W0622
+        bytes=False,  # pylint: disable=redefined-builtin
         file=None,
         total=None,
         postfix=None,
@@ -114,7 +114,7 @@ class Tqdm(tqdm):
 
     def update_to(self, current, total=None):
         if total:
-            self.total = total  # pylint: disable=W0613,W0201
+            self.total = total
         self.update(current - self.n)
 
     def wrap_fn(self, fn, callback=None):

--- a/dvc/repo/get_url.py
+++ b/dvc/repo/get_url.py
@@ -2,8 +2,7 @@ import os
 
 
 def get_url(url, out=None, jobs=None):
-    import dvc.dependency as dependency
-    import dvc.output as output
+    from dvc import dependency, output
     from dvc.utils import resolve_output
 
     out = resolve_output(url, out)

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Dict, Optional
 
 from funcy import cached_property, project
 
-import dvc.prompt as prompt
+from dvc import prompt
 from dvc.exceptions import (
     CacheLinkError,
     CheckoutError,

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -107,6 +107,7 @@ def test_experiments_run(dvc, scm, mocker):
     mocker.patch.object(cmd.repo, "reproduce")
     mocker.patch.object(cmd.repo.experiments, "run")
     cmd.run()
+    # pylint: disable=no-member
     cmd.repo.experiments.run.assert_called_with(**default_arguments)
 
 

--- a/tests/unit/command/test_repro.py
+++ b/tests/unit/command/test_repro.py
@@ -23,6 +23,7 @@ def test_default_arguments(dvc, mocker):
     cmd = CmdRepro(parse_args(["repro"]))
     mocker.patch.object(cmd.repo, "reproduce")
     cmd.run()
+    # pylint: disable=no-member
     cmd.repo.reproduce.assert_called_with(**default_arguments)
 
 
@@ -32,4 +33,5 @@ def test_downstream(dvc, mocker):
     cmd.run()
     arguments = default_arguments.copy()
     arguments.update({"downstream": True})
+    # pylint: disable=no-member
     cmd.repo.reproduce.assert_called_with(**arguments)

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 
 import mock
 
-import dvc.daemon as daemon
+from dvc import daemon
 
 
 class TestDaemon(TestCase):


### PR DESCRIPTION
`astroid==2.5.7` has improved inference and was throwing
errors that were false negatives before. Fixing these
and ignoring some.

Also opened https://github.com/PyCQA/pylint/issues/4527 for discussion on keeping `astroid` pinned in the `pylint` to avoid surprises.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Closes #6080.