### PR TITLE
output: cache loaded tree objects

### DIFF
--- a/dvc/output.py
+++ b/dvc/output.py
@@ -827,6 +827,9 @@ class Output:
         except FileNotFoundError:
             self.repo.cloud.pull([obj], **kwargs)
 
+        if self.obj:
+            return self.obj
+
         try:
             self.obj = objects.load(self.odb, self.hash_info)
         except (FileNotFoundError, ObjectFormatError):


### PR DESCRIPTION
A quick naive fix that reduces `dvc diff` from hours to around ~20sec for a dataset of dozens of thousands of files. That is still bad, but in order to speed it up more, we need to revisit our `.dir` storage and switch to using staging in `get_dir_cache`. That will be revisited after followups for https://github.com/iterative/dvc/pull/6308 

Related to #6173

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
