### PR TITLE
exp show: Add parallel coordinates plot.

### DIFF
--- a/dvc/compare.py
+++ b/dvc/compare.py
@@ -159,7 +159,9 @@ class TabularData(MutableSequence[Sequence["CellT"]]):
 
         index_path = write(
             output_path,
-            renderers=[ParallelCoordinatesRenderer(self, color_by)],
+            renderers=[
+                ParallelCoordinatesRenderer(self, color_by, self._fill_value)
+            ],
         )
         return index_path.as_uri()
 

--- a/dvc/compare.py
+++ b/dvc/compare.py
@@ -153,6 +153,16 @@ class TabularData(MutableSequence[Sequence["CellT"]]):
             writer.writerow(row)
         return buff.getvalue()
 
+    def to_parallel_coordinates(self, output_path, color_by):
+        from dvc.render.html import write
+        from dvc.render.plotly import ParallelCoordinatesRenderer
+
+        index_path = write(
+            output_path,
+            renderers=[ParallelCoordinatesRenderer(self, color_by)],
+        )
+        return index_path.as_uri()
+
     def add_column(self, name: str) -> None:
         self._columns[name] = Column([self._fill_value] * len(self))
         self._keys.append(name)
@@ -173,6 +183,14 @@ class TabularData(MutableSequence[Sequence["CellT"]]):
 
         if kwargs.pop("csv", False):
             ui.write(self.to_csv(), end="")
+
+        elif kwargs.pop("html", False):
+            ui.write(
+                self.to_parallel_coordinates(
+                    kwargs["output_path"], kwargs.get("color_by")
+                )
+            )
+
         else:
             ui.table(self, headers=self.keys(), **kwargs)
 

--- a/dvc/render/plotly.py
+++ b/dvc/render/plotly.py
@@ -26,11 +26,15 @@ class ParallelCoordinatesRenderer(Renderer):
 
     # pylint: disable=W0231
     def __init__(
-        self, tabular_data: "TabularData", color_by: Optional[str] = None
+        self,
+        tabular_data: "TabularData",
+        color_by: Optional[str] = None,
+        fill_value: str = "",
     ):
         self.tabular_data = tabular_data
         self.color_by = color_by
         self.filename = "experiments"
+        self.fill_value = fill_value
 
     def partial_html(self, **kwargs):
         return self.as_json()
@@ -44,15 +48,23 @@ class ParallelCoordinatesRenderer(Renderer):
         trace: Dict[str, Any] = {"type": "parcoords", "dimensions": []}
         for label, values in tabular_dict.items():
             is_categorical = False
-
             try:
-                float_values = [float(x) for x in values]
+                float_values = [
+                    float(x) if x != self.fill_value else None for x in values
+                ]
             except ValueError:
                 is_categorical = True
-                unique_values = sorted(set(values))
 
             if is_categorical:
+                non_missing = [x for x in values if x != self.fill_value]
+                unique_values = sorted(set(non_missing))
+                unique_values.append(self.fill_value)
+
                 dummy_values = [unique_values.index(x) for x in values]
+
+                values = [
+                    x if x != self.fill_value else "Missing" for x in values
+                ]
                 trace["dimensions"].append(
                     {
                         "label": label,
@@ -70,9 +82,7 @@ class ParallelCoordinatesRenderer(Renderer):
                 trace["line"] = {
                     "color": dummy_values if is_categorical else float_values,
                     "showscale": True,
-                    "colorbar": {
-                        "title": self.color_by
-                    }
+                    "colorbar": {"title": self.color_by},
                 }
                 if is_categorical:
                     trace["line"]["colorbar"]["tickmode"] = "array"

--- a/dvc/render/plotly.py
+++ b/dvc/render/plotly.py
@@ -1,0 +1,80 @@
+import json
+from collections import defaultdict
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+from dvc.render.base import Renderer
+
+if TYPE_CHECKING:
+    from dvc.compare import TabularData
+
+
+class ParallelCoordinatesRenderer(Renderer):
+    TYPE = "plotly"
+
+    DIV = """
+    <div id = "{id}">
+        <script type = "text/javascript">
+            var plotly_data = {partial};
+            Plotly.newPlot("{id}", plotly_data.data, plotly_data.layout);
+        </script>
+    </div>
+    """
+
+    SCRIPTS = """
+    <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+    """
+
+    # pylint: disable=W0231
+    def __init__(
+        self, tabular_data: "TabularData", color_by: Optional[str] = None
+    ):
+        self.tabular_data = tabular_data
+        self.color_by = color_by
+        self.filename = "experiments"
+
+    def partial_html(self, **kwargs):
+        return self.as_json()
+
+    def as_json(self, **kwargs) -> str:
+        tabular_dict = defaultdict(list)
+        for row in self.tabular_data.as_dict():
+            for col_name, value in row.items():
+                tabular_dict[col_name].append(str(value))
+
+        trace: Dict[str, Any] = {"type": "parcoords", "dimensions": []}
+        for label, values in tabular_dict.items():
+            is_categorical = False
+
+            try:
+                float_values = [float(x) for x in values]
+            except ValueError:
+                is_categorical = True
+                dummy_values = list(range(len(values)))
+
+            if is_categorical:
+                trace["dimensions"].append(
+                    {
+                        "label": label,
+                        "values": dummy_values,
+                        "tickvals": dummy_values,
+                        "ticktext": values,
+                    }
+                )
+            else:
+                trace["dimensions"].append(
+                    {"label": label, "values": float_values}
+                )
+
+            if label == self.color_by:
+                trace["line"] = {
+                    "color": dummy_values if is_categorical else float_values,
+                    "showscale": True,
+                }
+                if is_categorical:
+                    trace["line"]["colorbar"] = {
+                        "tickmode": "array",
+                        "tickvals": dummy_values,
+                        "ticktext": values,
+                    }
+
+        return json.dumps({"data": [trace], "layout": {}})

--- a/dvc/render/plotly.py
+++ b/dvc/render/plotly.py
@@ -49,9 +49,10 @@ class ParallelCoordinatesRenderer(Renderer):
                 float_values = [float(x) for x in values]
             except ValueError:
                 is_categorical = True
-                dummy_values = list(range(len(values)))
+                unique_values = sorted(set(values))
 
             if is_categorical:
+                dummy_values = [unique_values.index(x) for x in values]
                 trace["dimensions"].append(
                     {
                         "label": label,
@@ -69,12 +70,13 @@ class ParallelCoordinatesRenderer(Renderer):
                 trace["line"] = {
                     "color": dummy_values if is_categorical else float_values,
                     "showscale": True,
+                    "colorbar": {
+                        "title": self.color_by
+                    }
                 }
                 if is_categorical:
-                    trace["line"]["colorbar"] = {
-                        "tickmode": "array",
-                        "tickvals": dummy_values,
-                        "ticktext": values,
-                    }
+                    trace["line"]["colorbar"]["tickmode"] = "array"
+                    trace["line"]["colorbar"]["tickvals"] = dummy_values
+                    trace["line"]["colorbar"]["ticktext"] = values
 
         return json.dumps({"data": [trace], "layout": {}})

--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -637,9 +637,7 @@ def test_show_parallel_coordinates(tmp_dir, dvc, scm, mocker):
     assert main(["exp", "show", "--html"]) == 0
     kwargs = show_experiments.call_args[1]
 
-    assert kwargs["color_by"] == "Experiment"
     html_text = (tmp_dir / "dvc_plots" / "index.html").read_text()
-
     assert all(rev in html_text for rev in ["workspace", "master", "[exp-"])
 
     assert (
@@ -652,11 +650,10 @@ def test_show_parallel_coordinates(tmp_dir, dvc, scm, mocker):
     assert '"label": "metrics.yaml:bar"' not in html_text
 
     assert (
-        main(["exp", "show", "--html", "--color-by", "metrics.yaml:foo"]) == 0
+        main(["exp", "show", "--html", "--sort-by", "metrics.yaml:foo"]) == 0
     )
     kwargs = show_experiments.call_args[1]
 
-    assert kwargs["color_by"] == "metrics.yaml:foo"
     html_text = (tmp_dir / "dvc_plots" / "index.html").read_text()
     assert '"line": {"color": [2.0, 1.0, 2.0]' in html_text
 
@@ -669,3 +666,9 @@ def test_show_parallel_coordinates(tmp_dir, dvc, scm, mocker):
     assert main(["exp", "show", "--html", "--open"]) == 0
 
     webbroser_open.assert_called()
+
+    params_data = {"foo": 1, "bar": 1, "foobar": 2}
+    (tmp_dir / params_file).dump(params_data)
+    assert main(["exp", "show", "--html"]) == 0
+    html_text = (tmp_dir / "dvc_plots" / "index.html").read_text()
+    assert '{"label": "foobar", "values": [2.0, null, null]}' in html_text

--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -597,3 +597,75 @@ def test_show_only_changed(tmp_dir, dvc, scm, capsys):
     cap = capsys.readouterr()
 
     assert "bar" not in cap.out
+
+
+def test_show_parallel_coordinates(tmp_dir, dvc, scm, mocker):
+    from dvc.command.experiments import show
+
+    webbroser_open = mocker.patch("webbrowser.open")
+    show_experiments = mocker.spy(show, "show_experiments")
+
+    tmp_dir.gen("copy.py", COPY_SCRIPT)
+    params_file = tmp_dir / "params.yaml"
+    params_data = {
+        "foo": 1,
+        "bar": 1,
+    }
+    (tmp_dir / params_file).dump(params_data)
+
+    dvc.run(
+        cmd="python copy.py params.yaml metrics.yaml",
+        metrics_no_cache=["metrics.yaml"],
+        params=["foo", "bar"],
+        name="copy-file",
+        deps=["copy.py"],
+    )
+    scm.add(
+        [
+            "dvc.yaml",
+            "dvc.lock",
+            "copy.py",
+            "params.yaml",
+            "metrics.yaml",
+            ".gitignore",
+        ]
+    )
+    scm.commit("init")
+
+    dvc.experiments.run(params=["foo=2"])
+
+    assert main(["exp", "show", "--html"]) == 0
+    kwargs = show_experiments.call_args[1]
+
+    assert kwargs["color_by"] == "Experiment"
+    html_text = (tmp_dir / "dvc_plots" / "index.html").read_text()
+
+    assert all(rev in html_text for rev in ["workspace", "master", "[exp-"])
+
+    assert (
+        '{"label": "metrics.yaml:foo", "values": [2.0, 1.0, 2.0]}' in html_text
+    )
+    assert (
+        '{"label": "params.yaml:foo", "values": [2.0, 1.0, 2.0]}' in html_text
+    )
+    assert '"line": {"color": [2, 1, 0]' in html_text
+    assert '"label": "metrics.yaml:bar"' not in html_text
+
+    assert (
+        main(["exp", "show", "--html", "--color-by", "metrics.yaml:foo"]) == 0
+    )
+    kwargs = show_experiments.call_args[1]
+
+    assert kwargs["color_by"] == "metrics.yaml:foo"
+    html_text = (tmp_dir / "dvc_plots" / "index.html").read_text()
+    assert '"line": {"color": [2.0, 1.0, 2.0]' in html_text
+
+    assert main(["exp", "show", "--html", "--out", "experiments"]) == 0
+    kwargs = show_experiments.call_args[1]
+
+    assert kwargs["out"] == "experiments"
+    assert (tmp_dir / "experiments" / "index.html").exists()
+
+    assert main(["exp", "show", "--html", "--open"]) == 0
+
+    webbroser_open.assert_called()

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -785,7 +785,7 @@ def test_show_experiments_html(tmp_dir, mocker):
 
     show_experiments(all_experiments, html=True)
 
-    td.dropna.assert_called_with("rows")
+    td.dropna.assert_called_with("rows", how="all")
 
     render_kwargs = td.render.call_args[1]
 

--- a/tests/unit/render/test_parallel_coordinates.py
+++ b/tests/unit/render/test_parallel_coordinates.py
@@ -1,0 +1,123 @@
+import json
+
+from dvc.compare import TabularData
+from dvc.render.html import write
+from dvc.render.plotly import ParallelCoordinatesRenderer
+
+# pylint: disable=W1514
+
+
+def expected_format(result):
+    assert "data" in result
+    assert "layout" in result
+    assert isinstance(result["data"], list)
+    assert result["data"][0]["type"] == "parcoords"
+    assert isinstance(result["data"][0]["dimensions"], list)
+    return True
+
+
+def test_scalar_columns():
+    td = TabularData(["col-1", "col-2"])
+    td.extend([["0.1", "1"], ["2", "0.2"]])
+    renderer = ParallelCoordinatesRenderer(td)
+
+    result = json.loads(renderer.as_json())
+
+    assert expected_format(result)
+
+    assert result["data"][0]["dimensions"][0] == {
+        "label": "col-1",
+        "values": [0.1, 2.0],
+    }
+    assert result["data"][0]["dimensions"][1] == {
+        "label": "col-2",
+        "values": [1.0, 0.2],
+    }
+
+
+def test_categorical_columns():
+    td = TabularData(["col-1"])
+    td.extend([["foo"], ["bar"]])
+    renderer = ParallelCoordinatesRenderer(td)
+
+    result = json.loads(renderer.as_json())
+
+    assert expected_format(result)
+
+    assert result["data"][0]["dimensions"][0] == {
+        "label": "col-1",
+        "values": [0, 1],
+        "tickvals": [0, 1],
+        "ticktext": ["foo", "bar"],
+    }
+
+
+def test_mixed_columns():
+    td = TabularData(["categorical", "scalar"])
+    td.extend([["foo", "0.1"], ["bar", "2"]])
+    renderer = ParallelCoordinatesRenderer(td)
+
+    result = json.loads(renderer.as_json())
+
+    assert expected_format(result)
+
+    assert result["data"][0]["dimensions"][0] == {
+        "label": "categorical",
+        "values": [0, 1],
+        "tickvals": [0, 1],
+        "ticktext": ["foo", "bar"],
+    }
+    assert result["data"][0]["dimensions"][1] == {
+        "label": "scalar",
+        "values": [0.1, 2.0],
+    }
+
+
+def test_color_by_scalar():
+    td = TabularData(["categorical", "scalar"])
+    td.extend([["foo", "0.1"], ["bar", "2"]])
+    renderer = ParallelCoordinatesRenderer(td, color_by="scalar")
+
+    result = json.loads(renderer.as_json())
+
+    assert expected_format(result)
+    assert result["data"][0]["line"] == {
+        "color": [0.1, 2.0],
+        "showscale": True,
+    }
+
+
+def test_color_by_categorical():
+    td = TabularData(["categorical", "scalar"])
+    td.extend([["foo", "0.1"], ["bar", "2"]])
+    renderer = ParallelCoordinatesRenderer(td, color_by="categorical")
+
+    result = json.loads(renderer.as_json())
+
+    assert expected_format(result)
+    assert result["data"][0]["line"] == {
+        "color": [0, 1],
+        "showscale": True,
+        "colorbar": {
+            "tickmode": "array",
+            "tickvals": [0, 1],
+            "ticktext": ["foo", "bar"],
+        },
+    }
+
+
+def test_write_parallel_coordinates(tmp_dir):
+    td = TabularData(["categorical", "scalar"])
+    td.extend([["foo", "0.1"], ["bar", "2"]])
+
+    renderer = ParallelCoordinatesRenderer(td)
+    html_path = write(tmp_dir, renderers=[renderer])
+
+    html_text = html_path.read_text()
+
+    assert ParallelCoordinatesRenderer.SCRIPTS in html_text
+
+    div = ParallelCoordinatesRenderer.DIV.format(
+        id="plot_experiments", partial=renderer.as_json()
+    )
+    assert div in html_text

--- a/tests/unit/render/test_parallel_coordinates.py
+++ b/tests/unit/render/test_parallel_coordinates.py
@@ -37,7 +37,7 @@ def test_scalar_columns():
 
 def test_categorical_columns():
     td = TabularData(["col-1"])
-    td.extend([["foo"], ["bar"]])
+    td.extend([["foo"], ["bar"], ["foo"]])
     renderer = ParallelCoordinatesRenderer(td)
 
     result = json.loads(renderer.as_json())
@@ -46,9 +46,9 @@ def test_categorical_columns():
 
     assert result["data"][0]["dimensions"][0] == {
         "label": "col-1",
-        "values": [0, 1],
-        "tickvals": [0, 1],
-        "ticktext": ["foo", "bar"],
+        "values": [1, 0, 1],
+        "tickvals": [1, 0, 1],
+        "ticktext": ["foo", "bar", "foo"],
     }
 
 
@@ -63,8 +63,8 @@ def test_mixed_columns():
 
     assert result["data"][0]["dimensions"][0] == {
         "label": "categorical",
-        "values": [0, 1],
-        "tickvals": [0, 1],
+        "values": [1, 0],
+        "tickvals": [1, 0],
         "ticktext": ["foo", "bar"],
     }
     assert result["data"][0]["dimensions"][1] == {
@@ -84,6 +84,9 @@ def test_color_by_scalar():
     assert result["data"][0]["line"] == {
         "color": [0.1, 2.0],
         "showscale": True,
+        "colorbar": {
+            "title": "scalar"
+        }
     }
 
 
@@ -96,11 +99,12 @@ def test_color_by_categorical():
 
     assert expected_format(result)
     assert result["data"][0]["line"] == {
-        "color": [0, 1],
+        "color": [1, 0],
         "showscale": True,
         "colorbar": {
+            "title": "categorical",
             "tickmode": "array",
-            "tickvals": [0, 1],
+            "tickvals": [1, 0],
             "ticktext": ["foo", "bar"],
         },
     }

--- a/tests/unit/test_tabular_data.py
+++ b/tests/unit/test_tabular_data.py
@@ -264,3 +264,21 @@ def test_drop_duplicates_invalid_axis():
 
     with pytest.raises(ValueError, match="Invalid 'axis' value foo."):
         td.drop_duplicates("foo")
+
+
+def test_to_parallel_coordinates(tmp_dir, mocker):
+    (tmp_dir / "foo").mkdir()
+    td = TabularData(["categorical", "scalar"])
+    td.extend([["foo", "0.1"], ["bar", "2"]])
+
+    write = mocker.patch("dvc.render.html.write")
+    renderer_class = mocker.patch(
+        "dvc.render.plotly.ParallelCoordinatesRenderer"
+    )
+    renderer = renderer_class.return_value
+
+    td.render(html=True, output_path="foo")
+
+    renderer_class.assert_called_with(td, None)
+
+    write.assert_called_with("foo", renderers=[renderer])

--- a/tests/unit/test_tabular_data.py
+++ b/tests/unit/test_tabular_data.py
@@ -279,6 +279,6 @@ def test_to_parallel_coordinates(tmp_dir, mocker):
 
     td.render(html=True, output_path="foo")
 
-    renderer_class.assert_called_with(td, None)
+    renderer_class.assert_called_with(td, None, td._fill_value)
 
     write.assert_called_with("foo", renderers=[renderer])


### PR DESCRIPTION
* [X] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [X] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Closes #4455

Introduces the following new arguments / behavior to `dvc exp show`:

- `--html` 🤷
- `--sort-by {foo}` Defines the column to create colorscale from (Uses `Experiment` as default) 
- `--out {foo}`
- `--open`
- 
## Examples

Using https://github.com/iterative/demo-fashion-mnist

- Interactivity

https://user-images.githubusercontent.com/12677733/144048287-4baa1784-08c0-4b74-8704-1bb5345f0af8.mp4


- Default: `dvc exp show -T --html`

![newplot](https://user-images.githubusercontent.com/12677733/142024632-70ed20ae-8565-4de9-927a-483c110224e1.png)

- Customize color: `dvc exp show -T --html --sort-by accuracy`

![newplot(1)](https://user-images.githubusercontent.com/12677733/142026037-a11c4edf-ea4d-4830-8369-b274a6a5c880.png)

- Interaction with other options: `dvc exp show -T --html -sort-by accuracy --exclude-metrics loss`

![newplot(2)](https://user-images.githubusercontent.com/12677733/142026423-bea069be-4205-4ed5-80ea-04769b60998c.png)

