### PR TITLE
tests: timeout only on functions, excluding tests fixtures

### DIFF
--- a/tests/func/experiments/test_init.py
+++ b/tests/func/experiments/test_init.py
@@ -10,7 +10,7 @@ from dvc.repo.experiments.init import init
 from dvc.stage.exceptions import DuplicateStageName
 
 # the tests may hang on prompts on failure
-pytestmark = pytest.mark.timeout(1)
+pytestmark = pytest.mark.timeout(1, func_only=True)
 
 
 def test_init_simple(tmp_dir, scm, dvc, capsys):

--- a/tests/func/experiments/test_init.py
+++ b/tests/func/experiments/test_init.py
@@ -10,7 +10,7 @@ from dvc.repo.experiments.init import init
 from dvc.stage.exceptions import DuplicateStageName
 
 # the tests may hang on prompts on failure
-pytestmark = pytest.mark.timeout(1, func_only=True)
+pytestmark = pytest.mark.timeout(2, func_only=True)
 
 
 def test_init_simple(tmp_dir, scm, dvc, capsys):


### PR DESCRIPTION
Sometimes, `tmp_dir` fixtures take longer than a second. Using `func_only`
makes it only consider the duration of test function run, excluding fixtures
duration.

