### PR TITLE
oss: migrate to ossfs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -100,6 +100,9 @@ jobs:
         GDRIVE_CREDENTIALS_DATA: ${{ secrets.GDRIVE_CREDENTIALS_DATA }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        OSS_ACCESS_KEY_ID: ${{ secrets.OSS_ACCESS_KEY_ID}}
+        OSS_ACCESS_KEY_SECRET: ${{ secrets.OSS_ACCESS_KEY_SECRET}}
+        OSS_ENDPOINT: ${{ secrets.OSS_ENDPOINT}}
       run: >-
         python -m tests -n=4
         --cov-report=xml --cov-report=term

--- a/dvc/fs/oss.py
+++ b/dvc/fs/oss.py
@@ -53,15 +53,15 @@ class OSSFileSystem(ObjectFSWrapper):
     def _download(
         self, from_info, to_file, name=None, no_progress_bar=False, **pbar_args
     ):
-        total = self.fs.size(from_info.url)
+        # total = self.fs.size(from_info.url)
         with Tqdm(
             disable=no_progress_bar,
-            total=total,
+            # total=total,
             bytes=True,
             desc=name,
             **pbar_args,
         ) as pbar:
-            self.fs.download_file(
+            self.fs.get_file(
                 from_info.url,
                 to_file,
                 progress_callback=pbar.update_to,

--- a/dvc/fs/oss.py
+++ b/dvc/fs/oss.py
@@ -19,12 +19,18 @@ class OSSFileSystem(ObjectFSWrapper):
     PATH_CLS = CloudURLInfo
     REQUIRES = {"ossfs": "ossfs"}
     PARAM_CHECKSUM = "etag"
+    COPY_POLL_SECONDS = 5
+    LIST_OBJECT_PAGE_SIZE = 100
     DETAIL_FIELDS = frozenset(("etag", "size"))
 
     def _prepare_credentials(self, **config):
         login_info = {}
-        login_info["key"] = config.get("oss_key_id")
-        login_info["secret"] = config.get("oss_key_secret")
+        login_info["key"] = config.get("oss_key_id") or os.getenv(
+            "OSS_ACCESS_KEY_ID"
+        )
+        login_info["secret"] = config.get("oss_key_secret") or os.getenv(
+            "OSS_ACCESS_KEY_SECRET"
+        )
         login_info["endpoint"] = config.get("oss_endpoint")
         return login_info
 

--- a/dvc/fs/oss.py
+++ b/dvc/fs/oss.py
@@ -1,8 +1,10 @@
+import os
 import threading
 
 from funcy import cached_property, wrap_prop
 
 from dvc.path_info import CloudURLInfo
+from dvc.progress import Tqdm
 from dvc.scheme import Schemes
 
 from .fsspec_wrapper import ObjectFSWrapper
@@ -29,3 +31,42 @@ class OSSFileSystem(ObjectFSWrapper):
         from ossfs import OSSFileSystem as _OSSFileSystem
 
         return _OSSFileSystem(**self.fs_args)
+
+    def _upload(
+        self, from_file, to_info, name=None, no_progress_bar=False, **pbar_args
+    ):
+        total = os.path.getsize(from_file)
+        resumable = total > self.fs.SIMPLE_TRANSFER_SIZE
+        with Tqdm(
+            disable=no_progress_bar,
+            total=total,
+            bytes=True,
+            desc=name,
+            **pbar_args,
+        ) as pbar:
+            self.fs.put_file(
+                from_file,
+                to_info.url,
+                resumable=resumable,
+                progress_callback=pbar.update_to,
+            )
+        self.fs.invalidate_cache(self._with_bucket(to_info.parent))
+
+    def _download(
+        self, from_info, to_file, name=None, no_progress_bar=False, **pbar_args
+    ):
+        total = self.fs.size(from_info.url)
+        resumable = total > self.fs.SIMPLE_TRANSFER_SIZE
+        with Tqdm(
+            disable=no_progress_bar,
+            total=total,
+            bytes=True,
+            desc=name,
+            **pbar_args,
+        ) as pbar:
+            self.fs.get_file(
+                from_info.url,
+                to_file,
+                resumable=resumable,
+                progress_callback=pbar.update_to,
+            )

--- a/dvc/fs/oss.py
+++ b/dvc/fs/oss.py
@@ -53,10 +53,10 @@ class OSSFileSystem(ObjectFSWrapper):
     def _download(
         self, from_info, to_file, name=None, no_progress_bar=False, **pbar_args
     ):
-        # total = self.fs.size(from_info.url)
+        total = self.fs.size(from_info.url)
         with Tqdm(
             disable=no_progress_bar,
-            # total=total,
+            total=total,
             bytes=True,
             desc=name,
             **pbar_args,

--- a/dvc/fs/oss.py
+++ b/dvc/fs/oss.py
@@ -36,7 +36,6 @@ class OSSFileSystem(ObjectFSWrapper):
         self, from_file, to_info, name=None, no_progress_bar=False, **pbar_args
     ):
         total = os.path.getsize(from_file)
-        resumable = total > self.fs.SIMPLE_TRANSFER_SIZE
         with Tqdm(
             disable=no_progress_bar,
             total=total,
@@ -47,7 +46,6 @@ class OSSFileSystem(ObjectFSWrapper):
             self.fs.put_file(
                 from_file,
                 to_info.url,
-                resumable=resumable,
                 progress_callback=pbar.update_to,
             )
         self.fs.invalidate_cache(self._with_bucket(to_info.parent))
@@ -56,7 +54,6 @@ class OSSFileSystem(ObjectFSWrapper):
         self, from_info, to_file, name=None, no_progress_bar=False, **pbar_args
     ):
         total = self.fs.size(from_info.url)
-        resumable = total > self.fs.SIMPLE_TRANSFER_SIZE
         with Tqdm(
             disable=no_progress_bar,
             total=total,
@@ -67,6 +64,5 @@ class OSSFileSystem(ObjectFSWrapper):
             self.fs.get_file(
                 from_info.url,
                 to_file,
-                resumable=resumable,
                 progress_callback=pbar.update_to,
             )

--- a/dvc/fs/oss.py
+++ b/dvc/fs/oss.py
@@ -44,9 +44,6 @@ class OSSFileSystem(ObjectFSWrapper):
     def remove(self, path_info):
         self.fs.rm_file(self._with_bucket(path_info))
 
-    def _upload_fobj(self, fobj, to_info, size=None):
-        self.fs.pipe_file(self._with_bucket(to_info), fobj)
-
     def _upload(
         self, from_file, to_info, name=None, no_progress_bar=False, **kwargs
     ):

--- a/dvc/fs/oss.py
+++ b/dvc/fs/oss.py
@@ -42,7 +42,6 @@ class OSSFileSystem(ObjectFSWrapper):
         return _OSSFileSystem(**self.fs_args)
 
     def remove(self, path_info):
-        logger.debug(f"Removing oss://{path_info}")
         self.fs.rm_file(self._with_bucket(path_info))
 
     def _upload_fobj(self, fobj, to_info, size=None):

--- a/dvc/fs/oss.py
+++ b/dvc/fs/oss.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import threading
 
@@ -8,6 +9,8 @@ from dvc.progress import Tqdm
 from dvc.scheme import Schemes
 
 from .fsspec_wrapper import ObjectFSWrapper
+
+logger = logging.getLogger(__name__)
 
 
 # pylint:disable=abstract-method
@@ -31,6 +34,10 @@ class OSSFileSystem(ObjectFSWrapper):
         from ossfs import OSSFileSystem as _OSSFileSystem
 
         return _OSSFileSystem(**self.fs_args)
+
+    def remove(self, path_info):
+        logger.debug(f"Removing oss://{path_info}")
+        self.fs.rm_file(self._with_bucket(path_info))
 
     def _upload_fobj(self, fobj, to_info, size=None):
         self.fs.pipe_file(self._with_bucket(to_info), fobj)

--- a/dvc/fs/oss.py
+++ b/dvc/fs/oss.py
@@ -61,7 +61,7 @@ class OSSFileSystem(ObjectFSWrapper):
             desc=name,
             **pbar_args,
         ) as pbar:
-            self.fs.get_file(
+            self.fs.download_file(
                 from_info.url,
                 to_file,
                 progress_callback=pbar.update_to,

--- a/dvc/fs/oss.py
+++ b/dvc/fs/oss.py
@@ -32,6 +32,9 @@ class OSSFileSystem(ObjectFSWrapper):
 
         return _OSSFileSystem(**self.fs_args)
 
+    def _upload_fobj(self, fobj, to_info, size=None):
+        self.fs.pipe_file(self._with_bucket(to_info), fobj)
+
     def _upload(
         self, from_file, to_info, name=None, no_progress_bar=False, **kwargs
     ):
@@ -45,7 +48,7 @@ class OSSFileSystem(ObjectFSWrapper):
         ) as pbar:
             self.fs.put_file(
                 from_file,
-                to_info.url,
+                self._with_bucket(to_info),
                 progress_callback=pbar.update_to,
             )
         self.fs.invalidate_cache(self._with_bucket(to_info.parent))
@@ -53,7 +56,7 @@ class OSSFileSystem(ObjectFSWrapper):
     def _download(
         self, from_info, to_file, name=None, no_progress_bar=False, **pbar_args
     ):
-        total = self.fs.size(from_info.url)
+        total = self.fs.size(self._with_bucket(from_info))
         with Tqdm(
             disable=no_progress_bar,
             total=total,
@@ -62,7 +65,7 @@ class OSSFileSystem(ObjectFSWrapper):
             **pbar_args,
         ) as pbar:
             self.fs.get_file(
-                from_info.url,
+                self._with_bucket(from_info),
                 to_file,
                 progress_callback=pbar.update_to,
             )

--- a/dvc/fs/oss.py
+++ b/dvc/fs/oss.py
@@ -1,131 +1,31 @@
-import logging
-import os
 import threading
 
 from funcy import cached_property, wrap_prop
 
 from dvc.path_info import CloudURLInfo
-from dvc.progress import Tqdm
 from dvc.scheme import Schemes
 
-from .base import BaseFileSystem
-
-logger = logging.getLogger(__name__)
+from .fsspec_wrapper import ObjectFSWrapper
 
 
-class OSSFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
-    """
-    oss2 document:
-    https://www.alibabacloud.com/help/doc-detail/32026.htm
-
-
-    Examples
-    ----------
-    $ dvc remote add myremote oss://my-bucket/path
-    Set key id, key secret and endpoint using modify command
-    $ dvc remote modify myremote oss_key_id my-key-id
-    $ dvc remote modify myremote oss_key_secret my-key-secret
-    $ dvc remote modify myremote oss_endpoint endpoint
-    or environment variables
-    $ export OSS_ACCESS_KEY_ID="my-key-id"
-    $ export OSS_ACCESS_KEY_SECRET="my-key-secret"
-    $ export OSS_ENDPOINT="endpoint"
-    """
-
+# pylint:disable=abstract-method
+class OSSFileSystem(ObjectFSWrapper):
     scheme = Schemes.OSS
     PATH_CLS = CloudURLInfo
-    REQUIRES = {"oss2": "oss2"}
+    REQUIRES = {"ossfs": "ossfs"}
     PARAM_CHECKSUM = "etag"
-    COPY_POLL_SECONDS = 5
-    LIST_OBJECT_PAGE_SIZE = 100
+    DETAIL_FIELDS = frozenset(("etag", "size"))
 
-    def __init__(self, **config):
-        super().__init__(**config)
-
-        self.endpoint = config.get("oss_endpoint") or os.getenv("OSS_ENDPOINT")
-
-        self.key_id = (
-            config.get("oss_key_id")
-            or os.getenv("OSS_ACCESS_KEY_ID")
-            or "defaultId"
-        )
-
-        self.key_secret = (
-            config.get("oss_key_secret")
-            or os.getenv("OSS_ACCESS_KEY_SECRET")
-            or "defaultSecret"
-        )
+    def _prepare_credentials(self, **config):
+        login_info = {}
+        login_info["key"] = config.get("oss_key_id")
+        login_info["secret"] = config.get("oss_key_secret")
+        login_info["endpoint"] = config.get("oss_endpoint")
+        return login_info
 
     @wrap_prop(threading.Lock())
     @cached_property
-    def oss_service(self):
-        import oss2
+    def fs(self):
+        from ossfs import OSSFileSystem as _OSSFileSystem
 
-        logger.debug(f"key id: {self.key_id}")
-        logger.debug(f"key secret: {self.key_secret}")
-
-        return oss2.Auth(self.key_id, self.key_secret)
-
-    def _get_bucket(self, bucket):
-        import oss2
-
-        return oss2.Bucket(self.oss_service, self.endpoint, bucket)
-
-    def _generate_download_url(self, path_info, expires=3600):
-        return self._get_bucket(path_info.bucket).sign_url(
-            "GET", path_info.path, expires
-        )
-
-    def exists(self, path_info) -> bool:
-        paths = self._list_paths(path_info)
-        return any(path_info.path == path for path in paths)
-
-    def _list_paths(self, path_info):
-        import oss2
-
-        for blob in oss2.ObjectIterator(
-            self._get_bucket(path_info.bucket), prefix=path_info.path
-        ):
-            yield blob.key
-
-    def walk_files(self, path_info, **kwargs):
-        if not kwargs.pop("prefix", False):
-            path_info = path_info / ""
-        for fname in self._list_paths(path_info):
-            if fname.endswith("/"):
-                continue
-
-            yield path_info.replace(path=fname)
-
-    def remove(self, path_info):
-        if path_info.scheme != self.scheme:
-            raise NotImplementedError
-
-        logger.debug(f"Removing oss://{path_info}")
-        self._get_bucket(path_info.bucket).delete_object(path_info.path)
-
-    def _upload_fobj(self, fobj, to_info, **kwargs):
-        self._get_bucket(to_info.bucket).put_object(to_info.path, fobj)
-
-    def _upload(
-        self, from_file, to_info, name=None, no_progress_bar=False, **_kwargs
-    ):
-        with Tqdm(desc=name, disable=no_progress_bar, bytes=True) as pbar:
-            bucket = self._get_bucket(to_info.bucket)
-            bucket.put_object_from_file(
-                to_info.path, from_file, progress_callback=pbar.update_to
-            )
-
-    def _download(
-        self, from_info, to_file, name=None, no_progress_bar=False, **_kwargs
-    ):
-        with Tqdm(desc=name, disable=no_progress_bar, bytes=True) as pbar:
-            import oss2
-
-            bucket = self._get_bucket(from_info.bucket)
-            oss2.resumable_download(
-                bucket,
-                from_info.path,
-                to_file,
-                progress_callback=pbar.update_to,
-            )
+        return _OSSFileSystem(**self.fs_args)

--- a/dvc/fs/oss.py
+++ b/dvc/fs/oss.py
@@ -33,7 +33,7 @@ class OSSFileSystem(ObjectFSWrapper):
         return _OSSFileSystem(**self.fs_args)
 
     def _upload(
-        self, from_file, to_info, name=None, no_progress_bar=False, **pbar_args
+        self, from_file, to_info, name=None, no_progress_bar=False, **kwargs
     ):
         total = os.path.getsize(from_file)
         with Tqdm(
@@ -41,7 +41,7 @@ class OSSFileSystem(ObjectFSWrapper):
             total=total,
             bytes=True,
             desc=name,
-            **pbar_args,
+            **kwargs,
         ) as pbar:
             self.fs.put_file(
                 from_file,

--- a/dvc/objects/db/__init__.py
+++ b/dvc/objects/db/__init__.py
@@ -5,6 +5,7 @@ def get_odb(fs, path_info, **config):
     from .base import ObjectDB
     from .gdrive import GDriveObjectDB
     from .local import LocalObjectDB
+    from .oss import OSSObjectDB
     from .ssh import SSHObjectDB
 
     if fs.scheme == Schemes.LOCAL:
@@ -15,6 +16,9 @@ def get_odb(fs, path_info, **config):
 
     if fs.scheme == Schemes.GDRIVE:
         return GDriveObjectDB(fs, path_info, **config)
+
+    if fs.scheme == Schemes.OSS:
+        return OSSObjectDB(fs, path_info, **config)
 
     return ObjectDB(fs, path_info, **config)
 

--- a/dvc/objects/db/oss.py
+++ b/dvc/objects/db/oss.py
@@ -2,4 +2,9 @@ from .base import ObjectDB
 
 
 class OSSObjectDB(ObjectDB):
+    """
+    The oss remote is migrated to ossfs recently
+    add some additional verification for the data
+    """
+
     DEFAULT_VERIFY = True

--- a/dvc/objects/db/oss.py
+++ b/dvc/objects/db/oss.py
@@ -1,0 +1,5 @@
+from .base import ObjectDB
+
+
+class OSSObjectDB(ObjectDB):
+    DEFAULT_VERIFY = True

--- a/dvc/objects/db/oss.py
+++ b/dvc/objects/db/oss.py
@@ -3,8 +3,7 @@ from .base import ObjectDB
 
 class OSSObjectDB(ObjectDB):
     """
-    The oss remote is migrated to ossfs recently
-    add some additional verification for the data
+    Temporary extra verification
     """
 
     DEFAULT_VERIFY = True

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ gdrive = ["pydrive2>=1.8.1", "six >= 1.13.0"]
 s3 = ["s3fs==2021.6.1", "aiobotocore[boto3]==1.3.0"]
 azure = ["adlfs==0.7.1", "azure-identity>=1.4.0", "knack"]
 # https://github.com/Legrandin/pycryptodome/issues/465
-oss = ["oss2==2.6.1", "pycryptodome>=3.10"]
+oss = ["ossfs==2021.6.1"]
 ssh = ["paramiko[invoke]>=2.7.0"]
 
 # Remove the env marker if/when pyarrow is available for Python3.9

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ gdrive = ["pydrive2>=1.8.1", "six >= 1.13.0"]
 s3 = ["s3fs==2021.6.1", "aiobotocore[boto3]==1.3.0"]
 azure = ["adlfs==0.7.1", "azure-identity>=1.4.0", "knack"]
 # https://github.com/Legrandin/pycryptodome/issues/465
-oss = ["ossfs==2021.6.1"]
+oss = ["ossfs==2021.6.2"]
 ssh = ["paramiko[invoke]>=2.7.0"]
 
 # Remove the env marker if/when pyarrow is available for Python3.9

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ gdrive = ["pydrive2>=1.8.1", "six >= 1.13.0"]
 s3 = ["s3fs==2021.6.1", "aiobotocore[boto3]==1.3.0"]
 azure = ["adlfs==0.7.1", "azure-identity>=1.4.0", "knack"]
 # https://github.com/Legrandin/pycryptodome/issues/465
-oss = ["ossfs==2021.7.0"]
+oss = ["ossfs==2021.7.1"]
 ssh = ["paramiko[invoke]>=2.7.0"]
 
 # Remove the env marker if/when pyarrow is available for Python3.9

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ gdrive = ["pydrive2>=1.8.1", "six >= 1.13.0"]
 s3 = ["s3fs==2021.6.1", "aiobotocore[boto3]==1.3.0"]
 azure = ["adlfs==0.7.1", "azure-identity>=1.4.0", "knack"]
 # https://github.com/Legrandin/pycryptodome/issues/465
-oss = ["ossfs==2021.6.2"]
+oss = ["ossfs==2021.7.0"]
 ssh = ["paramiko[invoke]>=2.7.0"]
 
 # Remove the env marker if/when pyarrow is available for Python3.9

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ gdrive = ["pydrive2>=1.8.1", "six >= 1.13.0"]
 s3 = ["s3fs==2021.6.1", "aiobotocore[boto3]==1.3.0"]
 azure = ["adlfs==0.7.1", "azure-identity>=1.4.0", "knack"]
 # https://github.com/Legrandin/pycryptodome/issues/465
-oss = ["ossfs==2021.7.2"]
+oss = ["ossfs==2021.7.3"]
 ssh = ["paramiko[invoke]>=2.7.0"]
 
 # Remove the env marker if/when pyarrow is available for Python3.9

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ gdrive = ["pydrive2>=1.8.1", "six >= 1.13.0"]
 s3 = ["s3fs==2021.6.1", "aiobotocore[boto3]==1.3.0"]
 azure = ["adlfs==0.7.1", "azure-identity>=1.4.0", "knack"]
 # https://github.com/Legrandin/pycryptodome/issues/465
-oss = ["ossfs==2021.7.1"]
+oss = ["ossfs==2021.7.2"]
 ssh = ["paramiko[invoke]>=2.7.0"]
 
 # Remove the env marker if/when pyarrow is available for Python3.9

--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -30,14 +30,8 @@ all_clouds = [
         "hdfs",
         "webdav",
         "webhdfs",
+        "oss",
     ]
-] + [
-    pytest.param(
-        pytest.lazy_fixture("oss"),
-        marks=pytest.mark.xfail(
-            reason="https://github.com/iterative/dvc/issues/4633"
-        ),
-    )
 ]
 
 # Clouds that implement the general methods that can be tested

--- a/tests/remotes/oss.py
+++ b/tests/remotes/oss.py
@@ -9,7 +9,7 @@ from dvc.utils import env2bool
 
 from .base import Base
 
-TEST_OSS_REPO_BUCKET = "dvc-test"
+TEST_OSS_REPO_BUCKET = "dvc-temp"
 EMULATOR_OSS_ENDPOINT = "127.0.0.1:{port}"
 EMULATOR_OSS_ACCESS_KEY_ID = "AccessKeyID"
 EMULATOR_OSS_ACCESS_KEY_SECRET = "AccessKeySecret"
@@ -66,19 +66,12 @@ def oss_server(test_config, docker_compose, docker_services):
 def oss(real_oss):
     import oss2
 
-    url = OSS.get_url()
-    ret = OSS(url)
-    ret.config = {
-        "url": url,
-        "oss_key_id": EMULATOR_OSS_ACCESS_KEY_ID,
-        "oss_key_secret": EMULATOR_OSS_ACCESS_KEY_SECRET,
-        "oss_endpoint": oss_server,
-    }
+    ret = real_oss
 
-    auth = oss2.Auth(
-        EMULATOR_OSS_ACCESS_KEY_ID, EMULATOR_OSS_ACCESS_KEY_SECRET
+    auth = oss2.Auth(ret.config["oss_key_id"], ret.config["oss_key_secret"])
+    bucket = oss2.Bucket(
+        auth, ret.config["oss_endpoint"], TEST_OSS_REPO_BUCKET
     )
-    bucket = oss2.Bucket(auth, oss_server, TEST_OSS_REPO_BUCKET)
     try:
         bucket.get_bucket_info()
     except oss2.exceptions.NoSuchBucket:

--- a/tests/remotes/oss.py
+++ b/tests/remotes/oss.py
@@ -63,7 +63,7 @@ def oss_server(test_config, docker_compose, docker_services):
 
 
 @pytest.fixture
-def oss(oss_server):
+def oss(real_oss):
     import oss2
 
     url = OSS.get_url()

--- a/tests/remotes/oss.py
+++ b/tests/remotes/oss.py
@@ -9,7 +9,7 @@ from dvc.utils import env2bool
 
 from .base import Base
 
-TEST_OSS_REPO_BUCKET = "dvc-temp"
+TEST_OSS_REPO_BUCKET = "dvc-test-github"
 EMULATOR_OSS_ENDPOINT = "127.0.0.1:{port}"
 EMULATOR_OSS_ACCESS_KEY_ID = "AccessKeyID"
 EMULATOR_OSS_ACCESS_KEY_SECRET = "AccessKeySecret"

--- a/tests/unit/remote/test_oss.py
+++ b/tests/unit/remote/test_oss.py
@@ -16,6 +16,6 @@ def test_init(dvc):
         "oss_endpoint": endpoint,
     }
     fs = OSSFileSystem(**config)
-    assert fs.endpoint == endpoint
-    assert fs.key_id == key_id
-    assert fs.key_secret == key_secret
+    assert fs.fs._endpoint == endpoint
+    assert fs.fs._auth.id == key_id
+    assert fs.fs._auth.secret == key_secret


### PR DESCRIPTION
Fix #6177, migrate to ossfs

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

come from #6178 

Performance summary: 
> The latest version runs 1.5 times faster  in `gc` and `push` than the version we are using, and more than 2 times in `pull`.

| time cost \ version| current version | last week version | reuse session version  | dircache version (latest) |
|:--:|:--:|:--:|:--:|:--:|
| gc | 100% |  +115% | 70% |  68% |
| pull | 100% | 171% |  118% | 36% |
| push | 100% | 97% | 64% |  72 %|

![image](https://user-images.githubusercontent.com/6745454/125281418-c8be5780-e348-11eb-8837-b339abf57740.png)
The results from the current version compare to reuse of sessions optimization.

![image](https://user-images.githubusercontent.com/6745454/125281643-1044e380-e349-11eb-956a-5e1b5a970bd8.png)
The results from the current version compare to reuse of sessions optimization.

