### PR TITLE
Change ui message for the updater

### DIFF
--- a/dvc/command/version.py
+++ b/dvc/command/version.py
@@ -10,21 +10,12 @@ logger = logging.getLogger(__name__)
 class CmdVersion(CmdBaseNoRepo):
     def run(self):
         from dvc.info import get_dvc_info
-        from dvc.repo import NotDvcRepoError, Repo
+        from dvc.updater import notify_updates
 
         dvc_info = get_dvc_info()
         ui.write(dvc_info, force=True)
 
-        try:
-            with Repo() as repo:
-                from dvc.updater import Updater
-
-                hardlink_lock = repo.config["core"].get("hardlink_lock", False)
-                updater = Updater(repo.tmp_dir, hardlink_lock=hardlink_lock)
-                updater.check()
-        except NotDvcRepoError:
-            pass
-
+        notify_updates()
         return 0
 
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

On top of https://github.com/iterative/dvc/pull/6247.
Related to #5912.

<details>
  <summary>Screenshots</summary>
  
  1. Git installed, or unknown package:
  
<img width="712" alt="Screen Shot 2021-08-16 at 19 19 00" src="https://user-images.githubusercontent.com/18718008/129572151-0b55e195-83b5-47a9-93ea-0c83d7d99332.png">
<img width="883" alt="Screen Shot 2021-08-16 at 19 20 13" src="https://user-images.githubusercontent.com/18718008/129572264-22091450-654e-4368-ad94-b1139482e741.png">

2. Non-binary packages
<img width="667" alt="Screen Shot 2021-08-16 at 19 21 11" src="https://user-images.githubusercontent.com/18718008/129572396-824b0c69-cba6-4704-aa12-0da6caae730b.png">
<img width="805" alt="Screen Shot 2021-08-16 at 19 21 40" src="https://user-images.githubusercontent.com/18718008/129572474-497055ce-909a-40e9-9fe3-9ac51136d8d5.png">

3. Binary packages
<img width="648" alt="Screen Shot 2021-08-16 at 19 22 18" src="https://user-images.githubusercontent.com/18718008/129572546-9c9b2122-272e-4acd-8040-523b5cc2f198.png">
<img width="807" alt="Screen Shot 2021-08-16 at 19 22 41" src="https://user-images.githubusercontent.com/18718008/129572581-c2e063a1-d450-4926-81a8-55b91559004b.png">
</details>

I still have some doubts about the link in blue, could also color it in yellow. Please see if the messages are clearer too.

Also note that the ui messages only appear in `dvc version`.