### PR TITLE
fsspec: create directories on upload/upload_fobj

### DIFF
--- a/dvc/fs/base.py
+++ b/dvc/fs/base.py
@@ -187,7 +187,7 @@ class BaseFileSystem:
     def remove(self, path_info):
         raise RemoteActionNotImplemented("remove", self.scheme)
 
-    def makedirs(self, path_info):
+    def makedirs(self, path_info, **kwargs):
         """Optional: Implement only if the remote needs to create
         directories before copying/linking/moving data
         """

--- a/dvc/fs/hdfs.py
+++ b/dvc/fs/hdfs.py
@@ -183,7 +183,7 @@ class HDFSFileSystem(BaseFileSystem):
                 else:
                     hdfs.delete_file(path_info.path)
 
-    def makedirs(self, path_info):
+    def makedirs(self, path_info, **kwargs):
         with self.hdfs(path_info) as hdfs:
             # NOTE: fs.create_dir creates parents by default
             hdfs.create_dir(path_info.path)

--- a/dvc/fs/local.py
+++ b/dvc/fs/local.py
@@ -79,8 +79,8 @@ class LocalFileSystem(BaseFileSystem):
                 raise NotImplementedError
         remove(path_info)
 
-    def makedirs(self, path_info):
-        makedirs(path_info, exist_ok=True)
+    def makedirs(self, path_info, **kwargs):
+        makedirs(path_info, exist_ok=kwargs.pop("exist_ok", True))
 
     def isexec(self, path_info):
         mode = self.stat(path_info).st_mode

--- a/dvc/fs/ssh/__init__.py
+++ b/dvc/fs/ssh/__init__.py
@@ -173,7 +173,7 @@ class SSHFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
         with self.ssh() as ssh:
             ssh.remove(path_info.path)
 
-    def makedirs(self, path_info):
+    def makedirs(self, path_info, **kwargs):
         with self.ssh() as ssh:
             ssh.makedirs(path_info.path)
 

--- a/dvc/fs/webdav.py
+++ b/dvc/fs/webdav.py
@@ -81,10 +81,6 @@ class WebDAVFileSystem(FSSpecWrapper):  # pylint:disable=abstract-method
             fobj, rpath, overwrite=True, size=size
         )
 
-    def makedirs(self, path_info):
-        path = self.translate_path_info(path_info)
-        return self.fs.makedirs(path, exist_ok=True)
-
     @lru_cache(512)
     def translate_path_info(self, path):
         if isinstance(path, self.PATH_CLS):
@@ -92,9 +88,6 @@ class WebDAVFileSystem(FSSpecWrapper):  # pylint:disable=abstract-method
         return path
 
     _with_bucket = translate_path_info
-
-    def _strip_bucket(self, entry):
-        return entry
 
 
 class WebDAVSFileSystem(WebDAVFileSystem):  # pylint:disable=abstract-method


### PR DESCRIPTION
Since we start adding non-object systems (e.g webdav, ssh) there is now a requirement for `makedirs()` calls before `upload`/`upload_fobj`/`copy` operations. Also the `_with_bucket`, and `_strip_bucket` functions are closely tied with the object filesytems so they are moved under the `ObjectFsWrapper`. 