### PR TITLE
remote: add excludes for AzureDefaultCredentials

### DIFF
--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -189,7 +189,11 @@ SCHEMA = {
                     "tenant_id": str,
                     "client_id": str,
                     "client_secret": str,
-                    "allow_anonymous_login": bool,
+                    "allow_anonymous_login": Bool,
+                    "exclude_environment_credential": Bool,
+                    "exclude_visual_studio_code_credential": Bool,
+                    "exclude_shared_token_cache_credential": Bool,
+                    "exclude_managed_identity_credential": Bool,
                     **REMOTE_COMMON,
                 },
                 "oss": {

--- a/dvc/fs/azure.py
+++ b/dvc/fs/azure.py
@@ -108,7 +108,19 @@ class AzureFileSystem(ObjectFSWrapper):
         ):
             with fsspec_loop():
                 login_info["credential"] = DefaultAzureCredential(
-                    exclude_interactive_browser_credential=False
+                    exclude_interactive_browser_credential=False,
+                    exclude_environment_credential=config.get(
+                        "exclude_environment_credential", False
+                    ),
+                    exclude_visual_studio_code_credential=config.get(
+                        "exclude_visual_studio_code_credential", False
+                    ),
+                    exclude_shared_token_cache_credential=config.get(
+                        "exclude_shared_token_cache_credential", False
+                    ),
+                    exclude_managed_identity_credential=config.get(
+                        "exclude_managed_identity_credential", False
+                    ),
                 )
 
         for login_method, required_keys in [  # noqa


### PR DESCRIPTION
add additional excludes to DefaultAzureCredential
which are needed in a Windows Environment to
use az cli provided credentials, etc.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
