### PR TITLE
params: Use `ast.literal_eval` for python params.

### DIFF
--- a/dvc/utils/serialize/_py.py
+++ b/dvc/utils/serialize/_py.py
@@ -134,22 +134,22 @@ def _ast_assign_to_dict(assign, only_self_params=False, lineno=False):
         value = {}
         for key, val in zip(assign.value.keys, assign.value.values):
             if lineno:
-                value[_get_ast_value(key)] = {
+                value[ast.literal_eval(key)] = {
                     "lineno": assign.lineno - 1,
-                    "value": _get_ast_value(val),
+                    "value": ast.literal_eval(val),
                 }
             else:
-                value[_get_ast_value(key)] = _get_ast_value(val)
+                value[ast.literal_eval(key)] = ast.literal_eval(val)
     elif isinstance(assign.value, ast.List):
-        value = [_get_ast_value(val) for val in assign.value.elts]
+        value = [ast.literal_eval(val) for val in assign.value.elts]
     elif isinstance(assign.value, ast.Set):
-        values = [_get_ast_value(val) for val in assign.value.elts]
+        values = [ast.literal_eval(val) for val in assign.value.elts]
         value = set(values)
     elif isinstance(assign.value, ast.Tuple):
-        values = [_get_ast_value(val) for val in assign.value.elts]
+        values = [ast.literal_eval(val) for val in assign.value.elts]
         value = tuple(values)
     else:
-        value = _get_ast_value(assign.value)
+        value = ast.literal_eval(assign.value)
 
     if lineno and not isinstance(assign.value, ast.Dict):
         result[name] = {"lineno": assign.lineno - 1, "value": value}
@@ -166,16 +166,4 @@ def _get_ast_name(target, only_self_params=False):
         result = target.attr
     else:
         raise AttributeError
-    return result
-
-
-def _get_ast_value(value):
-    if isinstance(value, ast.Num):
-        result = value.n
-    elif isinstance(value, ast.Str):
-        result = value.s
-    elif isinstance(value, ast.NameConstant):
-        result = value.value
-    else:
-        raise ValueError
     return result

--- a/tests/unit/utils/serialize/test_python.py
+++ b/tests/unit/utils/serialize/test_python.py
@@ -1,0 +1,45 @@
+import pytest
+
+from dvc.utils.serialize import parse_py
+
+
+@pytest.mark.parametrize(
+    "text,result",
+    [
+        ("BOOL = True", {"BOOL": True}),
+        ("INT = 5", {"INT": 5}),
+        ("FLOAT = 0.001", {"FLOAT": 0.001}),
+        ("STR = 'abc'", {"STR": "abc"}),
+        ("DICT = {'a': 1, 'b': 2}", {"DICT": {"a": 1, "b": 2}}),
+        ("LIST = [1, 2, 3]", {"LIST": [1, 2, 3]}),
+        ("SET = {1, 2, 3}", {"SET": {1, 2, 3}}),
+        ("TUPLE = (10, 100)", {"TUPLE": (10, 100)}),
+        ("NONE = None", {"NONE": None}),
+        ("UNARY_OP = -1", {"UNARY_OP": -1}),
+        (
+            """class TrainConfig:
+
+            EPOCHS = 70
+
+            def __init__(self):
+                self.layers = 5
+                self.layers = 9  # TrainConfig.layers param will be 9
+                bar = 3  # Will NOT be found since it's locally scoped
+            """,
+            {"TrainConfig": {"EPOCHS": 70, "layers": 9}},
+        ),
+    ],
+)
+def test_parse_valid_types(text, result):
+    assert parse_py(text, "foo") == result
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "CONSTRUCTOR = dict(a=1, b=2)",
+        "SUM = 1 + 2",
+    ],
+)
+def test_parse_invalid_types(text):
+    assert parse_py(text, "foo") == {}


### PR DESCRIPTION
Add unit tests for `parse_py`

Closes  #6953

* [X] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

`dvc.org` P.R: https://github.com/iterative/dvc.org/pull/3014
