### PR TITLE
ssh: handle concurrency issues for raw command execution

### DIFF
--- a/dvc/fs/fsspec_wrapper.py
+++ b/dvc/fs/fsspec_wrapper.py
@@ -110,6 +110,9 @@ class FSSpecWrapper(BaseFileSystem):
         for file in self.find(path_info, **kwargs):
             yield path_info.replace(path=file)
 
+    def move(self, from_info, to_info):
+        self.fs.move(self._with_bucket(from_info), self._with_bucket(to_info))
+
     def remove(self, path_info):
         self.fs.rm_file(self._with_bucket(path_info))
 

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ s3 = ["s3fs==2021.7.0", "aiobotocore[boto3]>1.0.1"]
 azure = ["adlfs==2021.7.1", "azure-identity>=1.4.0", "knack"]
 # https://github.com/Legrandin/pycryptodome/issues/465
 oss = ["ossfs==2021.7.5"]
-ssh = ["sshfs>=2021.7.0"]
+ssh = ["sshfs>=2021.7.1a0"]
 
 # Remove the env marker if/when pyarrow is available for Python3.9
 hdfs = ["pyarrow>=2.0.0"]
@@ -111,7 +111,7 @@ webdav = ["webdav4>=0.9.0"]
 # for linux and mac, so it will fail to compile if user doesn't have all the
 # requirements, including kerberos itself. Once all the wheels are available,
 # we can start shipping it by default.
-ssh_gssapi = ["sshfs[gssapi]>=2021.7.0"]
+ssh_gssapi = ["sshfs[gssapi]>=2021.7.1a0"]
 all_remotes = gs + s3 + azure + ssh + oss + gdrive + hdfs + webhdfs + webdav
 
 tests_requirements = (

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ s3 = ["s3fs==2021.7.0", "aiobotocore[boto3]>1.0.1"]
 azure = ["adlfs==2021.7.1", "azure-identity>=1.4.0", "knack"]
 # https://github.com/Legrandin/pycryptodome/issues/465
 oss = ["ossfs==2021.7.5"]
-ssh = ["sshfs>=2021.7.1a0"]
+ssh = ["sshfs>=2021.7.1"]
 
 # Remove the env marker if/when pyarrow is available for Python3.9
 hdfs = ["pyarrow>=2.0.0"]
@@ -111,7 +111,7 @@ webdav = ["webdav4>=0.9.0"]
 # for linux and mac, so it will fail to compile if user doesn't have all the
 # requirements, including kerberos itself. Once all the wheels are available,
 # we can start shipping it by default.
-ssh_gssapi = ["sshfs[gssapi]>=2021.7.1a0"]
+ssh_gssapi = ["sshfs[gssapi]>=2021.7.1"]
 all_remotes = gs + s3 + azure + ssh + oss + gdrive + hdfs + webhdfs + webdav
 
 tests_requirements = (


### PR DESCRIPTION
From https://github.com/iterative/dvc/pull/6295#issuecomment-888495315. There are 2 primary issues, one is that we used to max out all the sessions with SFTP channels, so after a certain amount of operations there wasn't any channels to use for SSH. Now we allocate 2 channels for it. The second issue is that, `AsyncFileSystem` that fsspec offers overrides the `move()` command with it's own `copy()`+`remove()` implementation. Now that is also temporarily fixed on the sshfs, and will submit a patch against fsspec upstream. 