### PR TITLE
parsing: resolve wdir for empty string as curdir

### DIFF
--- a/dvc/parsing/__init__.py
+++ b/dvc/parsing/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from typing import (
@@ -133,17 +134,18 @@ def make_definition(
 
 
 class DataResolver:
-    def __init__(self, repo: "Repo", wdir: str, d: dict):
+    def __init__(self, repo: "Repo", wdir: str = "", d: Dict = None):
         self.fs = fs = repo.fs
-        self.wdir = wdir
+        self.wdir = wdir or os.curdir
         self.relpath = relpath(fs.path.join(self.wdir, "dvc.yaml"))
 
+        d = d or {}
         vars_ = d.get(VARS_KWD, [])
         check_interpolations(vars_, VARS_KWD, self.relpath)
         self.context: Context = Context()
 
         try:
-            args = fs, vars_, wdir  # load from `vars` section
+            args = fs, vars_, self.wdir  # load from `vars` section
             self.context.load_from_vars(*args, default=DEFAULT_PARAMS_FILE)
         except ContextError as exc:
             format_and_raise(exc, "'vars'", self.relpath)

--- a/tests/func/parsing/test_resolver.py
+++ b/tests/func/parsing/test_resolver.py
@@ -51,7 +51,7 @@ def test_vars_interpolation_errors(tmp_dir, dvc, vars_):
 )
 def test_default_params_file(tmp_dir, dvc, vars_):
     (tmp_dir / DEFAULT_PARAMS_FILE).dump(DATA)
-    resolver = DataResolver(dvc, tmp_dir.fs_path, vars_)
+    resolver = DataResolver(dvc, d=vars_)
     assert resolver.context == DATA
 
 


### PR DESCRIPTION
This PR does fix the issue within the parsing resolver
when the `wdir` is passed as an empty string. When it is passed
as such, it interprets it as a current working directory which
is a correct assumption internally.

This still does not fix the issue with fs.path.join. Original issue
with `fs.path.join` is still there.

```pycon
>>> os.path.join('', 'dvc.yaml')
'dvc.yaml'
>>> fs.path.join('', 'dvc.yaml')
'/dvc.yaml'
```

This fixes the regression introduced with 9aec8f1926b, which failed parameters/vars loading from the file
as `fs.path.join` turned the file into absolute path. This happened when `wdir` is relative path as is the case
with most stages (default `wdir` is assumed to be `""` which is also a relpath). But the tests were using `tmp_dir.fspath`
due to which we were not able to catch this. One of the test has been adjusted to use relative wdir to account for this change.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
