### PR TITLE
staging: optimize the number of info() calls

### DIFF
--- a/dvc/fs/dvc.py
+++ b/dvc/fs/dvc.py
@@ -233,7 +233,7 @@ class DvcFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
 
     def info(self, path_info):
         meta = self.metadata(path_info)
-        ret = {"type": "dir" if meta.isdir else "file"}
+        ret = {"type": "directory" if meta.isdir else "file"}
         if meta.is_output and len(meta.outs) == 1 and meta.outs[0].hash_info:
             hash_info = meta.outs[0].hash_info
             ret["size"] = hash_info.size

--- a/dvc/fs/git.py
+++ b/dvc/fs/git.py
@@ -1,5 +1,6 @@
 import errno
 import os
+import stat
 
 from dvc.utils import is_exec, relpath
 
@@ -106,7 +107,10 @@ class GitFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
             raise FileNotFoundError(
                 errno.ENOENT, os.strerror(errno.ENOENT), path_info
             )
-        return {"size": st.st_size}
+        return {
+            "size": st.st_size,
+            "type": "directory" if stat.S_ISDIR(st.st_mode) else "file",
+        }
 
     def stat(self, path):
         key = self._get_key(path)

--- a/dvc/fs/http.py
+++ b/dvc/fs/http.py
@@ -145,7 +145,7 @@ class HTTPFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
         resp = self._head(path_info.url)
         etag = resp.headers.get("ETag") or resp.headers.get("Content-MD5")
         size = self._content_length(resp)
-        return {"etag": etag, "size": size}
+        return {"etag": etag, "size": size, "type": "file"}
 
     def _upload_fobj(self, fobj, to_info, **kwargs):
         def chunks(fobj):

--- a/dvc/fs/local.py
+++ b/dvc/fs/local.py
@@ -157,7 +157,7 @@ class LocalFileSystem(BaseFileSystem):
         st = os.stat(path_info)
         return {
             "size": st.st_size,
-            "type": "dir" if stat.S_ISDIR(st.st_mode) else "file",
+            "type": "directory" if stat.S_ISDIR(st.st_mode) else "file",
         }
 
     def _upload(

--- a/dvc/fs/ssh/connection.py
+++ b/dvc/fs/ssh/connection.py
@@ -82,7 +82,7 @@ class SSHConnection:
         st = self.sftp.stat(path)
         return {
             "size": st.st_size,
-            "type": "dir" if stat.S_ISDIR(st.st_mode) else "file",
+            "type": "directory" if stat.S_ISDIR(st.st_mode) else "file",
         }
 
     def getsize(self, path):

--- a/dvc/fs/webhdfs.py
+++ b/dvc/fs/webhdfs.py
@@ -123,7 +123,7 @@ class WebHDFSFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
 
     def info(self, path_info):
         st = self.hdfs_client.status(path_info.path)
-        return {"size": st["length"]}
+        return {"size": st["length"], "type": "file"}
 
     def checksum(self, path_info):
         return HashInfo(

--- a/tests/unit/remote/test_http.py
+++ b/tests/unit/remote/test_http.py
@@ -175,5 +175,9 @@ def test_content_length(mocker, headers, expected_size):
 
     url = URLInfo("https://example.org/file.txt")
 
-    assert fs.info(url) == {"etag": None, "size": expected_size}
+    assert fs.info(url) == {
+        "etag": None,
+        "size": expected_size,
+        "type": "file",
+    }
     assert fs._content_length(res) == expected_size


### PR DESCRIPTION
We do 2 `.exists()` and `.isdir()` call for the same path in the same context, so we can reduce them into a single `info()` call and retrieve all information we need in one go. If the file is not there, it will raise an FileNotExistsError too. 