### PR TITLE
dvc: add 'repos' list to pre-commit config if it does not exist

### DIFF
--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -265,6 +265,9 @@ class Git(Base):
                 ],
             }
 
+            if "repos" not in config:
+                config["repos"] = []
+
             if entry not in config["repos"]:
                 config["repos"].append(entry)
 

--- a/tests/func/test_install.py
+++ b/tests/func/test_install.py
@@ -30,6 +30,12 @@ class TestInstall:
             assert hook_path.is_file()
             assert command in hook_path.read_text()
 
+    def test_install_pre_commit_tool(self, scm):
+        scm.install(use_pre_commit_tool=True)
+
+        precommit_path = pathlib.Path(".") / ".pre-commit-config.yaml"
+        assert precommit_path.is_file()
+
     def test_fail_if_hook_exists(self, scm):
         self._hook("post-checkout").write_text("hook content")
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Currently with an empty `.pre-commit-config.yaml` (and without this PR), `dvc install --use-pre-commit-tool` will fail with the following error:

```
❯ dvc install --use-pre-commit-tool -v
2021-10-12 20:44:21,442 ERROR: unexpected error - 'repos'
------------------------------------------------------------
Traceback (most recent call last):
  File "/home/michael/.local/pipx/venvs/dvc/lib64/python3.9/site-packages/dvc/main.py", line 55, in main
    ret = cmd.do_run()
  File "/home/michael/.local/pipx/venvs/dvc/lib64/python3.9/site-packages/dvc/command/base.py", line 45, in do_run
    return self.run()
  File "/home/michael/.local/pipx/venvs/dvc/lib64/python3.9/site-packages/dvc/command/install.py", line 13, in run
    self.repo.install(self.args.use_pre_commit_tool)
  File "/home/michael/.local/pipx/venvs/dvc/lib64/python3.9/site-packages/dvc/repo/install.py", line 2, in install
    self.scm.install(use_pre_commit_tool)
  File "/home/michael/.local/pipx/venvs/dvc/lib64/python3.9/site-packages/dvc/scm/git/__init__.py", line 268, in install
    if entry not in config["repos"]:
KeyError: 'repos'
------------------------
```