### PR TITLE
pin networkx to 2.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ install_requires = [
     "flufl.lock>=3.2,<4",
     "win-unicode-console>=0.5; sys_platform == 'win32'",
     "pywin32>=225; sys_platform == 'win32'",
-    "networkx>=2.1",
+    "networkx~=2.5",
     "psutil>=5.8.0",
     "pydot>=1.2.4",
     "speedcopy>=2.0.1; python_version < '3.8' and sys_platform == 'win32'",


### PR DESCRIPTION
2.1 is more than 3 years old, whereas the latest version 2.5 was released in Aug, 2020.
I am a bit hesitant to add an upper bound here as networkx seems to be requiring a lot of dependencies from the next version onwards.

2.1-2.3 versions were probably not compatible with Python3.9. 

Discord context: https://discord.com/channels/485586884165107732/485596304961962003/848943242481369088

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
