### PR TITLE
push params in the experiments table to the right

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -397,7 +397,7 @@ def show_experiments(
     styles.update(
         {
             header: {
-                "justify": "left" if typ == "metrics" else "params",
+                "justify": "right" if typ == "metrics" else "left",
                 "header_style": f"black on {header_bg_colors[typ]}",
                 "collapse": idx != 0,
                 "no_wrap": typ == "metrics",


### PR DESCRIPTION
Made a mistake during refactoring on styling before. Noticed while reviewing #6174.

#### Before
<img width="1386" alt="Screen Shot 2021-06-30 at 14 31 18" src="https://user-images.githubusercontent.com/18718008/123931505-4af56600-d9b0-11eb-92cc-e42c1aa001c2.png">

#### After

<img width="1386" alt="Screen Shot 2021-06-30 at 15 31 40" src="https://user-images.githubusercontent.com/18718008/123939835-4b91fa80-d9b8-11eb-876c-b840d6edcb37.png">

- metrics were left-aligned, whereas now it's right-aligned
- also fixed the mistake `params` as justify.