### PR TITLE
exp show:add parent value to table cols(#7001)

### DIFF
--- a/dvc/commands/experiments/show.py
+++ b/dvc/commands/experiments/show.py
@@ -126,7 +126,7 @@ def _collect_rows(
                 typ = "checkpoint_base"
             else:
                 typ = "checkpoint_commit"
-                parent = parent_rev[:7]
+            parent = parent_rev[:7]
         elif i < len(experiments) - 1:
             typ = "branch_commit"
         else:

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -864,3 +864,98 @@ def test_show_experiments_pcp(tmp_dir, mocker):
 
     assert kwargs["output_path"] == str(tmp_dir / "dvc_plots")
     assert kwargs["color_by"] == "Experiment"
+
+
+def test_show_checkpoint_csv(
+    capsys,
+):
+    all_experiments = {
+        "workspace": {
+            "baseline": {
+                "data": {
+                    "timestamp": None,
+                    "params": {
+                        "params.yaml": {"data": {"start": 0}},
+                        "checkpoint.py": {"data": {"EPOCHS": 2, "STEP": 1}},
+                    },
+                    "queued": False,
+                    "running": False,
+                    "executor": None,
+                    "metrics": {
+                        "scores.yaml": {"data": {"epoch": 1, "mult": 1}}
+                    },
+                }
+            }
+        },
+        "0fd92c2c0ff17c923a79b4b0b96e54fe4": {
+            "baseline": {
+                "data": {
+                    "timestamp": datetime(2021, 3, 10, 14, 5, 52),
+                    "params": {
+                        "params.yaml": {"data": {"start": 0}},
+                        "checkpoint.py": {"data": {"EPOCHS": 2, "STEP": 1}},
+                    },
+                    "queued": False,
+                    "running": False,
+                    "executor": None,
+                    "metrics": {},
+                    "name": "main",
+                }
+            },
+            "0a2b7379f2720a2fe240a826a611c285d": {
+                "data": {
+                    "checkpoint_tip": "0a2b7379f2720a2fe240a826a611c285d",
+                    "timestamp": datetime(2021, 11, 18, 20, 30, 27),
+                    "params": {
+                        "params.yaml": {"data": {"start": 0}},
+                        "checkpoint.py": {"data": {"EPOCHS": 2, "STEP": 1}},
+                    },
+                    "queued": False,
+                    "running": False,
+                    "executor": None,
+                    "metrics": {
+                        "scores.yaml": {"data": {"epoch": 1, "mult": 1}}
+                    },
+                    "name": "exp-e44da",
+                    "checkpoint_parent": "8acf8ec4ea2dcedc39eac011d35cf26a1",
+                }
+            },
+            "8acf8ec4ea2dcedc39eac011d35cf26a1": {
+                "data": {
+                    "checkpoint_tip": "0a2b7379f2720a2fe240a826a611c285d",
+                    "timestamp": datetime(2021, 11, 18, 20, 30, 26),
+                    "params": {
+                        "params.yaml": {"data": {"start": 0}},
+                        "checkpoint.py": {"data": {"EPOCHS": 2, "STEP": 1}},
+                    },
+                    "queued": False,
+                    "running": False,
+                    "executor": None,
+                    "metrics": {
+                        "scores.yaml": {"data": {"epoch": 0, "mult": 0}}
+                    },
+                    "checkpoint_parent": "0fd92c2c0ff17c923a79b4b0b96e54fe4",
+                }
+            },
+        },
+    }
+
+    show_experiments(
+        all_experiments, precision=None, fill_value="", iso=True, csv=True
+    )
+    cap = capsys.readouterr()
+    assert (
+        "Experiment,rev,typ,Created,parent,epoch,mult,start,EPOCHS,STEP"
+        in cap.out
+    )
+    assert ",workspace,baseline,,,1,1,0,2,1" in cap.out
+    assert "main,0fd92c2,baseline,2021-03-10T14:05:52,,,,0,2,1" in cap.out
+    print(cap.out)
+    assert (
+        "exp-e44da,0a2b737,checkpoint_tip,2021-11-18T20:30:27,"
+        "8acf8ec,1,1,0,2,1" in cap.out
+    )
+    assert (
+        ",8acf8ec,checkpoint_base,2021-11-18T20:30:26,0fd92c2,0,0,0,2,1"
+        in cap.out
+    )


### PR DESCRIPTION
fix: #7001
Current table col parent value is empty in the `branch_commit` and `branch_base` types of exps
Fill the value into it, and remove some debug print in tests/func/experiments/test_show.py

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏


current output example,  baselines still empty (they are the parents themselves )
```bash
$ dvc exp show --csv
Experiment,rev,typ,Created,parent,avg_prec,roc_auc,prepare.split,prepare.seed,featurize.max_features,featurize.ngrams,train.seed,train.n_est,train.min_split
,workspace,baseline,,,0.5803672533016505,0.9718078815854728,0.1,-20170428,3000,1,-20170428,100,36
master,b05eecc,baseline,2021-08-02T16:48:14,,0.5325162867864254,0.9106964878520005,0.2,20170428,3000,1,20170428,100,2
efg,7c6c0e2,branch_commit,2021-10-27T17:59:28,b05eecc,0.5803672533016505,0.9718078815854728,0.1,20170428,3000,1,20170428,100,36
123,057b80f,branch_commit,2021-10-27T17:58:49,b05eecc,0.5803672533016505,0.9718078815854728,0.1,20170428,3000,1,20170428,100,36
abc,3a64c32,branch_commit,2021-10-27T17:58:46,b05eecc,0.5803672533016505,0.9718078815854728,0.1,20170428,3000,1,20170428,100,36
,a8be3eb,branch_commit,2021-10-25T11:58:54,b05eecc,0.5803672533016505,0.9718078815854728,0.1,20170428,3000,1,20170428,100,36
,dfb89b7,branch_base,2021-10-25T11:58:51,b05eecc,0.5803672533016505,0.9718078815854728,0.1,20170428,3000,1,20170428,100,36
```