### PR TITLE
Fix ci failures

### DIFF
--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -495,6 +495,8 @@ def test_show_with_broken_repo(tmp_dir, scm, dvc, exp_stage, caplog):
 
 
 def test_show_csv(tmp_dir, scm, dvc, exp_stage, capsys):
+    import time
+
     baseline_rev = scm.get_rev()
 
     def _get_rev_isotimestamp(rev):
@@ -505,6 +507,7 @@ def test_show_csv(tmp_dir, scm, dvc, exp_stage, capsys):
     result1 = dvc.experiments.run(exp_stage.addressing, params=["foo=2"])
     rev1 = first(result1)
     ref_info1 = first(exp_refs_by_rev(scm, rev1))
+    time.sleep(1)
     result2 = dvc.experiments.run(exp_stage.addressing, params=["foo=3"])
     rev2 = first(result2)
     ref_info2 = first(exp_refs_by_rev(scm, rev2))


### PR DESCRIPTION
related to ci failures, and related to #6468 

The current ci failure was caused by wrong order of the experiments.
Because our test script runs so fast that they might share the same
commit timestamp, that makes them in an uncertain order. And then gives
a wrong branch_base.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
