### PR TITLE
exp init: timeout prompts' test

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -127,6 +127,7 @@ tests =
     pytest-docker==0.10.3; python_version < '3.10' or sys_platform != 'win32'
     flaky==3.7.0
     mock==4.0.3
+    pytest-timeout==2.0.1
     rangehttpserver==1.2.0
     mock-ssh-server==0.9.1
     wget==3.2

--- a/tests/func/experiments/test_init.py
+++ b/tests/func/experiments/test_init.py
@@ -9,6 +9,9 @@ from dvc.main import main
 from dvc.repo.experiments.init import init
 from dvc.stage.exceptions import DuplicateStageName
 
+# the tests may hang on prompts on failure
+pytestmark = pytest.mark.timeout(1)
+
 
 def test_init_simple(tmp_dir, scm, dvc, capsys):
     tmp_dir.gen(


### PR DESCRIPTION
The `exp init` tests may just keep waiting on the prompts blocking tests.
The blocking of prompts is likely a failure in tests setup or a bug
in the implementation. It's hard to find out these failures or avoid it.

If they take longer than 1 second, they most likely have failed as
most of the tests take 0.25 seconds at max in Windows. So, using `pytest-timeout` is the
easiest approach here.