### PR TITLE
exp init: hide metrics/plots from worktree on --type=live

### DIFF
--- a/dvc/repo/experiments/init.py
+++ b/dvc/repo/experiments/init.py
@@ -215,6 +215,9 @@ def init_interactive(
         )
         if not live and "live" not in provided:
             workspace.pop("live", None)
+        for key in ("plots", "metrics"):
+            if live and key not in provided:
+                workspace.pop(key, None)
         for value in sorted(workspace.values()):
             tree.add(f"[green]{value}[/green]")
         ui.error_write(tree, styled=True)


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.


Partially fixes #6969.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
