### PR TITLE
separate validation and transformation of args from the add func

### DIFF
--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -41,7 +41,7 @@ def check_arg_combinations(args):
 
     if to_remote or to_cache:
         message = "{option} can't be used with "
-        message += "--to-remote" if args.to_remote else "-o"
+        message += "--to-remote" if to_remote else "-o"
         if len(args.targets) != 1:
             invalid_opt = "multiple targets"
         elif args.no_commit:

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -61,9 +61,16 @@ def check_arg_combinations(args):
         raise InvalidArgumentError(message.format(option=invalid_opt))
 
 
+VALIDATORS = (
+    check_recursive_and_fname,
+    transform_targets,
+    check_arg_combinations,
+)
+
+
 @locked
 @scm_context
-@validate(check_recursive_and_fname, transform_targets, check_arg_combinations)
+@validate(*VALIDATORS)
 def add(  # noqa: C901
     repo,
     targets: "TargetType",

--- a/tests/unit/utils/test_collections.py
+++ b/tests/unit/utils/test_collections.py
@@ -1,4 +1,6 @@
 # pylint: disable=unidiomatic-typecheck
+from mock import create_autospec
+
 from dvc.utils.collections import apply_diff, chunk_dict, validate
 
 
@@ -69,7 +71,7 @@ def test_pre_validate_decorator(mocker):
     def test_func(x, y, *args, j=3, k=5, **kwargs):
         pass
 
-    func_mock = mocker.create_autospec(test_func)
+    func_mock = create_autospec(test_func)
     func = validate(mock)(func_mock)
 
     func("x", "y")
@@ -109,7 +111,7 @@ def test_pre_validate_decorator(mocker):
     assert "y" not in args
 
 
-def test_pre_validate_update_args(mocker):
+def test_pre_validate_update_args():
     def test_validator(args):
         args.x += 50
         del args.y
@@ -117,7 +119,7 @@ def test_pre_validate_update_args(mocker):
     def test_func(x=5, y=10, z=15):
         pass
 
-    mock = mocker.create_autospec(test_func)
+    mock = create_autospec(test_func)
     func = validate(test_validator)(mock)
 
     func(100, 100)

--- a/tests/unit/utils/test_collections.py
+++ b/tests/unit/utils/test_collections.py
@@ -1,5 +1,5 @@
 # pylint: disable=unidiomatic-typecheck
-from dvc.utils.collections import apply_diff, chunk_dict
+from dvc.utils.collections import apply_diff, chunk_dict, validate
 
 
 class MyDict(dict):
@@ -58,3 +58,79 @@ def test_chunk_dict():
     assert chunk_dict(d, 2) == [{"a": 1, "b": 2}, {"c": 3}]
     assert chunk_dict(d, 3) == [d]
     assert chunk_dict(d, 4) == [d]
+
+
+# pylint: disable=unused-argument
+
+
+def test_pre_validate_decorator(mocker):
+    mock = mocker.MagicMock()
+
+    def test_func(x, y, *args, j=3, k=5, **kwargs):
+        pass
+
+    func_mock = mocker.create_autospec(test_func)
+    func = validate(mock)(func_mock)
+
+    func("x", "y")
+
+    func_mock.assert_called_once_with("x", "y", j=3, k=5)
+    mock.assert_called_once()
+    (args,) = mock.call_args[0]
+    assert args.x == "x"
+    assert args.y == "y"
+    assert args.args == ()
+    assert args.j == 3
+    assert args.k == 5
+    assert args.kwargs == {}
+
+    mock.reset_mock()
+    func_mock.reset_mock()
+
+    func("x", "y", "part", "of", "args", j=1, k=10, m=100, n=1000)
+
+    mock.assert_called_once()
+    func_mock.assert_called_once_with(
+        "x", "y", "part", "of", "args", j=1, k=10, m=100, n=1000
+    )
+    (args,) = mock.call_args[0]
+    assert args.x == "x"
+    assert args.y == "y"
+    assert args.args == ("part", "of", "args")
+    assert args.j == 1
+    assert args.k == 10
+    assert args.kwargs == {"m": 100, "n": 1000}
+
+    # we can change values to it
+    args.x = 3
+    assert args.x == 3
+    # we can remove values from it
+    del args.y
+    assert "y" not in args
+
+
+def test_pre_validate_update_args(mocker):
+    def test_validator(args):
+        args.x += 50
+        del args.y
+
+    def test_func(x=5, y=10, z=15):
+        pass
+
+    mock = mocker.create_autospec(test_func)
+    func = validate(test_validator)(mock)
+
+    func(100, 100)
+    mock.assert_called_once_with(x=150, z=15)
+
+
+def test_post_validate_decorator(mocker):
+    def none_filter(result):
+        return list(filter(None, result))
+
+    test_func = mocker.MagicMock(return_value=[1, None, 2])
+    func = validate(none_filter, post=True)(test_func)
+
+    result = func()
+    test_func.assert_called_once()
+    assert result == [1, 2]


### PR DESCRIPTION
Just experimenting 🧪 with this, let me know what you think. 

The `validate` decorator can be used to validate and transform arguments and results from function calls (if `post=True`). Multiple validators can be provided, and the validators will get access to a dictionary that also supports dot-notation.

```python
def validator(args):
   assert args["x"] == args.x
```

Inside the validators, the arguments can also be modified/transformed, so it also acts as a converter/transformer.

Note that, there is one small difference. So, if you are calling it without default arguments, the function will receive the default arguments too.
i.e. calling function with signature `func(x, y, z=3)` as `func(x, y)` will call the function as `func(x, y, z=3)`.
It could be done, but I didn't want to complicate it.

Also note that the validator functions (or, args dotted notation specifically) are tied with the function signature. So, if we modify `dvc.add` function signature, we might need to modify the validator functions a little bit.

I could not find a good library that does this (except type-checking libraries).

Let me know what you think, or if you don't like the magic done here. ✨🪄✨  

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
