### PR TITLE
exp init: remove default in cli, add default in help instead

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -850,16 +850,6 @@ class CmdExperimentsInit(CmdBase):
         return 0
 
 
-class RawDefaultsHelpFormatter(
-    argparse.RawDescriptionHelpFormatter,
-    argparse.ArgumentDefaultsHelpFormatter,
-):
-    def _get_help_string(self, action: argparse.Action) -> Optional[str]:
-        if action.default:
-            return super()._get_help_string(action)
-        return action.help
-
-
 def add_parser(subparsers, parent_parser):
     EXPERIMENTS_HELP = "Commands to run and compare experiments."
 
@@ -1395,7 +1385,7 @@ def add_parser(subparsers, parent_parser):
         "init",
         parents=[parent_parser],
         description=append_doc_link(EXPERIMENTS_INIT_HELP, "exp/init"),
-        formatter_class=RawDefaultsHelpFormatter,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     experiments_init_parser.add_argument(
         "cmd",
@@ -1421,7 +1411,6 @@ def add_parser(subparsers, parent_parser):
         default=False,
         help="Overwrite existing stage",
     )
-
     experiments_init_parser.add_argument(
         "--explicit",
         action="store_true",
@@ -1433,46 +1422,46 @@ def add_parser(subparsers, parent_parser):
     )
     experiments_init_parser.add_argument(
         "--code",
-        default=CmdExperimentsInit.CODE,
         help="Path to the source file or directory "
-        "which your experiments depend",
+        "which your experiments depend"
+        f" (default: {CmdExperimentsInit.CODE})",
     )
     experiments_init_parser.add_argument(
         "--data",
-        default=CmdExperimentsInit.DATA,
         help="Path to the data file or directory "
-        "which your experiments depend",
+        "which your experiments depend"
+        f" (default: {CmdExperimentsInit.DATA})",
     )
     experiments_init_parser.add_argument(
         "--models",
-        default=CmdExperimentsInit.MODELS,
-        help="Path to the model file or directory for your experiments",
+        help="Path to the model file or directory for your experiments"
+        f" (default: {CmdExperimentsInit.MODELS})",
     )
     experiments_init_parser.add_argument(
         "--params",
-        default=CmdExperimentsInit.DEFAULT_PARAMS,
-        help="Path to the parameters file for your experiments",
+        help="Path to the parameters file for your experiments"
+        f" (default: {CmdExperimentsInit.DEFAULT_PARAMS})",
     )
     experiments_init_parser.add_argument(
         "--metrics",
-        default=CmdExperimentsInit.DEFAULT_METRICS,
-        help="Path to the metrics file for your experiments",
+        help="Path to the metrics file for your experiments"
+        f" (default: {CmdExperimentsInit.DEFAULT_METRICS})",
     )
     experiments_init_parser.add_argument(
         "--plots",
-        default=CmdExperimentsInit.PLOTS,
-        help="Path to the plots file or directory for your experiments",
+        help="Path to the plots file or directory for your experiments"
+        f" (default: {CmdExperimentsInit.PLOTS})",
     )
     experiments_init_parser.add_argument(
         "--live",
-        help="Path to log dvclive outputs for your experiments "
-        f"(default: {CmdExperimentsInit.DVCLIVE})",
+        help="Path to log dvclive outputs for your experiments"
+        f" (default: {CmdExperimentsInit.DVCLIVE})",
     )
     experiments_init_parser.add_argument(
         "--type",
         choices=["default", "live"],
         default="default",
-        help="Select type of stage to create",
+        help="Select type of stage to create (default: %(default)s)",
     )
     experiments_init_parser.set_defaults(func=CmdExperimentsInit)
 


### PR DESCRIPTION
The default made it harder to detect between the default and explicitly provided values, which we need for interactive mode.

#6763 broke `exp init --interactive.`
