### PR TITLE
machine: support instance size & startup script config

### DIFF
--- a/dvc/config.py
+++ b/dvc/config.py
@@ -263,6 +263,7 @@ class Config(dict):
                     "key_path": func,
                 }
             },
+            "machine": {str: {"startup_script": func}},
         }
         return Schema(dirs_schema, extra=ALLOW_EXTRA)(conf)
 

--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -228,6 +228,8 @@ SCHEMA = {
     "machine": {
         str: {
             "cloud": All(Lower, Choices("aws", "azure")),
+            "instance_type": Lower,
+            "startup_script": str,
         },
     },
     # section for experimental features

--- a/dvc/machine/__init__.py
+++ b/dvc/machine/__init__.py
@@ -30,10 +30,11 @@ sudo apt-get update
 sudo apt-get install --yes python3 python3-pip
 python3 -m pip install --upgrade pip
 
-cd /etc/apt/sources.list.d
+pushd /etc/apt/sources.list.d
 sudo wget https://dvc.org/deb/dvc.list
 sudo apt-get update
 sudo apt-get install --yes dvc
+popd
 """
 
 

--- a/dvc/machine/__init__.py
+++ b/dvc/machine/__init__.py
@@ -25,6 +25,17 @@ logger = logging.getLogger(__name__)
 
 RESERVED_NAMES = {"local", "localhost"}
 
+DEFAULT_STARTUP_SCRIPT = """#!/bin/bash
+sudo apt-get update
+sudo apt-get install --yes python3 python3-pip
+python3 -m pip install --upgrade pip
+
+cd /etc/apt/sources.list.d
+sudo wget https://dvc.org/deb/dvc.list
+sudo apt-get update
+sudo apt-get install --yes dvc
+"""
+
 
 def validate_name(name: str):
     from dvc.exceptions import InvalidArgumentError
@@ -168,6 +179,12 @@ class MachineManager:
     def create(self, name: Optional[str]):
         """Create and start the specified machine instance."""
         config, backend = self.get_config_and_backend(name)
+        if "startup_script" in config:
+            with open(config["startup_script"]) as fobj:
+                startup_script = fobj.read()
+        else:
+            startup_script = DEFAULT_STARTUP_SCRIPT
+        config["startup_script"] = startup_script
         return backend.create(**config)
 
     def destroy(self, name: Optional[str]):


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

* `instance_size` should be any string `instance_size` accepted by terraform-provider-iterative
* `startup_script` should be (config-relative) path to a shell script file (rather than the raw string used in terraform-provider-iterative)