### PR TITLE
fetched: correctly order mixed odbs

### DIFF
--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -61,7 +61,8 @@ def fetch(
 
     for odb, obj_ids in sorted(
         used.items(),
-        key=lambda item: item[0] and item[0].fs.scheme == Schemes.MEMORY,
+        key=lambda item: item[0] is not None
+        and item[0].fs.scheme == Schemes.MEMORY,
     ):
         d, f = _fetch(
             self,

--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -350,6 +350,27 @@ def test_pull_external_dvc_imports(tmp_dir, dvc, scm, erepo_dir):
     assert (tmp_dir / "new_dir" / "bar").read_text() == "bar"
 
 
+def test_pull_external_dvc_imports_mixed(
+    tmp_dir, dvc, scm, erepo_dir, local_remote
+):
+    with erepo_dir.chdir():
+        erepo_dir.dvc_gen("foo", "foo", commit="first")
+        os.remove("foo")
+
+    # imported: foo
+    dvc.imp(os.fspath(erepo_dir), "foo")
+
+    # local-object: bar
+    tmp_dir.dvc_gen("bar", "bar")
+    dvc.push("bar")
+
+    clean(["foo", "bar"], dvc)
+
+    assert dvc.pull()["fetched"] == 2
+    assert (tmp_dir / "foo").read_text() == "foo"
+    assert (tmp_dir / "bar").read_text() == "bar"
+
+
 def clean(outs, dvc=None):
     from tests.utils import clean_staging
 


### PR DESCRIPTION
Resolved #6435. If `item[0]` is `None`, python will shortcut at the `and` operator and use it's result (`None`) instead of `False` which would make the items unsortable. With adding an explicit check against `None`, it now returns either `False` or `True`.