### PR TITLE
dulwich: fallback to default SSH keys in asyncssh vendor

### DIFF
--- a/dvc/scm/git/backend/dulwich/asyncssh_vendor.py
+++ b/dvc/scm/git/backend/dulwich/asyncssh_vendor.py
@@ -79,10 +79,11 @@ class AsyncSSHVendor(BaseAsyncObject, SSHVendor):
 
         conn = await asyncssh.connect(
             host,
-            port=port,
+            port=port if port is not None else (),
             username=username,
             password=password,
-            client_keys=[key_filename] if key_filename else [],
+            client_keys=[key_filename] if key_filename else (),
+            ignore_encrypted=not key_filename,
             known_hosts=None,
             encoding=None,
         )

--- a/dvc/scm/git/backend/dulwich/asyncssh_vendor.py
+++ b/dvc/scm/git/backend/dulwich/asyncssh_vendor.py
@@ -41,11 +41,17 @@ class AsyncSSHWrapper(BaseAsyncObject):
 
     read = sync_wrapper(_read)
 
-    def write(self, data: bytes):
+    async def _write(self, data: bytes):
         self.proc.stdin.write(data)
+        await self.proc.stdin.drain()
 
-    def close(self):
+    write = sync_wrapper(_write)
+
+    async def _close(self):
         self.conn.close()
+        await self.conn.wait_closed()
+
+    close = sync_wrapper(_close)
 
 
 # NOTE: Github's SSH server does not strictly comply with the SSH protocol.

--- a/tests/unit/scm/test_git.py
+++ b/tests/unit/scm/test_git.py
@@ -594,3 +594,29 @@ def test_pygit_checkout_subdir(tmp_dir, scm, git):
     with (tmp_dir / "dir").chdir():
         git.checkout(rev)
         assert not (tmp_dir / "dir" / "bar").exists()
+
+
+@pytest.mark.parametrize(
+    "algorithm", [b"ssh-rsa", b"rsa-sha2-256", b"rsa-sha2-512"]
+)
+def test_dulwich_github_compat(mocker, algorithm):
+    from asyncssh.misc import ProtocolError
+
+    from dvc.scm.git.backend.dulwich.asyncssh_vendor import (
+        _process_public_key_ok_gh,
+    )
+
+    key_data = b"foo"
+    auth = mocker.Mock(
+        _keypair=mocker.Mock(algorithm=algorithm, public_data=key_data),
+    )
+    packet = mocker.Mock()
+
+    with pytest.raises(ProtocolError):
+        strings = iter((b"ed21556", key_data))
+        packet.get_string = lambda: next(strings)
+        _process_public_key_ok_gh(auth, None, None, packet)
+
+    strings = iter((b"ssh-rsa", key_data))
+    packet.get_string = lambda: next(strings)
+    _process_public_key_ok_gh(auth, None, None, packet)


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will fix #6920

Related to #2215