### PR TITLE
state: get rid of self.fs

### DIFF
--- a/dvc/state.py
+++ b/dvc/state.py
@@ -53,7 +53,6 @@ class State(StateBase):  # pylint: disable=too-many-instance-attributes
         self.tmp_dir = tmp_dir
         self.root_dir = root_dir
         self.dvcignore = dvcignore
-        self.fs = LocalFileSystem()
 
         if not tmp_dir:
             return
@@ -85,7 +84,7 @@ class State(StateBase):  # pylint: disable=too-many-instance-attributes
         assert isinstance(hash_info, HashInfo)
         assert os.path.exists(path_info)
 
-        mtime, size = get_mtime_and_size(path_info, self.fs, self.dvcignore)
+        mtime, size = get_mtime_and_size(path_info, fs, self.dvcignore)
         inode = get_inode(path_info)
 
         logger.debug(
@@ -121,7 +120,7 @@ class State(StateBase):  # pylint: disable=too-many-instance-attributes
         if not os.path.exists(path):
             return None
 
-        mtime, size = get_mtime_and_size(path, self.fs, self.dvcignore)
+        mtime, size = get_mtime_and_size(path, fs, self.dvcignore)
         inode = get_inode(path)
 
         value = self.md5s.get(inode)
@@ -143,10 +142,10 @@ class State(StateBase):  # pylint: disable=too-many-instance-attributes
 
         assert isinstance(path_info, str) or path_info.scheme == "local"
 
-        if not self.fs.exists(path_info):
+        if not fs.exists(path_info):
             return
 
-        mtime, _ = get_mtime_and_size(path_info, self.fs, self.dvcignore)
+        mtime, _ = get_mtime_and_size(path_info, fs, self.dvcignore)
         inode = get_inode(path_info)
         relative_path = relpath(path_info, self.root_dir)
 
@@ -168,11 +167,11 @@ class State(StateBase):  # pylint: disable=too-many-instance-attributes
             for relative_path in ref:
                 path = os.path.join(self.root_dir, relative_path)
 
-                if path in used or not self.fs.exists(path):
+                if path in used or not fs.exists(path):
                     continue
 
                 inode = get_inode(path)
-                mtime, _ = get_mtime_and_size(path, self.fs, self.dvcignore)
+                mtime, _ = get_mtime_and_size(path, fs, self.dvcignore)
 
                 if ref[relative_path] == (inode, mtime):
                     logger.debug("Removing '%s' as unused link.", path)


### PR DESCRIPTION
This is no longer used since the separation of dvcignore.