### PR TITLE
setup: bump flatten-dict to 0.4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ install_requires = [
     "speedcopy>=2.0.1; python_version < '3.8' and sys_platform == 'win32'",
     "dataclasses==0.7; python_version < '3.7'",
     "importlib-metadata>=1.4; python_version < '3.8'",
-    "flatten_dict>=0.3.0,<1",
+    "flatten_dict>=0.4.1,<1",
     "tabulate>=0.8.7",
     "pygtrie>=2.3.2",
     "dpath>=2.0.1,<3",


### PR DESCRIPTION
My [latest PR](https://github.com/ianlini/flatten-dict/pull/44) to flatten-dict should shave about 0.5 seconds on very complex environments for us, so upgrading it to 0.4.1. Resolves #6349