### PR TITLE
exp init: interactive and explicit options

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -794,8 +794,8 @@ class CmdExperimentsInit(CmdBase):
         from dvc.command.stage import parse_cmd
         from dvc.repo.experiments.init import init
 
-        cmd = parse_cmd(self.args.cmd)
-        if not cmd:
+        cmd = parse_cmd(self.args.cmd) or None
+        if not self.args.interactive and not cmd:
             raise InvalidArgumentError("command is not specified")
 
         data = {

--- a/dvc/repo/experiments/init.py
+++ b/dvc/repo/experiments/init.py
@@ -1,0 +1,121 @@
+import dataclasses
+import os
+from collections import ChainMap
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable, Dict, Optional
+
+from funcy import compact
+from voluptuous import MultipleInvalid, Schema
+
+from dvc.exceptions import DvcException
+from dvc.schema import STAGE_DEFINITION
+
+if TYPE_CHECKING:
+    from jinja2 import BaseLoader
+
+    from dvc.repo import Repo
+
+
+DEFAULT_TEMPLATE = "default"
+
+
+@dataclasses.dataclass
+class TemplateDefaults:
+    code: str = "src"
+    data: str = "data"
+    models: str = "models"
+    metrics: str = "metrics.json"
+    params: str = "params.yaml"
+    plots: str = "plots"
+    live: str = "dvclive"
+
+
+DEFAULT_VALUES = dataclasses.asdict(TemplateDefaults())
+STAGE_SCHEMA = Schema(STAGE_DEFINITION)
+
+
+def get_loader(repo: "Repo") -> "BaseLoader":
+    from jinja2 import ChoiceLoader, FileSystemLoader
+
+    default_path = Path(__file__).parents[3] / "resources" / "stages"
+    return ChoiceLoader(
+        [
+            # not initialized yet
+            FileSystemLoader(Path(repo.dvc_dir) / "stages"),
+            # won't work for other packages
+            FileSystemLoader(default_path),
+        ]
+    )
+
+
+def init(
+    repo: "Repo",
+    data: Dict[str, Optional[object]],
+    template_name: str = None,
+    interactive: bool = False,
+    explicit: bool = False,
+    template_loader: Callable[["Repo"], "BaseLoader"] = get_loader,
+    force: bool = False,
+):
+    from jinja2 import Environment
+
+    from dvc.dvcfile import make_dvcfile
+    from dvc.stage import check_circular_dependency, check_duplicated_arguments
+    from dvc.stage.loader import StageLoader
+    from dvc.utils.serialize import LOADERS, parse_yaml_for_update
+
+    data = compact(data)  # remove None values
+    loader = template_loader(repo)
+    environment = Environment(loader=loader)
+    name = template_name or DEFAULT_TEMPLATE
+
+    dvcfile = make_dvcfile(repo, "dvc.yaml")
+    if not force and dvcfile.exists() and name in dvcfile.stages:
+        raise DvcException(f"stage '{name}' already exists.")
+
+    template = environment.get_template(f"{name}.yaml")
+    context = ChainMap(data)
+    if interactive:
+        # TODO: interactive requires us to check for variables present
+        #  in the template and, adapt our prompts accordingly.
+        raise NotImplementedError("'-i/--interactive' is not supported yet.")
+    if not explicit:
+        context.maps.append(DEFAULT_VALUES)
+    else:
+        # TODO: explicit requires us to check for undefined variables.
+        raise NotImplementedError("'--explicit' is not implemented yet.")
+
+    assert "params" in context
+    # See https://github.com/iterative/dvc/issues/6605 for the support
+    # for depending on all params of a file.
+    param_path = str(context["params"])
+    _, ext = os.path.splitext(param_path)
+    param_names = list(LOADERS[ext](param_path))
+
+    # render, parse yaml and then validate schema
+    rendered = template.render(**context, param_names=param_names)
+    template_path = os.path.relpath(template.filename)
+    data = parse_yaml_for_update(rendered, template_path)
+    try:
+        validated = STAGE_SCHEMA(data)
+    except MultipleInvalid as exc:
+        raise DvcException(
+            f"template '{template_path}'"
+            "failed schema validation while rendering"
+        ) from exc
+
+    stage = StageLoader.load_stage(dvcfile, name, validated)
+    # ensure correctness, similar to what we have in `repo.stage.add`
+    check_circular_dependency(stage)
+    check_duplicated_arguments(stage)
+    new_index = repo.index.add(stage)
+    new_index.check_graph()
+
+    with repo.scm.track_file_changes(config=repo.config):
+        # note that we are not dumping the "template" as-is
+        # we are dumping a stage data, which is processed
+        # so formatting-wise, it may look different.
+        stage.dump(update_lock=False)
+        stage.ignore_outs()
+
+    return stage

--- a/dvc/repo/experiments/init.py
+++ b/dvc/repo/experiments/init.py
@@ -166,6 +166,7 @@ def init(
     from jinja2.sandbox import ImmutableSandboxedEnvironment
 
     from dvc.dvcfile import make_dvcfile
+    from dvc.utils import relpath
     from dvc.utils.serialize import LOADERS, parse_yaml_for_update
 
     data = compact(data)  # remove None values
@@ -217,7 +218,7 @@ def init(
 
     # render, parse yaml and build stage out of it
     rendered = template.render(**context)
-    template_path = os.path.relpath(template.filename)
+    template_path = relpath(template.filename)
     data = parse_yaml_for_update(rendered, template_path)
     try:
         return repo.stage.add_from_dict(name, data, force=force)

--- a/dvc/repo/experiments/init.py
+++ b/dvc/repo/experiments/init.py
@@ -2,21 +2,32 @@ import dataclasses
 import os
 from collections import ChainMap
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Dict, Optional
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Set,
+)
 
-from funcy import compact
-from voluptuous import MultipleInvalid, Schema
+from funcy import compact, post_processing
+from rich.prompt import Prompt as _Prompt
+from voluptuous import MultipleInvalid
 
 from dvc.exceptions import DvcException
-from dvc.schema import STAGE_DEFINITION
+from dvc.ui import ui
 
 if TYPE_CHECKING:
-    from jinja2 import BaseLoader
+    from jinja2 import BaseLoader, Environment, Template
 
     from dvc.repo import Repo
 
 
 DEFAULT_TEMPLATE = "default"
+STAGES_DIR = Path(__file__).parents[3] / "resources" / "stages"
 
 
 @dataclasses.dataclass
@@ -31,20 +42,114 @@ class TemplateDefaults:
 
 
 DEFAULT_VALUES = dataclasses.asdict(TemplateDefaults())
-STAGE_SCHEMA = Schema(STAGE_DEFINITION)
 
 
 def get_loader(repo: "Repo") -> "BaseLoader":
     from jinja2 import ChoiceLoader, FileSystemLoader
 
-    default_path = Path(__file__).parents[3] / "resources" / "stages"
     return ChoiceLoader(
         [
             # not initialized yet
             FileSystemLoader(Path(repo.dvc_dir) / "stages"),
             # won't work for other packages
-            FileSystemLoader(default_path),
+            FileSystemLoader(STAGES_DIR),
         ]
+    )
+
+
+class Prompt(_Prompt):
+    def __init__(self, *args, **kwargs):
+        self.default = kwargs.pop("default", False)
+        super().__init__(*args, **kwargs)
+
+    def process_response(self, value: str):
+        from rich.prompt import InvalidResponse
+
+        ret = super().process_response(value)
+        if not ret and self.default is None:
+            raise InvalidResponse(
+                "[prompt.invalid]Response required. Please try again."
+            )
+        return ret
+
+    def render_default(self, default):
+        from rich.text import Text
+
+        return Text(f"({default})", style="bold")
+
+    def __call__(self, *args, **kwargs):
+        if self.default is not None:
+            kwargs.setdefault("default", self.default)
+        return super().__call__(*args, **kwargs)
+
+
+@post_processing(dict)
+def init_interactive(keys, defaults=None):
+    defaults = defaults or {}
+    prompts = {
+        "cmd": "Enter command to run",
+        "code": "Enter path to a code file/directory",
+        "data": "Enter path to a data file/directory",
+        "models": "Enter path to a model file/directory",
+        "metrics": "Enter path to a metrics file",
+        "params": "Enter path to a parameters file",
+        "plots": "Enter path to a plots file/directory",
+        "live": "Enter path to log dvclive outputs",
+    }
+    for key, msg in prompts.items():
+        if key not in keys:
+            continue
+
+        default = defaults.get(key)
+        prompter = Prompt(msg, console=ui.error_console, default=default)
+        yield key, prompter()
+
+
+class Jinja2StaticAnalyzer:
+    def __init__(self, environment: "Environment", template: "Template"):
+        self.environment = environment
+        self.template = template
+        self.known_variables = ["cmd"] + list(DEFAULT_VALUES)
+
+    def find_undeclared_variables(
+        self, context: Mapping[str, Any] = None
+    ) -> Set[str]:
+        from jinja2.meta import find_undeclared_variables
+
+        context = context or {}
+        rendered = self.template.render(**context)
+        ast = self.environment.parse(rendered)
+        return find_undeclared_variables(ast)
+
+    def get_undefined_keys(
+        self,
+        context=None,
+        additional_known_keys: List[str] = None,
+        ignore_variables: List[str] = None,
+    ):
+        additional_known_keys = additional_known_keys or []
+        known_variables: List[str] = (
+            self.known_variables + additional_known_keys
+        )
+        ignore_variables = ignore_variables or []
+
+        undeclared_variables = self.find_undeclared_variables(context)
+        unknown_variables = (
+            undeclared_variables - set(ignore_variables) - set(known_variables)
+        )
+        if unknown_variables:
+            raise DvcException(
+                f"template '{self.template.name}' has unknown variables: "
+                f"{unknown_variables}"
+            )
+        return list(undeclared_variables - unknown_variables)
+
+
+def init_template(repo):
+    from shutil import copytree
+
+    copytree(
+        STAGES_DIR, os.path.join(repo.dvc_dir, "stages"), dirs_exist_ok=True
     )
 
 
@@ -57,16 +162,18 @@ def init(
     template_loader: Callable[["Repo"], "BaseLoader"] = get_loader,
     force: bool = False,
 ):
-    from jinja2 import Environment
+    from jinja2 import DebugUndefined
+    from jinja2.sandbox import ImmutableSandboxedEnvironment
 
     from dvc.dvcfile import make_dvcfile
-    from dvc.stage import check_circular_dependency, check_duplicated_arguments
-    from dvc.stage.loader import StageLoader
     from dvc.utils.serialize import LOADERS, parse_yaml_for_update
 
     data = compact(data)  # remove None values
     loader = template_loader(repo)
-    environment = Environment(loader=loader)
+    # let's start from strict for now
+    environment = ImmutableSandboxedEnvironment(
+        loader=loader, undefined=DebugUndefined
+    )
     name = template_name or DEFAULT_TEMPLATE
 
     dvcfile = make_dvcfile(repo, "dvc.yaml")
@@ -75,47 +182,55 @@ def init(
 
     template = environment.get_template(f"{name}.yaml")
     context = ChainMap(data)
+
+    local_context = context
+    config: Dict[str, Any] = {}  # TODO
+    defaults = DEFAULT_VALUES if not explicit else {}
+    context = context.new_child(config)
+    context = context.new_child(defaults)
+
+    analyzer = Jinja2StaticAnalyzer(environment, template)
     if interactive:
-        # TODO: interactive requires us to check for variables present
-        #  in the template and, adapt our prompts accordingly.
-        raise NotImplementedError("'-i/--interactive' is not supported yet.")
-    if not explicit:
-        context.maps.append(DEFAULT_VALUES)
-    else:
-        # TODO: explicit requires us to check for undefined variables.
-        raise NotImplementedError("'--explicit' is not implemented yet.")
+        keys = analyzer.get_undefined_keys(
+            local_context, ignore_variables=["param_names"]
+        )
+        defaults_context = context if not explicit else None
+        response = compact(init_interactive(keys, defaults=defaults_context))
+        context = context.new_child(response)
 
-    assert "params" in context
-    # See https://github.com/iterative/dvc/issues/6605 for the support
-    # for depending on all params of a file.
-    param_path = str(context["params"])
-    _, ext = os.path.splitext(param_path)
-    param_names = list(LOADERS[ext](param_path))
+    param_path = context.get("params")
+    if param_path:
+        # See https://github.com/iterative/dvc/issues/6605 for the support
+        # for depending on all params of a file.
+        param_path = str(param_path)
+        _, ext = os.path.splitext(str(param_path))
+        params = list(LOADERS[ext](param_path))
+        context = context.new_child({"param_names": params})
 
-    # render, parse yaml and then validate schema
-    rendered = template.render(**context, param_names=param_names)
+    # try to check for required variables that are missing
+    undeclared_variables = analyzer.get_undefined_keys(context)
+    if undeclared_variables:
+        raise DvcException(
+            f"template {template.name} has undefined variables: "
+            f"{undeclared_variables}"
+        )
+
+    # render, parse yaml and build stage out of it
+    rendered = template.render(**context)
     template_path = os.path.relpath(template.filename)
     data = parse_yaml_for_update(rendered, template_path)
     try:
-        validated = STAGE_SCHEMA(data)
+        return repo.stage.add_from_dict(name, data, force=force)
     except MultipleInvalid as exc:
         raise DvcException(
             f"template '{template_path}'"
             "failed schema validation while rendering"
         ) from exc
 
-    stage = StageLoader.load_stage(dvcfile, name, validated)
-    # ensure correctness, similar to what we have in `repo.stage.add`
-    check_circular_dependency(stage)
-    check_duplicated_arguments(stage)
-    new_index = repo.index.add(stage)
-    new_index.check_graph()
 
-    with repo.scm.track_file_changes(config=repo.config):
-        # note that we are not dumping the "template" as-is
-        # we are dumping a stage data, which is processed
-        # so formatting-wise, it may look different.
-        stage.dump(update_lock=False)
-        stage.ignore_outs()
+if __name__ == "__main__":
+    # pylint: disable=used-before-assignment
+    from dvc.repo import Repo  # noqa: F811
 
-    return stage
+    dvc_repo = Repo()
+    init_template(dvc_repo)

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -44,3 +44,4 @@ typing_extensions>=3.10.0.2
 fsspec[http]>=2021.8.1
 aiohttp-retry==2.4.5
 diskcache>=5.2.1
+jinja2>=2.11.3

--- a/resources/stages/default.yaml
+++ b/resources/stages/default.yaml
@@ -1,0 +1,17 @@
+cmd: {{ cmd }}
+deps:
+- {{ code }}
+- {{ data }}
+params:
+- {{ params }}:
+  {% for p in param_names %}
+  - {{ p }}
+  {% endfor %}
+outs:
+- {{ models }}
+metrics:
+- {{ metrics }}:
+    cache: false
+plots:
+- {{ plots }}:
+    cache: false

--- a/resources/stages/live.yaml
+++ b/resources/stages/live.yaml
@@ -1,0 +1,15 @@
+cmd: {{ cmd }}
+deps:
+- {{ code }}
+- {{ data }}
+params:
+- {{ params }}:
+  {% for p in param_names %}
+  - {{ p }}
+  {% endfor %}
+outs:
+- {{ models }}
+live:
+  {{ live }}:
+    summary: true
+    html: true

--- a/tests/func/experiments/test_init.py
+++ b/tests/func/experiments/test_init.py
@@ -1,34 +1,58 @@
 import os
 
-from dvc.command.experiments import CmdExperimentsInit
 from dvc.main import main
-from dvc.utils.serialize import load_yaml
 
 
 def test_init(tmp_dir, dvc):
     tmp_dir.gen(
         {
-            CmdExperimentsInit.CODE: {"copy.py": ""},
+            "src": {"copy.py": ""},
             "data": "data",
             "params.yaml": '{"foo": 1}',
             "dvclive": {},
             "plots": {},
         }
     )
-    code_path = os.path.join(CmdExperimentsInit.CODE, "copy.py")
+    code_path = os.path.join("src", "copy.py")
     script = f"python {code_path}"
 
     assert main(["exp", "init", script]) == 0
-    assert load_yaml(tmp_dir / "dvc.yaml") == {
+    assert (tmp_dir / "dvc.yaml").parse() == {
         "stages": {
             "default": {
                 "cmd": script,
                 "deps": ["data", "src"],
-                "live": {"dvclive": {"html": True, "summary": True}},
                 "metrics": [{"metrics.json": {"cache": False}}],
                 "outs": ["models"],
                 "params": ["foo"],
                 "plots": [{"plots": {"cache": False}}],
+            }
+        }
+    }
+
+
+def test_init_live(tmp_dir, dvc):
+    tmp_dir.gen(
+        {
+            "src": {"copy.py": ""},
+            "data": "data",
+            "params.yaml": '{"foo": 1}',
+            "dvclive": {},
+            "plots": {},
+        }
+    )
+    code_path = os.path.join("src", "copy.py")
+    script = f"python {code_path}"
+
+    assert main(["exp", "init", "--template", "live", script]) == 0
+    assert (tmp_dir / "dvc.yaml").parse() == {
+        "stages": {
+            "live": {
+                "cmd": script,
+                "deps": ["data", "src"],
+                "outs": ["models"],
+                "params": ["foo"],
+                "live": {"dvclive": {"html": True, "summary": True}},
             }
         }
     }


### PR DESCRIPTION
On top of https://github.com/iterative/dvc/pull/6630.

Defaults from the config is not supported yet.

The `--interactive` will ask for the options that are specified in the template file and will fall back to the default values from the command flags + configs (not implemented yet) + hardcoded defaults.


When `--explicit` is used, it won't fall back to the defaults from config or hardcoded values. Mixed with `--interactive`, it won't allow users to proceed ahead without answering. This is against the spec, that particular values should be skipped, but with templates, it's not possible to do that.

Custom templates are supported, whatever it is created in `.dvc/stages`. You can create default templates in `.dvc/stages` by running `python -m dvc.repo.experiments.init`, but it can also fallback to the default files it keeps in `resources/stages`.



