### PR TITLE
output: save: remove redundant changed() call

### DIFF
--- a/dvc/output.py
+++ b/dvc/output.py
@@ -555,10 +555,6 @@ class Output:
 
         assert not self.IS_DEPENDENCY
 
-        if not self.changed():
-            logger.debug("Output '%s' didn't change. Skipping saving.", self)
-            return
-
         _, self.meta, self.obj = ostage(
             self.odb,
             self.path_info,


### PR DESCRIPTION
No longer needed since object introduction, as we will compare staged
object during commit/checkout anyway.

Shaves off ~1s on `large` dataset in `dvc-bench`s `test_add`.