### PR TITLE
checkout: start switching to obj-based workflow 

### DIFF
--- a/dvc/objects/diff.py
+++ b/dvc/objects/diff.py
@@ -1,0 +1,135 @@
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    from .file import HashFile
+
+ADD = "add"
+MODIFY = "modify"
+DELETE = "delete"
+UNCHANGED = "unchanged"
+
+
+@dataclass
+class TreeEntry:
+    in_cache: bool
+    key: Tuple[str]
+    obj: Optional["HashFile"] = field(default=None)
+
+    def __bool__(self):
+        return bool(self.obj)
+
+    def __eq__(self, other):
+        if not isinstance(other, TreeEntry):
+            return False
+
+        if self.key != other.key or bool(self.obj) != bool(other.obj):
+            return False
+
+        if not self.obj:
+            return False
+
+        return self.obj.hash_info == other.obj.hash_info
+
+
+@dataclass
+class Change:
+    old: TreeEntry
+    new: TreeEntry
+
+    @property
+    def typ(self):
+        if not self.old and not self.new:
+            return UNCHANGED
+
+        if self.old and not self.new:
+            return DELETE
+
+        if not self.old and self.new:
+            return ADD
+
+        if self.old != self.new:
+            return MODIFY
+
+        return UNCHANGED
+
+    def __bool__(self):
+        return self.typ != UNCHANGED
+
+
+@dataclass
+class DiffResult:
+    added: List[Change] = field(default_factory=list, compare=True)
+    modified: List[Change] = field(default_factory=list, compare=True)
+    deleted: List[Change] = field(default_factory=list, compare=True)
+    unchanged: List[Change] = field(default_factory=list, compare=True)
+
+    def __bool__(self):
+        return bool(self.added or self.modified or self.deleted)
+
+
+ROOT = ("",)
+
+
+def diff(
+    old: Optional["HashFile"], new: Optional["HashFile"], cache
+) -> DiffResult:
+    from .tree import Tree
+
+    if old is None and new is None:
+        return DiffResult()
+
+    def _get_keys(obj):
+        if not obj:
+            return []
+        return [ROOT] + (
+            [key for key, _ in obj] if isinstance(obj, Tree) else []
+        )
+
+    old_keys = set(_get_keys(old))
+    new_keys = set(_get_keys(new))
+
+    def _get_obj(obj, key):
+        if not obj or key == ROOT:
+            return obj
+
+        return obj.get(key)
+
+    def _in_cache(obj, cache):
+        from . import check
+        from .errors import ObjectFormatError
+
+        if not obj:
+            return False
+
+        try:
+            check(cache, obj)
+            return True
+        except (FileNotFoundError, ObjectFormatError):
+            return False
+
+    ret = DiffResult()
+    for key in old_keys | new_keys:
+        old_obj = _get_obj(old, key)
+        new_obj = _get_obj(new, key)
+
+        change = Change(
+            old=TreeEntry(_in_cache(old_obj, cache), key, old_obj),
+            new=TreeEntry(_in_cache(new_obj, cache), key, new_obj),
+        )
+
+        if change.typ == ADD:
+            ret.added.append(change)
+        elif change.typ == MODIFY:
+            ret.modified.append(change)
+        elif change.typ == DELETE:
+            ret.deleted.append(change)
+        else:
+            assert change.typ == UNCHANGED
+            if not change.new.in_cache and not isinstance(
+                change.new.obj, Tree
+            ):
+                ret.modified.append(change)
+            else:
+                ret.unchanged.append(change)
+    return ret

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -496,27 +496,27 @@ def test_should_update_state_entry_for_directory_after_add(
 
     ret = main(["add", "data"])
     assert ret == 0
-    assert file_md5_counter.mock.call_count == 3
+    assert file_md5_counter.mock.call_count == 4
 
     ret = main(["status"])
     assert ret == 0
-    assert file_md5_counter.mock.call_count == 3
+    assert file_md5_counter.mock.call_count == 4
 
     ls = "dir" if os.name == "nt" else "ls"
     ret = main(
         ["run", "--single-stage", "-d", "data", "{} {}".format(ls, "data")]
     )
     assert ret == 0
-    assert file_md5_counter.mock.call_count == 3
+    assert file_md5_counter.mock.call_count == 4
 
     os.rename("data", "data" + ".back")
     ret = main(["checkout"])
     assert ret == 0
-    assert file_md5_counter.mock.call_count == 3
+    assert file_md5_counter.mock.call_count == 4
 
     ret = main(["status"])
     assert ret == 0
-    assert file_md5_counter.mock.call_count == 3
+    assert file_md5_counter.mock.call_count == 4
 
 
 class TestAddCommit(TestDvc):
@@ -537,13 +537,15 @@ def test_should_collect_dir_cache_only_once(mocker, tmp_dir, dvc):
     counter = mocker.spy(dvc_module.objects.stage, "_get_tree_obj")
     ret = main(["add", "data"])
     assert ret == 0
+    assert counter.mock.call_count == 2
 
     ret = main(["status"])
     assert ret == 0
+    assert counter.mock.call_count == 2
 
     ret = main(["status"])
     assert ret == 0
-    assert counter.mock.call_count == 1
+    assert counter.mock.call_count == 2
 
 
 class TestShouldPlaceStageInDataDirIfRepositoryBelowSymlink(TestDvc):


### PR DESCRIPTION
First steps in migrating checkout to object-based workflow. Introduces `dvc.objects.diff` that can be used in other applications (e.g. in `dvc diff`) later. Allows us to stage existing target first(multithreaded, benefiting from all current and future improvements in `dvc.objects.stage`), then compare the resulting object with the end result that we are trying to achieve and use that diff to only apply actual changes.

`diff()` has some pre-requisites for supporting granular `Tree`s in the future, but for the most part this is trying to carry over legacy things, that will be revisited in the followups.

Pre-requisite for #6594

Todo:
- [x] investigate checkpoints test failing
- [x] check benchmarks