### PR TITLE
gha: move cancelaltion into other workflows

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -2,13 +2,6 @@ name: benchmarks
 on: [pull_request, workflow_dispatch]
 
 jobs:
-  cancel_previous:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.1
-      with:
-        access_token: ${{ github.token }}
   bench:
     name: run benchmarks
     runs-on: ${{ matrix.os }}
@@ -17,6 +10,10 @@ jobs:
       matrix:
         os: [ubuntu-18.04]
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
       - uses: actions/setup-python@v2
         with:
             python-version: 3.7

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,17 +12,14 @@ env:
   SHELL: /bin/bash
 
 jobs:
-  cancel_previous:
+  lint:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.9.1
       with:
         access_token: ${{ github.token }}
-  lint:
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    steps:
     - uses: actions/checkout@v2.3.4
     - name: Set up Python 3.8
       uses: actions/setup-python@v2.2.2


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

In #6756 cancellation was introduced as separate workflow, which makes PR checklist ugly, lets keep cancellation action in other workflows.

<img width="813" alt="Screenshot 2021-10-08 at 12 08 17" src="https://user-images.githubusercontent.com/10195618/136538563-28925a9a-b269-472a-b9e0-7e93b07f1d38.png">

