### PR TITLE
ssh: support passphrases for private keys

### DIFF
--- a/dvc/fs/ssh.py
+++ b/dvc/fs/ssh.py
@@ -67,6 +67,7 @@ class SSHFileSystem(CallbackMixin, FSSpecWrapper):
         )
 
         login_info["password"] = config.get("password")
+        login_info["passphrase"] = config.get("password")
 
         raw_keys = []
         if config.get("keyfile"):

--- a/tests/unit/fs/test_ssh.py
+++ b/tests/unit/fs/test_ssh.py
@@ -34,10 +34,13 @@ def test_get_kwargs_from_urls():
 
 
 def test_init():
-    fs = SSHFileSystem(user="test", host="12.34.56.78", port="1234")
+    fs = SSHFileSystem(
+        user="test", host="12.34.56.78", port="1234", password="xxx"
+    )
     assert fs.fs_args["username"] == "test"
     assert fs.fs_args["host"] == "12.34.56.78"
     assert fs.fs_args["port"] == "1234"
+    assert fs.fs_args["password"] == fs.fs_args["passphrase"] == "xxx"
 
 
 mock_ssh_config = """


### PR DESCRIPTION
Seems like unlike [paramiko](http://docs.paramiko.org/en/stable/api/client.html#paramiko.client.SSHClient.connect), [asyncssh](https://asyncssh.readthedocs.io/en/latest/api.html#asyncssh.SSHClientConnectionOptions) has a separate option to store `passphrase`. Resolves #6561