### PR TITLE
Loosen versions for fsspec and pygtrie

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ install_requires = [
     "dataclasses==0.7; python_version < '3.7'",
     "flatten_dict>=0.3.0,<1",
     "tabulate>=0.8.7",
-    "pygtrie==2.3.2",
+    "pygtrie>=2.3.2",
     "dpath>=2.0.1,<3",
     "shtab>=1.3.4,<2",
     "rich>=10.0.0",
@@ -88,7 +88,7 @@ install_requires = [
     "python-benedict>=0.21.1",
     "pyparsing==2.4.7",
     "typing_extensions>=3.7.4",
-    "fsspec==2021.6.1",
+    "fsspec>=2021.6.1",
     "diskcache>=5.2.1",
 ]
 


### PR DESCRIPTION
Resolves #6102

In general modules with pinned requirements are difficult to integrate into existing systems.

Of course there is a benefit to pinning versions, you are sure your code works, but you also prevent someone from installing your package alongside other code that may require slightly newer versions.

Specifying a minimum version is always good practice, but specifying a maximum version should be done very sparingly and only when needed.

My other projects are failing to integrate with dvc because of incompatibilities in the pygtrie and fsspec packages. I'm not sure if there is a good reason why they are pinned to a maximum version. Submitting this PR to loosen them and see if the CI passes.