### PR TITLE
Force sorted order in plots rendering

### DIFF
--- a/dvc/render/utils.py
+++ b/dvc/render/utils.py
@@ -1,8 +1,8 @@
 import os.path
-from typing import Dict, List, Set
+from typing import Dict, List
 
 
-def get_files(data: Dict) -> Set:
+def get_files(data: Dict) -> List:
     files = set()
     for rev in data.keys():
         for file in data[rev].get("data", {}).keys():

--- a/dvc/render/utils.py
+++ b/dvc/render/utils.py
@@ -7,6 +7,7 @@ def get_files(data: Dict) -> Set:
     for rev in data.keys():
         for file in data[rev].get("data", {}).keys():
             files.add(file)
+    files = sorted(files)
     return files
 
 

--- a/dvc/render/utils.py
+++ b/dvc/render/utils.py
@@ -7,8 +7,8 @@ def get_files(data: Dict) -> List:
     for rev in data.keys():
         for file in data[rev].get("data", {}).keys():
             files.add(file)
-    files = sorted(files)
-    return files
+    sorted_files = sorted(files)
+    return sorted_files
 
 
 def group_by_filename(plots_data: Dict) -> List[Dict]:

--- a/tests/unit/render/test_render.py
+++ b/tests/unit/render/test_render.py
@@ -1,5 +1,4 @@
 import os
-import random
 
 from dvc.render.utils import find_vega, get_files, render
 
@@ -66,14 +65,3 @@ def test_render(tmp_dir, dvc):
     some_vega = find_vega(dvc, data, "some.csv")
     assert file_vega in index_content.strip()
     assert some_vega in index_content.strip()
-
-
-def test_get_files_order():
-    random.seed(42)
-    data = {
-        "workspace": {
-            "data": {str(random.randint(0, 10)): 1 for x in range(100)}
-        }
-    }
-
-    assert get_files(data) == sorted(get_files(data))

--- a/tests/unit/render/test_render.py
+++ b/tests/unit/render/test_render.py
@@ -1,6 +1,6 @@
 import os
 
-from dvc.render.utils import find_vega, get_files, render
+from dvc.render.utils import find_vega, render
 
 
 def assert_website_has_image(page_path, revision, filename, image_content):

--- a/tests/unit/render/test_render.py
+++ b/tests/unit/render/test_render.py
@@ -1,6 +1,7 @@
 import os
+import random
 
-from dvc.render.utils import find_vega, render
+from dvc.render.utils import find_vega, get_files, render
 
 
 def assert_website_has_image(page_path, revision, filename, image_content):
@@ -65,3 +66,18 @@ def test_render(tmp_dir, dvc):
     some_vega = find_vega(dvc, data, "some.csv")
     assert file_vega in index_content.strip()
     assert some_vega in index_content.strip()
+
+
+def test_get_files_order():
+    random.seed(42)
+    data = {
+        "workspace":
+        {
+            "data":
+            {
+                str(random.randint(0, 10)): 1 for x in range(100)
+            }
+        }
+    }
+
+    assert get_files(data) == sorted(get_files(data))

--- a/tests/unit/render/test_render.py
+++ b/tests/unit/render/test_render.py
@@ -71,12 +71,8 @@ def test_render(tmp_dir, dvc):
 def test_get_files_order():
     random.seed(42)
     data = {
-        "workspace":
-        {
-            "data":
-            {
-                str(random.randint(0, 10)): 1 for x in range(100)
-            }
+        "workspace": {
+            "data": {str(random.randint(0, 10)): 1 for x in range(100)}
         }
     }
 

--- a/tests/unit/test_plots.py
+++ b/tests/unit/test_plots.py
@@ -28,9 +28,9 @@ def test_plots_order(tmp_dir, dvc):
             name="stage2",
         )
 
-    assert get_files(dvc.plots.show()) == {
+    assert get_files(dvc.plots.show()) == [
         "p.json",
-        os.path.join("sub", "p4.json"),
         "p1.json",
         os.path.join("sub", "p3.json"),
-    }
+        os.path.join("sub", "p4.json"),
+    ]


### PR DESCRIPTION
* [X] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [X] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Close https://github.com/iterative/dvclive/issues/53

The plots rendered in `html` are _arbitrarily_ ordered on different calls as they depend on `RepoFyleSystem.walk_files` and on `dvc.render.utils.get_files` (which uses a `set` to return values).

This P.R. forces a sorted return in `dvc.render.utils.get_files` which ensures that the rendered plots are _equally_ ordered on different calls.
