### PR TITLE
deps: require chardet as a dependency for azure

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -99,6 +99,7 @@ azure =
     adlfs==2021.9.1
     azure-identity>=1.4.0
     knack
+    chardet
 gdrive = pydrive2[fsspec]>=1.9.4
 gs = gcsfs==2021.10.1
 hdfs =


### PR DESCRIPTION
Looks like azure-core is dependent on a dependency `chardet` that aiohttp brought it with, which has been replaced with `charset_normalizer`.
But azure-core depends on internal of aiohttp and looks like it tries to set it's own encoding parser, `chardet` which is now not available.

See if this fixes https://github.com/iterative/dvc/issues/6899.