### PR TITLE
setup.cfg: remove types-paramiko

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -156,7 +156,6 @@ tests =
     # type-checking
     mypy==0.910
     types-requests==2.25.9
-    types-paramiko==2.7.1
     types-tabulate==0.8.2
     types-toml==0.10.0
 


### PR DESCRIPTION
We are no longer using them since migration to sshfs.

Closes #6806

