### PR TITLE
s3, gs, azure: re-enable prefix-based search optimization

### DIFF
--- a/dvc/fs/base.py
+++ b/dvc/fs/base.py
@@ -170,7 +170,7 @@ class BaseFileSystem:
     def ls(self, path_info, detail=False):
         raise RemoteActionNotImplemented("ls", self.scheme)
 
-    def find(self, path_info, detail=False):
+    def find(self, path_info, detail=False, prefix=None):
         raise RemoteActionNotImplemented("find", self.scheme)
 
     def is_empty(self, path_info):

--- a/dvc/fs/gdrive.py
+++ b/dvc/fs/gdrive.py
@@ -538,7 +538,7 @@ class GDriveFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
         query = f"({query}) and trashed=false"
         return self._gdrive_list(query)
 
-    def find(self, path_info, detail=False):
+    def find(self, path_info, detail=False, prefix=None):
         root_path = path_info.path
         seen_paths = set()
 


### PR DESCRIPTION
It was turned off due to not all providers supporting `find(<something>, prefix=<something>)` but now it is safe to turn that back on. Resolves #6089. 