### PR TITLE
render: vega: data processing outside of renderers

### DIFF
--- a/dvc/command/live.py
+++ b/dvc/command/live.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 from dvc.command import completion
 from dvc.command.base import CmdBase, fix_subparsers
-from dvc.render.utils import match_renderers
 from dvc.ui import ui
 
 
@@ -11,11 +10,12 @@ class CmdLive(CmdBase):
     UNINITIALIZED = True
 
     def _run(self, target, revs=None):
+        from dvc.render.utils import match_renderers, render
+
         metrics, plots = self.repo.live.show(target=target, revs=revs)
 
         if plots:
             html_path = Path.cwd() / (self.args.target + "_html")
-            from dvc.render.utils import render
 
             renderers = match_renderers(plots, self.repo.plots.templates)
             index_path = render(self.repo, renderers, metrics, html_path)

--- a/dvc/command/plots.py
+++ b/dvc/command/plots.py
@@ -7,8 +7,6 @@ from funcy import first
 from dvc.command import completion
 from dvc.command.base import CmdBase, append_doc_link, fix_subparsers
 from dvc.exceptions import DvcException
-from dvc.render.utils import match_renderers, render
-from dvc.render.vega import VegaRenderer
 from dvc.ui import ui
 from dvc.utils import format_link
 
@@ -40,6 +38,9 @@ class CmdPlots(CmdBase):
 
     def run(self):
         from pathlib import Path
+
+        from dvc.render.utils import match_renderers, render
+        from dvc.render.vega import VegaRenderer
 
         if self.args.show_vega:
             if not self.args.targets:

--- a/dvc/render/base.py
+++ b/dvc/render/base.py
@@ -19,9 +19,8 @@ class Renderer(abc.ABC):
     REVISIONS_KEY = "revisions"
     TYPE_KEY = "type"
 
-    def __init__(self, data: Dict, templates=None):
+    def __init__(self, data: Dict, **kwargs):
         self.data = data
-        self.templates = templates
 
         from dvc.render.utils import get_files
 

--- a/dvc/render/data.py
+++ b/dvc/render/data.py
@@ -1,0 +1,194 @@
+from copy import deepcopy
+from functools import partial
+from typing import Dict, List, Optional, Set, Union
+
+from funcy import first, project
+
+from dvc.exceptions import DvcException
+from dvc.render.base import INDEX_FIELD, REVISION_FIELD
+
+
+class FieldsNotFoundError(DvcException):
+    def __init__(self, expected_fields, found_fields):
+        expected_str = ", ".join(expected_fields)
+        found_str = ", ".join(found_fields)
+        super().__init__(
+            f"Could not find all provided fields ('{expected_str}') "
+            f"in data fields ('{found_str}')."
+        )
+
+
+class PlotDataStructureError(DvcException):
+    def __init__(self):
+        super().__init__(
+            "Plot data extraction failed. Please see "
+            "https://man.dvc.org/plots for supported data formats."
+        )
+
+
+def _filter_fields(datapoints: List[Dict], fields: Set) -> List[Dict]:
+    if not fields:
+        return datapoints
+    assert isinstance(fields, set)
+
+    new_data = []
+    for data_point in datapoints:
+        keys = set(data_point.keys())
+        if not fields <= keys:
+            raise FieldsNotFoundError(fields, keys)
+
+        new_data.append(project(data_point, fields))
+
+    return new_data
+
+
+def _lists(dictionary: Dict):
+    for _, value in dictionary.items():
+        if isinstance(value, dict):
+            yield from _lists(value)
+        elif isinstance(value, list):
+            yield value
+
+
+def _find_first_list(data: Union[Dict, List], fields: Set) -> List[Dict]:
+    fields = fields or set()
+
+    if not isinstance(data, dict):
+        return data
+
+    for lst in _lists(data):
+        if (
+            all(isinstance(dp, dict) for dp in lst)
+            # if fields is empty, it will match any set
+            and set(first(lst).keys()) & fields == fields
+        ):
+            return lst
+
+    raise PlotDataStructureError()
+
+
+def _append_index(datapoints: List[Dict]) -> List[Dict]:
+    if INDEX_FIELD in first(datapoints).keys():
+        return datapoints
+
+    for index, data_point in enumerate(datapoints):
+        data_point[INDEX_FIELD] = index
+    return datapoints
+
+
+class Converter:
+    """
+    Class that takes care of converting unspecified data blob
+    (Dict or List[Dict]) into datapoints (List[Dict]).
+    If some properties that are required by Template class are missing
+    ('x', 'y') it will attempt to fill in the blanks.
+    """
+
+    @staticmethod
+    def update(datapoints: List[Dict], update_dict: Dict):
+        for data_point in datapoints:
+            data_point.update(update_dict)
+        return datapoints
+
+    def __init__(self, plot_properties: Optional[Dict] = None):
+        plot_properties = plot_properties or {}
+        self.props = deepcopy(plot_properties)
+        self.inferred_props: Dict = {}
+
+        self.steps = []
+
+        self._infer_x()
+        self._infer_fields()
+
+        self.steps.append(
+            (
+                "find_data",
+                partial(
+                    _find_first_list,
+                    fields=self.inferred_props.get("fields", set())
+                    - {INDEX_FIELD},
+                ),
+            )
+        )
+
+        if not self.props.get("x", None):
+            self.steps.append(("append_index", partial(_append_index)))
+
+        self.steps.append(
+            (
+                "filter_fields",
+                partial(
+                    _filter_fields,
+                    fields=self.inferred_props.get("fields", set()),
+                ),
+            )
+        )
+
+    def _infer_x(self):
+        if not self.props.get("x", None):
+            self.inferred_props["x"] = INDEX_FIELD
+
+    def skip_step(self, name: str):
+        self.steps = [(_name, fn) for _name, fn in self.steps if _name != name]
+
+    def _infer_fields(self):
+        fields = self.props.get("fields", set())
+        if fields:
+            fields = {
+                *fields,
+                self.props.get("x", None),
+                self.props.get("y", None),
+                self.inferred_props.get("x", None),
+            } - {None}
+            self.inferred_props["fields"] = fields
+
+    def _infer_y(self, datapoints: List[Dict]):
+        if "y" not in self.props:
+            data_fields = list(first(datapoints))
+            skip = (
+                REVISION_FIELD,
+                self.props.get("x", None) or self.inferred_props.get("x"),
+            )
+            inferred_y = first(
+                f for f in reversed(data_fields) if f not in skip
+            )
+            if "y" in self.inferred_props:
+                previous_y = self.inferred_props["y"]
+                if previous_y != inferred_y:
+                    raise DvcException(
+                        f"Inferred y ('{inferred_y}' value does not match"
+                        f"previously matched one ('f{previous_y}')."
+                    )
+            else:
+                self.inferred_props["y"] = inferred_y
+
+    def convert(self, data):
+        """
+        Convert the data. Fill necessary fields ('x', 'y') and return both
+        generated datapoints and updated properties.
+        """
+        processed = deepcopy(data)
+
+        for _, step in self.steps:
+            processed = step(processed)
+
+        self._infer_y(processed)
+
+        return processed, {**self.props, **self.inferred_props}
+
+
+def to_datapoints(data: Dict, props: Dict):
+    converter = Converter(props)
+
+    datapoints = []
+    for revision, rev_data in data.items():
+        for _, file_data in rev_data.get("data", {}).items():
+            if "data" in file_data:
+                processed, final_props = converter.convert(
+                    file_data.get("data")
+                )
+
+                Converter.update(processed, {REVISION_FIELD: revision})
+
+                datapoints.extend(processed)
+    return datapoints, final_props

--- a/dvc/render/utils.py
+++ b/dvc/render/utils.py
@@ -21,14 +21,31 @@ def group_by_filename(plots_data: Dict) -> List[Dict]:
     return grouped
 
 
+def squash_plots_properties(data: Dict) -> Dict:
+    resolved: Dict[str, str] = {}
+    for rev_data in data.values():
+        for file_data in rev_data.get("data", {}).values():
+            props = file_data.get("props", {})
+            resolved = {**resolved, **props}
+    return resolved
+
+
 def match_renderers(plots_data, templates):
     from dvc.render import RENDERERS
 
     renderers = []
-    for g in group_by_filename(plots_data):
+    for group in group_by_filename(plots_data):
+
+        plot_properties = squash_plots_properties(group)
+        template = templates.load(plot_properties.get("template", None))
+
         for renderer_class in RENDERERS:
-            if renderer_class.matches(g):
-                renderers.append(renderer_class(g, templates))
+            if renderer_class.matches(group):
+                renderers.append(
+                    renderer_class(
+                        group, template=template, properties=plot_properties
+                    )
+                )
     return renderers
 
 

--- a/dvc/render/vega.py
+++ b/dvc/render/vega.py
@@ -1,92 +1,12 @@
 import json
 import os
-from copy import copy, deepcopy
-from typing import Dict, List, Optional, Union
+from copy import deepcopy
+from typing import Dict, Optional
 
-from funcy import first
-
-from dvc.exceptions import DvcException
-from dvc.render.base import (
-    INDEX_FIELD,
-    REVISION_FIELD,
-    BadTemplateError,
-    Renderer,
-)
+from dvc.render.base import BadTemplateError, Renderer
+from dvc.render.data import to_datapoints
 from dvc.render.utils import get_files
-
-
-class PlotDataStructureError(DvcException):
-    def __init__(self):
-        super().__init__(
-            "Plot data extraction failed. Please see "
-            "https://man.dvc.org/plots for supported data formats."
-        )
-
-
-def _filter_fields(
-    datapoints: List[Dict], filename, revision, fields=None
-) -> List[Dict]:
-    if not fields:
-        return datapoints
-    assert isinstance(fields, set)
-
-    new_data = []
-    for data_point in datapoints:
-        new_dp = copy(data_point)
-
-        keys = set(data_point.keys())
-        if keys & fields != fields:
-            raise DvcException(
-                "Could not find fields: '{}' for '{}' at '{}'.".format(
-                    ", ".join(fields), filename, revision
-                )
-            )
-
-        to_del = keys - fields
-        for key in to_del:
-            del new_dp[key]
-        new_data.append(new_dp)
-    return new_data
-
-
-def _lists(dictionary):
-    for _, value in dictionary.items():
-        if isinstance(value, dict):
-            yield from _lists(value)
-        elif isinstance(value, list):
-            yield value
-
-
-def _find_data(data: Union[Dict, List], fields=None) -> List[Dict]:
-    if not isinstance(data, dict):
-        return data
-
-    if not fields:
-        # just look for first list of dicts
-        fields = set()
-
-    for lst in _lists(data):
-        if (
-            all(isinstance(dp, dict) for dp in lst)
-            and set(first(lst).keys()) & fields == fields
-        ):
-            return lst
-    raise PlotDataStructureError()
-
-
-def _append_index(datapoints: List[Dict], append_index=False) -> List[Dict]:
-    if not append_index or INDEX_FIELD in first(datapoints).keys():
-        return datapoints
-
-    for index, data_point in enumerate(datapoints):
-        data_point[INDEX_FIELD] = index
-    return datapoints
-
-
-def _append_revision(datapoints: List[Dict], revision) -> List[Dict]:
-    for data_point in datapoints:
-        data_point[REVISION_FIELD] = revision
-    return datapoints
+from dvc.repo.plots.template import Template
 
 
 class VegaRenderer(Renderer):
@@ -107,40 +27,15 @@ class VegaRenderer(Renderer):
     <script src="https://cdn.jsdelivr.net/npm/vega-embed@6.18.2"></script>
     """
 
-    def _squash_props(self) -> Dict:
-        resolved: Dict[str, str] = {}
-        for rev_data in self.data.values():
-            for file_data in rev_data.get("data", {}).values():
-                props = file_data.get("props", {})
-                resolved = {**resolved, **props}
-        return resolved
+    def __init__(
+        self, data: Dict, template: Template, properties: Dict = None
+    ):
+        super().__init__(data)
+        self.properties = properties or {}
+        self.template = template
 
     def _revisions(self):
         return list(self.data.keys())
-
-    def _datapoints(self, props: Dict):
-        fields = props.get("fields", set())
-        if fields:
-            fields = {*fields, props.get("x"), props.get("y")} - {None}
-
-        datapoints = []
-        for revision, rev_data in self.data.items():
-            for filename, file_data in rev_data.get("data", {}).items():
-                if "data" in file_data:
-                    tmp = deepcopy(file_data.get("data"))
-                    tmp = _find_data(tmp, fields=fields - {INDEX_FIELD})
-                    tmp = _append_index(
-                        tmp, append_index=props.get("append_index", False)
-                    )
-                    tmp = _filter_fields(
-                        tmp,
-                        filename=filename,
-                        revision=revision,
-                        fields=fields,
-                    )
-                    tmp = _append_revision(tmp, revision=revision)
-                    datapoints.extend(tmp)
-        return datapoints
 
     def _fill_template(self, template, datapoints, props=None):
         props = props or {}
@@ -172,24 +67,13 @@ class VegaRenderer(Renderer):
         return content
 
     def get_filled_template(self):
-        props = self._squash_props()
-
-        template = self.templates.load(props.get("template", None))
-
-        if not props.get("x") and template.has_anchor("x"):
-            props["append_index"] = True
-            props["x"] = INDEX_FIELD
-
-        datapoints = self._datapoints(props)
+        props = self.properties
+        datapoints, final_props = to_datapoints(self.data, props)
 
         if datapoints:
-            if not props.get("y") and template.has_anchor("y"):
-                fields = list(first(datapoints))
-                skip = (REVISION_FIELD, props.get("x"))
-                props["y"] = first(
-                    f for f in reversed(fields) if f not in skip
-                )
-            filled_template = self._fill_template(template, datapoints, props)
+            filled_template = self._fill_template(
+                self.template, datapoints, final_props
+            )
 
             return filled_template
         return None

--- a/tests/unit/command/test_plots.py
+++ b/tests/unit/command/test_plots.py
@@ -54,7 +54,7 @@ def test_plots_diff(dvc, mocker, plots_data):
     cmd = cli_args.func(cli_args)
     m = mocker.patch("dvc.repo.plots.diff.diff", return_value=plots_data)
     render_mock = mocker.patch(
-        "dvc.command.plots.render", return_value="html_path"
+        "dvc.render.utils.render", return_value="html_path"
     )
 
     assert cmd.run() == 0
@@ -99,7 +99,7 @@ def test_plots_show_vega(dvc, mocker, plots_data):
         return_value=plots_data,
     )
     render_mock = mocker.patch(
-        "dvc.command.plots.render", return_value="html_path"
+        "dvc.render.utils.render", return_value="html_path"
     )
 
     assert cmd.run() == 0
@@ -126,10 +126,10 @@ def test_plots_diff_vega(dvc, mocker, capsys, plots_data):
     cmd = cli_args.func(cli_args)
     mocker.patch("dvc.repo.plots.diff.diff", return_value=plots_data)
     mocker.patch(
-        "dvc.command.plots.VegaRenderer.asdict",
+        "dvc.render.VegaRenderer.asdict",
         return_value={"this": "is vega json"},
     )
-    render_mock = mocker.patch("dvc.command.plots.render")
+    render_mock = mocker.patch("dvc.render.utils.render")
     assert cmd.run() == 0
 
     out, _ = capsys.readouterr()
@@ -155,7 +155,7 @@ def test_plots_diff_open(tmp_dir, dvc, mocker, capsys, plots_data, auto_open):
     mocker.patch("dvc.repo.plots.diff.diff", return_value=plots_data)
 
     index_path = tmp_dir / "dvc_plots" / "index.html"
-    mocker.patch("dvc.command.plots.render", return_value=index_path)
+    mocker.patch("dvc.render.utils.render", return_value=index_path)
 
     assert cmd.run() == 0
     mocked_open.assert_called_once_with(index_path.as_uri())
@@ -177,7 +177,7 @@ def test_plots_diff_open_WSL(tmp_dir, dvc, mocker, plots_data):
     mocker.patch("dvc.repo.plots.diff.diff", return_value=plots_data)
 
     index_path = tmp_dir / "dvc_plots" / "index.html"
-    mocker.patch("dvc.command.plots.render", return_value=index_path)
+    mocker.patch("dvc.render.utils.render", return_value=index_path)
 
     assert cmd.run() == 0
     mocked_open.assert_called_once_with(str(Path("dvc_plots") / "index.html"))
@@ -252,9 +252,9 @@ def test_should_call_render(tmp_dir, mocker, capsys, plots_data, output):
     output = output or "dvc_plots"
     index_path = tmp_dir / output / "index.html"
     renderers = mocker.MagicMock()
-    mocker.patch("dvc.command.plots.match_renderers", return_value=renderers)
+    mocker.patch("dvc.render.utils.match_renderers", return_value=renderers)
     render_mock = mocker.patch(
-        "dvc.command.plots.render", return_value=index_path
+        "dvc.render.utils.render", return_value=index_path
     )
 
     assert cmd.run() == 0
@@ -287,8 +287,8 @@ def test_plots_diff_json(dvc, mocker, capsys):
     mocker.patch("dvc.repo.plots.diff.diff", return_value=data)
 
     renderers = mocker.MagicMock()
-    mocker.patch("dvc.command.plots.match_renderers", return_value=renderers)
-    render_mock = mocker.patch("dvc.command.plots.render")
+    mocker.patch("dvc.render.utils.match_renderers", return_value=renderers)
+    render_mock = mocker.patch("dvc.render.utils.render")
 
     show_json_mock = mocker.patch("dvc.command.plots._show_json")
 

--- a/tests/unit/render/test_data.py
+++ b/tests/unit/render/test_data.py
@@ -1,0 +1,161 @@
+from collections import OrderedDict
+
+import pytest
+
+from dvc.render.data import (
+    Converter,
+    FieldsNotFoundError,
+    _filter_fields,
+    _find_first_list,
+    _lists,
+    to_datapoints,
+)
+
+
+def test_find_first_list_in_dict():
+    m1 = [{"accuracy": 1, "loss": 2}, {"accuracy": 3, "loss": 4}]
+    m2 = [{"x": 1}, {"x": 2}]
+    dmetric = OrderedDict([("t1", m1), ("t2", m2)])
+
+    assert _find_first_list(dmetric, fields=set()) == m1
+    assert _find_first_list(dmetric, fields={"x"}) == m2
+
+
+def test_filter_fields():
+    m = [{"accuracy": 1, "loss": 2}, {"accuracy": 3, "loss": 4}]
+
+    assert _filter_fields(m, fields=set()) == m
+
+    expected = [{"accuracy": 1}, {"accuracy": 3}]
+    assert _filter_fields(m, fields={"accuracy"}) == expected
+
+    with pytest.raises(FieldsNotFoundError):
+        _filter_fields(m, fields={"bad_field"})
+
+
+@pytest.mark.parametrize(
+    "dictionary, expected_result",
+    [
+        ({}, []),
+        ({"x": ["a", "b", "c"]}, [["a", "b", "c"]]),
+        (
+            OrderedDict([("x", {"y": ["a", "b"]}), ("z", {"w": ["c", "d"]})]),
+            [["a", "b"], ["c", "d"]],
+        ),
+    ],
+)
+def test_finding_lists(dictionary, expected_result):
+    result = _lists(dictionary)
+
+    assert list(result) == expected_result
+
+
+@pytest.mark.parametrize(
+    "input_data,properties,expected_datapoints,expected_properties",
+    [
+        (
+            # default x and y
+            {"metric": [{"v": 1}, {"v": 2}]},
+            {},
+            [{"v": 1, "step": 0}, {"v": 2, "step": 1}],
+            {"x": "step", "y": "v"},
+        ),
+        (
+            # filter fields
+            {"metric": [{"v": 1, "v2": 0.1}, {"v": 2, "v2": 0.2}]},
+            {"fields": {"v"}},
+            [{"v": 1, "step": 0}, {"v": 2, "step": 1}],
+            {
+                "x": "step",
+                "y": "v",
+                "fields": {"v", "step"},
+            },
+        ),
+        (
+            # choose x and y
+            {"metric": [{"v": 1, "v2": 0.1}, {"v": 2, "v2": 0.2}]},
+            {"x": "v", "y": "v2"},
+            [{"v": 1, "v2": 0.1}, {"v": 2, "v2": 0.2}],
+            {"x": "v", "y": "v2"},
+        ),
+        (
+            # append x and y to filtered fields
+            {
+                "metric": [
+                    {"v": 1, "v2": 0.1, "v3": 0.01, "v4": 0.001},
+                    {"v": 2, "v2": 0.2, "v3": 0.02, "v4": 0.002},
+                ]
+            },
+            {"x": "v3", "y": "v4", "fields": {"v"}},
+            [
+                {"v": 1, "v3": 0.01, "v4": 0.001},
+                {"v": 2, "v3": 0.02, "v4": 0.002},
+            ],
+            {"x": "v3", "y": "v4", "fields": {"v", "v3", "v4"}},
+        ),
+        (
+            # find metric in nested structure
+            {
+                "some": "noise",
+                "very": {
+                    "nested": {
+                        "metric": [{"v": 1, "v2": 0.1}, {"v": 2, "v2": 0.2}]
+                    }
+                },
+            },
+            {"x": "v", "y": "v2"},
+            [{"v": 1, "v2": 0.1}, {"v": 2, "v2": 0.2}],
+            {"x": "v", "y": "v2"},
+        ),
+    ],
+)
+def test_convert(
+    input_data, properties, expected_datapoints, expected_properties
+):
+    converter = Converter(properties)
+    datapoints, resolved_properties = converter.convert(input_data)
+
+    assert datapoints == expected_datapoints
+    assert resolved_properties == expected_properties
+
+
+def test_convert_skip_step():
+    converter = Converter()
+    converter.skip_step("append_index")
+
+    datapoints, resolved_properties = converter.convert(
+        {"a": "b", "metric": [{"v": 1}, {"v": 2}]}
+    )
+
+    assert datapoints == [{"v": 1}, {"v": 2}]
+    assert resolved_properties == {"x": "step", "y": "v"}
+
+
+def test_to_datapoints():
+    input_data = {
+        "revision": {
+            "data": {
+                "filename": {
+                    "data": {
+                        "metric": [
+                            {"v": 1, "v2": 0.1, "v3": 0.01, "v4": 0.001},
+                            {"v": 2, "v2": 0.2, "v3": 0.02, "v4": 0.002},
+                        ]
+                    }
+                }
+            }
+        }
+    }
+    props = {"fields": {"v"}, "x": "v2", "y": "v3"}
+
+    datapoints, resolved_properties = to_datapoints(input_data, props)
+
+    assert datapoints == [
+        {"v": 1, "v2": 0.1, "v3": 0.01, "rev": "revision"},
+        {"v": 2, "v2": 0.2, "v3": 0.02, "rev": "revision"},
+    ]
+    assert resolved_properties == {
+        "fields": {"v", "v2", "v3"},
+        "x": "v2",
+        "y": "v3",
+    }

--- a/tests/unit/render/test_render.py
+++ b/tests/unit/render/test_render.py
@@ -69,7 +69,9 @@ def test_render(tmp_dir, dvc):
 
     def get_vega_string(data, filename):
         file_data = dpath.util.search(data, ["*", "*", filename])
-        return VegaRenderer(file_data, dvc.plots.templates).partial_html()
+        return VegaRenderer(
+            file_data, dvc.plots.templates.load()
+        ).partial_html()
 
     index_content = index_path.read_text()
     assert clean(get_vega_string(data, "file.json")) in clean(index_content)

--- a/tests/unit/repo/plots/test_templates.py
+++ b/tests/unit/repo/plots/test_templates.py
@@ -1,0 +1,45 @@
+import os
+
+import pytest
+
+from dvc.repo.plots.template import TemplateNotFoundError
+
+
+def test_raise_on_no_template(tmp_dir, dvc):
+    with pytest.raises(TemplateNotFoundError):
+        dvc.plots.templates.load("non_existing_template.json")
+
+
+@pytest.mark.parametrize(
+    "template_path, target_name",
+    [
+        (os.path.join(".dvc", "plots", "template.json"), "template"),
+        (os.path.join(".dvc", "plots", "template.json"), "template.json"),
+        (
+            os.path.join(".dvc", "plots", "subdir", "template.json"),
+            os.path.join("subdir", "template.json"),
+        ),
+        (
+            os.path.join(".dvc", "plots", "subdir", "template.json"),
+            os.path.join("subdir", "template"),
+        ),
+        ("template.json", "template.json"),
+    ],
+)
+def test_load_template(tmp_dir, dvc, template_path, target_name):
+    os.makedirs(os.path.abspath(os.path.dirname(template_path)), exist_ok=True)
+    with open(template_path, "w", encoding="utf-8") as fd:
+        fd.write("template_content")
+
+    assert dvc.plots.templates.load(target_name).content == "template_content"
+
+
+def test_load_default_template(tmp_dir, dvc):
+    with open(
+        os.path.join(dvc.plots.templates.templates_dir, "linear.json"),
+        "r",
+        encoding="utf-8",
+    ) as fd:
+        content = fd.read()
+
+    assert dvc.plots.templates.load(None).content == content


### PR DESCRIPTION
Fixes: #6943

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

@Suor I am addressing #6943 here which is a result of our [discussion in iterative/viewer#2657](https://github.com/iterative/viewer/issues/2657#issuecomment-939674364)

`dvc/render/utils.py::to_datapoints` accepts `data` and `props`, so you should be able to provide your own properties, which should allow to address the disrepancies between `dvc` and studio plot properties resolving.