### PR TITLE
fs: temporarily disable prefix-based search for fsspec-implementations

### DIFF
--- a/dvc/fs/fsspec_wrapper.py
+++ b/dvc/fs/fsspec_wrapper.py
@@ -11,6 +11,8 @@ from .base import BaseFileSystem
 
 # pylint: disable=no-member
 class FSSpecWrapper(BaseFileSystem):
+    TRAVERSE_PREFIX_LEN = 2
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.fs_args = {"skip_instance_cache": True}

--- a/dvc/objects/db/base.py
+++ b/dvc/objects/db/base.py
@@ -399,8 +399,15 @@ class ObjectDB:
         # hashes_exist() (see ssh, local)
         assert self.fs.TRAVERSE_PREFIX_LEN >= 2
 
+        # During the tests, for ensuring that the traverse behavior
+        # is working we turn on this option. It will ensure the
+        # list_hashes_traverse() is called.
+        always_traverse = getattr(self.fs, "_ALWAYS_TRAVERSE", False)
+
         hashes = set(hashes)
-        if len(hashes) == 1 or not self.fs.CAN_TRAVERSE:
+        if (
+            len(hashes) == 1 or not self.fs.CAN_TRAVERSE
+        ) and not always_traverse:
             remote_hashes = self.list_hashes_exists(hashes, jobs, name)
             return remote_hashes
 
@@ -418,7 +425,7 @@ class ObjectDB:
             )
         else:
             traverse_weight = traverse_pages
-        if len(hashes) < traverse_weight:
+        if len(hashes) < traverse_weight and not always_traverse:
             logger.debug(
                 "Large remote ('{}' hashes < '{}' traverse weight), "
                 "using object_exists for remaining hashes".format(


### PR DESCRIPTION
This is a temporary fix for #6089. It disables the partial prefix (`00/0`) search optimization entirely for all fsspec implementations and does it in the regular way (with only listing the full path of `00/`). This API is not actually supported to be optimized on the fsspec side so we will wait for all the clouds we support (s3, azure, google cloud) and then turn on the optimization (In the `ObjectFSWrapper`) this time with just fixing the custom `find()` method in the subclass. 