### PR TITLE
http/webdav: support specifying custom certs in `ssl_verify`

### DIFF
--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -93,7 +93,7 @@ HTTP_COMMON = {
     "user": str,
     "password": str,
     "ask_password": Bool,
-    "ssl_verify": Bool,
+    "ssl_verify": Any(Bool, str),
     "method": str,
 }
 WEBDAV_COMMON = {
@@ -104,6 +104,7 @@ WEBDAV_COMMON = {
     "cert_path": str,
     "key_path": str,
     "timeout": Coerce(int),
+    "ssl_verify": Any(Bool, str),
 }
 
 SCHEMA = {

--- a/dvc/fs/webdav.py
+++ b/dvc/fs/webdav.py
@@ -31,7 +31,10 @@ class WebDAVFileSystem(FSSpecWrapper):  # pylint:disable=abstract-method
         key_path = config.get("key_path", None)
         cert = cert_path if not key_path else (cert_path, key_path)
 
-        self.fs_args.update({"base_url": config["url"], "cert": cert})
+        ssl_verify = config.get("ssl_verify", True)
+        self.fs_args.update(
+            {"base_url": config["url"], "cert": cert, "verify": ssl_verify}
+        )
         self.prefix = config.get("prefix", "")
 
     @staticmethod

--- a/tests/unit/remote/test_http.py
+++ b/tests/unit/remote/test_http.py
@@ -106,6 +106,18 @@ def test_ssl_verify_disable(dvc):
     assert fs._session.verify is False
 
 
+def test_ssl_verify_custom_cert(dvc):
+    config = {
+        "url": "http://example.com/",
+        "path_info": "file.html",
+        "ssl_verify": "/path/to/custom/cabundle.pem",
+    }
+
+    fs = HTTPFileSystem(**config)
+
+    assert fs._session.verify == "/path/to/custom/cabundle.pem"
+
+
 def test_http_method(dvc):
     from requests.auth import HTTPBasicAuth
 

--- a/tests/unit/remote/test_webdav.py
+++ b/tests/unit/remote/test_webdav.py
@@ -16,3 +16,14 @@ def test_password(dvc):
     config = {"url": url, "user": user, "password": password}
     fs = WebDAVFileSystem(**config)
     assert fs.password == password
+
+
+def test_ssl_verify_custom_cert(dvc):
+    config = {
+        "url": "http://example.com/",
+        "path_info": "file.html",
+        "ssl_verify": "/path/to/custom/cabundle.pem",
+    }
+
+    fs = WebDAVFileSystem(**config)
+    assert fs.fs_args["verify"] == "/path/to/custom/cabundle.pem"


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.
https://github.com/iterative/dvc.org/pull/2547

Similar to `ssl_verify` done in https://github.com/iterative/dvc/pull/6018 for s3.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
