### PR TITLE
http: explicitly retry all http-related errors

### DIFF
--- a/dvc/fs/http.py
+++ b/dvc/fs/http.py
@@ -102,6 +102,7 @@ class HTTPFileSystem(NoDirectoriesMixin, FSSpecWrapper):
             attempts=self.SESSION_RETRIES,
             factor=self.SESSION_BACKOFF_FACTOR,
             max_timeout=self.REQUEST_TIMEOUT,
+            exceptions=[aiohttp.ClientError],
         )
 
         # The default timeout for the aiohttp is 300 seconds


### PR DESCRIPTION
Beside the server-side errors like timeouts, also retry stuff that is happening on the client (e.g internet connection drop for a second). 