### PR TITLE
exp init: initialize dvc repo if uninitialized

### DIFF
--- a/dvc/output.py
+++ b/dvc/output.py
@@ -327,9 +327,6 @@ class Output:
         self.desc = desc
 
         self.path_info = self._parse_path(self.fs, path_info)
-        if self.use_cache and self.odb is None:
-            raise RemoteCacheRequiredError(self.path_info)
-
         self.obj = None
         self.isexec = False if self.IS_DEPENDENCY else isexec
 
@@ -403,7 +400,10 @@ class Output:
 
     @property
     def odb(self):
-        return getattr(self.repo.odb, self.scheme)
+        odb = getattr(self.repo.odb, self.scheme)
+        if self.use_cache and odb is None:
+            raise RemoteCacheRequiredError(self.path_info)
+        return odb
 
     @property
     def cache_path(self):

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -345,6 +345,14 @@ class Repo:
         root_dir = cls.find_root(root)
         return os.path.join(root_dir, cls.DVC_DIR)
 
+    @property
+    def is_initialized(self):
+        try:
+            self.find_root()
+            return True
+        except NotDvcRepoError:
+            return False
+
     @staticmethod
     def init(root_dir=os.curdir, no_scm=False, force=False, subdir=False):
         from dvc.repo.init import init

--- a/tests/func/test_remote.py
+++ b/tests/func/test_remote.py
@@ -251,14 +251,15 @@ def test_external_dir_resource_on_no_cache(tmp_dir, dvc, tmp_path_factory):
     # https://github.com/iterative/dvc/issues/2647, is some situations
     # (external dir dependency) cache is required to calculate dir md5
     external_dir = tmp_path_factory.mktemp("external_dir")
-    (external_dir / "file").write_text("content")
+    file = external_dir / "file"
 
     dvc.odb.local = None
     with pytest.raises(RemoteCacheRequiredError):
         dvc.run(
-            cmd="echo hello world",
-            outs=[os.fspath(external_dir)],
+            cmd=f"echo content > {file}",
+            outs=[os.fspath(file)],
             single_stage=True,
+            external=True,
         )
 
 


### PR DESCRIPTION
Also autostages dvc.yaml/.gitignore/param files by default.

The whole solution feels a bit hacky, as we need to create an uninitialized dvc repo, create a stage in memory and initialize dvc repo if there is no `.dvc` directory. The "creating stage" part does not really work without creating a proper DVC repo, so we have to hack it around.
For now, removing the `RemoteCacheRequired` exception throwing does seem to make it work, but it's hard to guarantee that as we have never supported that before.

Part of https://github.com/iterative/dvc/issues/6446.

