### PR TITLE
merge yaml parsing and schema validation into one, aka strictyaml.load

### DIFF
--- a/dvc/stage/exceptions.py
+++ b/dvc/stage/exceptions.py
@@ -10,7 +10,8 @@ class StageCmdFailedError(DvcException):
 
 
 class StageFileFormatError(DvcException):
-    pass
+    def __init__(self, path):
+        super().__init__(f"'{path}' format error")
 
 
 class StageFileDoesNotExistError(DvcException):

--- a/dvc/utils/strictyaml.py
+++ b/dvc/utils/strictyaml.py
@@ -1,0 +1,147 @@
+"""
+This module combines schema and yaml parser into one, to provide better error
+messages through a single entrypoint `load`.
+
+Used for parsing dvc.yaml, dvc.lock and .dvc files.
+
+Not to be confused with strictyaml, a python library with similar motivations.
+"""
+from typing import TYPE_CHECKING, Any, Callable, List, TypeVar
+
+from dvc.exceptions import DvcException, PrettyDvcException
+from dvc.utils.serialize import (
+    EncodingError,
+    YAMLFileCorruptedError,
+    parse_yaml,
+)
+
+if TYPE_CHECKING:
+    from rich.syntax import Syntax
+    from rich.text import Text
+    from ruamel.yaml import StreamMark
+
+    from dvc.fs.base import BaseFileSystem
+
+
+_T = TypeVar("_T")
+
+
+def _prepare_cause(cause: str) -> "Text":
+    from rich.text import Text
+
+    return Text(cause, style="bold")
+
+
+def _prepare_code_snippets(code: str, start_line: int = 1) -> "Syntax":
+    from rich.syntax import Syntax
+
+    return Syntax(
+        code,
+        "yaml",
+        start_line=start_line,
+        theme="ansi_dark",
+        word_wrap=True,
+        line_numbers=True,
+        indent_guides=True,
+    )
+
+
+class YAMLSyntaxError(PrettyDvcException, YAMLFileCorruptedError):
+    def __init__(self, path: str, yaml_text: str, exc: Exception) -> None:
+        self.path: str = path
+        self.yaml_text: str = yaml_text
+        self.exc: Exception = exc
+        super().__init__(self.path)
+
+    def __pretty_exc__(self, **kwargs: Any) -> None:
+        from ruamel.yaml.error import MarkedYAMLError
+
+        from dvc.ui import ui
+        from dvc.utils import relpath
+
+        exc = self.exc.__cause__
+
+        if not isinstance(exc, MarkedYAMLError):
+            raise ValueError("nothing to pretty-print here. :)")
+
+        source = self.yaml_text.splitlines()
+
+        def prepare_linecol(mark: "StreamMark") -> str:
+            return f"in line {mark.line + 1}, column {mark.column + 1}"
+
+        def prepare_message(message: str, mark: "StreamMark" = None) -> "Text":
+            cause = ", ".join(
+                [message.capitalize(), prepare_linecol(mark) if mark else ""]
+            )
+            return _prepare_cause(cause)
+
+        def prepare_code(mark: "StreamMark") -> "Syntax":
+            line = mark.line + 1
+            code = "" if line > len(source) else source[line - 1]
+            return _prepare_code_snippets(code, line)
+
+        lines: List[object] = []
+        if hasattr(exc, "context"):
+            if exc.context_mark is not None:
+                lines.append(
+                    prepare_message(str(exc.context), exc.context_mark)
+                )
+            if exc.context_mark is not None and (
+                exc.problem is None
+                or exc.problem_mark is None
+                or exc.context_mark.name != exc.problem_mark.name
+                or exc.context_mark.line != exc.problem_mark.line
+                or exc.context_mark.column != exc.problem_mark.column
+            ):
+                lines.extend([prepare_code(exc.context_mark), ""])
+            if exc.problem is not None:
+                lines.append(
+                    prepare_message(str(exc.problem), exc.problem_mark)
+                )
+            if exc.problem_mark is not None:
+                lines.append(prepare_code(exc.problem_mark))
+
+        if lines and lines[-1]:
+            lines.insert(0, "")
+        lines.insert(0, f"[red]'{relpath(self.path)}' structure is corrupted.")
+        for message in lines:
+            ui.error_write(message, styled=True)
+
+
+class YAMLValidationError(DvcException):
+    def __init__(self, exc):
+        super().__init__(str(exc))
+
+
+def validate(data: _T, schema: Callable[[_T], _T], _text: str = None) -> _T:
+    from voluptuous import MultipleInvalid
+
+    try:
+        return schema(data)
+    except MultipleInvalid as exc:
+        raise YAMLValidationError(str(exc))
+
+
+def load(
+    path: str,
+    schema: Callable[[_T], _T] = None,
+    fs: "BaseFileSystem" = None,
+    encoding: str = "utf-8",
+    round_trip: bool = False,
+) -> Any:
+    open_fn = fs.open if fs else open
+    try:
+        with open_fn(path, encoding=encoding) as fd:  # type: ignore
+            text = fd.read()
+        data = parse_yaml(text, path, typ="rt" if round_trip else "safe")
+    except UnicodeDecodeError as exc:
+        raise EncodingError(path, encoding) from exc
+    except YAMLFileCorruptedError as exc:
+        cause = exc.__cause__
+        raise YAMLSyntaxError(path, text, exc) from cause
+
+    if schema:
+        # not returning validated data, as it may remove
+        # details from CommentedMap that we get from roundtrip parser
+        validate(data, schema, text)
+    return data, text

--- a/tests/func/test_dvcfile.py
+++ b/tests/func/test_dvcfile.py
@@ -7,6 +7,7 @@ from dvc.dvcfile import (
     PIPELINE_FILE,
     PIPELINE_LOCK,
     Dvcfile,
+    LockfileCorruptedError,
     ParametrizedDumpError,
     SingleStageFile,
 )
@@ -245,7 +246,7 @@ def test_remove_stage_on_lockfile_format_error(tmp_dir, dvc, run_copy):
     lock_data["gibberish"] = True
     data["gibberish"] = True
     (tmp_dir / lock_file.relpath).dump(lock_data)
-    with pytest.raises(StageFileFormatError):
+    with pytest.raises(LockfileCorruptedError):
         dvc_file.remove_stage(stage)
 
     lock_file.remove()

--- a/tests/func/test_lockfile.py
+++ b/tests/func/test_lockfile.py
@@ -212,8 +212,8 @@ def test_lockfile_invalid_versions(tmp_dir, dvc, version_info):
 
     assert str(exc_info.value) == "Lockfile 'dvc.lock' is corrupted."
     assert (
-        str(exc_info.value.__cause__) == "'dvc.lock' format error: "
-        f"invalid schema version {version_info['schema']}, "
+        str(exc_info.value.__cause__)
+        == f"invalid schema version {version_info['schema']}, "
         "expected one of ['2.0'] for dictionary value @ "
         "data['schema']"
     )

--- a/tests/unit/test_dvcfile.py
+++ b/tests/unit/test_dvcfile.py
@@ -15,6 +15,7 @@ from dvc.stage.exceptions import (
     StageFileIsNotDvcFileError,
 )
 from dvc.utils.fs import remove
+from dvc.utils.serialize import EncodingError
 
 
 @pytest.mark.parametrize(
@@ -123,3 +124,11 @@ def test_try_loading_dvcfile_that_is_gitignored(tmp_dir, dvc, scm, file):
         dvcfile._load()
 
     assert str(exc_info.value) == f"bad DVC file name '{file}' is git-ignored."
+
+
+def test_dvcfile_encoding_error(tmp_dir, dvc):
+    tmp_dir.gen(PIPELINE_FILE, b"\x80some: stuff")
+
+    dvcfile = Dvcfile(dvc, PIPELINE_FILE)
+    with pytest.raises(EncodingError):
+        dvcfile._load()


### PR DESCRIPTION
Closes https://github.com/iterative/dvc/issues/6290.

To solve #6285 and #5371 (i.e. better error messaging from schema errors and yaml syntax errors), I reckoned that we need to combine both yaml parsing and schema validation into one single pipeline. So, this merges both `parse_yaml` and `validate_schema` into one `strictyaml.load()` and may help us in providing better error messages. This is really useful for  loading `dvc.yaml`/`dvc.lock` and `.dvc` files as they are validated YAML files.

Moves previous changes from #6654 into strictyaml.

Schema error messaging is not in this PR, which will come after this gets merged. #6290 has been fixed by this change, as it now raises proper `EncodingError`. 

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
