### PR TITLE
ref: use fs.checksum instead of get_mtime_and_size

### DIFF
--- a/dvc/fs/base.py
+++ b/dvc/fs/base.py
@@ -124,6 +124,9 @@ class BaseFileSystem:
             f"dependencies: {missing}. {hint}"
         )
 
+    def checksum(self, path_info) -> str:
+        raise NotImplementedError
+
     def open(self, path_info, mode: str = "r", encoding: str = None, **kwargs):
         raise RemoteActionNotImplemented("open", self.scheme)
 

--- a/dvc/fs/dvc.py
+++ b/dvc/fs/dvc.py
@@ -261,3 +261,10 @@ class DvcFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
         fs._download(  # pylint: disable=protected-access
             path, to_file, **kwargs
         )
+
+    def checksum(self, path_info):
+        info = self.info(path_info)
+        md5 = info.get("md5")
+        if md5:
+            return md5
+        raise NotImplementedError

--- a/dvc/fs/fsspec_wrapper.py
+++ b/dvc/fs/fsspec_wrapper.py
@@ -85,6 +85,9 @@ class FSSpecWrapper(BaseFileSystem):
     ):  # pylint: disable=arguments-differ
         return self.fs.open(self._with_bucket(path_info), mode=mode)
 
+    def checksum(self, path_info):
+        return self.fs.checksum(self._with_bucket(path_info))
+
     def copy(self, from_info, to_info):
         self.makedirs(to_info.parent)
         self.fs.copy(self._with_bucket(from_info), self._with_bucket(to_info))

--- a/dvc/fs/repo.py
+++ b/dvc/fs/repo.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import stat
 import threading
 from contextlib import suppress
 from itertools import takewhile
@@ -256,8 +255,8 @@ class RepoFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
             return False
 
         try:
-            st = fs.stat(path)
-            return stat.S_ISDIR(st.st_mode)
+            info = fs.info(path)
+            return info["type"] == "directory"
         except (OSError, ValueError):
             # from CPython's os.path.isdir()
             pass
@@ -287,8 +286,8 @@ class RepoFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
             return False
 
         try:
-            st = fs.stat(path)
-            return stat.S_ISREG(st.st_mode)
+            info = fs.info(path)
+            return info["type"] == "file"
         except (OSError, ValueError):
             # from CPython's os.path.isfile()
             pass
@@ -312,10 +311,6 @@ class RepoFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
         if dvc_fs and dvc_fs.exists(path_info):
             return dvc_fs.isexec(path_info)
         return fs.isexec(path_info)
-
-    def stat(self, path):
-        fs, _ = self._get_fs_pair(path)
-        return fs.stat(path)
 
     def _dvc_walk(self, walk):
         try:
@@ -478,11 +473,11 @@ class RepoFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
             with suppress(FileNotFoundError):
                 dvc_meta = dvc_fs.metadata(path_info)
 
-        stat_result = None
+        info_result = None
         with suppress(FileNotFoundError):
-            stat_result = fs.stat(path_info)
+            info_result = fs.info(path_info)
 
-        if not stat_result and not dvc_meta:
+        if not info_result and not dvc_meta:
             raise FileNotFoundError
 
         from ._metadata import Metadata
@@ -492,13 +487,13 @@ class RepoFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
             repo=self._get_repo(abspath) or self._main_repo,
         )
 
-        isdir = bool(stat_result) and stat.S_ISDIR(stat_result.st_mode)
+        isdir = bool(info_result) and info_result["type"] == "directory"
         meta.isdir = meta.isdir or isdir
 
         if not dvc_meta:
             from dvc.utils import is_exec
 
-            meta.is_exec = bool(stat_result) and is_exec(stat_result.st_mode)
+            meta.is_exec = bool(info_result) and is_exec(info_result["mode"])
         return meta
 
     def info(self, path_info):
@@ -508,3 +503,11 @@ class RepoFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
             return fs.info(path_info)
         except FileNotFoundError:
             return dvc_fs.info(path_info)
+
+    def checksum(self, path_info):
+        fs, dvc_fs = self._get_fs_pair(path_info)
+
+        try:
+            return fs.checksum(path_info)
+        except FileNotFoundError:
+            return dvc_fs.checksum(path_info)

--- a/dvc/scm/git/backend/dulwich.py
+++ b/dvc/scm/git/backend/dulwich.py
@@ -39,7 +39,7 @@ class DulwichObject(GitObject):
         self.repo = repo
         self._name = name
         self._mode = mode
-        self.sha = sha
+        self._sha = sha
 
     def open(self, mode: str = "r", encoding: str = None):
         if not encoding:
@@ -67,6 +67,14 @@ class DulwichObject(GitObject):
             yield DulwichObject(
                 self.repo, entry.path.decode(), entry.mode, entry.sha
             )
+
+    @property
+    def size(self) -> int:
+        return len(self.repo[self.sha].as_raw_string())
+
+    @property
+    def sha(self) -> str:
+        return self._sha
 
 
 class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method

--- a/dvc/scm/git/backend/gitpython.py
+++ b/dvc/scm/git/backend/gitpython.py
@@ -92,6 +92,14 @@ class GitPythonObject(GitObject):
         for obj in self.obj:
             yield GitPythonObject(obj)
 
+    @property
+    def size(self) -> int:
+        return self.obj.size
+
+    @property
+    def sha(self) -> str:
+        return self.obj.hexsha
+
 
 class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
     """git-python Git backend."""

--- a/dvc/scm/git/backend/pygit2.py
+++ b/dvc/scm/git/backend/pygit2.py
@@ -58,6 +58,14 @@ class Pygit2Object(GitObject):
             return stat.S_IFDIR
         return self.obj.filemode
 
+    @property
+    def size(self) -> int:
+        return len(self.obj.read_raw())
+
+    @property
+    def sha(self) -> str:
+        return self.obj.hex
+
     def scandir(self) -> Iterable["Pygit2Object"]:
         for entry in self.obj:  # noqa: B301
             yield Pygit2Object(entry)

--- a/dvc/scm/git/objects.py
+++ b/dvc/scm/git/objects.py
@@ -1,4 +1,3 @@
-import os
 import stat
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -43,6 +42,16 @@ class GitObject(ABC):
     @property
     def issubmodule(self) -> bool:
         return S_ISGITLINK(self.mode)
+
+    @property
+    @abstractmethod
+    def size(self) -> int:
+        pass
+
+    @property
+    @abstractmethod
+    def sha(self) -> str:
+        pass
 
 
 class GitTrie:
@@ -116,9 +125,14 @@ class GitTrie:
         if not topdown:
             yield top, dirs, nondirs
 
-    def stat(self, key: tuple) -> os.stat_result:
+    def info(self, key: tuple) -> dict:
         obj = self.trie[key]
-        return os.stat_result((obj.mode, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+        return {
+            "size": obj.size,
+            "type": "directory" if stat.S_ISDIR(obj.mode) else "file",
+            "sha": obj.sha,
+            "mode": obj.mode,
+        }
 
 
 @dataclass

--- a/dvc/utils/fs.py
+++ b/dvc/utils/fs.py
@@ -47,22 +47,22 @@ def get_mtime_and_size(path, fs, dvcignore=None):
             walk_iterator = fs.walk_files(path)
         for file_path in walk_iterator:
             try:
-                stats = fs.stat(file_path)
+                stats = fs.info(file_path)
             except OSError as exc:
                 # NOTE: broken symlink case.
                 if exc.errno != errno.ENOENT:
                     raise
                 continue
-            size += stats.st_size
-            files_mtimes[os.fspath(file_path)] = stats.st_mtime
+            size += stats["size"]
+            files_mtimes[os.fspath(file_path)] = stats["mtime"]
 
         # We track file changes and moves, which cannot be detected with simply
         # max(mtime(f) for f in non_ignored_files)
         mtime = dict_md5(files_mtimes)
     else:
-        base_stat = fs.stat(path)
-        size = base_stat.st_size
-        mtime = base_stat.st_mtime
+        base_stat = fs.info(path)
+        size = base_stat["size"]
+        mtime = base_stat["mtime"]
         mtime = int(nanotime.timestamp(mtime))
 
     return str(mtime), size


### PR DESCRIPTION
We've been using get_mtime_and_size(+inode in state) as a checksum, to make sure that file didn't change. We don't really care about any underlying values, only the final checksum that is a combination of fs-specific values (mtime, size, inode, etc).

In case of ref objects, we are only using `get_mtime_and_size` for files and not for directories, which makes it really easy to migrate to fsspec-compatible `fs.checksum()`. We also don't ever save refodb anywhere persistent, so we can tweak checksums later if we find a need.

Pre-requisite for making state work with any filesystem.