### PR TITLE
exp show: display running/queued state for experiments

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -151,9 +151,9 @@ def _collect_rows(
     new_checkpoint = True
     for i, (rev, exp) in enumerate(experiments.items()):
         if exp.get("running"):
-            state = "Run"
+            state = "Running"
         elif exp.get("queued"):
-            state = "Queue"
+            state = "Queued"
         else:
             state = "-"
         is_baseline = rev == "baseline"

--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -97,16 +97,9 @@ def _update_names(names, items):
 def _collect_names(all_experiments, **kwargs):
     metric_names = defaultdict(dict)
     param_names = defaultdict(dict)
-    include_state = False
-    include_executor = False
 
     for _, experiments in all_experiments.items():
         for exp in experiments.values():
-            if exp.get("running"):
-                include_state = True
-                include_executor = True
-            elif exp.get("queued"):
-                include_state = True
             _update_names(metric_names, exp.get("metrics", {}).items())
             _update_names(param_names, exp.get("params", {}).items())
     metric_names = _filter_names(
@@ -122,7 +115,7 @@ def _collect_names(all_experiments, **kwargs):
         kwargs.get("exclude_params"),
     )
 
-    return metric_names, param_names, include_state, include_executor
+    return metric_names, param_names
 
 
 experiment_types = {
@@ -143,8 +136,6 @@ def _collect_rows(
     precision=DEFAULT_PRECISION,
     sort_by=None,
     sort_order=None,
-    include_state=True,
-    include_executor=True,
 ):
     from dvc.scm.git import Git
 
@@ -164,8 +155,8 @@ def _collect_rows(
         elif exp.get("queued"):
             state = "Queued"
         else:
-            state = None
-        executor = exp.get("executor")
+            state = FILL_VALUE
+        executor = exp.get("executor", FILL_VALUE)
         is_baseline = rev == "baseline"
 
         if is_baseline:
@@ -207,11 +198,9 @@ def _collect_rows(
             typ,
             _format_time(exp.get("timestamp")),
             parent,
+            state,
+            executor,
         ]
-        if include_state:
-            row.append(state)
-        if include_executor:
-            row.append(executor)
         _extend_row(
             row, metric_names, exp.get("metrics", {}).items(), precision
         )
@@ -317,18 +306,20 @@ def experiments_table(
     sort_by=None,
     sort_order=None,
     precision=DEFAULT_PRECISION,
-    include_state=True,
-    include_executor=True,
 ) -> "TabularData":
     from funcy import lconcat
 
     from dvc.compare import TabularData
 
-    headers = ["Experiment", "rev", "typ", "Created", "parent"]
-    if include_state:
-        headers.append("State")
-    if include_executor:
-        headers.append("Executor")
+    headers = [
+        "Experiment",
+        "rev",
+        "typ",
+        "Created",
+        "parent",
+        "State",
+        "Executor",
+    ]
     td = TabularData(
         lconcat(headers, metric_headers, param_headers), fill_value=FILL_VALUE
     )
@@ -341,8 +332,6 @@ def experiments_table(
             sort_by=sort_by,
             sort_order=sort_order,
             precision=precision,
-            include_state=include_state,
-            include_executor=include_executor,
         )
         td.extend(rows)
 
@@ -382,12 +371,7 @@ def show_experiments(
     include_params = _parse_filter_list(kwargs.pop("include_params", []))
     exclude_params = _parse_filter_list(kwargs.pop("exclude_params", []))
 
-    (
-        metric_names,
-        param_names,
-        include_state,
-        include_executor,
-    ) = _collect_names(
+    metric_names, param_names = _collect_names(
         all_experiments,
         include_metrics=include_metrics,
         exclude_metrics=exclude_metrics,
@@ -406,12 +390,14 @@ def show_experiments(
         kwargs.get("sort_by"),
         kwargs.get("sort_order"),
         kwargs.get("precision"),
-        include_state=include_state,
-        include_executor=include_executor,
     )
 
     if no_timestamp:
         td.drop("Created")
+
+    for col in ("State", "Executor"):
+        if td.is_empty(col):
+            td.drop(col)
 
     row_styles = lmap(baseline_styler, td.column("typ"))
 

--- a/dvc/compare.py
+++ b/dvc/compare.py
@@ -134,6 +134,10 @@ class TabularData(MutableSequence[Sequence["CellT"]]):
         self.drop(*(set(self._keys) - set(col_names)))
         self._keys = list(col_names)
 
+    def is_empty(self, col_name: str) -> bool:
+        col = self.column(col_name)
+        return not any(item != self._fill_value for item in col)
+
     def to_csv(self) -> str:
         import csv
         from io import StringIO

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -897,30 +897,33 @@ class Experiments:
 
             try:
                 info = ExecutorInfo.from_dict(load_yaml(pidfile))
-                result[rev] = info.to_dict()
                 if rev == "workspace":
                     # If we are appending to a checkpoint branch in a workspace
-                    # run, show both workspace and the latest checkpoint as
-                    # running.
+                    # run, show the latest checkpoint as running.
                     last_rev = self.scm.get_ref(EXEC_BRANCH)
-                    result[rev]["last"] = last_rev
                     if last_rev:
                         result[last_rev] = info.to_dict()
-                elif info.git_url:
+                    else:
+                        result[rev] = info.to_dict()
+                else:
+                    result[rev] = info.to_dict()
+                    if info.git_url:
 
-                    def on_diverged(_ref: str, _checkpoint: bool):
-                        return False
+                        def on_diverged(_ref: str, _checkpoint: bool):
+                            return False
 
-                    for ref in BaseExecutor.fetch_exps(
-                        self.scm,
-                        info.git_url,
-                        on_diverged=on_diverged,
-                    ):
-                        logger.debug("Updated running experiment '%s'.", ref)
-                        last_rev = self.scm.get_ref(ref)
-                        result[rev]["last"] = last_rev
-                        if last_rev:
-                            result[last_rev] = info.to_dict()
+                        for ref in BaseExecutor.fetch_exps(
+                            self.scm,
+                            info.git_url,
+                            on_diverged=on_diverged,
+                        ):
+                            logger.debug(
+                                "Updated running experiment '%s'.", ref
+                            )
+                            last_rev = self.scm.get_ref(ref)
+                            result[rev]["last"] = last_rev
+                            if last_rev:
+                                result[last_rev] = info.to_dict()
             except OSError:
                 pass
         return result

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -901,8 +901,10 @@ class Experiments:
                     # If we are appending to a checkpoint branch in a workspace
                     # run, show both workspace and the latest checkpoint as
                     # running.
-                    result[rev] = info
-                    rev = self.scm.get_ref(EXEC_BRANCH) or "workspace"
+                    branch_rev = self.scm.get_ref(EXEC_BRANCH)
+                    if branch_rev:
+                        result["workspace"] = info
+                        rev = branch_rev
                 elif info.git_url:
 
                     def on_diverged(_ref: str, _checkpoint: bool):

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -735,7 +735,10 @@ class Experiments:
             raise ExperimentExistsError(ref_info.name)
 
         for ref in executor.fetch_exps(
-            self.scm, force=exec_result.force, on_diverged=on_diverged
+            self.scm,
+            executor.git_url,
+            force=exec_result.force,
+            on_diverged=on_diverged,
         ):
             exp_rev = self.scm.get_ref(ref)
             if exp_rev:

--- a/dvc/repo/experiments/executor/base.py
+++ b/dvc/repo/experiments/executor/base.py
@@ -58,10 +58,12 @@ class ExecutorInfo:
     PARAM_PID = "pid"
     PARAM_GIT_URL = "git"
     PARAM_BASELINE_REV = "baseline"
+    PARAM_LOCATION = "location"
 
     pid: Optional[int]
     git_url: Optional[str]
     baseline_rev: Optional[str]
+    location: Optional[str]
 
     @classmethod
     def from_dict(cls, d):
@@ -69,6 +71,7 @@ class ExecutorInfo:
             d.get(cls.PARAM_PID),
             d.get(cls.PARAM_GIT_URL),
             d.get(cls.PARAM_BASELINE_REV),
+            d.get(cls.PARAM_LOCATION),
         )
 
     def to_dict(self):
@@ -76,6 +79,7 @@ class ExecutorInfo:
             self.PARAM_PID: self.pid,
             self.PARAM_GIT_URL: self.git_url,
             self.PARAM_BASELINE_REV: self.baseline_rev,
+            self.PARAM_LOCATION: self.location,
         }
 
 
@@ -94,6 +98,7 @@ class BaseExecutor(ABC):
     WARN_UNTRACKED = False
     QUIET = False
     PIDFILE_EXT = ".run"
+    DEFAULT_LOCATION: Optional[str] = "local (workspace)"
 
     def __init__(
         self,
@@ -403,7 +408,12 @@ class BaseExecutor(ABC):
         else:
             old_cwd = None
         if pidfile is not None:
-            info = ExecutorInfo(os.getpid(), git_url, dvc.scm.get_rev())
+            info = ExecutorInfo(
+                os.getpid(),
+                git_url,
+                dvc.scm.get_rev(),
+                cls.DEFAULT_LOCATION,
+            )
             with modify_yaml(pidfile) as d:
                 d.update(info.to_dict())
         logger.debug("Running repro in '%s'", os.getcwd())

--- a/dvc/repo/experiments/executor/base.py
+++ b/dvc/repo/experiments/executor/base.py
@@ -98,7 +98,7 @@ class BaseExecutor(ABC):
     WARN_UNTRACKED = False
     QUIET = False
     PIDFILE_EXT = ".run"
-    DEFAULT_LOCATION: Optional[str] = "local (workspace)"
+    DEFAULT_LOCATION: Optional[str] = "workspace"
 
     def __init__(
         self,

--- a/dvc/repo/experiments/executor/local.py
+++ b/dvc/repo/experiments/executor/local.py
@@ -45,7 +45,7 @@ class TempDirExecutor(BaseLocalExecutor):
     # suggestions) that are not applicable outside of workspace runs
     WARN_UNTRACKED = True
     QUIET = True
-    DEFAULT_LOCATION: Optional[str] = "local (background)"
+    DEFAULT_LOCATION: Optional[str] = "temp"
 
     def __init__(
         self,

--- a/dvc/repo/experiments/executor/local.py
+++ b/dvc/repo/experiments/executor/local.py
@@ -45,6 +45,7 @@ class TempDirExecutor(BaseLocalExecutor):
     # suggestions) that are not applicable outside of workspace runs
     WARN_UNTRACKED = True
     QUIET = True
+    DEFAULT_LOCATION: Optional[str] = "local (background)"
 
     def __init__(
         self,

--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from dvc.exceptions import InvalidArgumentError
 from dvc.repo import locked
 from dvc.repo.experiments.base import ExpRefInfo
+from dvc.repo.experiments.executor.base import ExecutorInfo
 from dvc.repo.experiments.utils import fix_exp_head
 from dvc.repo.metrics.show import _collect_metrics, _read_metrics
 from dvc.repo.params.show import _collect_configs, _read_params
@@ -34,7 +35,12 @@ def _collect_experiment_commit(
             res["params"] = params
 
         res["queued"] = stash
-        res["running"] = running is not None and exp_rev in running
+        if running is not None and exp_rev in running:
+            res["running"] = True
+            res["executor"] = running[exp_rev].get(ExecutorInfo.PARAM_LOCATION)
+        else:
+            res["running"] = False
+            res["executor"] = None
         if not stash:
             metrics = _collect_metrics(repo, None, rev, False)
             vals = _read_metrics(repo, metrics, rev)

--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -155,13 +155,14 @@ def show(
     # collect queued (not yet reproduced) experiments
     for stash_rev, entry in repo.experiments.stash_revs.items():
         if entry.baseline_rev in revs:
-            experiment = _collect_experiment_commit(
-                repo,
-                stash_rev,
-                stash=stash_rev not in running,
-                param_deps=param_deps,
-                running=running,
-            )
-            res[entry.baseline_rev][stash_rev] = experiment
+            if stash_rev not in running or not running[stash_rev].get("last"):
+                experiment = _collect_experiment_commit(
+                    repo,
+                    stash_rev,
+                    stash=stash_rev not in running,
+                    param_deps=param_deps,
+                    running=running,
+                )
+                res[entry.baseline_rev][stash_rev] = experiment
 
     return res

--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -7,7 +7,9 @@ from funcy import first
 
 from dvc.exceptions import InvalidArgumentError
 from dvc.main import main
-from dvc.repo.experiments.base import ExpRefInfo
+from dvc.repo.experiments.base import EXPS_STASH, ExpRefInfo
+from dvc.repo.experiments.executor.base import BaseExecutor, ExecutorInfo
+from dvc.utils.fs import makedirs
 from dvc.utils.serialize import dump_yaml
 from tests.func.test_repro_multistage import COPY_SCRIPT
 
@@ -18,6 +20,7 @@ def test_show_simple(tmp_dir, scm, dvc, exp_stage):
             "metrics": {"metrics.yaml": {"foo": 1}},
             "params": {"params.yaml": {"foo": 1}},
             "queued": False,
+            "running": False,
             "timestamp": None,
         }
     }
@@ -39,6 +42,7 @@ def test_show_experiment(tmp_dir, scm, dvc, exp_stage, workspace):
         "metrics": {"metrics.yaml": {"foo": 1}},
         "params": {"params.yaml": {"foo": 1}},
         "queued": False,
+        "running": False,
         "timestamp": timestamp,
         "name": "master",
     }
@@ -56,8 +60,6 @@ def test_show_experiment(tmp_dir, scm, dvc, exp_stage, workspace):
 
 
 def test_show_queued(tmp_dir, scm, dvc, exp_stage):
-    from dvc.repo.experiments.base import EXPS_STASH
-
     baseline_rev = scm.get_rev()
 
     dvc.experiments.run(exp_stage.addressing, params=["foo=2"], queue=True)
@@ -346,3 +348,77 @@ def test_show_sort(tmp_dir, scm, dvc, exp_stage, caplog):
     assert (
         main(["exp", "show", "--no-pager", "--sort-by=metrics.yaml:foo"]) == 0
     )
+
+
+def test_show_running_workspace(tmp_dir, scm, dvc, exp_stage, capsys):
+    pid_dir = os.path.join(dvc.tmp_dir, dvc.experiments.EXEC_PID_DIR)
+    makedirs(pid_dir, True)
+    info = ExecutorInfo(None, None, None)
+    pidfile = os.path.join(pid_dir, f"workspace{BaseExecutor.PIDFILE_EXT}")
+    dump_yaml(pidfile, info.to_dict())
+
+    assert dvc.experiments.show()["workspace"] == {
+        "baseline": {
+            "metrics": {"metrics.yaml": {"foo": 1}},
+            "params": {"params.yaml": {"foo": 1}},
+            "queued": False,
+            "running": True,
+            "timestamp": None,
+        }
+    }
+
+    capsys.readouterr()
+    assert main(["exp", "show", "--no-pager"]) == 0
+    cap = capsys.readouterr()
+    assert "Run" in cap.out
+
+
+def test_show_running_executor(tmp_dir, scm, dvc, exp_stage):
+    baseline_rev = scm.get_rev()
+    dvc.experiments.run(exp_stage.addressing, params=["foo=2"], queue=True)
+    exp_rev = dvc.experiments.scm.resolve_rev(f"{EXPS_STASH}@{{0}}")
+
+    pid_dir = os.path.join(dvc.tmp_dir, dvc.experiments.EXEC_PID_DIR)
+    makedirs(pid_dir, True)
+    info = ExecutorInfo(None, None, None)
+    pidfile = os.path.join(pid_dir, f"{exp_rev}{BaseExecutor.PIDFILE_EXT}")
+    dump_yaml(pidfile, info.to_dict())
+
+    results = dvc.experiments.show()
+    assert not results[baseline_rev][exp_rev]["queued"]
+    assert results[baseline_rev][exp_rev]["running"]
+    assert not results["workspace"]["baseline"]["running"]
+
+
+@pytest.mark.parametrize("workspace", [True, False])
+def test_show_running_checkpoint(
+    tmp_dir, scm, dvc, checkpoint_stage, workspace, mocker
+):
+    from dvc.repo.experiments.base import EXEC_BRANCH
+    from dvc.repo.experiments.utils import exp_refs_by_rev
+
+    baseline_rev = scm.get_rev()
+    dvc.experiments.run(
+        checkpoint_stage.addressing, params=["foo=2"], queue=True
+    )
+    stash_rev = dvc.experiments.scm.resolve_rev(f"{EXPS_STASH}@{{0}}")
+
+    run_results = dvc.experiments.run(run_all=True)
+    checkpoint_rev = first(run_results)
+    exp_ref = first(exp_refs_by_rev(scm, checkpoint_rev))
+
+    pid_dir = os.path.join(dvc.tmp_dir, dvc.experiments.EXEC_PID_DIR)
+    makedirs(pid_dir, True)
+    info = ExecutorInfo(123, "foo.git", baseline_rev)
+    rev = "workspace" if workspace else stash_rev
+    pidfile = os.path.join(pid_dir, f"{rev}{BaseExecutor.PIDFILE_EXT}")
+    dump_yaml(pidfile, info.to_dict())
+
+    mocker.patch.object(
+        BaseExecutor, "fetch_exps", return_value=[str(exp_ref)]
+    )
+    if workspace:
+        scm.set_ref(EXEC_BRANCH, str(exp_ref), symbolic=True)
+    results = dvc.experiments.show()
+    assert results[baseline_rev][checkpoint_rev]["running"]
+    assert results["workspace"]["baseline"]["running"] == workspace


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will close #5965

- For the DVC UI, this PR adds `State` column that will currently be Running, Queued or empty
    - If the table has no running or queued experiments the column will not be displayed
    - If `State` is `Running`, an additional `Executor` column will be displayed noting where the experiment is being run, currently this is limited to `local (workspace)` or `local (background)`
- For `--show-json` (VSCode), experiment dicts now have a `running` key that will be true or false, and an `executor` key which will be an optional string executor name
- Fixes bug where main repo would be locked during `--temp` or `--queue/--run-all` runs (related to #5739) which prevented `exp show` from being usable

Regular experiments example:
[![asciicast](https://asciinema.org/a/bHRMvG8V7Oja8fuk8oVO27D6O.svg)](https://asciinema.org/a/bHRMvG8V7Oja8fuk8oVO27D6O)

Checkpoints example:
[![asciicast](https://asciinema.org/a/1RVLUEvZBmAFxskL1C000SikI.svg)](https://asciinema.org/a/1RVLUEvZBmAFxskL1C000SikI)