### PR TITLE
restrict google-crc32c for Python3.10

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -21,7 +21,9 @@ crc32c==2.2.post0
 xmltodict==0.12.0
 google-compute-engine==2.8.13
 google-cloud-storage==1.42.0
-
+# until 3.10 support is added for google-crc32c
+# see: https://github.com/googleapis/python-crc32c/issues/49
+google-crc32c<=1.1.2; python_version >= '3.10'
 urllib3==1.26.6
 
 # required by collective.checkdocs
@@ -44,6 +46,3 @@ types-requests
 types-paramiko
 types-tabulate
 types-toml
-
-# pypi doesn't allow for direct dependencies
-# gdrivefs @ git+https://github.com/intake/gdrivefs.git


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
