### PR TITLE
exp init: add basic template support

### DIFF
--- a/dvc/repo/experiments/init.py
+++ b/dvc/repo/experiments/init.py
@@ -59,7 +59,7 @@ def init(
 ):
     from jinja2 import Environment
 
-    from dvc.dvcfile import make_dvcfile
+    from dvc.utils import relpath
     from dvc.stage import check_circular_dependency, check_duplicated_arguments
     from dvc.stage.loader import StageLoader
     from dvc.utils.serialize import LOADERS, parse_yaml_for_update
@@ -94,7 +94,7 @@ def init(
 
     # render, parse yaml and then validate schema
     rendered = template.render(**context, param_names=param_names)
-    template_path = os.path.relpath(template.filename)
+    template_path = relpath(template.filename)
     data = parse_yaml_for_update(rendered, template_path)
     try:
         validated = STAGE_SCHEMA(data)

--- a/dvc/repo/experiments/init.py
+++ b/dvc/repo/experiments/init.py
@@ -59,9 +59,9 @@ def init(
 ):
     from jinja2 import Environment
 
-    from dvc.utils import relpath
     from dvc.stage import check_circular_dependency, check_duplicated_arguments
     from dvc.stage.loader import StageLoader
+    from dvc.utils import relpath
     from dvc.utils.serialize import LOADERS, parse_yaml_for_update
 
     data = compact(data)  # remove None values

--- a/dvc/repo/experiments/init.py
+++ b/dvc/repo/experiments/init.py
@@ -100,7 +100,7 @@ def init(
         validated = STAGE_SCHEMA(data)
     except MultipleInvalid as exc:
         raise DvcException(
-            f"template '{template_path}'"
+            f"template '{template_path}' "
             "failed schema validation while rendering"
         ) from exc
 

--- a/dvc/repo/experiments/init.py
+++ b/dvc/repo/experiments/init.py
@@ -59,6 +59,7 @@ def init(
 ):
     from jinja2 import Environment
 
+    from dvc.dvcfile import make_dvcfile
     from dvc.stage import check_circular_dependency, check_duplicated_arguments
     from dvc.stage.loader import StageLoader
     from dvc.utils import relpath

--- a/dvc/repo/experiments/init.py
+++ b/dvc/repo/experiments/init.py
@@ -1,0 +1,121 @@
+import dataclasses
+import os
+from collections import ChainMap
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable, Dict, Optional
+
+from funcy import compact
+from voluptuous import MultipleInvalid, Schema
+
+from dvc.exceptions import DvcException
+from dvc.schema import STAGE_DEFINITION
+
+if TYPE_CHECKING:
+    from jinja2 import BaseLoader
+
+    from dvc.repo import Repo
+
+
+DEFAULT_TEMPLATE = "default"
+
+
+@dataclasses.dataclass
+class TemplateDefaults:
+    code: str = "src"
+    data: str = "data"
+    models: str = "models"
+    metrics: str = "metrics.json"
+    params: str = "params.yaml"
+    plots: str = "plots"
+    live: str = "dvclive"
+
+
+DEFAULT_VALUES = dataclasses.asdict(TemplateDefaults())
+STAGE_SCHEMA = Schema(STAGE_DEFINITION)
+
+
+def get_loader(repo: "Repo") -> "BaseLoader":
+    from jinja2 import ChoiceLoader, FileSystemLoader
+
+    default_path = Path(__file__).parents[3] / "resources" / "stages"
+    return ChoiceLoader(
+        [
+            # not initialized yet
+            FileSystemLoader(Path(repo.dvc_dir) / "stages"),
+            # won't work for other packages
+            FileSystemLoader(default_path),
+        ]
+    )
+
+
+def init(
+    repo: "Repo",
+    data: Dict[str, Optional[object]],
+    template_name: str = None,
+    interactive: bool = False,
+    explicit: bool = False,
+    template_loader: Callable[["Repo"], "BaseLoader"] = get_loader,
+    force: bool = False,
+):
+    from jinja2 import Environment
+
+    from dvc.dvcfile import make_dvcfile
+    from dvc.stage import check_circular_dependency, check_duplicated_arguments
+    from dvc.stage.loader import StageLoader
+    from dvc.utils.serialize import LOADERS, parse_yaml_for_update
+
+    data = compact(data)  # remove None values
+    loader = template_loader(repo)
+    environment = Environment(loader=loader)
+    name = template_name or DEFAULT_TEMPLATE
+
+    dvcfile = make_dvcfile(repo, "dvc.yaml")
+    if not force and dvcfile.exists() and name in dvcfile.stages:
+        raise DvcException(f"stage '{name}' already exists.")
+
+    template = environment.get_template(f"{name}.yaml")
+    context = ChainMap(data)
+    if interactive:
+        # TODO: interactive requires us to check for variables present
+        #  in the template and, adapt our prompts accordingly.
+        raise NotImplementedError("'-i/--interactive' is not supported yet.")
+    if not explicit:
+        context.maps.append(DEFAULT_VALUES)
+    else:
+        # TODO: explicit requires us to check for undefined variables.
+        raise NotImplementedError("'--explicit' is not implemented yet.")
+
+    assert "params" in context
+    # See https://github.com/iterative/dvc/issues/6605 for the support
+    # for depending on all params of a file.
+    param_path = str(context["params"])
+    _, ext = os.path.splitext(param_path)
+    param_names = list(LOADERS[ext](param_path))
+
+    # render, parse yaml and then validate schema
+    rendered = template.render(**context, param_names=param_names)
+    template_path = os.path.relpath(template.filename)
+    data = parse_yaml_for_update(rendered, template_path)
+    try:
+        validated = STAGE_SCHEMA(data)
+    except MultipleInvalid as exc:
+        raise DvcException(
+            f"template '{template_path}'"
+            "failed schema validation while rendering"
+        ) from exc
+
+    stage = StageLoader.load_stage(dvcfile, name, validated)
+    # ensure correctness, similar to what we have in `repo.stage.add`
+    check_circular_dependency(stage)
+    check_duplicated_arguments(stage)
+    new_index = repo.index.add(stage)
+    new_index.check_graph()
+
+    with repo.scm.track_file_changes(config=repo.config):
+        # note that we are not dumping the "template" as-is
+        # we are dumping a stage data, which is processed
+        # so formatting-wise, it may look different.
+        stage.dump(update_lock=False)
+        stage.ignore_outs()
+
+    return stage

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -44,3 +44,4 @@ typing_extensions>=3.10.0.2
 fsspec[http]>=2021.8.1
 aiohttp-retry==2.4.5
 diskcache>=5.2.1
+jinja2>=2.11.3

--- a/resources/stages/default.yaml
+++ b/resources/stages/default.yaml
@@ -1,0 +1,17 @@
+cmd: {{ cmd }}
+deps:
+- {{ code }}
+- {{ data }}
+params:
+- {{ params }}:
+  {% for p in param_names %}
+  - {{ p }}
+  {% endfor %}
+outs:
+- {{ models }}
+metrics:
+- {{ metrics }}:
+    cache: false
+plots:
+- {{ plots }}:
+    cache: false

--- a/resources/stages/live.yaml
+++ b/resources/stages/live.yaml
@@ -1,0 +1,15 @@
+cmd: {{ cmd }}
+deps:
+- {{ code }}
+- {{ data }}
+params:
+- {{ params }}:
+  {% for p in param_names %}
+  - {{ p }}
+  {% endfor %}
+outs:
+- {{ models }}
+live:
+  {{ live }}:
+    summary: true
+    html: true

--- a/tests/func/experiments/test_init.py
+++ b/tests/func/experiments/test_init.py
@@ -1,34 +1,58 @@
 import os
 
-from dvc.command.experiments import CmdExperimentsInit
 from dvc.main import main
-from dvc.utils.serialize import load_yaml
 
 
 def test_init(tmp_dir, dvc):
     tmp_dir.gen(
         {
-            CmdExperimentsInit.CODE: {"copy.py": ""},
+            "src": {"copy.py": ""},
             "data": "data",
             "params.yaml": '{"foo": 1}',
             "dvclive": {},
             "plots": {},
         }
     )
-    code_path = os.path.join(CmdExperimentsInit.CODE, "copy.py")
+    code_path = os.path.join("src", "copy.py")
     script = f"python {code_path}"
 
     assert main(["exp", "init", script]) == 0
-    assert load_yaml(tmp_dir / "dvc.yaml") == {
+    assert (tmp_dir / "dvc.yaml").parse() == {
         "stages": {
             "default": {
                 "cmd": script,
                 "deps": ["data", "src"],
-                "live": {"dvclive": {"html": True, "summary": True}},
                 "metrics": [{"metrics.json": {"cache": False}}],
                 "outs": ["models"],
                 "params": ["foo"],
                 "plots": [{"plots": {"cache": False}}],
+            }
+        }
+    }
+
+
+def test_init_live(tmp_dir, dvc):
+    tmp_dir.gen(
+        {
+            "src": {"copy.py": ""},
+            "data": "data",
+            "params.yaml": '{"foo": 1}',
+            "dvclive": {},
+            "plots": {},
+        }
+    )
+    code_path = os.path.join("src", "copy.py")
+    script = f"python {code_path}"
+
+    assert main(["exp", "init", "--template", "live", script]) == 0
+    assert (tmp_dir / "dvc.yaml").parse() == {
+        "stages": {
+            "live": {
+                "cmd": script,
+                "deps": ["data", "src"],
+                "outs": ["models"],
+                "params": ["foo"],
+                "live": {"dvclive": {"html": True, "summary": True}},
             }
         }
     }


### PR DESCRIPTION
This adds basic support for templating on `dvc exp init`.
`interactive` and `explicit` are not supported yet. The custom templates are supported, 
but right now, as we don't initialize it in `dvc init`, it has to be added manually in `.dvc/stages` by the
user.  I don't want to add that support yet before having this stable, as we may have some backward incompatible changes, so for testing, you'd have to do `mkdir .dvc/stages` yourself for a while.

The default templates are not usable yet for binary packages users.
Note that the stage is appended after the template has been parsed, validated and then processed by stage when dumping, so it may not reflect the template very well, there may be formatting differences.

I tried using direct updates first, but doing that, it leaves formatting issues generated by templates (like whitespaces, empty newlines, etc.) and comment gets left-shifted. So, I went with the `stage.dump()` option. We could roll back to it if we want to in the future.

In terms of code, all of the stuff related to initialization has been moved to `experiments.init` module, but I am still hesitant to add it to `repo.experiments` as a new API.

Also, it adds a dependency on `jinja2`. Regarding tests, I have only added simple ones and I don't plan to add until this feature starts taking shape.