### PR TITLE
doctor: show versions for fs requirements

### DIFF
--- a/dvc/fs/http.py
+++ b/dvc/fs/http.py
@@ -31,6 +31,7 @@ class HTTPFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
     PATH_CLS = HTTPURLInfo
     PARAM_CHECKSUM = "etag"
     CAN_TRAVERSE = False
+    REQUIRES = {"requests": "requests"}
 
     SESSION_RETRIES = 5
     SESSION_BACKOFF_FACTOR = 0.1

--- a/dvc/info.py
+++ b/dvc/info.py
@@ -2,7 +2,6 @@ import itertools
 import os
 import pathlib
 import platform
-import sys
 import uuid
 
 import psutil
@@ -21,10 +20,10 @@ if PKG is None:
 else:
     package = f"({PKG})"
 
-if sys.version_info < (3, 8):
-    import importlib_metadata
-else:
+try:
     import importlib.metadata as importlib_metadata
+except ImportError:  # < 3.8
+    import importlib_metadata  # type: ignore[no-redef]
 
 
 def get_dvc_info():
@@ -33,7 +32,7 @@ def get_dvc_info():
         "---------------------------------",
         f"Platform: Python {platform.python_version()} on "
         f"{platform.platform()}",
-        f"Plugins:{_get_supported_remotes()}",
+        f"Supports:{_get_supported_remotes()}",
     ]
 
     try:

--- a/dvc/info.py
+++ b/dvc/info.py
@@ -2,6 +2,7 @@ import itertools
 import os
 import pathlib
 import platform
+import sys
 import uuid
 
 import psutil
@@ -20,6 +21,11 @@ if PKG is None:
 else:
     package = f"({PKG})"
 
+if sys.version_info < (3, 8):
+    import importlib_metadata
+else:
+    import importlib.metadata as importlib_metadata
+
 
 def get_dvc_info():
     info = [
@@ -27,7 +33,7 @@ def get_dvc_info():
         "---------------------------------",
         f"Platform: Python {platform.python_version()} on "
         f"{platform.platform()}",
-        f"Supports: {_get_supported_remotes()}",
+        f"Plugins:{_get_supported_remotes()}",
     ]
 
     try:
@@ -113,19 +119,23 @@ def _get_linktype_support_info(repo):
 
 
 def _get_supported_remotes():
-
     supported_remotes = []
     for scheme, fs_cls in FS_MAP.items():
         if not fs_cls.get_missing_deps():
-            supported_remotes.append(scheme)
+            dependencies = []
+            for requirement in fs_cls.REQUIRES:
+                dependencies.append(
+                    f"{requirement} = "
+                    f"{importlib_metadata.version(requirement)}"
+                )
 
-    if len(supported_remotes) == len(FS_MAP):
-        return "All remotes"
+            remote_info = scheme
+            if dependencies:
+                remote_info += " (" + ", ".join(dependencies) + ")"
+            supported_remotes.append(remote_info)
 
-    if len(supported_remotes) == 1:
-        return supported_remotes
-
-    return ", ".join(supported_remotes)
+    assert len(supported_remotes) >= 1
+    return "\n\t" + ",\n\t".join(supported_remotes)
 
 
 def get_fs_type(path):

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ install_requires = [
     "pydot>=1.2.4",
     "speedcopy>=2.0.1; python_version < '3.8' and sys_platform == 'win32'",
     "dataclasses==0.7; python_version < '3.7'",
+    "importlib-metadata==1.4; python_version < '3.8'",
     "flatten_dict>=0.3.0,<1",
     "tabulate>=0.8.7",
     "pygtrie>=2.3.2",

--- a/tests/func/test_version.py
+++ b/tests/func/test_version.py
@@ -1,7 +1,7 @@
 import re
 
 from dvc.main import main
-from tests.unit.test_info import PYTHON_VERSION_REGEX
+from tests.unit.test_info import PYTHON_VERSION_REGEX, find_supported_remotes
 
 
 def test_(tmp_dir, dvc, scm, capsys):
@@ -10,7 +10,7 @@ def test_(tmp_dir, dvc, scm, capsys):
     out, _ = capsys.readouterr()
     assert re.search(r"DVC version: \d+\.\d+\.\d+.*", out)
     assert re.search(f"Platform: {PYTHON_VERSION_REGEX} on .*", out)
-    assert re.search(r"Supports: .*", out)
+    assert find_supported_remotes(out)
     assert re.search(r"Cache types: .*", out)
     assert re.search(r"Caches: local", out)
     assert re.search(r"Remotes: None", out)

--- a/tests/unit/test_info.py
+++ b/tests/unit/test_info.py
@@ -18,7 +18,7 @@ def find_supported_remotes(string):
     index = 0
 
     for index, line in enumerate(lines):
-        if line == "Plugins:":
+        if line == "Supports:":
             index += 1
             break
     else:

--- a/tests/unit/test_info.py
+++ b/tests/unit/test_info.py
@@ -13,6 +13,35 @@ from dvc.info import get_dvc_info
 PYTHON_VERSION_REGEX = r"Python \d\.\d+\.\d+\S*"
 
 
+def find_supported_remotes(string):
+    lines = string.splitlines()
+    index = 0
+
+    for index, line in enumerate(lines):
+        if line == "Plugins:":
+            index += 1
+            break
+    else:
+        return []
+
+    remotes = {}
+    for line in lines[index:]:
+        if not line.startswith("\t"):
+            break
+
+        remote_name, _, raw_dependencies = (
+            line.strip().strip(",").partition(" ")
+        )
+        remotes[remote_name] = {
+            dependency: version
+            for dependency, _, version in [
+                dependency.partition(" = ")
+                for dependency in raw_dependencies[1:-1].split(", ")
+            ]
+        }
+    return remotes
+
+
 @pytest.mark.parametrize("scm_init", [True, False])
 def test_info_in_repo(scm_init, tmp_dir):
     tmp_dir.init(scm=scm_init, dvc=True)
@@ -23,7 +52,7 @@ def test_info_in_repo(scm_init, tmp_dir):
 
     assert re.search(r"DVC version: \d+\.\d+\.\d+.*", dvc_info)
     assert re.search(f"Platform: {PYTHON_VERSION_REGEX} on .*", dvc_info)
-    assert re.search(r"Supports: .*", dvc_info)
+    assert find_supported_remotes(dvc_info)
     assert re.search(r"Cache types: .*", dvc_info)
 
     if scm_init:
@@ -98,7 +127,7 @@ def test_info_outside_of_repo(tmp_dir, caplog):
 
     assert re.search(r"DVC version: \d+\.\d+\.\d+.*", dvc_info)
     assert re.search(f"Platform: {PYTHON_VERSION_REGEX} on .*", dvc_info)
-    assert re.search(r"Supports: .*", dvc_info)
+    assert find_supported_remotes(dvc_info)
     assert not re.search(r"Cache types: .*", dvc_info)
     assert "Repo:" not in dvc_info
 
@@ -107,4 +136,14 @@ def test_fs_info_outside_of_repo(tmp_dir, caplog):
     dvc_info = get_dvc_info()
     assert re.search(r"DVC version: \d+\.\d+\.\d+.*", dvc_info)
     assert re.search(f"Platform: {PYTHON_VERSION_REGEX} on .*", dvc_info)
-    assert re.search(r"Supports: .*", dvc_info)
+    assert find_supported_remotes(dvc_info)
+
+
+def test_plugin_versions(tmp_dir, dvc):
+    from dvc.fs import FS_MAP
+
+    dvc_info = get_dvc_info()
+    remotes = find_supported_remotes(dvc_info)
+
+    for remote, dependencies in remotes.items():
+        assert dependencies.keys() == FS_MAP[remote].REQUIRES.keys()


### PR DESCRIPTION
Resolves #6248
Previous output:
```
DVC version: 2.4.3+ce45ec 
---------------------------------
Platform: Python 3.8.5+ on Linux-5.4.0-77-generic-x86_64-with-glibc2.29
Supports: s3, gs, http
Cache types: <https://error.dvc.org/no-dvc-cache>
Caches: local
Remotes: https
Workspace directory: ext4 on /dev/sda7
Repo: dvc, git
```

Current output:
```
DVC version: 2.4.3+fc7409 
---------------------------------
Platform: Python 3.8.5+ on Linux-5.4.0-77-generic-x86_64-with-glibc2.29
Plugins:
        gs (gcsfs = 2021.6.1),
        http (requests = 2.25.1),
        s3 (s3fs = 2021.6.1, boto3 = 1.17.49),
Cache types: <https://error.dvc.org/no-dvc-cache>
Caches: local
Remotes: https
Workspace directory: ext4 on /dev/sda7
Repo: dvc, git
```

Current output of all remotes:
```
DVC version: 2.4.3+fc7409 
---------------------------------
Platform: Python 3.8.5+ on Linux-5.4.0-77-generic-x86_64-with-glibc2.29
Plugins:
        azure (adlfs = 0.7.7, knack = 0.7.2, azure-identity = 1.5.0),
        gdrive (pydrive2 = 1.8.1),
        gs (gcsfs = 2021.6.1),
        hdfs (pyarrow = 2.0.0),
        webhdfs (hdfs = 2.5.8),
        http (requests = 2.25.1),
        https (requests = 2.25.1),
        s3 (s3fs = 2021.6.1, boto3 = 1.17.49),
        ssh (paramiko = 2.7.2),
        oss (oss2 = 2.6.1),
        webdav (webdav4 = 0.8.1),
        webdavs (webdav4 = 0.8.1)
Cache types: <https://error.dvc.org/no-dvc-cache>
Caches: local
Remotes: https
Workspace directory: ext4 on /dev/sda7
Repo: dvc, git
```