### PR TITLE
hardlink: fallback to other link methods if "Function not implemented" is raised

### DIFF
--- a/dvc/fs/utils.py
+++ b/dvc/fs/utils.py
@@ -37,7 +37,11 @@ def _link(
         except RemoteActionNotImplemented:
             continue
         except OSError as exc:
-            if exc.errno not in [errno.EXDEV, errno.ENOTSUP]:
+            if exc.errno not in [
+                errno.EXDEV,
+                errno.ENOTSUP,
+                errno.ENOSYS,  # https://github.com/iterative/dvc/issues/6962
+            ]:
                 raise
 
     raise OSError(errno.ENOTSUP, "reflink and hardlink are not supported")

--- a/dvc/objects/checkout.py
+++ b/dvc/objects/checkout.py
@@ -79,7 +79,7 @@ def _try_links(cache, from_info, to_info, link_types):
             return
 
         except OSError as exc:
-            if exc.errno not in [errno.EXDEV, errno.ENOTSUP]:
+            if exc.errno not in [errno.EXDEV, errno.ENOTSUP, errno.ENOSYS]:
                 raise
             logger.debug(
                 "Cache type '%s' is not supported: %s", link_types[0], exc


### PR DESCRIPTION
Fixes #6962, where GDdrive mounted on Colab was failing when trying to hardlink
with the message that the 'Function not implemented'.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
