### PR TITLE
build: remove numpy restriction

### DIFF
--- a/scripts/build-requirements.txt
+++ b/scripts/build-requirements.txt
@@ -1,2 +1,1 @@
 PyInstaller==4.6
-numpy==1.19.3


### PR DESCRIPTION
This was added for fixing https://github.com/iterative/dvc/issues/5012 on Windows. But it has been fixed for a long time now, so it should be okay to remove this. But we'll find out on the next release 😅.