### PR TITLE
repo: preserve meta field on move

### DIFF
--- a/dvc/repo/move.py
+++ b/dvc/repo/move.py
@@ -62,7 +62,11 @@ def move(self, from_path, to_path):
         )
         to_path = os.path.relpath(to_path, new_wdir)
         new_stage = self.stage.create(
-            single_stage=True, fname=new_fname, wdir=new_wdir, outs=[to_path]
+            single_stage=True,
+            fname=new_fname,
+            wdir=new_wdir,
+            outs=[to_path],
+            meta=stage.meta,
         )
 
         os.unlink(stage.path)


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Fixes #6200 
copy meta from src file stage to target file stage