### PR TITLE
exp init: show defaults in help message

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -840,6 +840,16 @@ class CmdExperimentsInit(CmdBase):
         return 0
 
 
+class RawDefaultsHelpFormatter(
+    argparse.RawDescriptionHelpFormatter,
+    argparse.ArgumentDefaultsHelpFormatter,
+):
+    def _get_help_string(self, action: argparse.Action) -> Optional[str]:
+        if action.default:
+            return super()._get_help_string(action)
+        return action.help
+
+
 def add_parser(subparsers, parent_parser):
     EXPERIMENTS_HELP = "Commands to run and compare experiments."
 
@@ -1364,7 +1374,7 @@ def add_parser(subparsers, parent_parser):
         "init",
         parents=[parent_parser],
         description=append_doc_link(EXPERIMENTS_INIT_HELP, "exp/init"),
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=RawDefaultsHelpFormatter,
     )
     experiments_init_parser.add_argument(
         "cmd",
@@ -1402,30 +1412,40 @@ def add_parser(subparsers, parent_parser):
     )
     experiments_init_parser.add_argument(
         "--code",
+        default=CmdExperimentsInit.CODE,
         help="Path to the source file or directory "
         "which your experiments depend",
     )
     experiments_init_parser.add_argument(
         "--data",
+        default=CmdExperimentsInit.DATA,
         help="Path to the data file or directory "
         "which your experiments depend",
     )
     experiments_init_parser.add_argument(
         "--models",
+        default=CmdExperimentsInit.MODELS,
         help="Path to the model file or directory for your experiments",
     )
     experiments_init_parser.add_argument(
-        "--params", help="Path to the parameters file for your experiments"
+        "--params",
+        default=CmdExperimentsInit.DEFAULT_PARAMS,
+        help="Path to the parameters file for your experiments",
     )
     experiments_init_parser.add_argument(
-        "--metrics", help="Path to the metrics file for your experiments"
+        "--metrics",
+        default=CmdExperimentsInit.DEFAULT_METRICS,
+        help="Path to the metrics file for your experiments",
     )
     experiments_init_parser.add_argument(
         "--plots",
+        default=CmdExperimentsInit.PLOTS,
         help="Path to the plots file or directory for your experiments",
     )
     experiments_init_parser.add_argument(
-        "--live", help="Path to log dvclive outputs for your experiments"
+        "--live",
+        help="Path to log dvclive outputs for your experiments "
+        f"(default: {CmdExperimentsInit.DVCLIVE})",
     )
     experiments_init_parser.add_argument(
         "--type",


### PR DESCRIPTION
Adds default to the help message for `exp init`.
```console
 dvc exp init -h
usage: dvc experiments init [-h] [-q | -v] [--run] [--interactive] [-f] [--explicit] [--name NAME] [--code CODE] [--data DATA] [--models MODELS] [--params PARAMS]
                            [--metrics METRICS] [--plots PLOTS] [--live LIVE] [--type {default,live}]
                            ...

Initialize experiments.
Documentation: <https://man.dvc.org/exp/init>

positional arguments:
  command               Command to execute.

optional arguments:
  -h, --help            show this help message and exit
  -q, --quiet           Be quiet.
  -v, --verbose         Be verbose.
  --run                 Run the experiment after initializing it
  --interactive, -i     Prompt for values that are not provided
  -f, --force           Overwrite existing stage
  --explicit            Only use the path values explicitly provided
  --name NAME, -n NAME  Name of the stage to create
  --code CODE           Path to the source file or directory which your experiments depend (default: src)
  --data DATA           Path to the data file or directory which your experiments depend (default: data)
  --models MODELS       Path to the model file or directory for your experiments (default: models)
  --params PARAMS       Path to the parameters file for your experiments (default: params.yaml)
  --metrics METRICS     Path to the metrics file for your experiments (default: metrics.json)
  --plots PLOTS         Path to the plots file or directory for your experiments (default: plots)
  --live LIVE           Path to log dvclive outputs for your experiments (default: dvclive)
  --type {default,live}
                        Select type of stage to create (default: default)
```