### PR TITLE
fs.download: add callback support

### DIFF
--- a/dvc/fs/azure.py
+++ b/dvc/fs/azure.py
@@ -11,7 +11,6 @@ from dvc.path_info import CloudURLInfo
 from dvc.scheme import Schemes
 from dvc.utils import format_link
 
-from ..progress import DEFAULT_CALLBACK
 from .fsspec_wrapper import CallbackMixin, ObjectFSWrapper
 
 logger = logging.getLogger(__name__)
@@ -40,7 +39,7 @@ def _az_config():
 
 
 # pylint:disable=abstract-method
-class AzureFileSystem(ObjectFSWrapper):
+class AzureFileSystem(CallbackMixin, ObjectFSWrapper):
     scheme = Schemes.AZURE
     PATH_CLS = CloudURLInfo
     PARAM_CHECKSUM = "etag"
@@ -160,11 +159,3 @@ class AzureFileSystem(ObjectFSWrapper):
                 " failed.\nLearn more about configuration settings at"
                 f" {format_link('https://man.dvc.org/remote/modify')}"
             ) from e
-
-    def put_file(
-        self, from_file, to_info, callback=DEFAULT_CALLBACK, **kwargs
-    ):
-        # AzureFileSystem.put_file does not support callbacks yet.
-        return CallbackMixin.put_file_compat(
-            self, from_file, to_info, callback=callback, **kwargs
-        )

--- a/dvc/fs/dvc.py
+++ b/dvc/fs/dvc.py
@@ -6,6 +6,7 @@ from dvc.exceptions import OutputNotFoundError
 from dvc.path_info import PathInfo
 from dvc.utils import relpath
 
+from ..progress import DEFAULT_CALLBACK
 from ._metadata import Metadata
 from .base import BaseFileSystem
 
@@ -256,10 +257,12 @@ class DvcFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
 
         return ret
 
-    def _download(self, from_info, to_file, **kwargs):
+    def get_file(
+        self, from_info, to_file, callback=DEFAULT_CALLBACK, **kwargs
+    ):
         fs, path = self._get_fs_path(from_info)
-        fs._download(  # pylint: disable=protected-access
-            path, to_file, **kwargs
+        fs.get_file(  # pylint: disable=protected-access
+            path, to_file, callback=callback, **kwargs
         )
 
     def checksum(self, path_info):

--- a/dvc/fs/fsspec_wrapper.py
+++ b/dvc/fs/fsspec_wrapper.py
@@ -245,29 +245,30 @@ class CallbackMixin:
     """Provides callback support for the filesystem that don't support yet."""
 
     def put_file(
-        self: FSSpecWrapper,
+        self,
         from_file,
         to_info,
         callback=DEFAULT_CALLBACK,
         **kwargs,
     ):
         """Add compatibility support for Callback."""
+        # pylint: disable=protected-access
         self.makedirs(to_info.parent)
         size = os.path.getsize(from_file)
         with open(from_file, "rb") as fobj:
             callback.set_size(size)
             wrapped = CallbackIOWrapper(callback.relative_update, fobj)
             self.upload_fobj(wrapped, to_info)
-            # pylint: disable=protected-access
             self.fs.invalidate_cache(self._with_bucket(to_info.parent))
 
     def get_file(
-        self: FSSpecWrapper,
+        self,
         from_info,
         to_info,
         callback=DEFAULT_CALLBACK,
         **kwargs,
     ):
+        # pylint: disable=protected-access
         total: int = self.getsize(from_info)
         if total:
             callback.set_size(total)

--- a/dvc/fs/gdrive.py
+++ b/dvc/fs/gdrive.py
@@ -12,8 +12,7 @@ from dvc.path_info import CloudURLInfo
 from dvc.scheme import Schemes
 from dvc.utils import format_link, tmp_fname
 
-from ..progress import DEFAULT_CALLBACK
-from .fsspec_wrapper import CallbackMixin, FSSpecWrapper
+from .fsspec_wrapper import FSSpecWrapper
 
 logger = logging.getLogger(__name__)
 FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
@@ -301,11 +300,3 @@ class GDriveFileSystem(FSSpecWrapper):  # pylint:disable=abstract-method
         rpath = self._with_bucket(to_info)
         self.makedirs(os.path.dirname(rpath))
         return self.fs.upload_fobj(fobj, rpath, **kwargs)
-
-    def get_file(
-        self, from_info, to_info, callback=DEFAULT_CALLBACK, **kwargs
-    ):
-        # see: https://github.com/iterative/PyDrive2/issues/136
-        return CallbackMixin.get_file(
-            self, from_info, to_info, callback=DEFAULT_CALLBACK, **kwargs
-        )

--- a/dvc/fs/gdrive.py
+++ b/dvc/fs/gdrive.py
@@ -12,7 +12,7 @@ from dvc.path_info import CloudURLInfo
 from dvc.scheme import Schemes
 from dvc.utils import format_link, tmp_fname
 
-from .fsspec_wrapper import CallbackMixin, FSSpecWrapper
+from .fsspec_wrapper import FSSpecWrapper
 
 logger = logging.getLogger(__name__)
 FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
@@ -79,9 +79,7 @@ class GDriveURLInfo(CloudURLInfo):
         self._spath = re.sub("/{2,}", "/", self._spath.rstrip("/"))
 
 
-class GDriveFileSystem(
-    CallbackMixin, FSSpecWrapper
-):  # pylint:disable=abstract-method
+class GDriveFileSystem(FSSpecWrapper):  # pylint:disable=abstract-method
     scheme = Schemes.GDRIVE
     PATH_CLS = GDriveURLInfo
     PARAM_CHECKSUM = "checksum"

--- a/dvc/fs/gdrive.py
+++ b/dvc/fs/gdrive.py
@@ -12,7 +12,8 @@ from dvc.path_info import CloudURLInfo
 from dvc.scheme import Schemes
 from dvc.utils import format_link, tmp_fname
 
-from .fsspec_wrapper import FSSpecWrapper
+from ..progress import DEFAULT_CALLBACK
+from .fsspec_wrapper import CallbackMixin, FSSpecWrapper
 
 logger = logging.getLogger(__name__)
 FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
@@ -300,3 +301,11 @@ class GDriveFileSystem(FSSpecWrapper):  # pylint:disable=abstract-method
         rpath = self._with_bucket(to_info)
         self.makedirs(os.path.dirname(rpath))
         return self.fs.upload_fobj(fobj, rpath, **kwargs)
+
+    def get_file(
+        self, from_info, to_info, callback=DEFAULT_CALLBACK, **kwargs
+    ):
+        # see: https://github.com/iterative/PyDrive2/issues/136
+        return CallbackMixin.get_file(
+            self, from_info, to_info, callback=DEFAULT_CALLBACK, **kwargs
+        )

--- a/dvc/fs/gs.py
+++ b/dvc/fs/gs.py
@@ -7,11 +7,10 @@ from dvc.path_info import CloudURLInfo
 from dvc.scheme import Schemes
 
 # pylint:disable=abstract-method
-from ..progress import DEFAULT_CALLBACK
 from .fsspec_wrapper import CallbackMixin, ObjectFSWrapper
 
 
-class GSFileSystem(ObjectFSWrapper):
+class GSFileSystem(CallbackMixin, ObjectFSWrapper):
     scheme = Schemes.GS
     PATH_CLS = CloudURLInfo
     REQUIRES = {"gcsfs": "gcsfs"}
@@ -36,11 +35,3 @@ class GSFileSystem(ObjectFSWrapper):
         from gcsfs import GCSFileSystem
 
         return GCSFileSystem(**self.fs_args)
-
-    def put_file(
-        self, from_file, to_info, callback=DEFAULT_CALLBACK, **kwargs
-    ):
-        # GCSFileSystem.put_file does not support callbacks yet.
-        return CallbackMixin.put_file_compat(
-            self, from_file, to_info, callback=callback, **kwargs
-        )

--- a/dvc/fs/hdfs.py
+++ b/dvc/fs/hdfs.py
@@ -8,8 +8,10 @@ import subprocess
 from collections import deque
 from contextlib import closing, contextmanager
 
+from tqdm.utils import CallbackIOWrapper
+
 from dvc.hash_info import HashInfo
-from dvc.progress import DEFAULT_CALLBACK, Tqdm
+from dvc.progress import DEFAULT_CALLBACK
 from dvc.scheme import Schemes
 from dvc.utils import fix_env, tmp_fname
 
@@ -252,8 +254,6 @@ class HDFSFileSystem(BaseFileSystem):
     def put_file(
         self, from_file, to_info, callback=DEFAULT_CALLBACK, **kwargs
     ):
-        from tqdm.utils import CallbackIOWrapper
-
         with self.hdfs(to_info) as hdfs:
             hdfs.create_dir(to_info.parent.path)
 
@@ -267,19 +267,16 @@ class HDFSFileSystem(BaseFileSystem):
                     shutil.copyfileobj(wrapped, sobj, self.BLOCK_SIZE)
             hdfs.move(tmp_file, to_info.path)
 
-    def _download(
-        self, from_info, to_file, name=None, no_progress_bar=False, **_kwargs
+    def get_file(
+        self, from_info, to_file, callback=DEFAULT_CALLBACK, **kwargs
     ):
         with self.hdfs(from_info) as hdfs:
             file_info = hdfs.get_file_info(from_info.path)
             total = file_info.size
-            with open(to_file, "wb+") as fobj:
-                with Tqdm.wrapattr(
-                    fobj,
-                    "write",
-                    desc=name,
-                    total=total,
-                    disable=no_progress_bar,
-                ) as wrapped:
-                    with hdfs.open_input_stream(from_info.path) as sobj:
-                        shutil.copyfileobj(sobj, wrapped, self.BLOCK_SIZE)
+            if total:
+                callback.set_size(total)
+
+            with hdfs.open_input_stream(from_info.path) as sobj:
+                with open(to_file, "wb+") as fobj:
+                    wrapped = CallbackIOWrapper(callback.relative_update, sobj)
+                    shutil.copyfileobj(wrapped, fobj, self.BLOCK_SIZE)

--- a/dvc/fs/http.py
+++ b/dvc/fs/http.py
@@ -6,7 +6,7 @@ from dvc import prompt
 from dvc.path_info import HTTPURLInfo
 from dvc.scheme import Schemes
 
-from .fsspec_wrapper import CallbackMixin, FSSpecWrapper, NoDirectoriesMixin
+from .fsspec_wrapper import FSSpecWrapper, NoDirectoriesMixin
 
 
 @wrap_with(threading.Lock())
@@ -32,7 +32,7 @@ def make_context(ssl_verify):
 
 
 # pylint: disable=abstract-method
-class HTTPFileSystem(CallbackMixin, NoDirectoriesMixin, FSSpecWrapper):
+class HTTPFileSystem(NoDirectoriesMixin, FSSpecWrapper):
     scheme = Schemes.HTTP
     PATH_CLS = HTTPURLInfo
     PARAM_CHECKSUM = "checksum"

--- a/dvc/fs/local.py
+++ b/dvc/fs/local.py
@@ -167,10 +167,7 @@ class LocalFileSystem(BaseFileSystem):
         copyfile(from_file, tmp_file, callback=callback)
         os.replace(tmp_file, to_info)
 
-    @staticmethod
-    def _download(
-        from_info, to_file, name=None, no_progress_bar=False, **_kwargs
+    def get_file(
+        self, from_info, to_file, callback=DEFAULT_CALLBACK, **kwargs
     ):
-        copyfile(
-            from_info, to_file, no_progress_bar=no_progress_bar, name=name
-        )
+        copyfile(from_info, to_file, callback=callback)

--- a/dvc/fs/oss.py
+++ b/dvc/fs/oss.py
@@ -7,13 +7,13 @@ from funcy import cached_property, wrap_prop
 from dvc.path_info import CloudURLInfo
 from dvc.scheme import Schemes
 
-from .fsspec_wrapper import CallbackMixin, ObjectFSWrapper
+from .fsspec_wrapper import ObjectFSWrapper
 
 logger = logging.getLogger(__name__)
 
 
 # pylint:disable=abstract-method
-class OSSFileSystem(CallbackMixin, ObjectFSWrapper):
+class OSSFileSystem(ObjectFSWrapper):
     scheme = Schemes.OSS
     PATH_CLS = CloudURLInfo
     REQUIRES = {"ossfs": "ossfs"}

--- a/dvc/fs/repo.py
+++ b/dvc/fs/repo.py
@@ -9,6 +9,7 @@ from funcy import lfilter, wrap_with
 
 from dvc.path_info import PathInfo
 
+from ..progress import DEFAULT_CALLBACK
 from .base import BaseFileSystem
 from .dvc import DvcFileSystem
 
@@ -448,19 +449,21 @@ class RepoFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
             for fname in files:
                 yield PathInfo(root) / fname
 
-    def _download(self, from_info, to_file, **kwargs):
+    def get_file(
+        self, from_info, to_file, callback=DEFAULT_CALLBACK, **kwargs
+    ):
         fs, dvc_fs = self._get_fs_pair(from_info)
         try:
-            fs._download(  # pylint: disable=protected-access
-                from_info, to_file, **kwargs
+            fs.get_file(  # pylint: disable=protected-access
+                from_info, to_file, callback=callback, **kwargs
             )
             return
         except FileNotFoundError:
             if not dvc_fs:
                 raise
 
-        dvc_fs._download(  # pylint: disable=protected-access
-            from_info, to_file, **kwargs
+        dvc_fs.get_file(  # pylint: disable=protected-access
+            from_info, to_file, callback=callback, **kwargs
         )
 
     def metadata(self, path):

--- a/dvc/fs/s3.py
+++ b/dvc/fs/s3.py
@@ -219,8 +219,8 @@ class S3FileSystem(BaseS3FileSystem):  # pylint:disable=abstract-method
 
     @_translate_exceptions
     def get_file(
-        self, from_info, to_file, callback=DEFAULT_CALLBACK, **pbar_args
+        self, from_info, to_info, callback=DEFAULT_CALLBACK, **kwargs
     ):
         obj = self._get_obj(from_info)
         callback.set_size(obj.content_length)
-        obj.download_file(to_file, Callback=callback.relative_update)
+        obj.download_file(to_info, Callback=callback.relative_update)

--- a/dvc/fs/ssh.py
+++ b/dvc/fs/ssh.py
@@ -9,7 +9,7 @@ from dvc.scheme import Schemes
 from dvc.utils.fs import as_atomic
 
 from ..progress import DEFAULT_CALLBACK
-from .fsspec_wrapper import CallbackMixin, FSSpecWrapper
+from .fsspec_wrapper import FSSpecWrapper
 
 _SSH_TIMEOUT = 60 * 30
 _SSH_CONFIG_FILE = os.path.expanduser(os.path.join("~", ".ssh", "config"))
@@ -27,7 +27,7 @@ def ask_password(host, user, port):
 
 
 # pylint:disable=abstract-method
-class SSHFileSystem(CallbackMixin, FSSpecWrapper):
+class SSHFileSystem(FSSpecWrapper):
     scheme = Schemes.SSH
     REQUIRES = {"sshfs": "sshfs"}
 

--- a/dvc/fs/webhdfs.py
+++ b/dvc/fs/webhdfs.py
@@ -9,7 +9,7 @@ from funcy import cached_property, wrap_prop
 
 from dvc.hash_info import HashInfo
 from dvc.path_info import CloudURLInfo
-from dvc.progress import DEFAULT_CALLBACK, Tqdm
+from dvc.progress import DEFAULT_CALLBACK
 from dvc.scheme import Schemes
 
 from .base import BaseFileSystem
@@ -168,13 +168,13 @@ class WebHDFSFileSystem(BaseFileSystem):  # pylint:disable=abstract-method
             progress=update_callback(callback, total),
         )
 
-    def _download(
-        self, from_info, to_file, name=None, no_progress_bar=False, **_kwargs
+    def get_file(
+        self, from_info, to_file, callback=DEFAULT_CALLBACK, **kwargs
     ):
         total = self.getsize(from_info)
-        with Tqdm(
-            desc=name, total=total, disable=no_progress_bar, bytes=True
-        ) as pbar:
-            self.hdfs_client.download(
-                from_info.path, to_file, progress=update_pbar(pbar, total)
-            )
+        if total:
+            callback.set_size(total)
+
+        self.hdfs_client.download(
+            from_info.path, to_file, progress=update_callback(callback, total)
+        )

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -191,6 +191,9 @@ class FsspecCallback(fsspec.Callback):
         self.progress_bar.update_to(value)
         super().absolute_update(value)
 
+    def branch(self, path_1, path_2, kwargs):
+        return FsspecCallback(self.fs, path_1, Tqdm(**kwargs))
+
 
 def tdqm_or_callback_wrapped(
     fobj, method, total, callback=None, **pbar_kwargs
@@ -206,4 +209,4 @@ def tdqm_or_callback_wrapped(
     return Tqdm.wrapattr(fobj, method, total=total, bytes=True, **pbar_kwargs)
 
 
-DEFAULT_CALLBACK = fsspec.callbacks.NoOpCallback
+DEFAULT_CALLBACK = fsspec.callbacks.NoOpCallback()

--- a/tests/func/test_fs.py
+++ b/tests/func/test_fs.py
@@ -442,7 +442,6 @@ def test_upload_callback(tmp_dir, dvc, cloud):
 
     assert callback.size == expected_size
     assert callback.value == expected_size
-    assert (cloud / "foo").read_text() == "foo"
 
 
 @pytest.mark.needs_internet
@@ -461,9 +460,9 @@ def test_upload_callback(tmp_dir, dvc, cloud):
     ],
 )
 def test_download_callback(tmp_dir, dvc, cloud):
-    cloud.gen("foo", "foo")
     cls, config, _ = get_cloud_fs(dvc, **cloud.config)
     fs = cls(**config)
+    fs.upload(io.BytesIO(b"foo"), cloud / "foo")
     expected_size = fs.getsize(cloud / "foo")
 
     callback = fsspec.Callback()

--- a/tests/func/test_fs.py
+++ b/tests/func/test_fs.py
@@ -450,6 +450,12 @@ def test_upload_callback(tmp_dir, dvc, cloud):
     [
         pytest.lazy_fixture("azure"),
         pytest.lazy_fixture("gs"),
+        pytest.param(
+            pytest.lazy_fixture("gdrive"),
+            marks=pytest.mark.xfail(
+                reason="https://github.com/iterative/PyDrive2/issues/136"
+            ),
+        ),
         pytest.lazy_fixture("gdrive"),
         pytest.lazy_fixture("hdfs"),
         pytest.lazy_fixture("local_cloud"),

--- a/tests/func/test_fs.py
+++ b/tests/func/test_fs.py
@@ -456,7 +456,6 @@ def test_upload_callback(tmp_dir, dvc, cloud):
                 reason="https://github.com/iterative/PyDrive2/issues/136"
             ),
         ),
-        pytest.lazy_fixture("gdrive"),
         pytest.lazy_fixture("hdfs"),
         pytest.lazy_fixture("local_cloud"),
         pytest.lazy_fixture("oss"),

--- a/tests/unit/remote/test_http.py
+++ b/tests/unit/remote/test_http.py
@@ -6,11 +6,11 @@ from mock import patch
 from dvc.fs.http import HTTPFileSystem
 
 
-def test_download_fails_on_error_code(dvc, http):
+def test_download_fails_on_error_code(tmp_dir, http):
     fs = HTTPFileSystem(**http.config)
 
     with pytest.raises(FileNotFoundError):
-        fs._download(http / "missing.txt", "missing.txt")
+        fs.download_file(http / "missing.txt", tmp_dir / "missing.txt")
 
 
 def test_public_auth_method(dvc):


### PR DESCRIPTION
With this, we won't have any progress bars in our filesystem, except on `base.py` where we have 3 progress bars on `upload`, `download_file`, and `download_dir`. `download_dir` requires nested/branched callback, so it has been tricky to remove those right away. Will be fixed in upcoming PRs.

With this PR, all the filesystems will use `get_file` irrespective of being fsspec-based or not to download files, and has callback support.