### PR TITLE
fs: get_fs_config: raise RemoteNotFoundError

### DIFF
--- a/dvc/config.py
+++ b/dvc/config.py
@@ -20,7 +20,15 @@ class ConfigError(DvcException):
         super().__init__(f"config file error: {msg}")
 
 
-class NoRemoteError(ConfigError):
+class RemoteConfigError(ConfigError):
+    pass
+
+
+class NoRemoteError(RemoteConfigError):
+    pass
+
+
+class RemoteNotFoundError(RemoteConfigError):
     pass
 
 

--- a/dvc/fs/__init__.py
+++ b/dvc/fs/__init__.py
@@ -40,7 +40,12 @@ def get_fs_cls(remote_conf):
 def get_fs_config(config, **kwargs):
     name = kwargs.get("name")
     if name:
-        remote_conf = config["remote"][name.lower()]
+        try:
+            remote_conf = config["remote"][name.lower()]
+        except KeyError:
+            from dvc.config import RemoteNotFoundError
+
+            raise RemoteNotFoundError(f"remote '{name}' doesn't exist")
     else:
         remote_conf = kwargs
     return _resolve_remote_refs(config, remote_conf)

--- a/tests/unit/fs/test_fs.py
+++ b/tests/unit/fs/test_fs.py
@@ -1,6 +1,7 @@
 import pytest
 
-from dvc.fs import get_fs_cls
+from dvc.config import RemoteNotFoundError
+from dvc.fs import get_fs_cls, get_fs_config
 from dvc.fs.hdfs import HDFSFileSystem
 from dvc.fs.http import HTTPFileSystem
 from dvc.fs.https import HTTPSFileSystem
@@ -29,3 +30,8 @@ from dvc.fs.ssh import SSHFileSystem
 )
 def test_get_fs_cls(url, cls):
     assert get_fs_cls({"url": url}) == cls
+
+
+def test_get_fs_config():
+    with pytest.raises(RemoteNotFoundError):
+        get_fs_config({"remote": {}}, name="myremote")


### PR DESCRIPTION
A simple temporary fix for studio. A proper fix would be to make metrics/plots/etc lazy and detached from dag build, so that this error is not even triggered. That will likely happen after #6300

Fixes #6082

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
