### PR TITLE
webdav: limit httpx to fix the CI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -110,7 +110,9 @@ s3 =
     aiobotocore[boto3]>1.0.1
 ssh = sshfs[bcrypt]>=2021.8.1
 ssh_gssapi = sshfs[gssapi]>=2021.8.1
-webdav = webdav4>=0.9.1
+webdav =
+    webdav4>=0.9.1
+    httpx>=0.18.1,<0.20.0
 # not to break `dvc[webhdfs]`
 webhdfs =
 terraform = tpi[ssh]>=2.0.0


### PR DESCRIPTION
`webdav4` uses `httpx>=0.18.2`, but the new `0.20.0` release is not compatible due to the new redirection [follow behavior](https://github.com/encode/httpx/blob/master/CHANGELOG.md). We can temporarily limit this on our requirements until it is fixed on the upstream `webdav4`.