### PR TITLE
repofs: use underlying fs.download to download files

### DIFF
--- a/dvc/fs/dvc.py
+++ b/dvc/fs/dvc.py
@@ -62,9 +62,7 @@ class DvcFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
             return obj.hash_info
         raise FileNotFoundError
 
-    def open(  # type: ignore
-        self, path: PathInfo, mode="r", encoding=None, remote=None, **kwargs
-    ):  # pylint: disable=arguments-differ
+    def _get_fs_path(self, path: PathInfo, remote=None):
         try:
             outs = self._find_outs(path, strict=False)
         except OutputNotFoundError as exc:
@@ -92,16 +90,20 @@ class DvcFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
             else:
                 checksum = out.hash_info.value
             remote_info = remote_odb.hash_to_path_info(checksum)
-            return remote_odb.fs.open(
-                remote_info, mode=mode, encoding=encoding
-            )
+            return remote_odb.fs, remote_info
 
         if out.is_dir_checksum:
             checksum = self._get_granular_hash(path, out).value
             cache_path = out.odb.hash_to_path_info(checksum).url
         else:
             cache_path = out.cache_path
-        return open(cache_path, mode=mode, encoding=encoding)
+        return out.odb.fs, cache_path
+
+    def open(  # type: ignore
+        self, path: PathInfo, mode="r", encoding=None, **kwargs
+    ):  # pylint: disable=arguments-renamed
+        fs, fspath = self._get_fs_path(path, **kwargs)
+        return fs.open(fspath, mode=mode, encoding=encoding)
 
     def exists(self, path):  # pylint: disable=arguments-renamed
         try:
@@ -253,3 +255,9 @@ class DvcFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
                 ret[obj.hash_info.name] = obj.hash_info.value
 
         return ret
+
+    def _download(self, from_info, to_file, **kwargs):
+        fs, path = self._get_fs_path(from_info)
+        fs._download(  # pylint: disable=protected-access
+            path, to_file, **kwargs
+        )

--- a/dvc/fs/git.py
+++ b/dvc/fs/git.py
@@ -126,3 +126,17 @@ class GitFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
             for file in files:
                 # NOTE: os.path.join is ~5.5 times slower
                 yield f"{root}{os.sep}{file}"
+
+    def _download(
+        self, from_info, to_file, name=None, no_progress_bar=False, **kwargs
+    ):
+        import shutil
+
+        from dvc.progress import Tqdm
+
+        with open(to_file, "wb+") as to_fobj:
+            with Tqdm.wrapattr(
+                to_fobj, "write", desc=name, disable=no_progress_bar
+            ) as wrapped:
+                with self.open(from_info, "rb", **kwargs) as from_fobj:
+                    shutil.copyfileobj(from_fobj, wrapped)


### PR DESCRIPTION
This makes `dvc get` work just as fast as `import/pull`. The reason is that `open()` is harder to make fast (e.g. we need to know what block size to use, etc, for which we don't yet have a very good internal infrastructure), and it is much easier to just use native `fs.download` method that has been already tuned for maximum performance.

Related to #5546
Fixes #6019

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
