### PR TITLE
objects: hash_file: retrieve size from hash_info

### DIFF
--- a/dvc/objects/file.py
+++ b/dvc/objects/file.py
@@ -28,12 +28,7 @@ class HashFile:
 
     @property
     def size(self):
-        if self.hash_info.size is not None:
-            return self.hash_info.size
-        if not (self.fs and self.path_info):
-            return None
-
-        return self.fs.getsize(self.path_info)
+        return self.hash_info.size
 
     def __len__(self):
         return 1

--- a/dvc/objects/file.py
+++ b/dvc/objects/file.py
@@ -28,8 +28,11 @@ class HashFile:
 
     @property
     def size(self):
-        if not (self.path_info and self.fs):
+        if self.hash_info.size is not None:
+            return self.hash_info.size
+        if not (self.fs and self.path_info):
             return None
+
         return self.fs.getsize(self.path_info)
 
     def __len__(self):

--- a/dvc/objects/tree.py
+++ b/dvc/objects/tree.py
@@ -28,13 +28,6 @@ class Tree(HashFile):
 
         return Trie(self._dict)
 
-    @property
-    def size(self):
-        try:
-            return sum(obj.size for _, obj in self)
-        except TypeError:
-            return None
-
     def add(self, key, obj):
         self.__dict__.pop("trie", None)
         self._dict[key] = obj
@@ -52,7 +45,10 @@ class Tree(HashFile):
         self.path_info = path_info
         self.hash_info = get_file_hash(path_info, memfs, "md5")
         self.hash_info.value += ".dir"
-        self.hash_info.size = self.size
+        try:
+            self.hash_info.size = sum(obj.size for _, obj in self)
+        except TypeError:
+            self.hash_info.size = None
         self.hash_info.nfiles = len(self)
 
     def __len__(self):

--- a/tests/unit/objects/test_tree.py
+++ b/tests/unit/objects/test_tree.py
@@ -69,19 +69,27 @@ def test_list(lst, trie_dict):
         ({}, 0),
         (
             {
-                ("a",): HashInfo("md5", "abc", size=1),
-                ("b",): HashInfo("md5", "def", size=2),
-                ("c",): HashInfo("md5", "ghi", size=3),
-                ("dir", "foo"): HashInfo("md5", "jkl", size=4),
-                ("dir", "bar"): HashInfo("md5", "mno", size=5),
-                ("dir", "baz"): HashInfo("md5", "pqr", size=6),
+                ("a",): HashFile(None, None, HashInfo("md5", "abc", size=1)),
+                ("b",): HashFile(None, None, HashInfo("md5", "def", size=2)),
+                ("c",): HashFile(None, None, HashInfo("md5", "ghi", size=3)),
+                ("dir", "foo"): HashFile(
+                    None, None, HashInfo("md5", "jkl", size=4)
+                ),
+                ("dir", "bar"): HashFile(
+                    None, None, HashInfo("md5", "mno", size=5)
+                ),
+                ("dir", "baz"): HashFile(
+                    None, None, HashInfo("md5", "pqr", size=6)
+                ),
             },
             21,
         ),
         (
             {
-                ("a",): HashInfo("md5", "abc", size=1),
-                ("b",): HashInfo("md5", "def", size=None),
+                ("a",): HashFile(None, None, HashInfo("md5", "abc", size=1)),
+                ("b",): HashFile(
+                    None, None, HashInfo("md5", "def", size=None)
+                ),
             },
             None,
         ),
@@ -90,6 +98,7 @@ def test_list(lst, trie_dict):
 def test_size(trie_dict, size):
     tree = Tree(None, None, None)
     tree._dict = trie_dict
+    tree.digest()
     assert tree.size == size
 
 


### PR DESCRIPTION
Resolves #6283. I am still not quite sure to whether we should keep `getsize()` logic at all, or not since this information should be propagated from an upper level (e.g staging, in this case fills HashInfos). Lazily retrieving this is very bad for performance, especially when you have a lot of files. 