### PR TITLE
push: prevent crash while using sqlite db on windows network share

### DIFF
--- a/dvc/state.py
+++ b/dvc/state.py
@@ -237,7 +237,7 @@ def _build_sqlite_uri(filename, options):
             # file://server/dir/file
             # doesn't work, so need to either use:
             # file:////server/dir/file
-            # or 
+            # or
             # file://localhost//server/dir/file
             # easiest to do the latter with current structure
             # In future versions of sqlite, this may not be necessary
@@ -249,4 +249,6 @@ def _build_sqlite_uri(filename, options):
         uri_path = re.sub(r"/+", "/", uri_path)
 
     # Empty netloc, params and fragment
-    return urlunparse(("file", authority, uri_path, "", urlencode(options), ""))
+    return urlunparse(
+        ("file", authority, uri_path, "", urlencode(options), "")
+    )

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -16,7 +16,11 @@ from dvc.state import _build_sqlite_uri
         ("C:\\abs\\path space", "nt", "file:///C:/abs/path space"),
         ("/abs/path%20encoded", "posix", "file:///abs/path%2520encoded"),
         ("C:\\abs\\path%20encoded", "nt", "file:///C:/abs/path%2520encoded"),
-        ("\\\\server\\share\\dir\\file", "nt", "file://localhost//server/share/dir/file"),
+        (
+            "\\\\server\\share\\dir\\file",
+            "nt",
+            "file://localhost//server/share/dir/file",
+        ),
     ],
 )
 def test_build_uri(path, osname, result, mocker):

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -16,6 +16,7 @@ from dvc.state import _build_sqlite_uri
         ("C:\\abs\\path space", "nt", "file:///C:/abs/path space"),
         ("/abs/path%20encoded", "posix", "file:///abs/path%2520encoded"),
         ("C:\\abs\\path%20encoded", "nt", "file:///C:/abs/path%2520encoded"),
+        ("\\\\server\\share\\dir\\file", "nt", "file://localhost//server/share/dir/file"),
     ],
 )
 def test_build_uri(path, osname, result, mocker):


### PR DESCRIPTION
There is no strict convention for URI paths that refer to UNC shares on
windows. Although the current model is using the most common approach,
this is not the approach that sqlite expects, and a authority that is
blank or "localhost" is required. This change prevents a crash when pushing
a DVC repo that is hosted on a windows network share affected by
the change in python 3.8 that resolves network shares to their UNC
path when using os.path.abspath. Note that drive letter paths on windows
are handled identically to how they were beforehand.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
