### PR TITLE
argparse: dont override cmd

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-latest]
-        pyv: ["3.7", "3.8", "3.9", "3.10"]
+        pyv: ["3.7", "3.8", "3.9.7", "3.10"]
         exclude:
           # no wheels for pygit2 yet
           - os: windows-latest

--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -814,7 +814,7 @@ class CmdExperimentsInit(CmdBase):
     def run(self):
         from dvc.command.stage import parse_cmd
 
-        cmd = parse_cmd(self.args.cmd)
+        cmd = parse_cmd(self.args.command)
         if not self.args.interactive and not cmd:
             raise InvalidArgumentError("command is not specified")
 
@@ -1416,7 +1416,7 @@ def add_parser(subparsers, parent_parser):
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     experiments_init_parser.add_argument(
-        "cmd",
+        "command",
         nargs=argparse.REMAINDER,
         help="Command to execute.",
         metavar="command",

--- a/dvc/command/run.py
+++ b/dvc/command/run.py
@@ -23,7 +23,7 @@ class CmdRun(CmdBase):
                 self.args.outs_persist_no_cache,
                 self.args.checkpoints,
                 self.args.params,
-                self.args.cmd,
+                self.args.command,
             ]
         ):  # pragma: no cover
             logger.error(
@@ -36,7 +36,7 @@ class CmdRun(CmdBase):
         kwargs = vars(self.args)
         kwargs.update(
             {
-                "cmd": parse_cmd(self.args.cmd),
+                "cmd": parse_cmd(self.args.command),
                 "fname": kwargs.pop("file"),
                 "no_exec": (self.args.no_exec or bool(self.args.checkpoints)),
                 "run_cache": not kwargs.pop("no_run_cache"),

--- a/dvc/command/stage.py
+++ b/dvc/command/stage.py
@@ -129,7 +129,7 @@ class CmdStageAdd(CmdBase):
         kwargs = vars(self.args)
         kwargs.update(
             {
-                "cmd": parse_cmd(kwargs.pop("cmd")),
+                "cmd": parse_cmd(kwargs.pop("command")),
                 "params": parse_params(self.args.params),
             }
         )
@@ -281,7 +281,7 @@ def _add_common_args(parser):
         ),
     )
     parser.add_argument(
-        "cmd",
+        "command",
         nargs=argparse.REMAINDER,
         help="Command to execute.",
         metavar="command",

--- a/tests/func/test_cli.py
+++ b/tests/func/test_cli.py
@@ -66,7 +66,7 @@ class TestRun(TestDvc):
         self.assertEqual(args.outs, [out1, out2])
         self.assertEqual(args.outs_no_cache, [out_no_cache1, out_no_cache2])
         self.assertEqual(args.file, fname)
-        self.assertEqual(args.cmd, [cmd, arg1, arg2])
+        self.assertEqual(args.command, [cmd, arg1, arg2])
 
         cmd_cls.repo.close()
 

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -590,3 +590,4 @@ def test_experiments_init_config(dvc, mocker):
         "plots": "plots",
         "live": "dvclive",
     }
+    assert m.call_args[1]["overrides"] == {"cmd": "cmd"}


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Recent bugfix in 3.9 release: https://bugs.python.org/issue45235
Has caused a regression. There were 2 problems:

1. we used to override `cmd` value for commands like `run`, `stage` and `exp init`. This one is on us, and while the proposed workaround does not require it, I renamed stage-related `cmd` into `command` so it does not clash with `dvc {cmd}` commands.
2. The fix has caused some other problems, for example: `dvc status -q` would not pass `-q` down to the status command, while `dvc -q status` would. I tried resolving the problem but today was not enough. Since the bugfix in question is most likely to get [scrapped](https://bugs.python.org/msg406123) I want to limit the python version to an unaffected one, and wait for another release to get pushed. ~~Since all Python versions seem to be affected, I am limiting all versions just in case.~~ - can't do that due to different versions released for different os-es. Lets limit `3.9` and see how fast the revert gets released.

The action point here is that we need to observe python releases and make sure to remove constraints once we know that the new version gets released. If for some reason the fix stays in the current format, we will need to research why the flags have not been passed down and fix that.

Closes: #6956 