### PR TITLE
[WIP] gha: enable all remote tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -107,7 +107,7 @@ jobs:
         OSS_ACCESS_KEY_SECRET: ${{ secrets.OSS_ACCESS_KEY_SECRET}}
         OSS_ENDPOINT: ${{ secrets.OSS_ENDPOINT}}
       run: >-
-        python -m tests -n=auto
+        python -m tests -n=auto --all
         --cov-report=xml --cov-report=term
         --enable-ssh ${{ env.extra_test_args }}
     - name: upload coverage report


### PR DESCRIPTION
Undoes part of #6789

Trying to see if it runs now with `-nauto` 