### PR TITLE
Revert "webdav: limit httpx to fix the CI"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -111,7 +111,7 @@ s3 =
     aiobotocore[boto3]>1.0.1
 ssh = sshfs[bcrypt]>=2021.8.1
 ssh_gssapi = sshfs[gssapi]>=2021.8.1
-webdav = webdav4>=0.9.1
+webdav = webdav4>=0.9.3
 # not to break `dvc[webhdfs]`
 webhdfs =
 terraform = tpi[ssh]>=2.0.0


### PR DESCRIPTION
Reverts iterative/dvc#6800. Also bumps the minimum requirement for webdav4 to 0.9.3, which pins the httpx version.