### PR TITLE
scm: remove ignore list

### DIFF
--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -368,7 +368,8 @@ class Repo:
         if path_isin(self.odb.local.cache_dir, self.root_dir):
             flist += [self.odb.local.cache_dir]
 
-        self.scm.ignore_list(flist)
+        for file in flist:
+            self.scm_context.ignore(file)
 
     def brancher(self, *args, **kwargs):
         from dvc.repo.brancher import brancher

--- a/dvc/scm/base.py
+++ b/dvc/scm/base.py
@@ -99,10 +99,6 @@ class Base:
     def ignore_file(self):
         """Filename for a file that contains ignored paths for this SCM."""
 
-    def ignore_list(self, p_list):
-        """Makes SCM ignore all paths specified in a list."""
-        return [self.ignore(path) for path in p_list]
-
     def add(self, paths):
         """Makes SCM track every path from a specified list of paths."""
 

--- a/tests/func/test_repo_index.py
+++ b/tests/func/test_repo_index.py
@@ -200,7 +200,7 @@ def test_dumpd(dvc):
 
 
 def test_unique_identifier(tmp_dir, dvc, scm, run_copy):
-    dvc.config["core"]["autostage"] = True
+    dvc.scm_context.autostage = True
     tmp_dir.dvc_gen("foo", "foo")
     run_copy("foo", "bar", name="copy-foo-bar")
 


### PR DESCRIPTION
There is no `scm_context.ignore_list`. Instead of adding APIs, I am removing its use and replacing it with a loop (which is what it really did).

Looking at the code, I think we should really stop having side effects by just initializing a `Repo` instance:
https://github.com/iterative/dvc/blob/318b269ad118f198bb97b203e151529398da0f54/dvc/repo/__init__.py#L206-L219

