### PR TITLE
gha: allow running tests on other branches

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,12 +1,8 @@
 name: Tests
 
 on:
-  pull_request:
-    branches:
-      - master
-  push:
-    branches:
-      - master
+  pull_request: {}
+  push: {}
   schedule:
     - cron: '5 1 * * *'  # every day at 01:05
 


### PR DESCRIPTION
Simplifies development for all contributors. Thanks to great work by @skshetry we have reasonable remote test defaults and so there is really no need to limit gha to master branch anymore.