### PR TITLE
exp init: add simple dvc exp init command

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -1360,7 +1360,7 @@ def add_parser(subparsers, parent_parser):
     )
     experiments_remove_parser.set_defaults(func=CmdExperimentsRemove)
 
-    EXPERIMENTS_INIT_HELP = "Create experiments."
+    EXPERIMENTS_INIT_HELP = "Initialize experiments."
     experiments_init_parser = experiments_subparsers.add_parser(
         "init",
         parents=[parent_parser],
@@ -1396,12 +1396,12 @@ def add_parser(subparsers, parent_parser):
     experiments_init_parser.add_argument(
         "--code",
         help="Path to the source file or directory "
-        "which your experiment depends",
+        "which your experiments depend",
     )
     experiments_init_parser.add_argument(
         "--data",
         help="Path to the data file or directory "
-        "which your experiment depends",
+        "which your experiments depend",
     )
     experiments_init_parser.add_argument(
         "--models",

--- a/tests/func/experiments/test_init.py
+++ b/tests/func/experiments/test_init.py
@@ -1,0 +1,34 @@
+import os
+
+from dvc.command.experiments import CmdExperimentsInit
+from dvc.main import main
+from dvc.utils.serialize import load_yaml
+
+
+def test_init(tmp_dir, dvc):
+    tmp_dir.gen(
+        {
+            CmdExperimentsInit.CODE: {"copy.py": ""},
+            "data": "data",
+            "params.yaml": '{"foo": 1}',
+            "dvclive": {},
+            "plots": {},
+        }
+    )
+    code_path = os.path.join(CmdExperimentsInit.CODE, "copy.py")
+    script = f"python {code_path}"
+
+    assert main(["exp", "init", script]) == 0
+    assert load_yaml(tmp_dir / "dvc.yaml") == {
+        "stages": {
+            "default": {
+                "cmd": script,
+                "deps": ["data", "src"],
+                "live": {"dvclive": {"html": True, "summary": True}},
+                "metrics": [{"metrics.json": {"cache": False}}],
+                "outs": ["models"],
+                "params": ["foo"],
+                "plots": [{"plots": {"cache": False}}],
+            }
+        }
+    }


### PR DESCRIPTION
Simpler, initial implementation for `exp init`.

Closes https://github.com/iterative/dvc/issues/6441.
Part of https://github.com/iterative/dvc/issues/6446.