### PR TITLE
s3: inline bucket region caching

### DIFF
--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -154,6 +154,7 @@ SCHEMA = {
                     "grant_read_acp": str,
                     "grant_write_acp": str,
                     "grant_full_control": str,
+                    "cache_regions": bool,
                     **REMOTE_COMMON,
                 },
                 "gs": {


### PR DESCRIPTION
This patch adds a new option (`cache_regions`) to enable bucket region caching in s3fs (https://github.com/dask/s3fs/pull/495). This basically caches regions for each buckets in-memory during the program's runtime. If you don't specify any region in your config, then you end up with resolving the same bucket's region over and over which comes with a burden for small running programs.

For `info()` calls on the same bucket, this was the stats I was able to gather without the bucket region caching:
```
total invocations: 1, total time: 2.765854, time/invoc: 2.765854
total invocations: 2, total time: 3.100261, time/invoc: 1.550131
total invocations: 3, total time: 4.330655, time/invoc: 1.443552
total invocations: 4, total time: 5.416423, time/invoc: 1.354106
total invocations: 5, total time: 6.585422, time/invoc: 1.317084
total invocations: 6, total time: 12.837526, time/invoc: 2.139588
total invocations: 7, total time: 9.008174, time/invoc: 1.286882
total invocations: 8, total time: 9.980438, time/invoc: 1.247555
total invocations: 9, total time: 11.341123, time/invoc: 1.260125
total invocations: 10, total time: 12.406109, time/invoc: 1.240611
```
As it can be seen, a simple `info()` call costs about ~1.2 seconds. However, if we cache buckets then the stats will look like this;
```
total invocations: 1, total time: 2.944956, time/invoc: 2.944956
total invocations: 2, total time: 3.025406, time/invoc: 1.512703
total invocations: 3, total time: 3.395653, time/invoc: 1.131884
total invocations: 4, total time: 3.698849, time/invoc: 0.924712
total invocations: 5, total time: 3.924782, time/invoc: 0.784956
total invocations: 6, total time: 4.052484, time/invoc: 0.675414
total invocations: 7, total time: 4.380276, time/invoc: 0.625754
total invocations: 8, total time: 4.702067, time/invoc: 0.587758
total invocations: 9, total time: 4.911772, time/invoc: 0.545752
total invocations: 10, total time: 5.013062, time/invoc: 0.501306
```

Which basically frees the overhead of resolving the bucket after the first call, and the per-call time as well as the total time gets reduced substantially (almost 2x) after the usage of a few invocation. At some point (around 16 calls), the difference becomes almost 3x (1.2 vs 0.45). 

Obviously we are trying to reduce the number of `info()` calls we are making, and from what I can see for basic workflows we only make a few of them but still this can yield some benefit for `status -c` (I will run benchmarks and share them here). 

Resolves #5969