### PR TITLE
plots: upgrade to latest Vega library versions

### DIFF
--- a/dvc/utils/html.py
+++ b/dvc/utils/html.py
@@ -7,9 +7,9 @@ PAGE_HTML = """<!DOCTYPE html>
 <html>
 <head>
     <title>DVC Plot</title>
-    <script src="https://cdn.jsdelivr.net/npm/vega@5.10.0"></script>
-    <script src="https://cdn.jsdelivr.net/npm/vega-lite@4.8.1"></script>
-    <script src="https://cdn.jsdelivr.net/npm/vega-embed@6.5.1"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega@5.20.2"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-lite@5.1.0"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vega-embed@6.18.2"></script>
 </head>
 <body>
     {plot_divs}


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [N/A] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

The current version of Vega included in the plots template page is quite outdated. Many of the features mentioned in the Vega Lite documentation are Vega-Lite 5.0 only, and thus fail to work on the 4.0 version included by DVC. I submitted this change that simply changes the version numbers to the latest versions released as of now.

One idea to consider is omitting the version entirely and allowing jsDelivr to pick the latest version it has available. Vega plots all require a `$schema` parameter that specifies the version of the Vega specification to adhere to when displaying, so even breaking changes to the latest spec should not cause issues to existing plots.