### PR TITLE
Fix dvclive running subdir

### DIFF
--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -273,7 +273,7 @@ class Stage(params.StageParams):
             from dvc.output import Output
             from dvc.schema import LIVE_PROPS
 
-            env[DVCLIVE_PATH] = str(os.path.relpath(out.path_info, self.wdir))
+            env[DVCLIVE_PATH] = relpath(out.path_info, self.wdir)
             if isinstance(out.live, dict):
                 config = project(out.live, LIVE_PROPS)
 

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -273,7 +273,7 @@ class Stage(params.StageParams):
             from dvc.output import Output
             from dvc.schema import LIVE_PROPS
 
-            env[DVCLIVE_PATH] = str(out.path_info)
+            env[DVCLIVE_PATH] = str(os.path.relpath(out.path_info, self.wdir))
             if isinstance(out.live, dict):
                 config = project(out.live, LIVE_PROPS)
 

--- a/tests/func/test_live.py
+++ b/tests/func/test_live.py
@@ -258,7 +258,6 @@ def test_dvc_generates_html_during_run(tmp_dir, dvc, mocker, live_stage):
 
 
 def test_dvclive_stage_with_different_wdir(tmp_dir, scm, dvc):
-
     (tmp_dir / "subdir").gen("train.py", LIVE_SCRIPT)
     (tmp_dir / "subdir" / "params.yaml").dump({"foo": 1})
     dvc.stage.add(

--- a/tests/func/test_live.py
+++ b/tests/func/test_live.py
@@ -258,10 +258,10 @@ def test_dvc_generates_html_during_run(tmp_dir, dvc, mocker, live_stage):
     assert show_spy.call_count == 2
 
 
-def test_dvclive_running_subir(tmp_dir, scm, dvc):
+def test_dvclive_stage_with_different_wdir(tmp_dir, scm, dvc):
 
-    tmp_dir.gen("subdir/train.py", LIVE_SCRIPT)
-    tmp_dir.gen("subdir/params.yaml", "foo: 1")
+    (tmp_dir / "subdir").gen("train.py", LIVE_SCRIPT)
+    (tmp_dir / "subdir" / "params.yaml").dump({"foo": 1})
     with cd("subdir"):
         dvc.stage.add(
             cmd="python train.py",

--- a/tests/func/test_live.py
+++ b/tests/func/test_live.py
@@ -7,7 +7,6 @@ from funcy import first
 
 from dvc import stage as stage_module
 from dvc.render.utils import get_files
-from tests.utils import cd
 
 LIVE_SCRIPT = dedent(
     """
@@ -262,20 +261,17 @@ def test_dvclive_stage_with_different_wdir(tmp_dir, scm, dvc):
 
     (tmp_dir / "subdir").gen("train.py", LIVE_SCRIPT)
     (tmp_dir / "subdir" / "params.yaml").dump({"foo": 1})
-    with cd("subdir"):
-        dvc.stage.add(
-            cmd="python train.py",
-            params=["foo"],
-            deps=["train.py"],
-            name="live_stage",
-            live="dvclive",
-            live_no_html=True,
-        )
+    dvc.stage.add(
+        cmd="python train.py",
+        params=["foo"],
+        deps=["train.py"],
+        name="live_stage",
+        live="dvclive",
+        live_no_html=True,
+        wdir="subdir",
+    )
 
-    scm.add(["subdir/dvc.yaml", "subdir/train.py", "subdir/params.yaml"])
-    scm.commit("initial: live_stage")
-
-    dvc.reproduce("subdir", recursive=True)
+    dvc.reproduce()
 
     assert (tmp_dir / "subdir" / "dvclive").is_dir()
     assert (tmp_dir / "subdir" / "dvclive.json").is_file()


### PR DESCRIPTION
Closes https://github.com/iterative/dvclive/issues/169

`DVCLIVE_PATH` env var was not taking into account the stage's workdir causing `dvclive` to write outputs to the wrong path on some occasions (i.e. when running `dvc repro "subdir"`)