### PR TITLE
system: get rid of speedcopy

### DIFF
--- a/dvc/system.py
+++ b/dvc/system.py
@@ -2,23 +2,10 @@ import errno
 import logging
 import os
 import platform
-import sys
 
 from dvc.exceptions import DvcException
 
 logger = logging.getLogger(__name__)
-
-if (
-    sys.platform == "win32"
-    and sys.version_info < (3, 8)
-    and sys.getwindowsversion() >= (6, 2)
-):
-    try:
-        import speedcopy
-
-        speedcopy.patch_copyfile()
-    except ImportError:
-        pass
 
 
 class System:

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -27,7 +27,6 @@ win-unicode-console>=0.5; sys_platform == 'win32'
 networkx>=2.5
 psutil>=5.8.0
 pydot>=1.2.4
-speedcopy>=2.0.1; python_version < '3.8' and sys_platform == 'win32'
 dataclasses==0.7; python_version < '3.7'
 importlib-metadata>=1.4; python_version < '3.8'
 flatten_dict>=0.4.1,<1


### PR DESCRIPTION
`speedcopy` only patches `shutil.copyfile`, which we don't even use
anywhere because it lacks callbacks/progress and we instead use
our own `copyfile` implementation, so this is totally useless for
us and can be removed.