### PR TITLE
add: do not delete stage files before add

### DIFF
--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -1222,12 +1222,14 @@ def test_add_does_not_remove_stage_file_on_failure(
     tmp_dir.gen("foo", "foobar")  # update file
     dvcfile_contents = (tmp_dir / stage.path).read_text()
 
+    exc_msg = f"raising error from mocked '{target}'"
     mocker.patch(
         target,
-        side_effect=DvcException(f"raising error from mocked '{target}'"),
+        side_effect=DvcException(exc_msg),
     )
 
-    with pytest.raises(DvcException):
+    with pytest.raises(DvcException) as exc_info:
         dvc.add("foo")
+    assert str(exc_info.value) == exc_msg
     assert (tmp_dir / "foo.dvc").exists()
     assert (tmp_dir / stage.path).read_text() == dvcfile_contents


### PR DESCRIPTION
Because of the way we collect stages and cache them, we were not able to
collect them for the `add` without removing them from the workspace.
As doing so, we'd have two same/similar stages - one collected from the
workspace and the other just created from the `dvc add` in-memory.

This would raise errors during graph checks, so we started to delete them
and reset them (which is very recently, see #2886 and #3349).

By deleting the file before we even do any checks, we are making DVC
fragile, and results in data loss for the users with even simple mistakes.
This should make it more reliable and robust.

And, recently, we have started to keep states of a lot of things, that by
resetting them on each stage, we waste a lot of performance, especially
on gitignores. We cache the Dulwich's IgnoreManager, which when reset
too many times will waste a lot of our time just collecting them again
next time (see #6227).

It's hard to say how much this improves, as this very much depends on
no. of gitignores in the repo (which can be assumed to be quite a number
for a DVC repo) and the number of files that we are adding
(eg: `-R` adding a large directory).

On a directory with 10,000 files (in a dataset-registry repo),
creating stages on `dvc add -R` went from 64 files/sec to 1.1k files/sec.

Also relevant discussion: https://github.com/iterative/dvc/issues/3362

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
