### PR TITLE
fs.download: remove unused copy between same fs

### DIFF
--- a/dvc/fs/base.py
+++ b/dvc/fs/base.py
@@ -300,10 +300,6 @@ class BaseFileSystem:
         if from_info.scheme != self.scheme:
             raise NotImplementedError
 
-        if to_info.scheme == self.scheme != "local":
-            self.copy(from_info, to_info)
-            return 0
-
         if to_info.scheme != "local":
             raise NotImplementedError
 


### PR DESCRIPTION
Since we don't use this `copy` between same filesystems, it's better we remove it. It'd be tricky to implement callbacks here, so it's best to just get rid of it, while we can. `fs.utils.transfer` is the one that we should use.
