### PR TITLE
ui: Prevent tqdm from breaking on output

### DIFF
--- a/dvc/ui/__init__.py
+++ b/dvc/ui/__init__.py
@@ -79,18 +79,23 @@ class Console:
         styled: bool = False,
         file: TextIO = None,
     ) -> None:
+        from dvc.progress import Tqdm
+
         sep = " " if sep is None else sep
         end = "\n" if end is None else end
         if not self._enabled and not force:
             return
 
-        if styled:
-            console = self.error_console if stderr else self.rich_console
-            return console.print(*objects, sep=sep, end=end)
-
         file = file or (sys.stderr if stderr else sys.stdout)
-        values = (self.formatter.format(obj, style=style) for obj in objects)
-        return print(*values, sep=sep, end=end, file=file)
+        with Tqdm.external_write_mode(file=file):
+            if styled:
+                console = self.error_console if stderr else self.rich_console
+                return console.print(*objects, sep=sep, end=end)
+
+            values = (
+                self.formatter.format(obj, style=style) for obj in objects
+            )
+            return print(*values, sep=sep, end=end, file=file)
 
     @staticmethod
     def progress(*args, **kwargs) -> "Tqdm":


### PR DESCRIPTION
#### Before
[![asciicast](https://asciinema.org/a/7jNT179lBY6mastJsBl5Y04F6.svg)](https://asciinema.org/a/7jNT179lBY6mastJsBl5Y04F6)

#### After
[![asciicast](https://asciinema.org/a/XyiXXKqSDteLmqTMchtnxe5cy.svg)](https://asciinema.org/a/XyiXXKqSDteLmqTMchtnxe5cy)


Note that I haven't been able to figure out adding support for `rich`'s console, so mixing `console` might interleave other outputs (though not with the tqdm itself thanks to this PR).

Related to #6224.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
