### PR TITLE
tests: skip based on conditional import on pyarrow

### DIFF
--- a/tests/remotes/hdfs.py
+++ b/tests/remotes/hdfs.py
@@ -2,7 +2,6 @@ import locale
 import os
 import platform
 import subprocess
-import sys
 import uuid
 from contextlib import contextmanager
 from pathlib import Path
@@ -74,10 +73,7 @@ class HDFS(Base, URLInfo):  # pylint: disable=abstract-method
 @pytest.fixture(scope="session")
 def hadoop(test_config):
     test_config.requires("real_hdfs")
-
-    if sys.version_info >= (3, 10):
-        pytest.skip("pyarrow is not available for 3.10 yet.")
-
+    pytest.importorskip("pyarrow.fs")
     if platform.system() != "Linux":
         pytest.skip("only supported on Linux")
 
@@ -280,9 +276,7 @@ def hdfs(test_config, mocker):
     # "The pyarrow installation is not built with support for
     # 'HadoopFileSystem'"
     test_config.requires("hdfs")
-
-    if sys.version_info >= (3, 10):
-        pytest.skip("pyarrow is not available for 3.10 yet.")
+    pytest.importorskip("pyarrow.fs")
 
     mocker.patch("pyarrow.fs._not_imported", [])
     mocker.patch(


### PR DESCRIPTION
From now on, pyarrow is optional for the tests.

I am adding this PR before fixing https://github.com/iterative/dvc/issues/6878 to check whether we can depend on it in the future (eg: when we will be adding 3.11 support). I will remove requirements for python version on the next PR.