### PR TITLE
config: introduce core.tmp_dir to allow running on nfs/cifs/etc

### DIFF
--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -114,6 +114,7 @@ SCHEMA = {
         Optional("interactive", default=False): Bool,
         Optional("analytics", default=True): Bool,
         Optional("hardlink_lock", default=False): Bool,
+        "tmp_dir": str,
         Optional("no_scm", default=False): Bool,
         Optional("autostage", default=False): Bool,
         Optional("experiments"): Bool,  # obsoleted

--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -226,8 +226,12 @@ SCHEMA = {
         )
     },
     "state": {
+        "dir": str,  # noop, reserved
         "row_limit": All(Coerce(int), Range(1)),  # obsoleted
         "row_cleanup_quota": All(Coerce(int), Range(0, 100)),  # obsoleted
+    },
+    "index": {
+        "dir": str,  # noop, reserved
     },
     "machine": {
         str: {

--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -225,12 +225,8 @@ SCHEMA = {
         )
     },
     "state": {
-        "dir": str,
         "row_limit": All(Coerce(int), Range(1)),  # obsoleted
         "row_cleanup_quota": All(Coerce(int), Range(0, 100)),  # obsoleted
-    },
-    "index": {
-        "dir": str,
     },
     "machine": {
         str: {

--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -59,7 +59,7 @@ class DataCloud:
         from dvc.objects.db import get_odb
 
         cls, config, path_info = get_cloud_fs(self.repo, name=name)
-        config["tmp_dir"] = self.repo.index_db_dir
+        config["tmp_dir"] = self.repo.tmp_dir
         return get_odb(cls(**config), path_info, **config)
 
     def push(

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -120,34 +120,6 @@ class Repo:
 
         return root_dir, dvc_dir, tmp_dir
 
-    def _get_database_dir(self, db_name):
-        # NOTE: by default, store SQLite-based remote indexes and state's
-        # `links` and `md5s` caches in the repository itself to avoid any
-        # possible state corruption in 'shared cache dir' scenario, but allow
-        # user to override this through config when, say, the repository is
-        # located on a mounted volume — see
-        # https://github.com/iterative/dvc/issues/4420
-        base_db_dir = self.config.get(db_name, {}).get("dir", None)
-        if not base_db_dir:
-            return self.tmp_dir
-
-        import hashlib
-
-        from dvc.utils.fs import makedirs
-
-        root_dir_hash = hashlib.sha224(
-            self.root_dir.encode("utf-8")
-        ).hexdigest()
-
-        db_dir = os.path.join(
-            base_db_dir,
-            self.DVC_DIR,
-            f"{os.path.basename(self.root_dir)}-{root_dir_hash[0:7]}",
-        )
-
-        makedirs(db_dir, exist_ok=True)
-        return db_dir
-
     def __init__(
         self,
         root_dir=None,
@@ -211,8 +183,10 @@ class Repo:
                 friendly=True,
             )
 
-            state_db_dir = self._get_database_dir("state")
-            self.state = State(self.root_dir, state_db_dir, self.dvcignore)
+            # NOTE: storing state and link_state in the repository itself to
+            # avoid any possible state corruption in 'shared cache dir'
+            # scenario.
+            self.state = State(self.root_dir, self.tmp_dir, self.dvcignore)
             self.odb = ODBManager(self)
 
             self.stage_cache = StageCache(self)
@@ -477,10 +451,6 @@ class Repo:
         from dvc.fs.repo import RepoFileSystem
 
         return RepoFileSystem(self, subrepos=self.subrepos, **self._fs_conf)
-
-    @cached_property
-    def index_db_dir(self):
-        return self._get_database_dir("index")
 
     @contextmanager
     def open_by_relpath(self, path, remote=None, mode="r", encoding=None):

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -184,9 +184,6 @@ class Repo:
                 friendly=True,
             )
 
-            # NOTE: storing state and link_state in the repository itself to
-            # avoid any possible state corruption in 'shared cache dir'
-            # scenario.
             self.state = State(self.root_dir, self.tmp_dir, self.dvcignore)
             self.odb = ODBManager(self)
 

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -152,7 +152,7 @@ class Repo:
         if rev and not scm:
             scm = SCM(root_dir or os.curdir)
 
-        self.root_dir, self.dvc_dir, self.tmp_dir = self._get_repo_dirs(
+        self.root_dir, self.dvc_dir, tmp_dir = self._get_repo_dirs(
             root_dir=root_dir, scm=scm, rev=rev, uninitialized=uninitialized
         )
 
@@ -162,6 +162,7 @@ class Repo:
             self._fs = LocalFileSystem(url=self.root_dir)
 
         self.config = Config(self.dvc_dir, fs=self.fs, config=config)
+        self.tmp_dir = self.config["core"].get("tmp_dir") or tmp_dir
         self._uninitialized = uninitialized
         self._scm = scm
 

--- a/tests/func/test_state.py
+++ b/tests/func/test_state.py
@@ -1,9 +1,7 @@
 import os
-import re
 
 from dvc.hash_info import HashInfo
 from dvc.path_info import PathInfo
-from dvc.repo import Repo
 from dvc.state import State
 from dvc.utils import file_md5
 
@@ -78,18 +76,4 @@ def test_get_unused_links(tmp_dir, dvc):
             )
         )
         == {"bar"}
-    )
-
-
-def test_state_dir_config(make_tmp_dir, dvc):
-    assert dvc.state.tmp_dir == dvc.tmp_dir
-
-    index_dir = str(make_tmp_dir("tmp_index"))
-    repo = Repo(config={"state": {"dir": index_dir}})
-    assert os.path.dirname(repo.state.tmp_dir) == os.path.join(
-        index_dir, ".dvc"
-    )
-    assert re.match(
-        r"^test_state_dir_config0-([0-9a-f]+)$",
-        os.path.basename(repo.state.tmp_dir),
     )

--- a/tests/unit/remote/test_index.py
+++ b/tests/unit/remote/test_index.py
@@ -8,7 +8,7 @@ from dvc.objects.db.index import ObjectDBIndex
 
 @pytest.fixture
 def index(dvc):
-    index_ = ObjectDBIndex(dvc.index_db_dir, "foo")
+    index_ = ObjectDBIndex(dvc.tmp_dir, "foo")
     yield index_
 
 

--- a/tests/unit/remote/test_remote.py
+++ b/tests/unit/remote/test_remote.py
@@ -1,11 +1,8 @@
-import os
-
 import pytest
 
 from dvc.fs import get_cloud_fs
 from dvc.fs.gs import GSFileSystem
 from dvc.fs.s3 import S3FileSystem
-from dvc.objects.db import get_index
 
 
 def test_remote_with_hash_jobs(dvc):
@@ -58,16 +55,3 @@ def test_makedirs_not_create_for_top_level_path(fs_cls, dvc, mocker):
 
     fs.makedirs(fs.PATH_CLS(url))
     assert not mocked_client.called
-
-
-def test_remote_index_dir_config(make_tmp_dir, dvc):
-    index_dir = str(make_tmp_dir("tmp_index"))
-    with dvc.config.edit() as conf:
-        conf["index"]["dir"] = index_dir
-        conf["remote"]["s3"] = {"url": "s3://bucket/name"}
-
-    dvc.root_dir = "/usr/local/test_repo"
-
-    assert os.path.dirname(
-        get_index(dvc.cloud.get_remote_odb(name="s3")).index_dir
-    ) == os.path.join(index_dir, ".dvc", "test_repo-a473718", "index")

--- a/tests/unit/repo/test_repo.py
+++ b/tests/unit/repo/test_repo.py
@@ -137,3 +137,12 @@ def test_dynamic_cache_initalization(tmp_dir, scm):
     dvc.close()
 
     Repo(str(tmp_dir)).close()
+
+
+def test_config_tmp_dir(tmp_dir, dvc, tmp_path_factory):
+    tmp = os.fspath(tmp_path_factory.mktemp("tmp_dir"))
+
+    with dvc.config.edit() as conf:
+        conf["core"]["tmp_dir"] = tmp
+
+    assert Repo().tmp_dir == tmp


### PR DESCRIPTION
`core.tmp_dir` is a one-stop-shop for making dvc work on nfs, as it covers all sqlite databases and all locks. After careful consideration of https://github.com/iterative/dvc/pull/6419 , it is clear that even though `state.dir` and `index.dir` could be useful in the future for sharing state and index db, but `core.tmp_dir` solves the issue of running on nfs/cifs/etc better in one option. `core.tmp_dir` also makes `core.hardlink_lock` no longer needed, because we used to use it with lock-less sqlite connection, but these days our sqlite databases are all using locks, so that option it is not enough anyway. That being said, `core.hardlink_lock` has to stay for now for backward compatibility, but will be removed in 3.0.

Also, please note that `state/core.dir` have not yet been officially released, so we are fine removing them without worrying about backward compatibility.

Compared to `state/core.dir` that were autogenerated based on a hash of `root_dir`, `tmp_dir` is taken litterally,  to avoid making any assumptions and to allow using the same one even if you move your repository around, which made `state/core.dir` lose track of old state.

Example for making 1 dvc repo work on nfs/cifs/etc:

```
dvc config core.tmp_dir $(mktemp -d) --local
```

Reverts #6419 
Fixes #4420