### PR TITLE
tests: additional callbacks test for remaining filesystems

### DIFF
--- a/requirements/gdrive.txt
+++ b/requirements/gdrive.txt
@@ -1,1 +1,1 @@
-pydrive2[fsspec]>=1.9.2
+pydrive2[fsspec]>=1.9.4


### PR DESCRIPTION
Gdrive will fail unless the `pydrive2` is updated.

Added a few more remotes for tests of the callbacks as well.