### PR TITLE
scm: hint to autostage

### DIFF
--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -258,7 +258,11 @@ class Git(Base):
             "\n"
             "To track the changes with git, run:\n"
             "\n"
-            "\tgit add {files}".format(files=files)
+            "\tgit add {files}\n"
+            "\n"
+            "To enable auto staging, run:\n"
+            "\n"
+            "\tdvc config core.autostage true".format(files=files)
         )
 
     def track_changed_files(self):


### PR DESCRIPTION
Adds hint (when reminding to track files) to set core.autostage.

Related to #6929 and https://github.com/iterative/dvc.org/issues/2969.

Thoughts on this?