### PR TITLE
output: optimize obj collection

### DIFF
--- a/dvc/fs/base.py
+++ b/dvc/fs/base.py
@@ -33,6 +33,8 @@ class RemoteMissingDepsError(DvcException):
 
 
 class BaseFileSystem:
+    sep = "/"
+
     scheme = "base"
     REQUIRES: ClassVar[Dict[str, str]] = {}
     PATH_CLS = URLInfo  # type: Any

--- a/dvc/fs/dvc.py
+++ b/dvc/fs/dvc.py
@@ -23,6 +23,8 @@ class DvcFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
         repo: DVC repo.
     """
 
+    sep = os.sep
+
     scheme = "local"
     PARAM_CHECKSUM = "md5"
 

--- a/dvc/fs/git.py
+++ b/dvc/fs/git.py
@@ -9,6 +9,8 @@ from .base import BaseFileSystem
 class GitFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
     """Proxies the repo file access methods to Git objects"""
 
+    sep = os.sep
+
     scheme = "local"
 
     def __init__(self, root_dir, trie):

--- a/dvc/fs/local.py
+++ b/dvc/fs/local.py
@@ -14,6 +14,8 @@ logger = logging.getLogger(__name__)
 
 
 class LocalFileSystem(BaseFileSystem):
+    sep = os.sep
+
     scheme = Schemes.LOCAL
     PATH_CLS = PathInfo
     PARAM_CHECKSUM = "md5"

--- a/dvc/fs/repo.py
+++ b/dvc/fs/repo.py
@@ -31,6 +31,8 @@ class RepoFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
         kwargs: Additional keyword arguments passed to the `DvcFileSystem()`.
     """
 
+    sep = os.sep
+
     scheme = "local"
     PARAM_CHECKSUM = "md5"
 

--- a/dvc/output.py
+++ b/dvc/output.py
@@ -887,7 +887,7 @@ class Output:
         obj.name = str(self)
         if isinstance(obj, Tree):
             for key, entry_obj in obj:
-                entry_obj.name = os.path.join(obj.name, *key)
+                entry_obj.name = os.path.sep.join([obj.name, *key])
 
     def get_used_external(
         self, **kwargs

--- a/dvc/output.py
+++ b/dvc/output.py
@@ -271,8 +271,6 @@ class Output:
     IsStageFileError = OutputIsStageFileError  # type: Type[DvcException]
     IsIgnoredError = OutputIsIgnoredError  # type: Type[DvcException]
 
-    sep = "/"
-
     def __init__(
         self,
         stage,

--- a/dvc/output.py
+++ b/dvc/output.py
@@ -887,7 +887,7 @@ class Output:
         obj.name = str(self)
         if isinstance(obj, Tree):
             for key, entry_obj in obj:
-                entry_obj.name = os.path.sep.join([obj.name, *key])
+                entry_obj.name = self.fs.sep.join([obj.name, *key])
 
     def get_used_external(
         self, **kwargs

--- a/dvc/output.py
+++ b/dvc/output.py
@@ -887,7 +887,7 @@ class Output:
         obj.name = str(self)
         if isinstance(obj, Tree):
             for key, entry_obj in obj:
-                entry_obj.name = os.path.join(str(self), *key)
+                entry_obj.name = os.path.join(obj.name, *key)
 
     def get_used_external(
         self, **kwargs


### PR DESCRIPTION
A few leftovers from recent temporary odb changes. On 700K dataset, this shaves off around 22seconds.
Still a long way to go and a lot of additional stuff could be done (including maybe pbar), but this should mitigate it for now.

Related to #6276

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
