### PR TITLE
updater: only notify in dvc doctor

### DIFF
--- a/dvc/command/base.py
+++ b/dvc/command/base.py
@@ -33,17 +33,12 @@ class CmdBase(ABC):
 
     def __init__(self, args):
         from dvc.repo import Repo
-        from dvc.updater import Updater
 
         os.chdir(args.cd)
 
         self.repo = Repo(uninitialized=self.UNINITIALIZED)
         self.config = self.repo.config
         self.args = args
-        if self.repo.tmp_dir:
-            hardlink_lock = self.config["core"].get("hardlink_lock", False)
-            updater = Updater(self.repo.tmp_dir, hardlink_lock=hardlink_lock)
-            updater.check()
 
     def do_run(self):
         with self.repo:

--- a/dvc/command/version.py
+++ b/dvc/command/version.py
@@ -10,9 +10,21 @@ logger = logging.getLogger(__name__)
 class CmdVersion(CmdBaseNoRepo):
     def run(self):
         from dvc.info import get_dvc_info
+        from dvc.repo import NotDvcRepoError, Repo
 
         dvc_info = get_dvc_info()
         ui.write(dvc_info, force=True)
+
+        try:
+            with Repo() as repo:
+                from dvc.updater import Updater
+
+                hardlink_lock = repo.config["core"].get("hardlink_lock", False)
+                updater = Updater(repo.tmp_dir, hardlink_lock=hardlink_lock)
+                updater.check()
+        except NotDvcRepoError:
+            pass
+
         return 0
 
 


### PR DESCRIPTION
We've used updater for years now to notify our users ASAP about new
releases. These days dvc is more stable and we've actually been
receiving numerous complains about updater being too annoying and
even introduced a config flag to turn it off, which a lot of people do
and which defeats its purpose. Instead of introducing some complex logic
that would notify more rarely and once for the user instead of once for
every dvc project they have - this PR just turns it off for everything,
except `dvc doctor/version`, which is the command that people use when
they are running into issues and that will give them a hint to just try
out the newest version first, as it might be already fixed.

This PR is a more of a compromise, to get the most out of updater while
removing a pain point of it being too annoying, without investing much
time into it and not having to maintain complex unnecessary logic. We
might get back to introducing something more intricate in the future,
if the need arises (hence not removing the config option for now).

Fixes #5912

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
