### PR TITLE
tests: run on Windows with Python 3.10

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,8 +29,8 @@ jobs:
         python-version: 3.8
     - name: Install requirements
       run: |
-        pip install wheel
-        pip install ".[all,tests,terraform]" pre-commit
+        pip install --upgrade pip setuptools wheel
+        pip install ".[dev]" pre-commit
     - name: install temporary dependencies
       run: |
         pip install git+https://github.com/isidentical/gdrivefs@service-account
@@ -46,10 +46,6 @@ jobs:
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-latest]
         pyv: ["3.7", "3.8", "3.9.7", "3.10"]
-        exclude:
-          # no wheels for pygit2 yet
-          - os: windows-latest
-            pyv: "3.10"
     steps:
     - uses: actions/checkout@v2.4.0
       with:
@@ -74,7 +70,7 @@ jobs:
       if: steps.cache.pip-cache-dir.cache-hit != 'true'
       run: |
         pip install --upgrade pip setuptools wheel
-        pip install -e ".[all,tests,terraform]"
+        pip install -e ".[dev]"
     - name: install temporary dependencies
       run: |
         pip install git+https://github.com/isidentical/gdrivefs@service-account

--- a/setup.cfg
+++ b/setup.cfg
@@ -123,7 +123,8 @@ tests =
     pytest-xdist==2.4.0
     pytest-mock==3.6.1
     pytest-lazy-fixture==0.6.3
-    pytest-docker==0.10.3
+    # https://github.com/docker/docker-py/issues/2902
+    pytest-docker==0.10.3; python_version < '3.10' or sys_platform != 'win32'
     flaky==3.7.0
     mock==4.0.3
     rangehttpserver==1.2.0


### PR DESCRIPTION
pygit2 wheels should be now available.
Had to skip pytest-docker for Windows + Python 3.10 due to a dependency issue, see: docker/docker-py#2902.
