### PR TITLE
gdrive: strip bucket

### DIFF
--- a/dvc/fs/gdrive.py
+++ b/dvc/fs/gdrive.py
@@ -296,6 +296,15 @@ class GDriveFileSystem(FSSpecWrapper):  # pylint:disable=abstract-method
 
         return super()._with_bucket(path)
 
+    def _strip_bucket(self, entry):
+        try:
+            bucket, path = entry.split("/", 1)
+        except ValueError:
+            # If there is no path attached, only returns
+            # the bucket (top-level).
+            bucket, path = entry, None
+        return path or bucket
+
     def upload_fobj(self, fobj, to_info, **kwargs):
         rpath = self._with_bucket(to_info)
         self.makedirs(os.path.dirname(rpath))

--- a/tests/func/test_fs.py
+++ b/tests/func/test_fs.py
@@ -493,9 +493,7 @@ def test_download_callback(tmp_dir, dvc, cloud):
                 os.name == "nt", reason="unsupported on Windows."
             ),
         ),
-        pytest.param(
-            pytest.lazy_fixture("gdrive"), marks=pytest.mark.xfail(strict=True)
-        ),
+        pytest.lazy_fixture("gdrive"),
     ],
 )
 def test_download_dir_callback(tmp_dir, dvc, cloud):


### PR DESCRIPTION
This was giving me the entries such as `root/root/dir/{foo,bar}` instead of just `root/dir/{foo,bar}`. Though I am not sure if this has any effects on existing users.