### PR TITLE
plots: fix the dictionary to return PathInfos

### DIFF
--- a/dvc/repo/plots/__init__.py
+++ b/dvc/repo/plots/__init__.py
@@ -20,6 +20,7 @@ from dvc.utils.serialize import LOADERS
 if TYPE_CHECKING:
     from dvc.output import Output
     from dvc.repo import Repo
+    from dvc.types import DvcPath
 
 logger = logging.getLogger(__name__)
 
@@ -204,7 +205,7 @@ def _collect_plots(
     targets: List[str] = None,
     rev: str = None,
     recursive: bool = False,
-) -> Dict[str, Dict]:
+) -> Dict["DvcPath", Dict]:
     from dvc.repo.collect import collect
 
     plots, path_infos = collect(


### PR DESCRIPTION
`collect()` returns a bunch of path infos, probably some of the unannotated stuff making mypy not to catch this. 