### PR TITLE
git: Keep trailing slash when checking if directory is gitignored

### DIFF
--- a/dvc/repo/stage.py
+++ b/dvc/repo/stage.py
@@ -462,7 +462,8 @@ class StageLoad:
 
         def is_out_or_ignored(root, directory):
             dir_path = f"{root}{sep}{directory}"
-            return dir_path in outs or is_ignored(dir_path)
+            # trailing slash needed to check if a directory is gitignored
+            return dir_path in outs or is_ignored(f"{dir_path}/")
 
         stages = []
         for root, dirs, files in self.repo.dvcignore.walk(

--- a/dvc/repo/stage.py
+++ b/dvc/repo/stage.py
@@ -463,7 +463,7 @@ class StageLoad:
         def is_out_or_ignored(root, directory):
             dir_path = f"{root}{sep}{directory}"
             # trailing slash needed to check if a directory is gitignored
-            return dir_path in outs or is_ignored(f"{dir_path}/")
+            return dir_path in outs or is_ignored(f"{dir_path}{sep}")
 
         stages = []
         for root, dirs, files in self.repo.dvcignore.walk(

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -160,7 +160,7 @@ class Git(Base):
     def ignore(self, path):
         entry, gitignore = self._get_gitignore(path)
 
-        if self.is_ignored(path):
+        if self.is_ignored(str(path)):
             return
 
         msg = "Adding '{}' to '{}'.".format(relpath(path), relpath(gitignore))

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -160,7 +160,7 @@ class Git(Base):
     def ignore(self, path):
         entry, gitignore = self._get_gitignore(path)
 
-        if self.is_ignored(str(path)):
+        if self.is_ignored(path):
             return
 
         msg = "Adding '{}' to '{}'.".format(relpath(path), relpath(gitignore))

--- a/dvc/scm/git/backend/dulwich.py
+++ b/dvc/scm/git/backend/dulwich.py
@@ -283,8 +283,8 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
         # `None` if it's not mentioned at all. `True` if it is ignored.
         relative_path = relpath(path, self.root_dir)
         # if checking a directory, a trailing slash must be included
-        if path[-1] == "/":
-            relative_path += "/"
+        if path[-1] == os.sep:
+            relative_path += os.sep
         return bool(self.ignore_manager.is_ignored(relative_path))
 
     def set_ref(

--- a/dvc/scm/git/backend/dulwich.py
+++ b/dvc/scm/git/backend/dulwich.py
@@ -281,9 +281,11 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
     def is_ignored(self, path: str) -> bool:
         # `is_ignored` returns `false` if excluded in `.gitignore` and
         # `None` if it's not mentioned at all. `True` if it is ignored.
-        return bool(
-            self.ignore_manager.is_ignored(relpath(path, self.root_dir))
-        )
+        relative_path = relpath(path, self.root_dir)
+        # if checking a directory, a trailing slash must be included
+        if path[-1] == "/":
+            relative_path += "/"
+        return bool(self.ignore_manager.is_ignored(relative_path))
 
     def set_ref(
         self,

--- a/dvc/scm/git/backend/dulwich.py
+++ b/dvc/scm/git/backend/dulwich.py
@@ -27,6 +27,8 @@ from ..objects import GitObject
 from .base import BaseGitBackend
 
 if TYPE_CHECKING:
+    from dvc.types import StrPath
+
     from ..objects import GitCommit
 
 logger = logging.getLogger(__name__)
@@ -278,12 +280,12 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
 
         return IgnoreFilterManager.from_repo(self.repo)
 
-    def is_ignored(self, path: str) -> bool:
+    def is_ignored(self, path: "StrPath") -> bool:
         # `is_ignored` returns `false` if excluded in `.gitignore` and
         # `None` if it's not mentioned at all. `True` if it is ignored.
         relative_path = relpath(path, self.root_dir)
         # if checking a directory, a trailing slash must be included
-        if path[-1] == os.sep:
+        if str(path)[-1] == os.sep:
             relative_path += os.sep
         return bool(self.ignore_manager.is_ignored(relative_path))
 

--- a/dvc/scm/git/backend/gitpython.py
+++ b/dvc/scm/git/backend/gitpython.py
@@ -3,7 +3,16 @@ import locale
 import logging
 import os
 from functools import partial
-from typing import Callable, Iterable, List, Mapping, Optional, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    Union,
+)
 
 from funcy import ignore
 
@@ -13,6 +22,9 @@ from dvc.utils import fix_env, is_binary, relpath
 
 from ..objects import GitCommit, GitObject
 from .base import BaseGitBackend
+
+if TYPE_CHECKING:
+    from dvc.types import StrPath
 
 logger = logging.getLogger(__name__)
 
@@ -111,11 +123,11 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
     def git(self):
         return self.repo.git
 
-    def is_ignored(self, path: str) -> bool:
+    def is_ignored(self, path: "StrPath") -> bool:
         from git.exc import GitCommandError
 
         func = ignore(GitCommandError)(self.repo.git.check_ignore)
-        return bool(func(path))
+        return bool(func(str(path)))
 
     @property
     def root_dir(self) -> str:

--- a/dvc/scm/git/backend/pygit2.py
+++ b/dvc/scm/git/backend/pygit2.py
@@ -4,7 +4,16 @@ import os
 import stat
 from contextlib import contextmanager
 from io import BytesIO, StringIO
-from typing import Callable, Iterable, List, Mapping, Optional, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    Union,
+)
 
 from funcy import cached_property
 
@@ -15,6 +24,10 @@ from ..objects import GitCommit, GitObject
 from .base import BaseGitBackend
 
 logger = logging.getLogger(__name__)
+
+
+if TYPE_CHECKING:
+    from dvc.types import StrPath
 
 
 class Pygit2Object(GitObject):
@@ -234,7 +247,7 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
     def _get_stash(self, ref: str):
         raise NotImplementedError
 
-    def is_ignored(self, path: str) -> bool:
+    def is_ignored(self, path: "StrPath") -> bool:
         rel = relpath(path, self.root_dir)
         if os.name == "nt":
             rel.replace("\\", "/")

--- a/tests/func/test_scm.py
+++ b/tests/func/test_scm.py
@@ -99,6 +99,21 @@ def test_ignored(tmp_dir, scm):
     assert not scm.is_ignored(tmp_dir / "dir1" / "file2.txt")
 
 
+def test_ignored_dir_unignored_subdirs(tmp_dir, scm):
+    tmp_dir.gen({".gitignore": "data/**\n!data/**/\n!data/**/*.csv"})
+    scm.add([".gitignore"])
+    tmp_dir.gen(
+        {"data/raw/tracked.csv": "cont", "data/raw/not_tracked.json": "cont"}
+    )
+
+    assert not scm.is_ignored("data/raw/tracked.csv")
+    assert scm.is_ignored("data/raw/not_tracked.json")
+
+    assert not scm.is_ignored("data/")
+    assert scm.is_ignored("data/raw")
+    assert not scm.is_ignored("data/raw/")
+
+
 def test_get_gitignore(tmp_dir, scm):
     tmp_dir.gen({"file1": "contents", "dir": {}})
 

--- a/tests/func/test_scm.py
+++ b/tests/func/test_scm.py
@@ -95,8 +95,8 @@ def test_ignored(tmp_dir, scm):
     tmp_dir.gen({"dir1": {"file1.jpg": "cont", "file2.txt": "cont"}})
     tmp_dir.gen({".gitignore": "dir1/*.jpg"})
 
-    assert scm.is_ignored(tmp_dir / "dir1" / "file1.jpg")
-    assert not scm.is_ignored(tmp_dir / "dir1" / "file2.txt")
+    assert scm.is_ignored(str(tmp_dir / "dir1" / "file1.jpg"))
+    assert not scm.is_ignored(str(tmp_dir / "dir1" / "file2.txt"))
 
 
 def test_get_gitignore(tmp_dir, scm):

--- a/tests/func/test_scm.py
+++ b/tests/func/test_scm.py
@@ -95,8 +95,8 @@ def test_ignored(tmp_dir, scm):
     tmp_dir.gen({"dir1": {"file1.jpg": "cont", "file2.txt": "cont"}})
     tmp_dir.gen({".gitignore": "dir1/*.jpg"})
 
-    assert scm.is_ignored(str(tmp_dir / "dir1" / "file1.jpg"))
-    assert not scm.is_ignored(str(tmp_dir / "dir1" / "file2.txt"))
+    assert scm.is_ignored(tmp_dir / "dir1" / "file1.jpg")
+    assert not scm.is_ignored(tmp_dir / "dir1" / "file2.txt")
 
 
 def test_get_gitignore(tmp_dir, scm):

--- a/tests/func/test_scm.py
+++ b/tests/func/test_scm.py
@@ -113,7 +113,15 @@ def test_ignored_dir_unignored_subdirs(tmp_dir, scm):
     assert scm.is_ignored(tmp_dir / "data" / "raw" / "not_tracked.json")
 
     assert not scm.is_ignored(f"data{os.sep}")
-    assert not scm.is_ignored(f"data{os.sep}raw{os.sep}")
+    # git check-ignore would now mark "data/raw" as ignored
+    # after detecting it's a directory in the file system;
+    # instead, we rely on the trailing separator to determine if handling a
+    # a directory - for consistency between existent and non-existent paths
+    assert scm.is_ignored(os.path.join("data", "raw"))
+    assert not scm.is_ignored(os.path.join("data", f"raw{os.sep}"))
+
+    assert scm.is_ignored(os.path.join("data", "non_existent"))
+    assert not scm.is_ignored(os.path.join("data", f"non_existent{os.sep}"))
 
 
 def test_get_gitignore(tmp_dir, scm):

--- a/tests/func/test_scm.py
+++ b/tests/func/test_scm.py
@@ -103,15 +103,17 @@ def test_ignored_dir_unignored_subdirs(tmp_dir, scm):
     tmp_dir.gen({".gitignore": "data/**\n!data/**/\n!data/**/*.csv"})
     scm.add([".gitignore"])
     tmp_dir.gen(
-        {"data/raw/tracked.csv": "cont", "data/raw/not_tracked.json": "cont"}
+        {
+            os.path.join("data", "raw", "tracked.csv"): "cont",
+            os.path.join("data", "raw", "not_tracked.json"): "cont",
+        }
     )
 
-    assert not scm.is_ignored("data/raw/tracked.csv")
-    assert scm.is_ignored("data/raw/not_tracked.json")
+    assert not scm.is_ignored(tmp_dir / "data" / "raw" / "tracked.csv")
+    assert scm.is_ignored(tmp_dir / "data" / "raw" / "not_tracked.json")
 
-    assert not scm.is_ignored("data/")
-    assert scm.is_ignored("data/raw")
-    assert not scm.is_ignored("data/raw/")
+    assert not scm.is_ignored(f"data{os.sep}")
+    assert not scm.is_ignored(f"data{os.sep}raw{os.sep}")
 
 
 def test_get_gitignore(tmp_dir, scm):

--- a/tests/func/test_scm.py
+++ b/tests/func/test_scm.py
@@ -111,6 +111,10 @@ def test_ignored_dir_unignored_subdirs(tmp_dir, scm):
 
     assert not scm.is_ignored(tmp_dir / "data" / "raw" / "tracked.csv")
     assert scm.is_ignored(tmp_dir / "data" / "raw" / "not_tracked.json")
+    assert not scm.is_ignored(tmp_dir / "data" / "raw" / "non_existent.csv")
+    assert scm.is_ignored(tmp_dir / "data" / "raw" / "non_existent.json")
+    assert not scm.is_ignored(tmp_dir / "data" / "non_existent.csv")
+    assert scm.is_ignored(tmp_dir / "data" / "non_existent.json")
 
     assert not scm.is_ignored(f"data{os.sep}")
     # git check-ignore would now mark "data/raw" as ignored

--- a/tests/func/test_stage.py
+++ b/tests/func/test_stage.py
@@ -227,6 +227,13 @@ def test_parent_repo_collect_stages(tmp_dir, scm, dvc):
     assert deep_subrepo_stages != []
 
 
+def test_collect_repo_ignored_dir_unignored_pattern(tmp_dir, dvc, scm):
+    tmp_dir.gen({".gitignore": "data/**\n!data/**/\n!data/**/*.dvc"})
+    scm.add([".gitignore"])
+    (stage,) = tmp_dir.dvc_gen({"data/raw/tracked.csv": "5,6,7,8"})
+    assert dvc.stage.collect_repo() == [stage]
+
+
 def test_stage_strings_representation(tmp_dir, dvc, run_copy):
     tmp_dir.dvc_gen("foo", "foo")
     stage1 = run_copy("foo", "bar", single_stage=True)


### PR DESCRIPTION
Closes https://github.com/iterative/dvc/issues/5748

When querying `dulwich` to check if a directory is gitignored, the path we query should include the trailing slash:
https://github.com/dulwich/dulwich/blob/76dd8356f9d8870f44226e4232c24fbc1e573e93/dulwich/ignore.py#L228-L231

Without it, we get "false positives" and effectively ignore some `.dvc` files that should not be ignored (see issue for details)


* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.


Remaining issues:
1. Is it reasonable to write unit tests for this? Can existing machinery for testing handle "un-ignores" (corresponding to gitignore lines prefixed with `!`)?
2. `is_ignored` [was type-hinted as expecting string-typed paths](https://github.com/tpietruszka/dvc/blob/master/dvc/scm/git/backend/dulwich.py#L281); I assumed that type, but 2 unit tests failed, as they were causing `PosixPath`-like types (temporary ones?) to be passed to this function; I changed everything to be passed as string - but another solution would be to  handle Path-likes. Not sure what's the general strategy here.
