### PR TITLE
 LiveTask: write output path at start/end 

### DIFF
--- a/dvc/repo/live.py
+++ b/dvc/repo/live.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from typing import TYPE_CHECKING, List, Optional
 
 from dvc.render.utils import render
@@ -19,10 +18,7 @@ def create_summary(out):
 
     html_path = out.path_info.fspath + "_dvc_plots"
 
-    index_path = render(
-        out.repo, plots, metrics=metrics, path=html_path, refresh_seconds=5
-    )
-    logger.info(f"\nfile://{os.path.abspath(index_path)}")
+    render(out.repo, plots, metrics=metrics, path=html_path, refresh_seconds=5)
 
 
 def summary_path_info(out: "Output") -> Optional["PathInfo"]:

--- a/dvc/stage/monitor.py
+++ b/dvc/stage/monitor.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Callable, List
 from dvc.repo.live import create_summary
 from dvc.stage.decorators import relock_repo
 from dvc.stage.exceptions import StageCmdFailedError
+from dvc.ui import ui
 
 if TYPE_CHECKING:
     from dvc.output import Output
@@ -86,11 +87,16 @@ class LiveTask(MonitorTask):
     error_cls = LiveKilledError
 
     def __init__(self, stage: "Stage", out: "Output", proc: subprocess.Popen):
+        self.output_path = os.path.join(
+            os.getcwd(), out.path_info.fspath + "_dvc_plots", "index.html"
+        )
+        ui.write(f"Live summary will be created at:\n{self.output_path}")
         super().__init__(stage, functools.partial(create_summary, out), proc)
 
     def after_run(self):
         # make sure summary is prepared for all the data
         self.execute()
+        ui.write(f"Live summary has been created at:\n{self.output_path}")
 
 
 class Monitor:


### PR DESCRIPTION
* [X] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

Closes https://github.com/iterative/dvclive/issues/177

Logging at the end of each step can mess up with some ML Framework progress bars, I moved the message to the instantiation of the monitor task, as the path won't change during training.

@pared Do you consider necessary logging at each `create_summary` call? If so, we could maybe keep the call but at `debug` level
