### PR TITLE
exp init: ask for command before paths

### DIFF
--- a/dvc/repo/experiments/init.py
+++ b/dvc/repo/experiments/init.py
@@ -124,16 +124,14 @@ def init_interactive(
     show_tree: bool = False,
     live: bool = False,
 ) -> Dict[str, str]:
-    primary = lremove(
-        provided.keys(), ["cmd", "code", "data", "models", "params"]
-    )
+    command = provided.pop("cmd", None)
+    primary = lremove(provided.keys(), ["code", "data", "models", "params"])
     secondary = lremove(
         provided.keys(), ["live"] if live else ["metrics", "plots"]
     )
 
     ret: Dict[str, str] = {}
-
-    if not (primary or secondary):
+    if not (command or primary or secondary):
         return ret
 
     message = ui.rich_text.assemble(
@@ -148,6 +146,13 @@ def init_interactive(
     )
     ui.error_write(message, doc_link, "", sep="\n", styled=True)
 
+    if not command:
+        ret.update(_prompts(["cmd"], defaults))
+        ui.write()
+    else:
+        ret.update({"cmd": command})
+
+    ui.write("Enter the paths for dependencies and outputs of the command.")
     if show_tree:
         from rich.tree import Tree
 
@@ -156,7 +161,6 @@ def init_interactive(
             highlight=True,
         )
         workspace = {**defaults, **provided}
-        workspace.pop("cmd", None)
         if not live and "live" not in provided:
             workspace.pop("live", None)
         for value in sorted(workspace.values()):


### PR DESCRIPTION
This changes the ordering of prompts, now it'll ask for command first before showing the workspace tree and prompts for the paths.

This is an RFC PR. I find it a bit confusing as it seems to break the linear flow of the prompts. I have yet another suggestion to move this prompt to the end. cc @dberenbaum @daavoo 

Part of https://github.com/iterative/dvc/issues/6446.

### Before this PR

[![asciicast](https://asciinema.org/a/RU9HNkdfuq40zKvSsAOgYTygg.svg)](https://asciinema.org/a/RU9HNkdfuq40zKvSsAOgYTygg)

### After this PR

[![asciicast](https://asciinema.org/a/2NmpIbMDJpzYe39iI7ei8LeGX.svg)](https://asciinema.org/a/2NmpIbMDJpzYe39iI7ei8LeGX)

### Alternative 

[![asciicast](https://asciinema.org/a/lrRFXb0OfBmjHnPGRCc5nx07B.svg)](https://asciinema.org/a/lrRFXb0OfBmjHnPGRCc5nx07B)


