### PR TITLE
make dependabot updates work

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -100,7 +100,8 @@ azure =
     knack
 gdrive = pydrive2[fsspec]>=1.9.4
 gs = gcsfs==2021.10.0
-hdfs = fsspec[arrow]; python_version < '3.10'
+hdfs =
+    fsspec[arrow]; python_version < '3.10'
 oss = ossfs==2021.8.0
 s3 =
     s3fs==2021.10.0

--- a/setup.py
+++ b/setup.py
@@ -17,12 +17,23 @@ except ImportError:
 
 # Read package meta-data from version.py
 # see https://packaging.python.org/guides/single-sourcing-package-version/
-pkg_dir = os.path.dirname(os.path.abspath(__file__))
-version_path = os.path.join(pkg_dir, "dvc", "version.py")
-spec = importlib.util.spec_from_file_location("dvc.version", version_path)
-dvc_version = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(dvc_version)
-version = dvc_version.__version__  # noqa: F821
+try:
+    pkg_dir = os.path.dirname(os.path.abspath(__file__))
+    version_path = os.path.join(pkg_dir, "dvc", "version.py")
+    spec = importlib.util.spec_from_file_location("dvc.version", version_path)
+    dvc_version = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(dvc_version)
+    version = dvc_version.__version__  # noqa: F821
+except Exception as exc:  # pylint: disable=broad-except
+    # Dependabot seem to stop working when we don't handle this except block.
+    # Most likely, it's because of the restrictions in execution of the module.
+    # We workaround it, and print the error message if it also happens on other
+    # installations (though this message may likely be suppressed by build
+    # tools, eg: pip only shows this message on `--verbose` mode).
+    import sys
+
+    print("Could not load version info: ", exc, file=sys.stderr)
+    version = "UNKNOWN"
 
 
 # To achieve consistency between the build version and the one provided


### PR DESCRIPTION
Dependabot was throwing Illformed requirements `"< '3.10'"` for the
hdfs. But I noticed that it did accept other requirements where we
do similar. So it seems the indentation fixes it.

Even then, dependabot did not update any dependencies. I removed
setup.py file, after which immediately it started creating PRs.
So, I reckoned that it must have been due to some mechanism
in place from dependabot to disallow execution, so I tried to
remove few blocks of code from setup.py. And, I was eventually
able to figure out that it was from the block where we import version.

So, I added a try-except block and it magically worked again. :)

