### PR TITLE
machine:remove help text for irrelevant commands

### DIFF
--- a/dvc/command/machine.py
+++ b/dvc/command/machine.py
@@ -396,7 +396,7 @@ def add_parser(subparsers, parent_parser):
     machine_CREATE_HELP = "Create and start a machine instance."
     machine_create_parser = machine_subparsers.add_parser(
         "create",
-        parents=[parent_config_parser, parent_parser],
+        parents=[parent_parser],
         description=append_doc_link(machine_CREATE_HELP, "machine/create"),
         help=machine_CREATE_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -411,7 +411,7 @@ def add_parser(subparsers, parent_parser):
     )
     machine_status_parser = machine_subparsers.add_parser(
         "status",
-        parents=[parent_config_parser, parent_parser],
+        parents=[parent_parser],
         description=append_doc_link(machine_STATUS_HELP, "machine/status"),
         help=machine_STATUS_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -424,7 +424,7 @@ def add_parser(subparsers, parent_parser):
     machine_DESTROY_HELP = "Destroy an machine instance."
     machine_destroy_parser = machine_subparsers.add_parser(
         "destroy",
-        parents=[parent_config_parser, parent_parser],
+        parents=[parent_parser],
         description=append_doc_link(machine_DESTROY_HELP, "machine/destroy"),
         help=machine_DESTROY_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -437,7 +437,7 @@ def add_parser(subparsers, parent_parser):
     machine_SSH_HELP = "Connect to a machine via SSH."
     machine_ssh_parser = machine_subparsers.add_parser(
         "ssh",
-        parents=[parent_config_parser, parent_parser],
+        parents=[parent_parser],
         description=append_doc_link(machine_SSH_HELP, "machine/ssh"),
         help=machine_SSH_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/tests/unit/command/test_machine.py
+++ b/tests/unit/command/test_machine.py
@@ -1,4 +1,5 @@
 import configobj
+import pytest
 from mock import call
 
 from dvc.cli import parse_args
@@ -139,3 +140,29 @@ def test_rename(tmp_dir, scm, dvc):
     assert cmd.run() == 0
     config = configobj.ConfigObj(str(tmp_dir / ".dvc" / "config"))
     assert config['machine "bar"']["cloud"] == "aws"
+
+
+@pytest.mark.parametrize(
+    "cmd,use_config",
+    [
+        ("add", True),
+        ("default", True),
+        ("remove", True),
+        ("list", True),
+        ("modify", True),
+        ("create", False),
+        ("destroy", False),
+        ("rename", True),
+        ("status", False),
+        ("ssh", False),
+    ],
+)
+def test_help_message(tmp_dir, scm, dvc, cmd, use_config, capsys):
+
+    try:
+        parse_args(["machine", cmd, "--help"])
+    except SystemExit:
+        pass
+    cap = capsys.readouterr()
+    print(cap.out)
+    assert ("--global" in cap.out) is use_config


### PR DESCRIPTION
fix: #6940

`--global/system/project/local` help message are in some irrelevant
command `status`, `ssh`, `create`, `destroy`. These commands are more
related to running instances rather than `machine config`, level
options didn't work for them.

1. Remove `--global/system/project/local` options in `status`, `ssh`,
   `create`, `destroy`.
2. Add a test for it.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
