### PR TITLE
Use GDriveURLInfo instead of CloudURLInfo

### DIFF
--- a/tests/remotes/gdrive.py
+++ b/tests/remotes/gdrive.py
@@ -8,7 +8,6 @@ import pytest
 from funcy import cached_property, retry
 
 from dvc.fs.gdrive import GDriveFileSystem, GDriveURLInfo
-from dvc.path_info import CloudURLInfo
 from dvc.utils import tmp_fname
 
 from .base import Base

--- a/tests/remotes/gdrive.py
+++ b/tests/remotes/gdrive.py
@@ -7,7 +7,7 @@ from functools import partialmethod
 import pytest
 from funcy import cached_property, retry
 
-from dvc.fs.gdrive import GDriveFileSystem
+from dvc.fs.gdrive import GDriveFileSystem, GDriveURLInfo
 from dvc.path_info import CloudURLInfo
 from dvc.utils import tmp_fname
 
@@ -44,7 +44,7 @@ def _gdrive_retry(func):
     )(func)
 
 
-class GDrive(Base, CloudURLInfo):
+class GDrive(Base, GDriveURLInfo):
     @staticmethod
     def should_test():
         return bool(os.getenv(GDriveFileSystem.GDRIVE_CREDENTIALS_DATA))


### PR DESCRIPTION
Using `CloudURLInfo`, it makes this following path parsing fail:
https://github.com/iterative/dvc/blob/1a1294848b5f9b574e40f69b31022da353f0d34b/dvc/fs/gdrive.py#L295-L297