### PR TITLE
refodb: cache ref objects

### DIFF
--- a/dvc/objects/db/base.py
+++ b/dvc/objects/db/base.py
@@ -2,6 +2,7 @@ import itertools
 import logging
 import os
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import suppress
 from copy import copy
 from typing import TYPE_CHECKING, Optional
 
@@ -203,7 +204,8 @@ class ObjectDB:
             obj.check(self, check_hash=check_hash)
         except ObjectFormatError:
             logger.warning("corrupted cache file '%s'.", obj.path_info)
-            self.fs.remove(obj.path_info)
+            with suppress(FileNotFoundError):
+                self.fs.remove(obj.path_info)
             raise
 
         if check_hash:


### PR DESCRIPTION
Caching ref objects to avoid wasting lots of time on loading in [_get_file_obj](https://github.com/iterative/dvc/blob/fd76e0991f6dd47e554b874c2efb8c280dee96c0/dvc/objects/stage.py#L93). Overall this brings back the lost parity between import and pull performance.

Followup for #6360.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
