### PR TITLE
machine: add `dvc machine ssh`

### DIFF
--- a/dvc/command/machine.py
+++ b/dvc/command/machine.py
@@ -136,6 +136,15 @@ class CmdMachineDestroy(CmdBase):
         return 0
 
 
+class CmdMachineSsh(CmdBase):
+    def run(self):
+        if self.repo.machine is None:
+            raise MachineDisabledError
+
+        self.repo.machine.run_shell(self.args.name)
+        return 0
+
+
 def add_parser(subparsers, parent_parser):
     from dvc.command.config import parent_config_parser
 
@@ -272,3 +281,16 @@ def add_parser(subparsers, parent_parser):
         "name", help="Name of the machine instance to destroy."
     )
     machine_destroy_parser.set_defaults(func=CmdMachineDestroy)
+
+    machine_SSH_HELP = "Connect to a machine via SSH."
+    machine_ssh_parser = machine_subparsers.add_parser(
+        "ssh",
+        parents=[parent_config_parser, parent_parser],
+        description=append_doc_link(machine_SSH_HELP, "machine/ssh"),
+        help=machine_SSH_HELP,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    machine_ssh_parser.add_argument(
+        "name", help="Name of the machine instance to connect to."
+    )
+    machine_ssh_parser.set_defaults(func=CmdMachineSsh)

--- a/dvc/machine/__init__.py
+++ b/dvc/machine/__init__.py
@@ -164,3 +164,7 @@ class MachineManager:
     def get_sshfs(self, name: Optional[str]):
         config, backend = self.get_config_and_backend(name)
         return backend.get_sshfs(**config)
+
+    def run_shell(self, name: Optional[str]):
+        config, backend = self.get_config_and_backend(name)
+        return backend.run_shell(**config)

--- a/dvc/machine/backend/base.py
+++ b/dvc/machine/backend/base.py
@@ -1,8 +1,12 @@
+import asyncio
 import logging
+import os
+import sys
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Iterator, Optional
 
+from dvc.exceptions import DvcException
 from dvc.types import StrPath
 from dvc.utils.fs import makedirs
 
@@ -50,3 +54,33 @@ class BaseMachineBackend(ABC):
     ) -> Iterator["SSHFileSystem"]:
         """Return an sshfs instance for the default directory on the
         specified machine."""
+
+    @abstractmethod
+    def run_shell(self, name: Optional[str] = None, **config):
+        """Spawn an interactive SSH shell for the specified machine.
+
+        Requires a valid 'ssh' client in the user's PATH.
+        """
+
+    def _shell(self, *args, **kwargs):
+        """Spawn an interactive asyncssh shell session.
+
+        Args will be passed into asyncssh.connect().
+        """
+        import asyncssh
+
+        try:
+            asyncio.run(self._shell_async(*args, **kwargs))
+        except (OSError, asyncssh.Error) as exc:
+            raise DvcException("SSH connection failed") from exc
+
+    async def _shell_async(self, *args, **kwargs):
+        import asyncssh
+
+        async with asyncssh.connect(*args, **kwargs) as conn:
+            await conn.run(
+                term_type=os.environ.get("TERM", "xterm"),
+                stdin=sys.stdin,
+                stdout=sys.stdout,
+                stderr=sys.stderr,
+            )

--- a/dvc/machine/backend/base.py
+++ b/dvc/machine/backend/base.py
@@ -66,10 +66,15 @@ class BaseMachineBackend(ABC):
         """
         import asyncssh
 
+        loop = asyncio.new_event_loop()
         try:
-            asyncio.run(self._shell_async(*args, **kwargs))
+            asyncio.set_event_loop(loop)
+            loop.run_until_complete(self._shell_async(*args, **kwargs))
         except (OSError, asyncssh.Error) as exc:
             raise DvcException("SSH connection failed") from exc
+        finally:
+            asyncio.set_event_loop(None)
+            loop.close()
 
     async def _shell_async(self, *args, **kwargs):
         import asyncssh

--- a/dvc/machine/backend/base.py
+++ b/dvc/machine/backend/base.py
@@ -57,13 +57,10 @@ class BaseMachineBackend(ABC):
 
     @abstractmethod
     def run_shell(self, name: Optional[str] = None, **config):
-        """Spawn an interactive SSH shell for the specified machine.
-
-        Requires a valid 'ssh' client in the user's PATH.
-        """
+        """Spawn an interactive SSH shell for the specified machine."""
 
     def _shell(self, *args, **kwargs):
-        """Spawn an interactive asyncssh shell session.
+        """Sync wrapper for an asyncssh shell session.
 
         Args will be passed into asyncssh.connect().
         """

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ webdav = ["webdav4>=0.9.0"]
 ssh_gssapi = ["sshfs[gssapi]>=2021.7.1"]
 all_remotes = gs + s3 + azure + ssh + oss + gdrive + hdfs + webhdfs + webdav
 
-terraform = ["python-terraform>=0.10.1", "jinja2>=2.0.0"]
+terraform = ssh + ["python-terraform>=0.10.1", "jinja2>=2.0.0"]
 
 tests_requirements = (
     Path("test_requirements.txt").read_text().strip().splitlines()

--- a/tests/unit/command/test_machine.py
+++ b/tests/unit/command/test_machine.py
@@ -6,6 +6,7 @@ from dvc.command.machine import (
     CmdMachineCreate,
     CmdMachineDestroy,
     CmdMachineRemove,
+    CmdMachineSsh,
 )
 
 
@@ -60,6 +61,19 @@ def test_destroy(tmp_dir, dvc, mocker):
     cmd = cli_args.func(cli_args)
     m = mocker.patch.object(
         cmd.repo.machine, "destroy", autospec=True, return_value=0
+    )
+
+    assert cmd.run() == 0
+    m.assert_called_once_with("foo")
+
+
+def test_ssh(tmp_dir, dvc, mocker):
+    cli_args = parse_args(["machine", "ssh", "foo"])
+    assert cli_args.func == CmdMachineSsh
+
+    cmd = cli_args.func(cli_args)
+    m = mocker.patch.object(
+        cmd.repo.machine, "run_shell", autospec=True, return_value=0
     )
 
     assert cmd.run() == 0

--- a/tests/unit/machine/test_terraform.py
+++ b/tests/unit/machine/test_terraform.py
@@ -1,5 +1,6 @@
 import json
 import os
+from unittest.mock import ANY
 
 import pytest
 from python_terraform import IsFlagged
@@ -127,3 +128,16 @@ def test_instances(tmp_dir, terraform, resource):
     data = json.loads(TEST_RESOURCE_STATE)
     expected = data["resources"][0]["instances"][0]["attributes"]
     assert list(terraform.instances(resource)) == [expected]
+
+
+def test_shell(tmp_dir, terraform, resource, mocker):
+    data = json.loads(TEST_RESOURCE_STATE)
+    expected = data["resources"][0]["instances"][0]["attributes"]
+    mock_connect = mocker.patch("asyncssh.connect")
+    terraform.run_shell(name=resource)
+    mock_connect.assert_called_once_with(
+        host=expected["instance_ip"],
+        username="ubuntu",
+        client_keys=ANY,
+        known_hosts=None,
+    )

--- a/tests/unit/machine/test_terraform.py
+++ b/tests/unit/machine/test_terraform.py
@@ -1,8 +1,8 @@
 import json
 import os
-from unittest.mock import ANY, MagicMock
 
 import pytest
+from mock import ANY, MagicMock
 from python_terraform import IsFlagged
 
 from dvc.machine.backend.terraform import DvcTerraform, TerraformError
@@ -130,21 +130,10 @@ def test_instances(tmp_dir, terraform, resource):
     assert list(terraform.instances(resource)) == [expected]
 
 
-# NOTE: native MagicMock doesn't support async context managers in Python < 3.8
-class ConnectionMock(MagicMock):
-    async def __aenter__(self, *args, **kwargs):
-        return MagicMock()
-
-    async def __aexit__(self, *args, **kwargs):
-        return MagicMock()
-
-
 def test_shell(tmp_dir, terraform, resource, mocker):
     data = json.loads(TEST_RESOURCE_STATE)
     expected = data["resources"][0]["instances"][0]["attributes"]
-    mock_connect = mocker.patch(
-        "asyncssh.connect", return_value=ConnectionMock()
-    )
+    mock_connect = mocker.patch("asyncssh.connect", return_value=MagicMock())
     terraform.run_shell(name=resource)
     mock_connect.assert_called_once_with(
         host=expected["instance_ip"],


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will close #6483

* Adds `dvc machine ssh` command to connect to `dvc machine create`ed remote machine instances - shell/PTY session is done via asyncssh and does not require the user to have a separate OpenSSH/putty/etc SSH client on their machine (meaning it should work from Windows hosts out of the box as long as `dvc[terraform]` is installed)
* Adds `ssh` requirements to the `terraform` install extras - eventually `ssh` may need to be added to the default installed remotes if/when `dvc machine` has basic functionality independent of terraform