### PR TITLE
dependencies: remove python 3.10 restriction for pyarrow

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -102,7 +102,7 @@ azure =
 gdrive = pydrive2[fsspec]>=1.9.4
 gs = gcsfs==2021.10.1
 hdfs =
-    fsspec[arrow]; python_version < '3.10'
+    fsspec[arrow]
 oss = ossfs==2021.8.0
 s3 =
     s3fs==2021.10.1


### PR DESCRIPTION
Pyarrow 6 is now available for Python 3.10. Fixes https://github.com/iterative/dvc/issues/6878.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
