### PR TITLE
ssh: bundle bcrypt by default

### DIFF
--- a/requirements/ssh.txt
+++ b/requirements/ssh.txt
@@ -1,1 +1,1 @@
-sshfs>=2021.8.1
+sshfs[bcrypt]>=2021.8.1


### PR DESCRIPTION
It seems like some of the cases bcrypt is required for the SSH key decoding, and from what I can see paramiko was already coming bundled with `bcrypt` by default. For AsyncSSH, it is an extra dependency. See https://discord.com/channels/485586884165107732/485596304961962003/890347398918971412 for more context