### PR TITLE
machine status: include two new field in the output

### DIFF
--- a/dvc/command/machine.py
+++ b/dvc/command/machine.py
@@ -193,7 +193,14 @@ class CmdMachineCreate(CmdBase):
 
 
 class CmdMachineStatus(CmdBase):
-    SHOWN_FIELD = ["name", "cloud", "instance_hdd_size", "instance_ip"]
+    SHOWN_FIELD = [
+        "name",
+        "cloud",
+        "instance_ip",
+        "instance_type",
+        "instance_hdd_size",
+        "instance_gpu",
+    ]
 
     def run(self):
         if self.repo.machine is None:


### PR DESCRIPTION
fix #6863 

1. include instance_type and instance_gpu in the output.
2. rerange the field by importance.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
