### PR TITLE
machine status: Make name argument optional

### DIFF
--- a/dvc/command/machine.py
+++ b/dvc/command/machine.py
@@ -202,16 +202,32 @@ class CmdMachineStatus(CmdBase):
         "instance_gpu",
     ]
 
+    def _show_machine_status(self, name: str):
+        ui.write(f"machine '{name}':")
+        all_status = list(self.repo.machine.status(name))
+        if not all_status:
+            ui.write("\toffline")
+        for i, status in enumerate(all_status, start=1):
+            ui.write(f"\tinstance_num_{i}:")
+            for field in self.SHOWN_FIELD:
+                value = status.get(field, None)
+                ui.write(f"\t\t{field:20}: {value}")
+
     def run(self):
         if self.repo.machine is None:
             raise MachineDisabledError
 
-        all_status = self.repo.machine.status(self.args.name)
-        for i, status in enumerate(all_status, start=1):
-            ui.write(f"instance_num_{i}:")
-            for field in self.SHOWN_FIELD:
-                value = status.get(field, None)
-                ui.write(f"\t{field:20}: {value}")
+        if self.args.name:
+            self._show_machine_status(self.args.name)
+        else:
+            name_set = set()
+            for level in self.repo.config.LEVELS:
+                conf = self.repo.config.read(level)["machine"]
+                name_set.update(conf.keys())
+            name_list = list(name_set)
+            for name in sorted(name_list):
+                self._show_machine_status(name)
+
         return 0
 
 
@@ -390,7 +406,9 @@ def add_parser(subparsers, parent_parser):
     )
     machine_create_parser.set_defaults(func=CmdMachineCreate)
 
-    machine_STATUS_HELP = "List the status of a running machine."
+    machine_STATUS_HELP = (
+        "List the status of running instances for one/all machines."
+    )
     machine_status_parser = machine_subparsers.add_parser(
         "status",
         parents=[parent_config_parser, parent_parser],
@@ -399,7 +417,7 @@ def add_parser(subparsers, parent_parser):
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     machine_status_parser.add_argument(
-        "name", help="Name of the running machine."
+        "name", nargs="?", help="(optional) Name of the machine."
     )
     machine_status_parser.set_defaults(func=CmdMachineStatus)
 

--- a/tests/func/machine/test_machine_status.py
+++ b/tests/func/machine/test_machine_status.py
@@ -8,6 +8,7 @@ def test_status(
     status = machine_instance
     assert main(["machine", "status", "foo"]) == 0
     cap = capsys.readouterr()
-    assert "instance_num_1:" in cap.out
+    assert "machine 'foo':\n" in cap.out
+    assert "\tinstance_num_1:\n" in cap.out
     for key in CmdMachineStatus.SHOWN_FIELD:
-        assert f"\t{key:20}: {status[key]}" in cap.out
+        assert f"\t\t{key:20}: {status[key]}\n" in cap.out


### PR DESCRIPTION
fix #6838 

1. make machine status name optional.
2. show all machine status if no name provide.
3. add a new test for it.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

An example of it.
![image](https://user-images.githubusercontent.com/6745454/138589406-b8dade9f-916f-4985-a074-54b822ee4365.png)

