### PR TITLE
build: bump sshfs from 2021.8.1 to 2021.11.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -107,8 +107,8 @@ oss = ossfs==2021.8.0
 s3 =
     s3fs==2021.11.0
     aiobotocore[boto3]>1.0.1
-ssh = sshfs[bcrypt]>=2021.8.1
-ssh_gssapi = sshfs[gssapi]>=2021.8.1
+ssh = sshfs[bcrypt]>=2021.11.2
+ssh_gssapi = sshfs[gssapi]>=2021.11.2
 webdav = webdav4>=0.9.3
 # not to break `dvc[webhdfs]`
 webhdfs =


### PR DESCRIPTION
This version uses bumps asyncssh to a version that supports ProxyJump. This fixes the issue reported on discord: https://discord.com/channels/485586884165107732/485596304961962003/910866142594203689


#### Checklist:

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.  
        *(With the exception that I haven't created a Github Issue, since we have already discussed this on the discord server)*.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.
