### PR TITLE
enable pywin32 for Python3.10, make it an optional dependency

### DIFF
--- a/dvc/daemon.py
+++ b/dvc/daemon.py
@@ -48,17 +48,17 @@ def _spawn_posix(cmd, env):
     # with PyInstaller has trouble with SystemExit exception and throws
     # errors such as "[26338] Failed to execute script __main__"
     try:
-        pid = os.fork()
+        pid = os.fork()  # pylint: disable=no-member
         if pid > 0:
             return
     except OSError:
         logger.exception("failed at first fork")
         os._exit(1)  # pylint: disable=protected-access
 
-    os.setsid()
+    os.setsid()  # pylint: disable=no-member
 
     try:
-        pid = os.fork()
+        pid = os.fork()  # pylint: disable=no-member
         if pid > 0:
             os._exit(0)  # pylint: disable=protected-access
     except OSError:

--- a/dvc/system.py
+++ b/dvc/system.py
@@ -60,7 +60,7 @@ class System:
 
     @staticmethod
     def _reflink_linux(src, dst):
-        import fcntl
+        import fcntl  # pylint: disable=import-error
 
         FICLONE = 0x40049409
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ disable = [
 enable = ["c-extension-no-member", "no-else-return"]
 
 [tool.pylint.typecheck]
-generated-members = ["pytest.lazy_fixture", "logging.TRACE", "logger.trace", "sys.getwindowsversion"]
+generated-members = ["pytest.lazy_fixture", "logging.TRACE", "logger.trace", "sys.getwindowsversion", "argparse.Namespace"]
 ignored-classes = ["Dvcfile"]
 ignored-modules = ["azure"]
 signature-mutators = ["funcy.decorators.decorator"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -134,7 +134,6 @@ tests =
     google-compute-engine==2.8.13
     google-cloud-storage==1.42.3
     dvclive==0.4.1
-    pywin32>=225; sys_platform == 'win32' and python_version < '3.10'
     hdfs==2.6.0
     # required by collective.checkdocs
     Pygments==2.10.0
@@ -153,6 +152,8 @@ tests =
     types-requests==2.25.11
     types-tabulate==0.8.3
     types-toml==0.10.1
+    # optional dependencies
+    pywin32>=225; sys_platform == 'win32'
 
 [options.packages.find]
 exclude =

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,9 +5,12 @@ import sys
 if os.name == "nt":
     import subprocess
 
-    import win32file  # pylint: disable=import-error
-
-    win32file._setmaxstdio(4096)
+    try:
+        import win32file  # pylint: disable=import-error
+    except ImportError:
+        pass
+    else:
+        win32file._setmaxstdio(4096)
 
     # Workaround for two bugs:
     #
@@ -34,7 +37,7 @@ if os.name == "nt":
         subprocess._cleanup = noop
         subprocess._active = None
 else:
-    import resource
+    import resource  # pylint: disable=import-error
 
     resource.setrlimit(resource.RLIMIT_NOFILE, (4096, 4096))
 

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -677,8 +677,12 @@ def temporary_windows_drive(tmp_path_factory):
     import string
     from ctypes import windll
 
-    import win32api  # pylint: disable=import-error
-    from win32con import DDD_REMOVE_DEFINITION  # pylint: disable=import-error
+    try:
+        # pylint: disable=import-error
+        import win32api
+        from win32con import DDD_REMOVE_DEFINITION
+    except ImportError:
+        pytest.skip("pywin32 not installed")
 
     drives = [
         s[0].upper()
@@ -999,7 +1003,7 @@ def test_add_preserve_meta(tmp_dir, dvc):
 # are the same 260 chars, which makes the test unnecessarily complex
 @pytest.mark.skipif(os.name == "nt", reason="unsupported on Windows")
 def test_add_long_fname(tmp_dir, dvc):
-    name_max = os.pathconf(tmp_dir, "PC_NAME_MAX")
+    name_max = os.pathconf(tmp_dir, "PC_NAME_MAX")  # pylint: disable=no-member
     name = "a" * name_max
     tmp_dir.gen({"data": {name: "foo"}})
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Made `pywin32` an optional test dependency, so that it won't cause issues again when introducing 3.11 support in the future.
Also had to fix some pylint issues along the way. 
Thank you for the contribution - we'll try to review it as soon as possible. 🙏
