### PR TITLE
Allow user to specify different state and index tmp dir locations, re: #4420

### DIFF
--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -221,8 +221,12 @@ SCHEMA = {
         )
     },
     "state": {
+        "dir": str,
         "row_limit": All(Coerce(int), Range(1)),  # obsoleted
         "row_cleanup_quota": All(Coerce(int), Range(0, 100)),  # obsoleted
+    },
+    "index": {
+        "dir": str,
     },
     # section for experimental features
     "feature": {

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -119,6 +119,33 @@ class Repo:
 
         return root_dir, dvc_dir, tmp_dir
 
+    def _get_subsystem_tmp_dir(
+        self, subsystem, root_dir, tmp_dir, config: dict
+    ):
+        # NOTE: by default, store remote indexes and state's `links` and
+        # `md5s` caches in the repository itself to avoid any possible state
+        # corruption in 'shared cache dir' scenario, but allow user to
+        # override this through config when, say, the repository is located
+        # on a mounted volume — see
+        # https://github.com/iterative/dvc/issues/4420
+        base_state_dir = config.get(subsystem, {}).get("dir", None)
+        if not base_state_dir:
+            return tmp_dir
+
+        import hashlib
+
+        from dvc.utils.fs import makedirs
+
+        root_dir_hash = hashlib.sha224(root_dir.encode("utf-8")).hexdigest()
+        state_tmp_dir = os.path.join(
+            base_state_dir,
+            self.DVC_DIR,
+            f"{os.path.basename(root_dir)}-{root_dir_hash[0:7]}",
+        )
+
+        makedirs(state_tmp_dir, exist_ok=True)
+        return state_tmp_dir
+
     def __init__(
         self,
         root_dir=None,
@@ -181,10 +208,10 @@ class Repo:
                 friendly=True,
             )
 
-            # NOTE: storing state and link_state in the repository itself to
-            # avoid any possible state corruption in 'shared cache dir'
-            # scenario.
-            self.state = State(self.root_dir, self.tmp_dir, self.dvcignore)
+            state_tmp_dir = self._get_subsystem_tmp_dir(
+                "state", self.root_dir, self.tmp_dir, self.config
+            )
+            self.state = State(self.root_dir, state_tmp_dir, self.dvcignore)
             self.odb = ODBManager(self)
 
             self.stage_cache = StageCache(self)
@@ -441,6 +468,12 @@ class Repo:
         from dvc.fs.repo import RepoFileSystem
 
         return RepoFileSystem(self, subrepos=self.subrepos, **self._fs_conf)
+
+    @cached_property
+    def index_tmp_dir(self):
+        return self._get_subsystem_tmp_dir(
+            "index", self.root_dir, self.tmp_dir, self.config
+        )
 
     @contextmanager
     def open_by_relpath(self, path, remote=None, mode="r", encoding=None):

--- a/tests/func/test_state.py
+++ b/tests/func/test_state.py
@@ -1,7 +1,9 @@
 import os
+import re
 
 from dvc.hash_info import HashInfo
 from dvc.path_info import PathInfo
+from dvc.repo import Repo
 from dvc.state import State
 from dvc.utils import file_md5
 
@@ -76,4 +78,18 @@ def test_get_unused_links(tmp_dir, dvc):
             )
         )
         == {"bar"}
+    )
+
+
+def test_state_dir_config(dvc):
+    assert dvc.state.tmp_dir == dvc.tmp_dir
+
+    index_dir = "/tmp"
+    repo = Repo(config={"state": {"dir": index_dir}})
+    assert os.path.dirname(repo.state.tmp_dir) == os.path.join(
+        index_dir, ".dvc"
+    )
+    assert re.match(
+        r"^test_state_dir_config0-([0-9a-f]+)$",
+        os.path.basename(repo.state.tmp_dir),
     )

--- a/tests/unit/remote/test_index.py
+++ b/tests/unit/remote/test_index.py
@@ -8,7 +8,7 @@ from dvc.objects.db.index import ObjectDBIndex
 
 @pytest.fixture
 def index(dvc):
-    index_ = ObjectDBIndex(dvc.tmp_dir, "foo")
+    index_ = ObjectDBIndex(dvc.index_tmp_dir, "foo")
     yield index_
 
 

--- a/tests/unit/remote/test_index.py
+++ b/tests/unit/remote/test_index.py
@@ -8,7 +8,7 @@ from dvc.objects.db.index import ObjectDBIndex
 
 @pytest.fixture
 def index(dvc):
-    index_ = ObjectDBIndex(dvc.index_tmp_dir, "foo")
+    index_ = ObjectDBIndex(dvc.index_db_dir, "foo")
     yield index_
 
 

--- a/tests/unit/remote/test_remote.py
+++ b/tests/unit/remote/test_remote.py
@@ -1,8 +1,11 @@
+import os
+
 import pytest
 
 from dvc.fs import get_cloud_fs
 from dvc.fs.gs import GSFileSystem
 from dvc.fs.s3 import S3FileSystem
+from dvc.remote import get_remote
 
 
 def test_remote_with_hash_jobs(dvc):
@@ -55,3 +58,15 @@ def test_makedirs_not_create_for_top_level_path(fs_cls, dvc, mocker):
 
     fs.makedirs(fs.PATH_CLS(url))
     assert not mocked_client.called
+
+
+def test_remote_index_dir_config(dvc):
+    index_dir = "/tmp"
+    with dvc.config.edit() as conf:
+        conf["index"]["dir"] = index_dir
+        conf["remote"]["s3"] = {"url": "s3://bucket/name"}
+
+    dvc.root_dir = "/usr/local/test_repo"
+    assert os.path.dirname(
+        get_remote(dvc, name="s3").index.path
+    ) == os.path.join(index_dir, ".dvc", "test_repo-a473718", "index")


### PR DESCRIPTION
This PR introduces two new config options, `state.dir` and `index.dir`, which allow user to override state's cache and remote's index files location, correspondingly. The primary use case is to be able to move SQLite-based caches/indexes outside of the repository when the repository is located on a mounted volume (#4420), e.g. to be able to say something like

```sh
dvc config state.dir /tmp
dvc config index.dir /tmp
```

I debated the option names as well as whether this should be two or just one option, and am not fully sold on what I ended up with, so please treat this PR as it currently stands as a conversation starter. I'm willing to do the legwork of renaming/consolidating the config options, adding tests, and tweaking the docs as needed, or you can take over from here :)

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
