### PR TITLE
Improved WebDAV authentication

### DIFF
--- a/dvc/fs/webdav.py
+++ b/dvc/fs/webdav.py
@@ -61,6 +61,13 @@ class WebDAVFileSystem(FSSpecWrapper):  # pylint:disable=abstract-method
             if not password and config.get("ask_password"):
                 password = ask_password(config["host"], user)
             auth = (user, password)
+        else:
+            # check environment variables
+            user = os.getenv("WEBDAV_USER", None)
+            password = os.getenv("WEBDAV_PASSWORD", None)
+
+            if user and password:
+                auth = (user, password)
 
         return {"headers": headers, "auth": auth}
 


### PR DESCRIPTION
The following environment variables can now be used for WebDAV authentication:
- WEBDAV_USER: to specify the username
- WEBDAV_PASSWORD: to specify the password of the user

Closes #6416 
WebDAV documentation should be updated #6417

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏