### PR TITLE
fsspec: use rm_file()

### DIFF
--- a/dvc/fs/fsspec_wrapper.py
+++ b/dvc/fs/fsspec_wrapper.py
@@ -102,7 +102,7 @@ class FSSpecWrapper(BaseFileSystem):
             yield path_info.replace(path=file)
 
     def remove(self, path_info):
-        self.fs.rm(self._with_bucket(path_info))
+        self.fs.rm_file(self._with_bucket(path_info))
 
     def info(self, path_info):
         info = self.fs.info(self._with_bucket(path_info)).copy()

--- a/dvc/fs/oss.py
+++ b/dvc/fs/oss.py
@@ -39,6 +39,3 @@ class OSSFileSystem(CallbackMixin, ObjectFSWrapper):
         from ossfs import OSSFileSystem as _OSSFileSystem
 
         return _OSSFileSystem(**self.fs_args)
-
-    def remove(self, path_info):
-        self.fs.rm_file(self._with_bucket(path_info))


### PR DESCRIPTION
Our `remove()` is actually `rm_file()` since it is only responsible with removing an individual file. `fsspec`'s `rm()` is a little bit more powerful, with recursive functionality etc. but more expensive in terms of target expanding. s3fs was the only filesystem which didn't support this, though with 2021.7.0 it is now supporting it (https://github.com/dask/s3fs/pull/499). 