### PR TITLE
fs: find(..., detail=True) now casts values properly

### DIFF
--- a/dvc/fs/fsspec_wrapper.py
+++ b/dvc/fs/fsspec_wrapper.py
@@ -217,7 +217,7 @@ class ObjectFSWrapper(FSSpecWrapper):
             files = self.fs.find(path, detail=detail)
 
         if detail:
-            files = files.values()
+            files = list(files.values())
 
         # When calling find() on a file, it returns the same file in a list.
         # For object-based storages, the same behavior applies to empty

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ install_requires = [
 # Extra dependencies for remote integrations
 
 gs = ["gcsfs==2021.7.0"]
-gdrive = ["pydrive2[fsspec]>=1.9.0"]
+gdrive = ["pydrive2[fsspec]>=1.9.1"]
 s3 = ["s3fs==2021.7.0", "aiobotocore[boto3]>1.0.1"]
 azure = ["adlfs==2021.7.1", "azure-identity>=1.4.0", "knack"]
 # https://github.com/Legrandin/pycryptodome/issues/465

--- a/tests/func/test_fs.py
+++ b/tests/func/test_fs.py
@@ -335,6 +335,10 @@ def test_fs_find(dvc, cloud):
     assert {
         os.path.basename(file_key) for file_key in fs.find(path_info / "data")
     } == {"foo", "baz", "quux"}
+    assert {
+        os.path.basename(file_info["name"])
+        for file_info in fs.find(path_info / "data", detail=True)
+    } == {"foo", "baz", "quux"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
In the following statement we try to access the first index, which is not possible when using `dict.values()`. 