### PR TITLE
Revert "deps: require chardet as a dependency for azure"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -99,7 +99,6 @@ azure =
     adlfs==2021.9.1
     azure-identity>=1.4.0
     knack
-    chardet
 gdrive = pydrive2[fsspec]>=1.9.4
 gs = gcsfs==2021.10.1
 hdfs =


### PR DESCRIPTION
Reverts iterative/dvc#6902.

This has now been fixed upstream: https://github.com/Azure/azure-sdk-for-python/issues/21516.

Related: https://github.com/iterative/dvc/issues/6899