### PR TITLE
localfs: remove LocalPath

### DIFF
--- a/dvc/fs/base.py
+++ b/dvc/fs/base.py
@@ -331,7 +331,7 @@ class BaseFileSystem:
             return None
 
         to_infos = (
-            localfs.path.join(to_info, self.path.relpath(info, from_info))
+            localfs.path.join(to_info, *self.path.relparts(info, from_info))
             for info in from_infos
         )
         callback.set_size(len(from_infos))

--- a/dvc/fs/local.py
+++ b/dvc/fs/local.py
@@ -1,8 +1,6 @@
 import logging
 import os
 
-from funcy import cached_property
-
 from dvc.scheme import Schemes
 from dvc.system import System
 from dvc.utils import is_exec, tmp_fname
@@ -10,17 +8,8 @@ from dvc.utils.fs import copy_fobj_to_file, copyfile, makedirs, move, remove
 
 from ..progress import DEFAULT_CALLBACK
 from .base import BaseFileSystem
-from .path import Path
 
 logger = logging.getLogger(__name__)
-
-
-class LocalPath(Path):
-    def parent(self, path):
-        return os.path.dirname(path)
-
-    def drive(self, path):
-        return os.path.splitdrive(path)[0]
 
 
 class LocalFileSystem(BaseFileSystem):
@@ -36,10 +25,6 @@ class LocalFileSystem(BaseFileSystem):
 
         super().__init__(**config)
         self.fs = LocalFS()
-
-    @cached_property
-    def path(self):
-        return LocalPath(os.sep)
 
     @staticmethod
     def open(path, mode="r", encoding=None, **kwargs):

--- a/dvc/fs/path.py
+++ b/dvc/fs/path.py
@@ -77,5 +77,8 @@ class Path:
         normbase = base.rstrip(self.sep)
         return normpath[len(normbase) + 1 :]
 
+    def relparts(self, path, base):
+        return self.parts(self.relpath(path, base))
+
     def as_posix(self, path):
         return path.replace(self.sep, posixpath.sep)

--- a/dvc/objects/stage.py
+++ b/dvc/objects/stage.py
@@ -163,8 +163,7 @@ def _build_tree(fs_path, fs, name, **kwargs):
         # Yes, this is a BUG, as long as we permit "/" in
         # filenames on Windows and "\" on Unix
 
-        relpath = fs.path.relpath(file_fs_path, fs_path)
-        key = tuple(relpath.split(fs.path.sep))
+        key = fs.path.relparts(file_fs_path, fs_path)
         assert key
         tree.add(key, meta, obj.hash_info)
 

--- a/dvc/output.py
+++ b/dvc/output.py
@@ -718,7 +718,7 @@ class Output:
 
         fs_path = self.fs.path
         if filter_info and filter_info != self.fs_path:
-            prefix = fs_path.parts(fs_path.relpath(filter_info, self.fs_path))
+            prefix = fs_path.relparts(filter_info, self.fs_path)
             obj = obj.get(self.odb, prefix)
 
         return obj

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -376,7 +376,7 @@ def resolve_paths(repo, out, always_local=False):
 
     scheme = urlparse(out).scheme
 
-    if os.name == "nt" and scheme == localfs.path.drive(abspath)[0].lower():
+    if os.name == "nt" and scheme == os.path.splitdrive(abspath)[0][0].lower():
         # urlparse interprets windows drive letters as URL scheme
         scheme = ""
 


### PR DESCRIPTION
fs.path is meant to be lightweight, and we should try to avoid using os.path.

Leftover from #6946