### PR TITLE
get rid of pytest-timeout

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -6,7 +6,6 @@ pytest-cov==2.12.1
 pytest-xdist==2.3.0
 pytest-mock==3.6.1
 pytest-lazy-fixture==0.6.3
-pytest-timeout==1.4.2
 pytest-docker==0.10.3
 
 flaky==3.7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,8 +17,6 @@ known_first_party=dvc,tests
 line_length=79
 
 [tool:pytest]
-timeout = 200
-timeout_method = thread
 log_level = debug
 addopts = -ra
 markers =


### PR DESCRIPTION
Trying to see if getting rid of this dependency, our issue with the timeout
gets solved or not.

We use timeout-minutes anyway on GHA, so we probably don't need it.
Locally, users can monitor this themselves.
