### PR TITLE
move scm.install to dvc.install

### DIFF
--- a/dvc/scm/base.py
+++ b/dvc/scm/base.py
@@ -149,14 +149,6 @@ class Base:
         """Returns a list of commits in the repo."""
         return []
 
-    def install(self, use_pre_commit_tool=False):
-        """
-        Adds dvc commands to SCM hooks for the repo.
-
-        If use_pre_commit_tool is set and pre-commit is
-        installed it will be used to install the hooks.
-        """
-
     def cleanup_ignores(self):
         """
         This method should clean up ignores (eg. entries in .gitignore),


### PR DESCRIPTION
scm.install does 3 different things, and all of those are
very much tied to DVC. As we are splitting scm out,
it should now belong to `dvc.install`.

Part of #6836.