### PR TITLE
exp init: suppress plots if live is selected as a stage type

### DIFF
--- a/dvc/repo/experiments/init.py
+++ b/dvc/repo/experiments/init.py
@@ -303,11 +303,11 @@ def init(
         )
     else:
         if with_live:
-            # suppress `metrics`/`params` if live is selected, unless
+            # suppress `metrics`/`plots` if live is selected, unless
             # it is also provided via overrides/cli.
             # This makes output to be a checkpoint as well.
             defaults.pop("metrics", None)
-            defaults.pop("params", None)
+            defaults.pop("plots", None)
         else:
             defaults.pop("live", None)  # suppress live otherwise
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Fixes issue of showing `plots` in non-interactive mode in `exp init`, mentioned in https://github.com/iterative/dvc/issues/6969.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
