### PR TITLE
add terraform to tests dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ terraform = ["python-terraform>=0.10.1", "jinja2>=2.0.0"]
 
 tests_requirements = (
     Path("test_requirements.txt").read_text().strip().splitlines()
-)
+) + terraform
 
 setup(
     name="dvc",


### PR DESCRIPTION
It is breaking the pattern of setting up a development environment for DVC (`pip install -e ".[all,tests]"`) as suggested in the [Contributing Guide](https://dvc.org/doc/user-guide/contributing/core#development-environment).

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
