### PR TITLE
dvc render: Add RENDERERS registry.

### DIFF
--- a/dvc/render/__init__.py
+++ b/dvc/render/__init__.py
@@ -1,33 +1,4 @@
-import logging
-from typing import TYPE_CHECKING, Dict
+from .image import ImageRenderer
+from .vega import VegaRenderer
 
-if TYPE_CHECKING:
-    from dvc.types import StrPath
-
-logger = logging.getLogger(__name__)
-
-
-class Renderer:
-    def __init__(self, data: Dict):
-        self.data = data
-
-        from dvc.render.utils import get_files
-
-        files = get_files(self.data)
-
-        # we assume comparison of same file between revisions for now
-        assert len(files) == 1
-        self.filename = files.pop()
-
-    def _convert(self, path: "StrPath"):
-        raise NotImplementedError
-
-    @property
-    def DIV(self):
-        raise NotImplementedError
-
-    def generate_html(self, path: "StrPath"):
-        """this method might edit content of path"""
-        partial = self._convert(path)
-        div_id = f"plot_{self.filename.replace('.', '_').replace('/', '_')}"
-        return self.DIV.format(id=div_id, partial=partial)
+RENDERERS = [ImageRenderer, VegaRenderer]

--- a/dvc/render/base.py
+++ b/dvc/render/base.py
@@ -1,0 +1,52 @@
+import abc
+from typing import TYPE_CHECKING, Dict
+
+from dvc.exceptions import DvcException
+
+if TYPE_CHECKING:
+    from dvc.types import StrPath
+
+
+REVISION_FIELD = "rev"
+INDEX_FIELD = "step"
+
+
+class BadTemplateError(DvcException):
+    pass
+
+
+class Renderer(abc.ABC):
+    def __init__(self, data: Dict, templates=None):
+        self.data = data
+        self.templates = templates
+
+        from dvc.render.utils import get_files
+
+        files = get_files(self.data)
+
+        # we assume comparison of same file between revisions for now
+        assert len(files) == 1
+        self.filename = files.pop()
+
+    def _convert(self, path: "StrPath"):
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def DIV(self):
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def SCRIPTS(self):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def as_json(self):
+        raise NotImplementedError
+
+    def generate_html(self, path: "StrPath"):
+        """this method might edit content of path"""
+        partial = self._convert(path)
+        div_id = f"plot_{self.filename.replace('.', '_').replace('/', '_')}"
+        return self.DIV.format(id=div_id, partial=partial)

--- a/dvc/render/image.py
+++ b/dvc/render/image.py
@@ -1,7 +1,7 @@
 import os
 from typing import TYPE_CHECKING
 
-from dvc.render import Renderer
+from dvc.render.base import Renderer
 from dvc.render.utils import get_files
 from dvc.utils import relpath
 
@@ -16,6 +16,8 @@ class ImageRenderer(Renderer):
             style="border: 1px solid;">
             {partial}
         </div>"""
+
+    SCRIPTS = ""
 
     def _write_image(
         self,
@@ -55,6 +57,9 @@ class ImageRenderer(Renderer):
             div_content.insert(0, f"<p>{self.filename}</p>")
             return "\n".join(div_content)
         return ""
+
+    def as_json(self):
+        raise NotImplementedError
 
     @staticmethod
     def matches(data):

--- a/dvc/render/utils.py
+++ b/dvc/render/utils.py
@@ -26,20 +26,18 @@ def find_vega(repo, plots_data, target):
     from dvc.render.vega import VegaRenderer
 
     if found and VegaRenderer.matches(found):
-        return VegaRenderer(found, repo.plots.templates).get_vega()
+        return VegaRenderer(found, repo.plots.templates).as_json()
     return ""
 
 
 def match_renderers(plots_data, templates):
-    from dvc.render.image import ImageRenderer
-    from dvc.render.vega import VegaRenderer
+    from dvc.render import RENDERERS
 
     renderers = []
     for g in group_by_filename(plots_data):
-        if VegaRenderer.matches(g):
-            renderers.append(VegaRenderer(g, templates))
-        if ImageRenderer.matches(g):
-            renderers.append(ImageRenderer(g))
+        for renderer_class in RENDERERS:
+            if renderer_class.matches(g):
+                renderers.append(renderer_class(g, templates))
     return renderers
 
 

--- a/dvc/repo/plots/__init__.py
+++ b/dvc/repo/plots/__init__.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Callable, Dict, Generator, List, Optional
 from funcy import cached_property, first, project
 
 from dvc.exceptions import DvcException
-from dvc.render.vega import PlotMetricTypeError
 from dvc.utils import (
     error_handler,
     errored_revisions,
@@ -22,6 +21,14 @@ if TYPE_CHECKING:
     from dvc.repo import Repo
 
 logger = logging.getLogger(__name__)
+
+
+class PlotMetricTypeError(DvcException):
+    def __init__(self, file):
+        super().__init__(
+            "'{}' - file type error\n"
+            "Only JSON, YAML, CSV and TSV formats are supported.".format(file)
+        )
 
 
 class NotAPlotError(DvcException):

--- a/tests/func/plots/test_show.py
+++ b/tests/func/plots/test_show.py
@@ -6,8 +6,8 @@ from funcy import get_in
 from dvc.dvcfile import PIPELINE_FILE
 from dvc.exceptions import OverlappingOutputPathsError
 from dvc.main import main
-from dvc.render.vega import PlotMetricTypeError
 from dvc.repo import Repo
+from dvc.repo.plots import PlotMetricTypeError
 from dvc.utils import onerror_collect
 from dvc.utils.fs import remove
 from dvc.utils.serialize import EncodingError, YAMLFileCorruptedError

--- a/tests/unit/render/test_html.py
+++ b/tests/unit/render/test_html.py
@@ -22,7 +22,7 @@ CUSTOM_PAGE_HTML = """<!DOCTYPE html>
         (
             None,
             ["content"],
-            PAGE_HTML.format(plot_divs="content", refresh_tag=""),
+            PAGE_HTML.format(plot_divs="content", refresh_tag="", scripts=""),
         ),
         (
             CUSTOM_PAGE_HTML,

--- a/tests/unit/render/test_vega.py
+++ b/tests/unit/render/test_vega.py
@@ -9,15 +9,12 @@ from dvc.render.utils import find_vega, group_by_filename
 from dvc.render.vega import (
     INDEX_FIELD,
     REVISION_FIELD,
+    BadTemplateError,
     VegaRenderer,
     _find_data,
     _lists,
 )
-from dvc.repo.plots.template import (
-    BadTemplateError,
-    NoFieldInDataError,
-    TemplateNotFoundError,
-)
+from dvc.repo.plots.template import NoFieldInDataError, TemplateNotFoundError
 
 
 @pytest.mark.parametrize(
@@ -110,7 +107,7 @@ def test_one_column(tmp_dir, scm, dvc):
         }
     }
 
-    plot_string = VegaRenderer(data, dvc.plots.templates).get_vega()
+    plot_string = VegaRenderer(data, dvc.plots.templates).as_json()
 
     plot_content = json.loads(plot_string)
     assert plot_content["title"] == "mytitle"
@@ -136,7 +133,7 @@ def test_multiple_columns(tmp_dir, scm, dvc):
         "workspace": {"data": {"file.json": {"data": metric, "props": {}}}}
     }
 
-    plot_string = VegaRenderer(data, dvc.plots.templates).get_vega()
+    plot_string = VegaRenderer(data, dvc.plots.templates).as_json()
 
     plot_content = json.loads(plot_string)
     assert plot_content["data"]["values"] == [
@@ -172,7 +169,7 @@ def test_choose_axes(tmp_dir, scm, dvc):
     data = {
         "workspace": {"data": {"file.json": {"data": metric, "props": props}}}
     }
-    plot_string = VegaRenderer(data, dvc.plots.templates).get_vega()
+    plot_string = VegaRenderer(data, dvc.plots.templates).as_json()
 
     plot_content = json.loads(plot_string)
     assert plot_content["data"]["values"] == [
@@ -210,7 +207,7 @@ def test_confusion(tmp_dir, dvc):
         }
     }
 
-    plot_string = VegaRenderer(data, dvc.plots.templates).get_vega()
+    plot_string = VegaRenderer(data, dvc.plots.templates).as_json()
 
     plot_content = json.loads(plot_string)
     assert plot_content["data"]["values"] == [
@@ -248,7 +245,7 @@ def test_multiple_revs_default(tmp_dir, scm, dvc):
         },
     }
 
-    plot_string = VegaRenderer(data, dvc.plots.templates).get_vega()
+    plot_string = VegaRenderer(data, dvc.plots.templates).as_json()
 
     plot_content = json.loads(plot_string)
     assert plot_content["data"]["values"] == [
@@ -274,7 +271,7 @@ def test_metric_missing(tmp_dir, scm, dvc, caplog):
             "data": {"file.json": {"error": FileNotFoundError(), "props": {}}}
         },
     }
-    plot_string = VegaRenderer(data, dvc.plots.templates).get_vega()
+    plot_string = VegaRenderer(data, dvc.plots.templates).as_json()
 
     plot_content = json.loads(plot_string)
     assert plot_content["data"]["values"] == [
@@ -294,7 +291,7 @@ def test_custom_template(tmp_dir, scm, dvc, custom_template):
         "workspace": {"data": {"file.json": {"data": metric, "props": props}}}
     }
 
-    plot_string = VegaRenderer(data, dvc.plots.templates).get_vega()
+    plot_string = VegaRenderer(data, dvc.plots.templates).as_json()
 
     plot_content = json.loads(plot_string)
     assert plot_content["data"]["values"] == [
@@ -313,7 +310,7 @@ def test_raise_on_no_template(tmp_dir, dvc):
     }
 
     with pytest.raises(TemplateNotFoundError):
-        VegaRenderer(data, dvc.plots.templates).get_vega()
+        VegaRenderer(data, dvc.plots.templates).as_json()
 
 
 def test_bad_template(tmp_dir, dvc):
@@ -325,7 +322,7 @@ def test_bad_template(tmp_dir, dvc):
     }
 
     with pytest.raises(BadTemplateError):
-        VegaRenderer(data, dvc.plots.templates).get_vega()
+        VegaRenderer(data, dvc.plots.templates).as_json()
 
 
 def test_plot_choose_columns(tmp_dir, scm, dvc, custom_template):
@@ -340,7 +337,7 @@ def test_plot_choose_columns(tmp_dir, scm, dvc, custom_template):
         "workspace": {"data": {"file.json": {"data": metric, "props": props}}}
     }
 
-    plot_string = VegaRenderer(data, dvc.plots.templates).get_vega()
+    plot_string = VegaRenderer(data, dvc.plots.templates).as_json()
 
     plot_content = json.loads(plot_string)
     assert plot_content["data"]["values"] == [
@@ -359,7 +356,7 @@ def test_plot_default_choose_column(tmp_dir, scm, dvc):
         }
     }
 
-    plot_string = VegaRenderer(data, dvc.plots.templates).get_vega()
+    plot_string = VegaRenderer(data, dvc.plots.templates).as_json()
     plot_content = json.loads(plot_string)
 
     assert plot_content["data"]["values"] == [
@@ -381,7 +378,7 @@ def test_raise_on_wrong_field(tmp_dir, scm, dvc):
     }
 
     with pytest.raises(NoFieldInDataError):
-        VegaRenderer(data, dvc.plots.templates).get_vega()
+        VegaRenderer(data, dvc.plots.templates).as_json()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
* [X] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

Pre-requisite for #6840 -> #4455 

These changes *should* not break any existing behavior. 

Refactored existing `render` / `plots.template` logic in order to make it more "plugin" friendly so it's easier to add new renderers (i.e. plotly / parallel coordinates plot).

Open questions:

- Should `ImageRenderer` implement `as_json` (meaning a machine-shareable representation of the "plot"). Maybe we should use base64 for that (potentially even internally as `src`). 

- Should `ImageRenderer` be, somehow, template-based?. It looks that it could be generalized to follow a similar logic as `VegaRenderer` where DVC provides "anchor" data (the `src` in `<img>`) and the template can customize how to insert that data in the HTML. 

- Is there a reason to have `templates` in `dvc.repo.plots`? It looks like there is the only remaining connection to other dvc subsystems that prevents `render` to be extracted as a separate library.




