### PR TITLE
fsspec: implement makedirs() & create dirs on upload/copy

### DIFF
--- a/dvc/fs/base.py
+++ b/dvc/fs/base.py
@@ -185,7 +185,7 @@ class BaseFileSystem:
     def remove(self, path_info):
         raise RemoteActionNotImplemented("remove", self.scheme)
 
-    def makedirs(self, path_info):
+    def makedirs(self, path_info, **kwargs):
         """Optional: Implement only if the remote needs to create
         directories before copying/linking/moving data
         """

--- a/dvc/fs/webdav.py
+++ b/dvc/fs/webdav.py
@@ -72,10 +72,6 @@ class WebDAVFileSystem(FSSpecWrapper):  # pylint:disable=abstract-method
         # TODO: retry upload on failure
         return self.fs.client.upload_fileobj(fobj, rpath)
 
-    def makedirs(self, path_info):
-        path = self.translate_path_info(path_info)
-        return self.fs.makedirs(path, exist_ok=True)
-
     @lru_cache(512)
     def translate_path_info(self, path):
         if isinstance(path, self.PATH_CLS):

--- a/tests/func/test_fs.py
+++ b/tests/func/test_fs.py
@@ -324,7 +324,7 @@ def test_fs_ls(dvc, cloud):
         pytest.lazy_fixture("gdrive"),
     ],
 )
-def test_fs_find_recursive(dvc, cloud):
+def test_fs_find(dvc, cloud):
     cloud.gen({"data": {"foo": "foo", "bar": {"baz": "baz"}, "quux": "quux"}})
     cls, config, path_info = get_cloud_fs(dvc, **cloud.config)
     fs = cls(**config)


### PR DESCRIPTION
This patch implements the missing `makedirs()` method to the `FSSpecWrapper` and calls it in a bunch of places (upload_fobj/copy). Tests are awaiting dask/adlfs/pull/237