### PR TITLE
ui: Add `open_browser`.

### DIFF
--- a/dvc/command/plots.py
+++ b/dvc/command/plots.py
@@ -62,23 +62,11 @@ class CmdPlots(CmdBase):
                 html_template_path=self.args.html_template,
             )
 
-            assert index_path.is_absolute()
-            url = index_path.as_uri()
-            ui.write(url)
+            ui.write(index_path.as_uri())
 
             if self.args.open:
-                import webbrowser
-                from platform import uname
+                return ui.open_browser(index_path)
 
-                if "Microsoft" in uname().release:
-                    url = Path(rel) / "index.html"
-
-                opened = webbrowser.open(url)
-                if not opened:
-                    ui.error_write(
-                        "Failed to open. Please try opening it manually."
-                    )
-                    return 1
             return 0
 
         except DvcException:

--- a/dvc/repo/live.py
+++ b/dvc/repo/live.py
@@ -1,6 +1,4 @@
 import logging
-from pathlib import Path
-from platform import uname
 from typing import TYPE_CHECKING, List, Optional
 
 from funcy import once_per_args
@@ -16,9 +14,9 @@ if TYPE_CHECKING:
 
 @once_per_args
 def webbrowser_open(url: str) -> int:
-    import webbrowser
+    from dvc.ui import ui
 
-    return webbrowser.open(url)
+    return ui.open_browser(url)
 
 
 def create_summary(out):
@@ -33,12 +31,7 @@ def create_summary(out):
         out.repo, plots, metrics=metrics, path=html_path, refresh_seconds=5
     )
 
-    url = index_path.as_uri()
-
-    if "Microsoft" in uname().release:
-        url = Path(index_path) / "index.html"
-
-    webbrowser_open(url)
+    webbrowser_open(index_path)
 
 
 def summary_fs_path(out: "Output") -> Optional[str]:

--- a/dvc/ui/__init__.py
+++ b/dvc/ui/__init__.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from rich.text import Text as RichText
 
     from dvc.progress import Tqdm
+    from dvc.types import StrPath
     from dvc.ui.table import Headers, Styles, TableData
 
 
@@ -259,6 +260,28 @@ class Console:
         import sys
 
         return sys.stdout.isatty()
+
+    def open_browser(self, file: "StrPath") -> int:
+        import webbrowser
+        from pathlib import Path
+        from platform import uname
+
+        from dvc.utils import relpath
+
+        path = Path(file).resolve()
+        url = (
+            relpath(path) if "Microsoft" in uname().release else path.as_uri()
+        )
+
+        opened = webbrowser.open(url)
+
+        if not opened:
+            ui.error_write(
+                f"Failed to open {url}. " "Please try opening it manually."
+            )
+            return 1
+
+        return 0
 
 
 ui = Console()

--- a/tests/unit/command/test_plots.py
+++ b/tests/unit/command/test_plots.py
@@ -172,7 +172,7 @@ def test_plots_diff_open_WSL(tmp_dir, dvc, mocker, plots_data):
     mocker.patch("dvc.command.plots.render", return_value=index_path)
 
     assert cmd.run() == 0
-    mocked_open.assert_called_once_with(Path("dvc_plots") / "index.html")
+    mocked_open.assert_called_once_with(str(Path("dvc_plots") / "index.html"))
 
 
 def test_plots_diff_open_failed(tmp_dir, dvc, mocker, capsys, plots_data):
@@ -189,7 +189,10 @@ def test_plots_diff_open_failed(tmp_dir, dvc, mocker, capsys, plots_data):
     expected_url = tmp_dir / "dvc_plots" / "index.html"
     mocked_open.assert_called_once_with(expected_url.as_uri())
 
-    error_message = "Failed to open. Please try opening it manually."
+    error_message = (
+        f"Failed to open {expected_url.as_uri()}. "
+        "Please try opening it manually."
+    )
 
     out, err = capsys.readouterr()
     assert expected_url.as_uri() in out


### PR DESCRIPTION
Use `webbrowser.open` and resolve relpath for non WSL plattforms.

For reusing in #6913 and #6933 
