### PR TITLE
fs.upload: add support for optional callback

### DIFF
--- a/dvc/fs/azure.py
+++ b/dvc/fs/azure.py
@@ -11,7 +11,8 @@ from dvc.path_info import CloudURLInfo
 from dvc.scheme import Schemes
 from dvc.utils import format_link
 
-from .fsspec_wrapper import ObjectFSWrapper
+from ..progress import DEFAULT_CALLBACK
+from .fsspec_wrapper import ObjectFSWrapper, CallbackMixin
 
 logger = logging.getLogger(__name__)
 _DEFAULT_CREDS_STEPS = (
@@ -159,3 +160,9 @@ class AzureFileSystem(ObjectFSWrapper):
                 " failed.\nLearn more about configuration settings at"
                 f" {format_link('https://man.dvc.org/remote/modify')}"
             ) from e
+
+    def put_file(
+        self, from_file, to_info, callback=DEFAULT_CALLBACK, **kwargs
+    ):
+        # AzureFileSystem.put_file does not support callbacks yet.
+        return CallbackMixin.put_file_compat(self, from_file, to_info, callback=callback, **kwargs)

--- a/dvc/fs/azure.py
+++ b/dvc/fs/azure.py
@@ -12,7 +12,7 @@ from dvc.scheme import Schemes
 from dvc.utils import format_link
 
 from ..progress import DEFAULT_CALLBACK
-from .fsspec_wrapper import ObjectFSWrapper, CallbackMixin
+from .fsspec_wrapper import CallbackMixin, ObjectFSWrapper
 
 logger = logging.getLogger(__name__)
 _DEFAULT_CREDS_STEPS = (
@@ -165,4 +165,6 @@ class AzureFileSystem(ObjectFSWrapper):
         self, from_file, to_info, callback=DEFAULT_CALLBACK, **kwargs
     ):
         # AzureFileSystem.put_file does not support callbacks yet.
-        return CallbackMixin.put_file_compat(self, from_file, to_info, callback=callback, **kwargs)
+        return CallbackMixin.put_file_compat(
+            self, from_file, to_info, callback=callback, **kwargs
+        )

--- a/dvc/fs/fsspec_wrapper.py
+++ b/dvc/fs/fsspec_wrapper.py
@@ -3,8 +3,9 @@ import shutil
 from functools import lru_cache
 
 from funcy import cached_property
+from tqdm.utils import CallbackIOWrapper
 
-from dvc.progress import Tqdm
+from dvc.progress import DEFAULT_CALLBACK, Tqdm
 
 from .base import BaseFileSystem
 from .local import LocalFileSystem
@@ -130,27 +131,18 @@ class FSSpecWrapper(BaseFileSystem):
             self._with_bucket(path_info), exist_ok=kwargs.pop("exist_ok", True)
         )
 
+    def put_file(
+        self, from_file, to_info, callback=DEFAULT_CALLBACK, **kwargs
+    ):
+        self.fs.put_file(
+            from_file, self._with_bucket(to_info), callback=callback, **kwargs
+        )
+        self.fs.invalidate_cache(self._with_bucket(to_info.parent))
+
     def upload_fobj(self, fobj, to_info, **kwargs):
         self.makedirs(to_info.parent)
         with self.open(to_info, "wb") as fdest:
             shutil.copyfileobj(fobj, fdest, length=fdest.blocksize)
-
-    def _upload(
-        self, from_file, to_info, name=None, no_progress_bar=False, **kwargs
-    ):
-        self.makedirs(to_info.parent)
-        size = os.path.getsize(from_file)
-        with open(from_file, "rb") as fobj:
-            with Tqdm.wrapattr(
-                fobj,
-                "read",
-                disable=no_progress_bar,
-                bytes=True,
-                total=size,
-                desc=name,
-            ) as wrapped:
-                self.upload_fobj(wrapped, to_info, size=size)
-        self.fs.invalidate_cache(self._with_bucket(to_info.parent))
 
     def _download(
         self, from_info, to_file, name=None, no_progress_bar=False, **pbar_args
@@ -263,22 +255,17 @@ class CallbackMixin:
     """Use the native ``get_file()``/``put_file()`` APIs
     if the target filesystem supports callbacks."""
 
-    def _upload(
-        self, from_file, to_info, name=None, no_progress_bar=False, **pbar_args
-    ):
-        with Tqdm(
-            desc=name,
-            disable=no_progress_bar,
-            bytes=True,
-            total=-1,
-            **pbar_args,
-        ) as pbar:
-            self.fs.put_file(
-                os.fspath(from_file),
-                self._with_bucket(to_info),
-                callback=pbar.as_callback(_LOCAL_FS, from_file),
-            )
-        self.fs.invalidate_cache(self._with_bucket(to_info.parent))
+    @staticmethod
+    def put_file_compat(fs, from_file, to_info, callback=DEFAULT_CALLBACK, **kwargs):
+        """Add compatibility support for Callback."""
+        fs.makedirs(to_info.parent)
+        size = os.path.getsize(from_file)
+        with open(from_file, "rb") as fobj:
+            callback.set_size(size)
+            wrapped = CallbackIOWrapper(callback.relative_update, fobj)
+            fs.upload_fobj(wrapped, to_info)
+            # pylint: disable=protected-access
+            fs.fs.invalidate_cache(fs._with_bucket(to_info.parent))
 
     def _download(
         self, from_info, to_file, name=None, no_progress_bar=False, **pbar_args

--- a/dvc/fs/fsspec_wrapper.py
+++ b/dvc/fs/fsspec_wrapper.py
@@ -256,7 +256,9 @@ class CallbackMixin:
     if the target filesystem supports callbacks."""
 
     @staticmethod
-    def put_file_compat(fs, from_file, to_info, callback=DEFAULT_CALLBACK, **kwargs):
+    def put_file_compat(
+        fs, from_file, to_info, callback=DEFAULT_CALLBACK, **kwargs
+    ):
         """Add compatibility support for Callback."""
         fs.makedirs(to_info.parent)
         size = os.path.getsize(from_file)

--- a/dvc/fs/gs.py
+++ b/dvc/fs/gs.py
@@ -6,10 +6,12 @@ from funcy import cached_property, wrap_prop
 from dvc.path_info import CloudURLInfo
 from dvc.scheme import Schemes
 
-from .fsspec_wrapper import ObjectFSWrapper
-
+from .fsspec_wrapper import ObjectFSWrapper, CallbackMixin
 
 # pylint:disable=abstract-method
+from ..progress import DEFAULT_CALLBACK
+
+
 class GSFileSystem(ObjectFSWrapper):
     scheme = Schemes.GS
     PATH_CLS = CloudURLInfo
@@ -35,3 +37,7 @@ class GSFileSystem(ObjectFSWrapper):
         from gcsfs import GCSFileSystem
 
         return GCSFileSystem(**self.fs_args)
+
+    def put_file(self, from_file, to_info, callback=DEFAULT_CALLBACK, **kwargs):
+        # GCSFileSystem.put_file does not support callbacks yet.
+        return CallbackMixin.put_file_compat(self, from_file, to_info, callback=callback, **kwargs)

--- a/dvc/fs/gs.py
+++ b/dvc/fs/gs.py
@@ -6,10 +6,9 @@ from funcy import cached_property, wrap_prop
 from dvc.path_info import CloudURLInfo
 from dvc.scheme import Schemes
 
-from .fsspec_wrapper import ObjectFSWrapper, CallbackMixin
-
 # pylint:disable=abstract-method
 from ..progress import DEFAULT_CALLBACK
+from .fsspec_wrapper import CallbackMixin, ObjectFSWrapper
 
 
 class GSFileSystem(ObjectFSWrapper):
@@ -38,6 +37,10 @@ class GSFileSystem(ObjectFSWrapper):
 
         return GCSFileSystem(**self.fs_args)
 
-    def put_file(self, from_file, to_info, callback=DEFAULT_CALLBACK, **kwargs):
+    def put_file(
+        self, from_file, to_info, callback=DEFAULT_CALLBACK, **kwargs
+    ):
         # GCSFileSystem.put_file does not support callbacks yet.
-        return CallbackMixin.put_file_compat(self, from_file, to_info, callback=callback, **kwargs)
+        return CallbackMixin.put_file_compat(
+            self, from_file, to_info, callback=callback, **kwargs
+        )

--- a/dvc/fs/local.py
+++ b/dvc/fs/local.py
@@ -7,6 +7,7 @@ from dvc.system import System
 from dvc.utils import is_exec, tmp_fname
 from dvc.utils.fs import copy_fobj_to_file, copyfile, makedirs, move, remove
 
+from ..progress import DEFAULT_CALLBACK
 from .base import BaseFileSystem
 
 logger = logging.getLogger(__name__)
@@ -158,15 +159,12 @@ class LocalFileSystem(BaseFileSystem):
     def info(self, path_info):
         return self.fs.info(path_info)
 
-    def _upload(
-        self, from_file, to_info, name=None, no_progress_bar=False, **_kwargs
+    def put_file(
+        self, from_file, to_info, callback=DEFAULT_CALLBACK, **kwargs
     ):
         makedirs(to_info.parent, exist_ok=True)
-
         tmp_file = tmp_fname(to_info)
-        copyfile(
-            from_file, tmp_file, name=name, no_progress_bar=no_progress_bar
-        )
+        copyfile(from_file, tmp_file, callback=callback)
         os.replace(tmp_file, to_info)
 
     @staticmethod

--- a/dvc/fs/ssh.py
+++ b/dvc/fs/ssh.py
@@ -8,6 +8,7 @@ from dvc import prompt
 from dvc.scheme import Schemes
 from dvc.utils.fs import as_atomic
 
+from ..progress import DEFAULT_CALLBACK
 from .fsspec_wrapper import CallbackMixin, FSSpecWrapper
 
 _SSH_TIMEOUT = 60 * 30
@@ -124,6 +125,8 @@ class SSHFileSystem(CallbackMixin, FSSpecWrapper):
         with as_atomic(self, to_info) as tmp_file:
             super().upload_fobj(fobj, tmp_file, **kwargs)
 
-    def _upload(self, from_file, to_info, *args, **kwargs):
+    def put_file(
+        self, from_file, to_info, callback=DEFAULT_CALLBACK, **kwargs
+    ):
         with as_atomic(self, to_info) as tmp_file:
-            super()._upload(from_file, tmp_file, *args, **kwargs)
+            super().put_file(from_file, tmp_file, callback=callback, **kwargs)

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -1,5 +1,4 @@
 """Manages progress bars for DVC repo."""
-
 import logging
 import sys
 from threading import RLock
@@ -182,9 +181,29 @@ class FsspecCallback(fsspec.Callback):
             size = self.fs.info(self.path_info)["size"]
         self.progress_bar.total = size
         self.progress_bar.refresh()
+        super().set_size(size)
 
     def relative_update(self, inc=1):
         self.progress_bar.update(inc)
+        super().relative_update(inc)
 
     def absolute_update(self, value):
         self.progress_bar.update_to(value)
+        super().absolute_update(value)
+
+
+def tdqm_or_callback_wrapped(
+    fobj, method, total, callback=None, **pbar_kwargs
+):
+    if callback:
+        from funcy import nullcontext
+        from tqdm.utils import CallbackIOWrapper
+
+        callback.set_size(total)
+        wrapper = CallbackIOWrapper(callback.relative_update, fobj, method)
+        return nullcontext(wrapper)
+
+    return Tqdm.wrapattr(fobj, method, total=total, bytes=True, **pbar_kwargs)
+
+
+DEFAULT_CALLBACK = fsspec.callbacks.NoOpCallback

--- a/dvc/utils/fs.py
+++ b/dvc/utils/fs.py
@@ -193,33 +193,39 @@ def makedirs(path, exist_ok=False, mode=None):
         logger.trace("failed to chmod '%o' '%s'", mode, path, exc_info=True)
 
 
-def copyfile(src, dest, no_progress_bar=False, name=None):
+def copyfile(src, dest, callback=None, no_progress_bar=False, name=None):
     """Copy file with progress bar"""
-    from dvc.progress import Tqdm
-
     name = name if name else os.path.basename(dest)
     total = os.stat(src).st_size
 
     if os.path.isdir(dest):
         dest = os.path.join(dest, os.path.basename(src))
 
+    if callback:
+        callback.set_size(total)
+
     try:
         System.reflink(src, dest)
     except DvcException:
+        from dvc.progress import tdqm_or_callback_wrapped
+
         with open(src, "rb") as fsrc, open(dest, "wb+") as fdest:
-            with Tqdm.wrapattr(
+            with tdqm_or_callback_wrapped(
                 fdest,
                 "write",
-                desc=name,
+                total,
+                callback=callback,
                 disable=no_progress_bar,
-                total=total,
-                bytes=True,
-            ) as fdest_wrapped:
+                desc=name,
+            ) as wrapped:
                 while True:
                     buf = fsrc.read(LOCAL_CHUNK_SIZE)
                     if not buf:
                         break
-                    fdest_wrapped.write(buf)
+                    wrapped.write(buf)
+
+    if callback:
+        callback.absolute_update(total)
 
 
 def copy_fobj_to_file(fsrc, dest):

--- a/tests/func/objects/db/test_index.py
+++ b/tests/func/objects/db/test_index.py
@@ -76,7 +76,7 @@ def test_partial_upload(tmp_dir, dvc, index, mocker):
     tmp_dir.dvc_gen({"foo": "foo content"})
     tmp_dir.dvc_gen({"bar": {"baz": "baz content"}})
 
-    original = LocalFileSystem._upload
+    original = LocalFileSystem.upload
 
     def unreliable_upload(self, from_file, to_info, name=None, **kwargs):
         if "baz" in name:

--- a/tests/func/test_fs.py
+++ b/tests/func/test_fs.py
@@ -3,6 +3,7 @@ import os
 from operator import itemgetter
 from os.path import join
 
+import fsspec
 import pytest
 
 from dvc.fs import get_cloud_fs
@@ -413,3 +414,30 @@ def test_fs_makedirs_on_upload_and_copy(dvc, cloud):
     fs.copy(cloud / "dir" / "foo", cloud / "dir2" / "foo")
     assert fs.isdir(cloud / "dir2")
     assert fs.exists(cloud / "dir2" / "foo")
+
+
+@pytest.mark.needs_internet
+@pytest.mark.parametrize(
+    "cloud",
+    [
+        pytest.lazy_fixture("azure"),
+        pytest.lazy_fixture("gs"),
+        pytest.lazy_fixture("gdrive"),
+        pytest.lazy_fixture("hdfs"),
+        pytest.lazy_fixture("local_cloud"),
+        pytest.lazy_fixture("oss"),
+        pytest.lazy_fixture("s3"),
+        pytest.lazy_fixture("ssh"),
+        pytest.lazy_fixture("webhdfs"),
+    ],
+)
+def test_upload_callback(tmp_dir, dvc, cloud):
+    tmp_dir.gen("foo", "foo")
+    cls, config, _ = get_cloud_fs(dvc, **cloud.config)
+    fs = cls(**config)
+    expected_size = os.path.getsize(tmp_dir / "foo")
+
+    callback = fsspec.Callback()
+    fs.upload(tmp_dir / "foo", cloud / "foo", callback=callback)
+    assert callback.size == expected_size
+    assert callback.value == expected_size

--- a/tests/unit/remote/test_remote_tree.py
+++ b/tests/unit/remote/test_remote_tree.py
@@ -91,8 +91,8 @@ def test_walk_files(remote):
 def test_copy_preserve_etag_across_buckets(cloud, dvc):
     cloud.gen(FILE_WITH_CONTENTS)
     rem = _get_odb(dvc, cloud.config)
-    s3 = rem.fs
-    s3.fs.mkdir("another/")
+    s3 = rem.fs.s3
+    s3.create_bucket(Bucket="another")
 
     config = cloud.config.copy()
     config["url"] = "s3://another"


### PR DESCRIPTION
Also removes _upload methods in other fses, and replaces them
with fsspec-compatible put_file which supports fsspec callback
even if they are not fsspec based filesystem.


