### PR TITLE
gha: run benchmarks on PRs

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,0 +1,19 @@
+name: benchmarks
+on: [pull_request, workflow_dispatch]
+
+jobs:
+  bench:
+    name: run benchmarks
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04]
+    steps:
+      - uses: actions/setup-python@v2
+        with:
+            python-version: 3.7
+      - uses: iterative/dvc-bench@master
+        with:
+            pytest_options: "${{ github.event_name == 'workflow_dispatch' && '' || '-k test_init -k test_help' }}"
+


### PR DESCRIPTION
Qucik&dirty way to run dvc-bench for our PRs to help with things like #6707

Need to clarify that this is not all-in-one regression detection, but rather this is specific to test regressions within one PR. We need a similar thing for specific dvc versions to detect slow regressions that accumulate over a long period of time, but that is out of scope for this PR.