### PR TITLE
import: error message when imported file does not exist 

### DIFF
--- a/dvc/dependency/repo.py
+++ b/dvc/dependency/repo.py
@@ -97,10 +97,7 @@ class RepoDependency(Dependency):
         self, **kwargs
     ) -> Dict[Optional["ObjectDB"], Set["HashFile"]]:
         from dvc.config import NoRemoteError
-        from dvc.exceptions import (
-            NoOutputInExternalRepoError,
-            NoOutputOrStageError,
-        )
+        from dvc.exceptions import NoOutputOrStageError, PathMissingError
         from dvc.objects.db.git import GitObjectDB
         from dvc.objects.stage import stage
 
@@ -137,12 +134,9 @@ class RepoDependency(Dependency):
                     local_odb.fs.PARAM_CHECKSUM,
                 )
             except FileNotFoundError as exc:
-                if not os.path.exists(repo.url):
-                    raise NoOutputInExternalRepoError(
-                        str(self.def_path), "", str(repo)
-                    ) from exc
-                else:
-                    raise exc
+                raise PathMissingError(
+                    self.def_path, self.def_repo[self.PARAM_URL]
+                ) from exc
 
             self._staged_objs[rev] = staged_obj
             git_odb = GitObjectDB(repo.repo_fs, repo.root_dir)

--- a/tests/func/test_import.py
+++ b/tests/func/test_import.py
@@ -8,7 +8,7 @@ from mock import patch
 import dvc.data_cloud as cloud
 from dvc.config import NoRemoteError
 from dvc.dvcfile import Dvcfile
-from dvc.exceptions import DownloadError
+from dvc.exceptions import DownloadError, PathMissingError
 from dvc.objects.db import ODBManager
 from dvc.stage.exceptions import StagePathNotFoundError
 from dvc.system import System
@@ -289,7 +289,7 @@ def test_push_wildcard_from_bare_git_repo(
     dvc_repo = make_tmp_dir("dvc-repo", scm=True, dvc=True)
     with dvc_repo.chdir():
         dvc_repo.dvc.imp(os.fspath(tmp_dir), "dirextra")
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(PathMissingError):
             dvc_repo.dvc.imp(os.fspath(tmp_dir), "dir123")
 
 
@@ -347,11 +347,11 @@ def test_pull_non_workspace(tmp_dir, scm, dvc, erepo_dir):
 
 
 def test_import_non_existing(erepo_dir, tmp_dir, dvc):
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(PathMissingError):
         tmp_dir.dvc.imp(os.fspath(erepo_dir), "invalid_output")
 
     # https://github.com/iterative/dvc/pull/2837#discussion_r352123053
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(PathMissingError):
         tmp_dir.dvc.imp(os.fspath(erepo_dir), "/root/", "root")
 
 


### PR DESCRIPTION
Closes #6207

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

This is a quite simple simplest solution for the problem that avoids a larger refactor of the actual code. 

I just extended [test_import_non_existing](https://github.com/iterative/dvc/blob/master/tests/func/test_import.py#L349) with a simple test that tries to import a non-existent file from dvc repo so I could test this. 

```python
def test_import_non_existing(erepo_dir, tmp_dir, dvc):
    with pytest.raises(FileNotFoundError):
        tmp_dir.dvc.imp(os.fspath(erepo_dir), "invalid_output")

    # https://github.com/iterative/dvc/pull/2837#discussion_r352123053
    with pytest.raises(FileNotFoundError):
        tmp_dir.dvc.imp(os.fspath(erepo_dir), "/root/", "root")

    with pytest.raises(NoOutputInExternalRepoError):
        dvc.imp("https://github.com/iterative/dvc.git", "non-existent")
```

I am not adding the test to the PR since it requires to download a GH repo and I am not sure about how would you handle this specific case (I have seen other tests where you locally create a repo and add some commits but I think that does not adjust to this)