### PR TITLE
Machine: use table for machine list and status outputs 

### DIFF
--- a/dvc/compare.py
+++ b/dvc/compare.py
@@ -188,9 +188,6 @@ class TabularData(MutableSequence[Sequence["CellT"]]):
                 f"Invalid 'axis' value {axis}."
                 "Choose one of ['rows', 'cols']"
             )
-<<<<<<< HEAD
-        to_drop: Set = set()
-=======
         if how not in ["any", "all"]:
             raise ValueError(
                 f"Invalid 'how' value {how}." "Choose one of ['any', 'all']"
@@ -201,7 +198,6 @@ class TabularData(MutableSequence[Sequence["CellT"]]):
         if how == "all":
             match = False
 
->>>>>>> 8ad4b8aa (TabularData: add a new how `arg` to dropna(#6892))
         for n_row, row in enumerate(self):
             for n_col, col in enumerate(row):
                 if (col == self._fill_value) is match:

--- a/dvc/compare.py
+++ b/dvc/compare.py
@@ -182,21 +182,42 @@ class TabularData(MutableSequence[Sequence["CellT"]]):
             {k: self._columns[k][i] for k in keys} for i in range(len(self))
         ]
 
-    def dropna(self, axis: str = "rows"):
+    def dropna(self, axis: str = "rows", how="any"):
         if axis not in ["rows", "cols"]:
             raise ValueError(
                 f"Invalid 'axis' value {axis}."
                 "Choose one of ['rows', 'cols']"
             )
+<<<<<<< HEAD
         to_drop: Set = set()
+=======
+        if how not in ["any", "all"]:
+            raise ValueError(
+                f"Invalid 'how' value {how}." "Choose one of ['any', 'all']"
+            )
+
+        match_line: Set = set()
+        match = True
+        if how == "all":
+            match = False
+
+>>>>>>> 8ad4b8aa (TabularData: add a new how `arg` to dropna(#6892))
         for n_row, row in enumerate(self):
             for n_col, col in enumerate(row):
-                if col == self._fill_value:
+                if (col == self._fill_value) is match:
                     if axis == "rows":
-                        to_drop.add(n_row)
+                        match_line.add(n_row)
                         break
                     else:
-                        to_drop.add(self.keys()[n_col])
+                        match_line.add(self.keys()[n_col])
+
+        to_drop = match_line
+        if how == "all":
+            if axis == "rows":
+                to_drop = set(range(len(self)))
+            else:
+                to_drop = set(self.keys())
+            to_drop -= match_line
 
         if axis == "rows":
             for name in self.keys():

--- a/dvc/compare.py
+++ b/dvc/compare.py
@@ -116,6 +116,8 @@ class TabularData(MutableSequence[Sequence["CellT"]]):
             del col[item]
 
     def __len__(self) -> int:
+        if not self._columns:
+            return 0
         return len(self.columns[0])
 
     @property

--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -241,7 +241,6 @@ SCHEMA = {
                 Lower, Choices("us-west", "us-east", "eu-west", "eu-north")
             ),
             "image": str,
-            "name": str,
             "spot": Bool,
             "spot_price": Coerce(float),
             "instance_hdd_size": Coerce(int),

--- a/dvc/ui/table.py
+++ b/dvc/ui/table.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 SHOW_MAX_WIDTH = 1024
 
 
-CellT = Union[str, "RichText"]  # RichText is mostly compatible with str
+CellT = Union[str, "RichText", None]  # RichText is mostly compatible with str
 Row = Sequence[CellT]
 TableData = Sequence[Row]
 Headers = Sequence[str]

--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -13,6 +13,7 @@ from dvc.repo.experiments.utils import exp_refs_by_rev
 from dvc.utils.fs import makedirs
 from dvc.utils.serialize import YAMLFileCorruptedError
 from tests.func.test_repro_multistage import COPY_SCRIPT
+from tests.utils import console_width
 
 
 def test_show_simple(tmp_dir, scm, dvc, exp_stage):
@@ -270,8 +271,6 @@ def test_show_filter(
     included,
     excluded,
 ):
-    from contextlib import contextmanager
-
     from dvc.ui import ui
 
     capsys.readouterr()
@@ -317,21 +316,7 @@ def test_show_filter(
     if e_params is not None:
         command.append(f"--exclude-params={e_params}")
 
-    @contextmanager
-    def console_with(console, width):
-        console_options = console.options
-        original = console_options.max_width
-        con_width = console._width
-
-        try:
-            console_options.max_width = width
-            console._width = width
-            yield
-        finally:
-            console_options.max_width = original
-            console._width = con_width
-
-    with console_with(ui.rich_console, 255):
+    with console_width(ui.rich_console, 255):
         assert main(command) == 0
     cap = capsys.readouterr()
 

--- a/tests/func/machine/conftest.py
+++ b/tests/func/machine/conftest.py
@@ -40,14 +40,16 @@ def machine_config(tmp_dir):
 
 @pytest.fixture
 def machine_instance(tmp_dir, dvc, mocker):
-    from tpi.terraform import TerraformBackend
-
     with dvc.config.edit() as conf:
         conf["machine"]["foo"] = {"cloud": "aws"}
-    mocker.patch.object(
-        TerraformBackend,
-        "instances",
-        autospec=True,
-        return_value=[TEST_INSTANCE],
+
+    def mock_instances(name=None, **kwargs):
+        if name == "foo":
+            return iter([TEST_INSTANCE])
+        return iter([])
+
+    mocker.patch(
+        "tpi.terraform.TerraformBackend.instances",
+        mocker.MagicMock(side_effect=mock_instances),
     )
     yield TEST_INSTANCE

--- a/tests/func/machine/test_machine_config.py
+++ b/tests/func/machine/test_machine_config.py
@@ -16,7 +16,6 @@ from .conftest import BASIC_CONFIG
     [
         ("region", "us-west"),
         ("image", "iterative-cml"),
-        ("name", "iterative_test"),
         ("spot", "True"),
         ("spot_price", "1.2345"),
         ("spot_price", "12345"),
@@ -75,7 +74,6 @@ FULL_CONFIG_TEXT = textwrap.dedent(
             cloud = aws
             region = us-west
             image = iterative-cml
-            name = iterative_test
             spot = True
             spot_price = 1.2345
             instance_hdd_size = 10

--- a/tests/func/machine/test_machine_status.py
+++ b/tests/func/machine/test_machine_status.py
@@ -1,14 +1,23 @@
-from dvc.command.machine import CmdMachineStatus
 from dvc.main import main
+from dvc.ui import ui
+from tests.utils import console_width
 
 
-def test_status(
-    tmp_dir, scm, dvc, machine_config, machine_instance, mocker, capsys
-):
-    status = machine_instance
-    assert main(["machine", "status", "foo"]) == 0
+def test_status(tmp_dir, scm, dvc, machine_config, machine_instance, capsys):
+
+    assert main(["machine", "add", "bar", "aws"]) == 0
+    with console_width(ui.rich_console, 255):
+        assert main(["machine", "status"]) == 0
     cap = capsys.readouterr()
-    assert "machine 'foo':\n" in cap.out
-    assert "\tinstance_num_1:\n" in cap.out
-    for key in CmdMachineStatus.SHOWN_FIELD:
-        assert f"\t\t{key:20}: {status[key]}\n" in cap.out
+    assert (
+        "name    instance    status    cloud    instance_ip      "
+        "instance_type    instance_hdd_size    instance_gpu"
+    ) in cap.out
+    assert (
+        "bar     -           offline   -        -                "
+        "-                -                    -"
+    ) in cap.out
+    assert (
+        "foo     num_1       running   aws      123.123.123.123  "
+        "m                35                   None"
+    ) in cap.out

--- a/tests/unit/command/test_machine.py
+++ b/tests/unit/command/test_machine.py
@@ -1,3 +1,5 @@
+import os
+
 import configobj
 import pytest
 from mock import call
@@ -110,16 +112,24 @@ def test_ssh(tmp_dir, dvc, mocker):
     m.assert_called_once_with("foo")
 
 
-def test_list(tmp_dir, mocker):
+@pytest.mark.parametrize("show_origin", [["--show-origin"], []])
+def test_list(tmp_dir, mocker, show_origin):
+    from dvc.compare import TabularData
     from dvc.ui import ui
 
     tmp_dir.gen(DATA)
-    cli_args = parse_args(["machine", "list", "foo"])
+    cli_args = parse_args(["machine", "list"] + show_origin + ["foo"])
     assert cli_args.func == CmdMachineList
     cmd = cli_args.func(cli_args)
-    m = mocker.patch.object(ui, "write", autospec=True)
+    if show_origin:
+        m = mocker.patch.object(ui, "write", autospec=True)
+    else:
+        m = mocker.patch.object(TabularData, "render", autospec=True)
     assert cmd.run() == 0
-    m.assert_called_once_with("cloud=aws")
+    if show_origin:
+        m.assert_called_once_with(f".dvc{os.sep}config	cloud=aws")
+    else:
+        m.assert_called_once()
 
 
 def test_modified(tmp_dir):

--- a/tests/unit/test_tabular_data.py
+++ b/tests/unit/test_tabular_data.py
@@ -180,28 +180,43 @@ def test_row_from_dict():
 
 
 @pytest.mark.parametrize(
-    "axis,expected",
+    "axis,how,data,expected",
     [
         (
             "rows",
+            "any",
+            [["foo"], ["foo", "bar"], ["foo", "bar", "foobar"]],
             [
                 ["foo", "bar", "foobar"],
             ],
         ),
-        ("cols", [["foo"], ["foo"], ["foo"]]),
+        (
+            "rows",
+            "all",
+            [["foo"], ["foo", "bar"], ["", "", ""]],
+            [
+                ["foo", "", ""],
+                ["foo", "bar", ""],
+            ],
+        ),
+        (
+            "cols",
+            "any",
+            [["foo"], ["foo", "bar"], ["foo", "bar", "foobar"]],
+            [["foo"], ["foo"], ["foo"]],
+        ),
+        (
+            "cols",
+            "all",
+            [["foo"], ["foo", "bar"], ["", "", ""]],
+            [["foo", ""], ["foo", "bar"], ["", ""]],
+        ),
     ],
 )
-def test_dropna(axis, expected):
+def test_dropna(axis, how, data, expected):
     td = TabularData(["col-1", "col-2", "col-3"])
-    td.extend([["foo"], ["foo", "bar"], ["foo", "bar", "foobar"]])
-    assert list(td) == [
-        ["foo", "", ""],
-        ["foo", "bar", ""],
-        ["foo", "bar", "foobar"],
-    ]
-
-    td.dropna(axis)
-
+    td.extend(data)
+    td.dropna(axis, how)
     assert list(td) == expected
 
 

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -54,3 +54,18 @@ def clean_staging():
         )
     except FileNotFoundError:
         pass
+
+
+@contextmanager
+def console_width(console, width):
+    console_options = console.options
+    original = console_options.max_width
+    con_width = console._width
+
+    try:
+        console_options.max_width = width
+        console._width = width
+        yield
+    finally:
+        console_options.max_width = original
+        console._width = con_width


### PR DESCRIPTION
fix #6892 

use table for the machine list outputs

Now the outputs looks like
```
$  dvc machine list
┏━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
┃ name  ┃ cloud ┃ spot_price ┃ instance_hdd_size ┃ instance_type ┃ ssh_private ┃ instance_gpu ┃
┡━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
│ new   │ aws   │            │ 20                │               │ ***         │              │
│ myaws │ aws   │ 100.00000  │ 10                │ l             │             │ k80          │
└───────┴───────┴────────────┴───────────────────┴───────────────┴─────────────┴──────────────┘

$ dvc machine status foo
┏━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓
┃ name ┃ instance ┃ status  ┃ cloud ┃ instance_hdd_size ┃ instance_ip     ┃
┡━━━━━━╇━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩
│ foo  │ num_1    │ running │ aws   │ 35                │ 123.123.123.123 │
└──────┴──────────┴─────────┴───────┴───────────────────┴─────────────────┘
```


* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
