### PR TITLE
deps: add contextvars as a dependency for Python3.6

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -28,6 +28,7 @@ networkx>=2.5
 psutil>=5.8.0
 pydot>=1.2.4
 dataclasses==0.7; python_version < '3.7'
+contextvars>=2.1; python_version < '3.7'
 importlib-metadata>=1.4; python_version < '3.8'
 flatten_dict>=0.4.1,<1
 tabulate>=0.8.7


### PR DESCRIPTION
Closes #6703.
