### PR TITLE
gha: allow builds for new 3.9 releases

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-latest]
-        pyv: ["3.7", "3.8", "3.9.7", "3.10"]
+        pyv: ["3.7", "3.8", "3.9", "3.10"]
     steps:
     - uses: actions/checkout@v2.4.0
       with:


### PR DESCRIPTION
Closes: #6975

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Seems like 3.9.9 got released yesterday. So the argparse should be back to previous behavior.