### PR TITLE
command: Should not consume 'print' to output default remote info

### DIFF
--- a/dvc/command/remote.py
+++ b/dvc/command/remote.py
@@ -86,7 +86,7 @@ class CmdRemoteDefault(CmdRemote):
         if self.args.name is None and not self.args.unset:
             conf = self.config.read(self.args.level)
             try:
-                print(conf["core"]["remote"])
+                ui.write(conf["core"]["remote"])
             except KeyError:
                 ui.write("No default remote set")
                 return 1


### PR DESCRIPTION
1. should not consume 'print' to output default remote info,
   otherwise the --quiet would not work.

* [ ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
