### PR TITLE
exp init: hide message about workspace tree on --explicit

### DIFF
--- a/dvc/repo/experiments/init.py
+++ b/dvc/repo/experiments/init.py
@@ -175,21 +175,21 @@ def init_interactive(
         ret.update({"cmd": command})
 
     ui.write("Enter the paths for dependencies and outputs of the command.")
-    if show_tree:
+    workspace = {**defaults, **provided}
+    if show_tree and workspace:
         from rich.tree import Tree
 
         tree = Tree(
             "DVC assumes the following workspace structure:",
             highlight=True,
         )
-        workspace = {**defaults, **provided}
         if not live and "live" not in provided:
             workspace.pop("live", None)
         for value in sorted(workspace.values()):
             tree.add(f"[green]{value}[/green]")
         ui.error_write(tree, styled=True)
-        ui.error_write()
 
+    ui.error_write()
     ret.update(_prompts(primary, defaults))
     ret.update(_prompts(secondary, defaults))
     return compact(ret)


### PR DESCRIPTION
On `--explict`, it displayed no worktree at all, as `exp init` does not know about default paths:
```console
$ dvc exp init -if --explicit
This command will guide you to set up a default stage in dvc.yaml.
See https://dvc.org/doc/user-guide/project-structure/pipelines-files.

Command to execute: test

Enter the paths for dependencies and outputs of the command.
DVC assumes the following workspace structure:

Path to a code file/directory [n to omit]:
```

The message "DVC assumes ..." won't be shown now on the explicit mode. 

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
