### PR TITLE
try to fix flaky dvclive test

### DIFF
--- a/tests/func/test_live.py
+++ b/tests/func/test_live.py
@@ -249,7 +249,7 @@ def test_dvc_generates_html_during_run(tmp_dir, dvc, mocker, live_stage):
         dvclive.log("accuracy", 1/2)
         dvclive.next_step()
         time.sleep({})""".format(
-            str(monitor_await_time * 2)
+            str(monitor_await_time * 10)
         )
     )
     live_stage(summary=True, live="logs", code=script)


### PR DESCRIPTION
See https://github.com/iterative/dvc/runs/3515886615#step:12:9305.

Making sure that script takes a bit more time than the await time
I am not really sure this was the cause though, will monitor after this is merged.
Also the tests are flaky only in MacOS, but I haven't been able to reproduce.

