### PR TITLE
machine: Add a new command `dvc machine status`

### DIFF
--- a/dvc/command/machine.py
+++ b/dvc/command/machine.py
@@ -143,6 +143,21 @@ class CmdMachineCreate(CmdBase):
         return 0
 
 
+class CmdMachineStatus(CmdBase):
+    def run(self):
+        if self.repo.machine is None:
+            raise MachineDisabledError
+
+        all_status = self.repo.machine.status(self.args.name)
+        for i, status in enumerate(all_status):
+            ui.write(f"instance_num_{i+1}:")
+            keys = list(status.keys())
+            keys.sort()
+            for key in keys:
+                ui.write(f"\t{key:20}: {status[key]}")
+        return 0
+
+
 class CmdMachineDestroy(CmdBase):
     def run(self):
         if self.repo.machine is None:
@@ -305,6 +320,19 @@ def add_parser(subparsers, parent_parser):
         "name", help="Name of the machine to create."
     )
     machine_create_parser.set_defaults(func=CmdMachineCreate)
+
+    machine_STATUS_HELP = "List the status of a running machine."
+    machine_status_parser = machine_subparsers.add_parser(
+        "status",
+        parents=[parent_config_parser, parent_parser],
+        description=append_doc_link(machine_STATUS_HELP, "machine/status"),
+        help=machine_STATUS_HELP,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    machine_status_parser.add_argument(
+        "name", help="Name of the running machine."
+    )
+    machine_status_parser.set_defaults(func=CmdMachineStatus)
 
     machine_DESTROY_HELP = "Destroy an machine instance."
     machine_destroy_parser = machine_subparsers.add_parser(

--- a/dvc/machine/__init__.py
+++ b/dvc/machine/__init__.py
@@ -2,8 +2,10 @@ import logging
 import os
 from typing import (
     TYPE_CHECKING,
+    Any,
     Dict,
     Iterable,
+    Iterator,
     Mapping,
     Optional,
     Tuple,
@@ -200,3 +202,7 @@ class MachineManager:
     def run_shell(self, name: Optional[str]):
         config, backend = self.get_config_and_backend(name)
         return backend.run_shell(**config)
+
+    def status(self, name: Optional[str]) -> Iterator[Dict[Any, Any]]:
+        config, backend = self.get_config_and_backend(name)
+        return backend.instances(**config)

--- a/tests/func/machine/__init__.py
+++ b/tests/func/machine/__init__.py
@@ -1,0 +1,10 @@
+import textwrap
+
+CONFIG_TEXT = textwrap.dedent(
+    """\
+        [feature]
+            machine = true
+        ['machine \"foo\"']
+            cloud = aws
+    """
+)

--- a/tests/func/machine/test_machine_config.py
+++ b/tests/func/machine/test_machine_config.py
@@ -5,14 +5,7 @@ import pytest
 
 from dvc.main import main
 
-CONFIG_TEXT = textwrap.dedent(
-    """\
-        [feature]
-            machine = true
-        ['machine \"foo\"']
-            cloud = aws
-    """
-)
+from . import CONFIG_TEXT
 
 
 @pytest.mark.parametrize(

--- a/tests/func/machine/test_machine_status.py
+++ b/tests/func/machine/test_machine_status.py
@@ -1,0 +1,42 @@
+import json
+
+from tpi.terraform import TerraformBackend
+
+from dvc.main import main
+
+from . import CONFIG_TEXT
+
+STATUS = """{
+    "aws_security_group": null,
+    "cloud": "aws",
+    "id": "iterative-2jyhw8j9ieov6",
+    "image": "ubuntu-bionic-18.04-amd64-server-20210818",
+    "instance_gpu": null,
+    "instance_hdd_size": 35,
+    "instance_ip": "123.123.123.123",
+    "instance_launch_time": "2021-08-25T07:13:03Z",
+    "instance_type": "m",
+    "name": "test-resource",
+    "region": "us-west",
+    "spot": false,
+    "spot_price": -1,
+    "ssh_name": null,
+    "ssh_private": "-----BEGIN RSA PRIVATE KEY-----\\n",
+    "startup_script": "IyEvYmluL2Jhc2g=",
+    "timeouts": null
+}"""
+
+
+def test_status(tmp_dir, scm, dvc, mocker, capsys):
+    (tmp_dir / ".dvc" / "config").write_text(CONFIG_TEXT)
+    status = json.loads(STATUS)
+
+    mocker.patch.object(
+        TerraformBackend, "instances", autospec=True, return_value=[status]
+    )
+
+    assert main(["machine", "status", "foo"]) == 0
+    cap = capsys.readouterr()
+    assert "instance_num_1:" in cap.out
+    for key, value in status.items():
+        assert f"\t{key:20}: {value}" in cap.out

--- a/tests/unit/command/test_machine.py
+++ b/tests/unit/command/test_machine.py
@@ -9,6 +9,7 @@ from dvc.command.machine import (
     CmdMachineModify,
     CmdMachineRemove,
     CmdMachineSsh,
+    CmdMachineStatus,
 )
 
 DATA = {
@@ -50,6 +51,19 @@ def test_create(tmp_dir, dvc, mocker):
     cmd = cli_args.func(cli_args)
     m = mocker.patch.object(
         cmd.repo.machine, "create", autospec=True, return_value=0
+    )
+
+    assert cmd.run() == 0
+    m.assert_called_once_with("foo")
+
+
+def test_status(tmp_dir, dvc, mocker):
+    cli_args = parse_args(["machine", "status", "foo"])
+    assert cli_args.func == CmdMachineStatus
+
+    cmd = cli_args.func(cli_args)
+    m = mocker.patch.object(
+        cmd.repo.machine, "status", autospec=True, return_value=[]
     )
 
     assert cmd.run() == 0


### PR DESCRIPTION
fix#6482
1. add a new command `dvc machien status`
2. add a unit test for the cli call.
3. add a unit test for the shown result.

* [ ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
