### PR TITLE
Set timeout for jobs in Github Actions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,6 +13,7 @@ env:
 
 jobs:
   lint:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.3.4
@@ -32,6 +33,7 @@ jobs:
       run: python setup.py checkdocs
     - uses: pre-commit/action@v2.0.3
   tests:
+    timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -97,6 +99,7 @@ jobs:
       run: |
         echo "extra_test_args=--disable-gdrive" >> $GITHUB_ENV
     - name: run tests
+      timeout-minutes: 30
       env:
         GDRIVE_CREDENTIALS_DATA: ${{ secrets.GDRIVE_CREDENTIALS_DATA }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ known_first_party=dvc,tests
 line_length=79
 
 [tool:pytest]
-timeout = 600
+timeout = 100
 timeout_method = thread
 log_level = debug
 addopts = -ra

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ known_first_party=dvc,tests
 line_length=79
 
 [tool:pytest]
-timeout = 100
+timeout = 200
 timeout_method = thread
 log_level = debug
 addopts = -ra


### PR DESCRIPTION
The jobs in CI are getting frozen sometimes, either of an issue with `pytest-xdist` or pip resolver due to some weird constraints set by us or one of our dependencies.

The default timeout is 360 minutes (6hrs), but our test completes on ~18 minutes at maximum, so I think 30mins should be enough to account for occasional CI slowdown.

Also keeping the total test job timeout at 45 mins, we usually require just 4 mins of extra time to do installation and setup but giving it 11 more minutes just in case.

Similarly, `lint` completes in <5 mins usually, but giving it a 10 mins timeout.

This should give us early feedback on the issue.