### PR TITLE
fs: transfer: try reflink

### DIFF
--- a/tests/func/objects/db/test_index.py
+++ b/tests/func/objects/db/test_index.py
@@ -66,7 +66,7 @@ def test_clear_on_download_err(tmp_dir, dvc, index, mocker):
 
     assert list(index.hashes())
 
-    mocker.patch("dvc.fs.local.LocalFileSystem.upload", side_effect=Exception)
+    mocker.patch("dvc.fs.utils.transfer", side_effect=Exception)
     with pytest.raises(DownloadError):
         dvc.pull()
     assert not list(index.hashes())
@@ -83,7 +83,7 @@ def test_partial_upload(tmp_dir, dvc, index, mocker):
             raise Exception("stop baz")
         return original(self, from_file, to_info, name, **kwargs)
 
-    mocker.patch.object(LocalFileSystem, "upload", unreliable_upload)
+    mocker.patch("dvc.fs.utils.transfer", unreliable_upload)
     with pytest.raises(UploadError):
         dvc.push()
     assert not list(index.hashes())

--- a/tests/func/test_external_repo.py
+++ b/tests/func/test_external_repo.py
@@ -2,7 +2,6 @@ import os
 from unittest.mock import ANY, patch
 
 from dvc.external_repo import CLONES, external_repo
-from dvc.fs.local import LocalFileSystem
 from dvc.objects.stage import stage
 from dvc.objects.transfer import transfer
 from dvc.path_info import PathInfo
@@ -48,12 +47,14 @@ def test_source_change(erepo_dir):
 
 
 def test_cache_reused(erepo_dir, mocker, local_cloud):
+    import dvc.fs.utils
+
     erepo_dir.add_remote(config=local_cloud.config)
     with erepo_dir.chdir():
         erepo_dir.dvc_gen("file", "text", commit="add file")
     erepo_dir.dvc.push()
 
-    download_spy = mocker.spy(LocalFileSystem, "upload")
+    download_spy = mocker.spy(dvc.fs.utils, "transfer")
 
     # Use URL to prevent any fishy optimizations
     url = f"file://{erepo_dir}"

--- a/tests/func/test_import.py
+++ b/tests/func/test_import.py
@@ -308,9 +308,9 @@ def test_download_error_pulling_imported_stage(tmp_dir, dvc, erepo_dir):
     remove("foo_imported")
     remove(dst_cache)
 
-    with patch(
-        "dvc.fs.local.LocalFileSystem.upload", side_effect=Exception
-    ), pytest.raises(DownloadError):
+    with patch("dvc.fs.utils.transfer", side_effect=Exception), pytest.raises(
+        DownloadError
+    ):
         dvc.pull(["foo_imported.dvc"])
 
 


### PR DESCRIPTION
If supported, reflink, will provide the fastest transfer possible.
That being said, right now we use `move` in most of the places,
which still takes presidence and defeats the purpose. `move` will
be removed in the upcoming PR in favor of a safer approach.

Pre-requisite for #6387
