### PR TITLE
pathspec 0.9.0 quickfix

### DIFF
--- a/dvc/pathspec_math.py
+++ b/dvc/pathspec_math.py
@@ -51,7 +51,11 @@ def change_rule(rule, rel):
         rule = f"!/{rel}{rule}"
     else:
         rule = f"/{rel}{rule}"
-    rule = normalize_file(rule)
+    norm_rule = normalize_file(rule)
+    if rule.startswith("/") and (not norm_rule.startswith("/")):
+        rule = f"/{norm_rule}"
+    else:
+        rule = norm_rule        
     return rule
 
 

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -17,7 +17,7 @@ appdirs>=1.4.3
 ruamel.yaml>=0.17.11
 toml>=0.10.1
 funcy>=1.14
-pathspec>=0.6.0,<0.9.0
+pathspec<1.0.0
 shortuuid>=0.5.0
 tqdm>=4.45.0,<5
 packaging>=19.0


### PR DESCRIPTION
quick fix for #6555 although i really think all this should be handled with `pathlib.Path` as currently it looks quite convoluted. 

for some reason from 0.9.0 pathspec added removing leading slashes to the `normalize_file` function, dvc did not expect it, this quickly makes the test work, but does not do much else

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.
