### PR TITLE
exp diff: Remove `--old` option.

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -583,7 +583,6 @@ class CmdExperimentsDiff(CmdBase):
                     title=title,
                     markdown=self.args.markdown,
                     no_path=self.args.no_path,
-                    old=self.args.old,
                     on_empty_diff="diff not supported",
                     precision=precision if key == "metrics" else None,
                     a_rev=self.args.a_rev,
@@ -1100,12 +1099,6 @@ def add_parser(subparsers, parent_parser):
         default=False,
         dest="markdown",
         help="Show tabulated output in the Markdown format (GFM).",
-    )
-    experiments_diff_parser.add_argument(
-        "--old",
-        action="store_true",
-        default=False,
-        help="Show old ('a_rev') metric/param value.",
     )
     experiments_diff_parser.add_argument(
         "--no-path",

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -46,7 +46,6 @@ def test_experiments_diff(dvc, scm, mocker):
             "--param-deps",
             "--json",
             "--md",
-            "--old",
             "--precision",
             "10",
         ]
@@ -61,6 +60,29 @@ def test_experiments_diff(dvc, scm, mocker):
     m.assert_called_once_with(
         cmd.repo, a_rev="HEAD~10", b_rev="HEAD~1", all=True, param_deps=True
     )
+
+
+def test_experiments_diff_revs(mocker, capsys):
+    mocker.patch(
+        "dvc.repo.experiments.diff.diff",
+        return_value={
+            "params": {
+                "params.yaml": {"foo": {"diff": 1, "old": 1, "new": 2}}
+            },
+            "metrics": {
+                "metrics.yaml": {"foo": {"diff": 1, "old": 1, "new": 2}}
+            },
+        },
+    )
+
+    cli_args = parse_args(["exp", "diff", "exp_a", "exp_b"])
+    cmd = cli_args.func(cli_args)
+
+    capsys.readouterr()
+    assert cmd.run() == 0
+    cap = capsys.readouterr()
+    assert "exp_a" in cap.out
+    assert "exp_b" in cap.out
 
 
 def test_experiments_show(dvc, scm, mocker):


### PR DESCRIPTION
* [X] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [X] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

For consistency (https://github.com/iterative/dvc/issues/5515) with output format of other `diff_table` uses.

Docs P.R: https://github.com/iterative/dvc.org/pull/2988

---

Before:

```
$ dvc exp diff exp-1dad0 exp-1df77

Path         Metric    Value    Change
scores.json  auc       0.51676  -0.060799

Path         Param                   Value    Change
params.yaml  featurize.max_features  500      -1500
```

After: 

```
$ dvc exp diff exp-1dad0 exp-1df77

Path         Metric  exp-1dad0  exp-1df77  Change
scores.json  auc     0.577559   0.51676    -0.060799

Path         Param                   exp-1dad0  exp-1df77  Change
params.yaml  featurize.max_features  2000       500        -1500
```