### PR TITLE
do not print in style by default for errors

### DIFF
--- a/dvc/ui/__init__.py
+++ b/dvc/ui/__init__.py
@@ -61,7 +61,7 @@ class Console:
         style: str = None,
         sep: str = None,
         end: str = None,
-        styled: bool = True,
+        styled: bool = False,
         force: bool = True,
     ) -> None:
         return self.write(


### PR DESCRIPTION
I mistakenly set the `styled` parameter default value in the `error_write` to `True`, which was printing using `rich` by default. This caused the messages to also include the ANSI codes to display.

```console
$ dvc add foo
100% Adding...|████████████████████████████████████████|1/1 [00:00, 76.95file/s]

Some targets could not be linked from cache to workspace.
See <[36mhttps://dvc.org/doc/user-guide/troubleshooting#cache-types[39m> for 
more information.
To re-link these targets, reconfigure cache types and then run:

        dvc checkout foo.dvc

To track the changes with git, run:

	git add foo.dvc
```
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
