### PR TITLE
dvc.scm: refactor exceptions

### DIFF
--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -16,12 +16,14 @@ from dvc.exceptions import (
     PathMissingError,
 )
 from dvc.repo import Repo
+from dvc.scm import map_scm_exception
 from dvc.utils import relpath
 
 logger = logging.getLogger(__name__)
 
 
 @contextmanager
+@map_scm_exception()
 def external_repo(
     url, rev=None, for_write=False, cache_dir=None, cache_types=None, **kwargs
 ):

--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -198,6 +198,8 @@ def _clone_default_branch(url, rev, for_write=False):
                     logger.debug("erepo: git pull '%s'", url)
                     git.pull()
         else:
+            from dvc.scm import clone
+
             logger.debug("erepo: git clone '%s' to a temporary dir", url)
             clone_path = tempfile.mkdtemp("dvc-clone")
             if not for_write and rev and not Git.is_sha(rev):
@@ -205,7 +207,7 @@ def _clone_default_branch(url, rev, for_write=False):
                 from dvc.scm.base import CloneError
 
                 try:
-                    git = Git.clone(url, clone_path, shallow_branch=rev)
+                    git = clone(url, clone_path, shallow_branch=rev)
                     shallow = True
                     logger.debug(
                         "erepo: using shallow clone for branch '%s'", rev
@@ -213,7 +215,7 @@ def _clone_default_branch(url, rev, for_write=False):
                 except CloneError:
                     pass
             if not git:
-                git = Git.clone(url, clone_path)
+                git = clone(url, clone_path)
                 shallow = False
             CLONES[url] = (clone_path, shallow)
     finally:

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -286,7 +286,10 @@ class Repo:
 
         assert self.scm
         if isinstance(self.fs, LocalFileSystem):
-            return self.scm.get_rev()
+            from dvc.scm import map_scm_exception
+
+            with map_scm_exception():
+                return self.scm.get_rev()
         return self.fs.rev
 
     @cached_property

--- a/dvc/repo/brancher.py
+++ b/dvc/repo/brancher.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 from funcy import group_by
 
 
@@ -58,7 +60,10 @@ def brancher(  # noqa: E302
 
     try:
         if revs:
-            for sha, names in group_by(scm.resolve_rev, revs).items():
+            from dvc.scm import resolve_rev
+
+            rev_resolver = partial(resolve_rev, scm)
+            for sha, names in group_by(rev_resolver, revs).items():
                 self.fs = scm.get_fs(sha)
                 # ignore revs that don't contain repo root
                 # (i.e. revs from before a subdir=True repo was init'ed)

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -409,7 +409,9 @@ class Experiments:
                 self.scm.reset()
 
         if checkpoint_resume:
-            resume_rev = self.scm.resolve_rev(checkpoint_resume)
+            from dvc.scm import resolve_rev
+
+            resume_rev = resolve_rev(self.scm, checkpoint_resume)
             try:
                 self.check_baseline(resume_rev)
                 checkpoint_resume = resume_rev
@@ -879,7 +881,9 @@ class Experiments:
         return self._get_baseline(rev)
 
     def _get_baseline(self, rev):
-        rev = self.scm.resolve_rev(rev)
+        from dvc.scm import resolve_rev
+
+        rev = resolve_rev(self.scm, rev)
 
         if rev in self.stash_revs:
             entry = self.stash_revs.get(rev)

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -42,7 +42,9 @@ def scm_locked(f):
     # different sequences of git operations at once
     @wraps(f)
     def wrapper(exp, *args, **kwargs):
-        with exp.scm_lock:
+        from dvc.scm import map_scm_exception
+
+        with map_scm_exception(), exp.scm_lock:
             return f(exp, *args, **kwargs)
 
     return wrapper

--- a/dvc/repo/experiments/apply.py
+++ b/dvc/repo/experiments/apply.py
@@ -3,7 +3,6 @@ import os
 
 from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
-from dvc.scm.base import RevError
 from dvc.utils.fs import remove
 
 from .base import (
@@ -21,13 +20,14 @@ logger = logging.getLogger(__name__)
 @scm_context
 def apply(repo, rev, force=True, **kwargs):
     from dvc.repo.checkout import checkout as dvc_checkout
-    from dvc.scm.base import SCMError
+    from dvc.scm import resolve_rev
+    from dvc.scm.base import RevError, SCMError
     from dvc.scm.exceptions import MergeConflictError
 
     exps = repo.experiments
 
     try:
-        exp_rev = repo.scm.resolve_rev(rev)
+        exp_rev = resolve_rev(repo.scm, rev)
         exps.check_baseline(exp_rev)
     except (RevError, BaselineMismatchError) as exc:
         raise InvalidExpRevError(rev) from exc

--- a/dvc/repo/experiments/apply.py
+++ b/dvc/repo/experiments/apply.py
@@ -21,7 +21,8 @@ logger = logging.getLogger(__name__)
 @scm_context
 def apply(repo, rev, force=True, **kwargs):
     from dvc.repo.checkout import checkout as dvc_checkout
-    from dvc.scm.base import MergeConflictError, SCMError
+    from dvc.scm.base import SCMError
+    from dvc.scm.exceptions import MergeConflictError
 
     exps = repo.experiments
 

--- a/dvc/repo/experiments/apply.py
+++ b/dvc/repo/experiments/apply.py
@@ -46,7 +46,12 @@ def apply(repo, rev, force=True, **kwargs):
     else:
         workspace = None
 
-    repo.scm.merge(exp_rev, commit=False)
+    from dvc.scm.exceptions import SCMError as _SCMError
+
+    try:
+        repo.scm.merge(exp_rev, commit=False)
+    except _SCMError as exc:
+        raise SCMError(str(exc))
 
     if workspace:
         try:
@@ -61,7 +66,7 @@ def apply(repo, rev, force=True, **kwargs):
                 repo.scm.reset(hard=True)
                 repo.scm.stash.pop()
                 raise ApplyConflictError(rev) from exc
-        except SCMError as exc:
+        except _SCMError as exc:
             raise ApplyConflictError(rev) from exc
         repo.scm.stash.drop()
     repo.scm.reset()

--- a/dvc/repo/experiments/branch.py
+++ b/dvc/repo/experiments/branch.py
@@ -14,8 +14,10 @@ logger = logging.getLogger(__name__)
 @locked
 @scm_context
 def branch(repo, exp_rev, branch_name, *args, **kwargs):
+    from dvc.scm import resolve_rev
+
     try:
-        rev = repo.scm.resolve_rev(exp_rev)
+        rev = resolve_rev(repo.scm, exp_rev)
     except RevError:
         raise InvalidArgumentError(exp_rev)
     ref_info = None

--- a/dvc/repo/experiments/diff.py
+++ b/dvc/repo/experiments/diff.py
@@ -9,13 +9,14 @@ logger = logging.getLogger(__name__)
 
 def diff(repo, *args, a_rev=None, b_rev=None, param_deps=False, **kwargs):
     from dvc.repo.experiments.show import _collect_experiment_commit
+    from dvc.scm import resolve_rev
 
     if repo.scm.no_commits:
         return {}
 
     if a_rev:
         a_rev = fix_exp_head(repo.scm, a_rev)
-        rev = repo.scm.resolve_rev(a_rev)
+        rev = resolve_rev(repo.scm, a_rev)
         old = _collect_experiment_commit(repo, rev, param_deps=param_deps)
     else:
         old = _collect_experiment_commit(
@@ -24,7 +25,7 @@ def diff(repo, *args, a_rev=None, b_rev=None, param_deps=False, **kwargs):
 
     if b_rev:
         b_rev = fix_exp_head(repo.scm, b_rev)
-        rev = repo.scm.resolve_rev(b_rev)
+        rev = resolve_rev(repo.scm, b_rev)
         new = _collect_experiment_commit(repo, rev, param_deps=param_deps)
     else:
         new = _collect_experiment_commit(

--- a/dvc/repo/experiments/ls.py
+++ b/dvc/repo/experiments/ls.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 
 from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
-from dvc.scm.base import RevError
 
 from .utils import (
     exp_refs,
@@ -18,11 +17,13 @@ logger = logging.getLogger(__name__)
 @locked
 @scm_context
 def ls(repo, *args, rev=None, git_remote=None, all_=False, **kwargs):
+    from dvc.scm import resolve_rev
+    from dvc.scm.base import RevError
     from dvc.scm.git import Git
 
     if rev:
         try:
-            rev = repo.scm.resolve_rev(rev)
+            rev = resolve_rev(repo.scm, rev)
         except RevError:
             if not (git_remote and Git.is_sha(rev)):
                 # This could be a remote rev that has not been fetched yet

--- a/dvc/repo/experiments/push.py
+++ b/dvc/repo/experiments/push.py
@@ -4,7 +4,7 @@ from dvc.exceptions import DvcException, InvalidArgumentError
 from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
 
-from .utils import exp_commits, resolve_exp_ref
+from .utils import exp_commits, push_refspec, resolve_exp_ref
 
 logger = logging.getLogger(__name__)
 
@@ -37,8 +37,13 @@ def push(
 
     refname = str(exp_ref)
     logger.debug("git push experiment '%s' -> '%s'", exp_ref, git_remote)
-    repo.scm.push_refspec(
-        git_remote, refname, refname, force=force, on_diverged=on_diverged
+    push_refspec(
+        repo.scm,
+        git_remote,
+        refname,
+        refname,
+        force=force,
+        on_diverged=on_diverged,
     )
 
     if push_cache:

--- a/dvc/repo/experiments/remove.py
+++ b/dvc/repo/experiments/remove.py
@@ -6,7 +6,7 @@ from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
 from dvc.scm.base import RevError
 
-from .utils import exp_refs, remove_exp_refs, resolve_exp_ref
+from .utils import exp_refs, push_refspec, remove_exp_refs, resolve_exp_ref
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +78,7 @@ def _remove_commited_exps(
             remove_exp_refs(repo.scm, remove_list)
         else:
             for ref_info in remove_list:
-                repo.scm.push_refspec(remote, None, str(ref_info))
+                push_refspec(repo.scm, remote, None, str(ref_info))
     return remain_list
 
 

--- a/dvc/repo/experiments/remove.py
+++ b/dvc/repo/experiments/remove.py
@@ -52,8 +52,11 @@ def _get_exp_stash_index(repo, ref_or_rev: str) -> Optional[int]:
     for _, ref_info in stash_revs.items():
         if ref_info.name == ref_or_rev:
             return ref_info.index
+
+    from dvc.scm import resolve_rev
+
     try:
-        rev = repo.scm.resolve_rev(ref_or_rev)
+        rev = resolve_rev(repo.scm, ref_or_rev)
         if rev in stash_revs:
             return stash_revs.get(rev).index
     except RevError:

--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -10,7 +10,6 @@ from dvc.repo.experiments.executor.base import ExecutorInfo
 from dvc.repo.experiments.utils import fix_exp_head
 from dvc.repo.metrics.show import _gather_metrics
 from dvc.repo.params.show import _gather_params
-from dvc.scm.base import SCMError
 from dvc.utils import error_handler, onerror_collect
 
 logger = logging.getLogger(__name__)
@@ -121,12 +120,16 @@ def show(
         raise InvalidArgumentError(f"Invalid number of commits '{num}'")
 
     if revs is None:
+        from dvc.scm import resolve_rev
+        from dvc.scm.base import RevError
+
         revs = []
         for n in range(num):
             try:
                 head = fix_exp_head(repo.scm, f"HEAD~{n}")
-                revs.append(repo.scm.resolve_rev(head))
-            except SCMError:
+                assert head
+                revs.append(resolve_rev(repo.scm, head))
+            except RevError:
                 break
 
     revs = OrderedDict(

--- a/dvc/repo/experiments/utils.py
+++ b/dvc/repo/experiments/utils.py
@@ -1,4 +1,4 @@
-from typing import Generator, Iterable, Optional, Set
+from typing import Callable, Generator, Iterable, Optional, Set
 
 from dvc.exceptions import InvalidArgumentError
 from dvc.scm.git import Git
@@ -49,11 +49,45 @@ def exp_refs_by_baseline(
         yield ExpRefInfo.from_ref(ref)
 
 
+def iter_remote_refs(
+    scm: "Git", url: str, base: Optional[str] = None, **kwargs
+):
+    from dvc.scm.base import GitAuthError, InvalidRemoteSCMRepo
+    from dvc.scm.exceptions import AuthError, InvalidRemote
+
+    try:
+        yield from scm.iter_remote_refs(url, base=base, **kwargs)
+    except InvalidRemote as exc:
+        raise InvalidRemoteSCMRepo(str(exc))
+    except AuthError as exc:
+        raise GitAuthError(str(exc))
+
+
+def push_refspec(
+    scm: "Git",
+    url: str,
+    src: Optional[str],
+    dest: str,
+    force: bool = False,
+    on_diverged: Optional[Callable[[str, str], bool]] = None,
+    **kwargs,
+):
+    from dvc.scm.base import GitAuthError
+    from dvc.scm.exceptions import AuthError
+
+    try:
+        return scm.push_refspec(
+            url, src, dest, force=force, on_diverged=on_diverged, **kwargs
+        )
+    except AuthError as exc:
+        raise GitAuthError(str(exc))
+
+
 def remote_exp_refs(
     scm: "Git", url: str
 ) -> Generator["ExpRefInfo", None, None]:
     """Iterate over all remote experiment refs."""
-    for ref in scm.iter_remote_refs(url, base=EXPS_NAMESPACE):
+    for ref in iter_remote_refs(scm, url, base=EXPS_NAMESPACE):
         if ref.startswith(EXEC_NAMESPACE) or ref == EXPS_STASH:
             continue
         yield ExpRefInfo.from_ref(ref)
@@ -73,7 +107,7 @@ def remote_exp_refs_by_baseline(
 ) -> Generator["ExpRefInfo", None, None]:
     """Iterate over all remote experiment refs with the specified baseline."""
     ref_info = ExpRefInfo(baseline_sha=rev)
-    for ref in scm.iter_remote_refs(url, base=str(ref_info)):
+    for ref in iter_remote_refs(scm, url, base=str(ref_info)):
         if ref.startswith(EXEC_NAMESPACE) or ref == EXPS_STASH:
             continue
         yield ExpRefInfo.from_ref(ref)

--- a/dvc/repo/scm_context.py
+++ b/dvc/repo/scm_context.py
@@ -37,15 +37,29 @@ class SCMContext:
         return self.scm.add(self.files_to_track)
 
     def ignore(self, path: str) -> None:
+        from dvc.scm.base import SCMError
+        from dvc.scm.exceptions import FileNotInRepoError
+
         logger.debug("Adding '%s' to gitignore file.", path)
-        gitignore_file = self.scm.ignore(path)
+        try:
+            gitignore_file = self.scm.ignore(path)
+        except FileNotInRepoError as exc:
+            raise SCMError(str(exc))
+
         if gitignore_file:
             self.track_file(gitignore_file)
             return self.ignored_paths.append(path)
 
     def ignore_remove(self, path: str) -> None:
+        from dvc.scm.base import SCMError
+        from dvc.scm.exceptions import FileNotInRepoError
+
         logger.debug("Removing '%s' from gitignore file.", path)
-        gitignore_file = self.scm.ignore_remove(path)
+        try:
+            gitignore_file = self.scm.ignore_remove(path)
+        except FileNotInRepoError as exc:
+            raise SCMError(str(exc))
+
         if gitignore_file:
             return self.track_file(gitignore_file)
 

--- a/dvc/scm/__init__.py
+++ b/dvc/scm/__init__.py
@@ -31,3 +31,13 @@ def SCM(
         return NoSCM(root_dir)
 
     return Git(root_dir, search_parent_directories=search_parent_directories)
+
+
+def clone(url: str, to_path: str, **kwargs):
+    from .exceptions import CloneError as InternalCloneError
+    from .base import CloneError
+
+    try:
+        return Git.clone(url, to_path, **kwargs)
+    except InternalCloneError as exc:
+        raise CloneError(str(exc))

--- a/dvc/scm/__init__.py
+++ b/dvc/scm/__init__.py
@@ -26,11 +26,17 @@ def SCM(
     Returns:
         dvc.scm.base.Base: SCM instance.
     """
+    from dvc.scm.base import SCMError
+    from dvc.scm.exceptions import SCMError as InternalSCMError
 
-    if no_scm:
-        return NoSCM(root_dir)
-
-    return Git(root_dir, search_parent_directories=search_parent_directories)
+    try:
+        if no_scm:
+            return NoSCM(root_dir)
+        return Git(
+            root_dir, search_parent_directories=search_parent_directories
+        )
+    except InternalSCMError as exc:
+        raise SCMError(str(exc))
 
 
 def clone(url: str, to_path: str, **kwargs):

--- a/dvc/scm/__init__.py
+++ b/dvc/scm/__init__.py
@@ -34,10 +34,20 @@ def SCM(
 
 
 def clone(url: str, to_path: str, **kwargs):
-    from .exceptions import CloneError as InternalCloneError
     from .base import CloneError
+    from .exceptions import CloneError as InternalCloneError
 
     try:
         return Git.clone(url, to_path, **kwargs)
     except InternalCloneError as exc:
         raise CloneError(str(exc))
+
+
+def resolve_rev(scm: "Git", rev: str) -> str:
+    from .base import RevError
+    from .exceptions import RevError as InternalRevError
+
+    try:
+        return scm.resolve_rev(rev)
+    except InternalRevError as exc:
+        raise RevError(str(exc))

--- a/dvc/scm/base.py
+++ b/dvc/scm/base.py
@@ -29,18 +29,13 @@ class NoSCMError(SCMError):
 
 
 class InvalidRemoteSCMRepo(SCMError):
-    def __init__(self, url: str):
-        msg = f"'{url}' is not a valid Git remote or URL"
-        super().__init__(msg)
+    pass
 
 
 class GitAuthError(SCMError):
-    def __init__(self, url: str):
-        super().__init__(
-            f"HTTP Git authentication is not supported: '{url}'"
-            "\nSee https://dvc.org/doc//user-guide/"
-            "troubleshooting#git-auth"
-        )
+    def __init__(self, reason: str) -> None:
+        doc = "See https://dvc.org/doc//user-guide/troubleshooting#git-auth"
+        super().__init__(f"{reason}\n{doc}")
 
 
 class Base:

--- a/dvc/scm/base.py
+++ b/dvc/scm/base.py
@@ -9,12 +9,6 @@ class SCMError(DvcException):
     """Base class for source control management errors."""
 
 
-class FileNotInRepoError(SCMError):
-    """Thrown when trying to find .gitignore for a file that is not in a scm
-    repository.
-    """
-
-
 class CloneError(SCMError):
     def __init__(self, url, path):
         super().__init__(f"Failed to clone repo '{url}' to '{path}'")
@@ -32,10 +26,6 @@ class NoSCMError(SCMError):
             "configuration with `dvc config core.no_scm false`."
         )
         super().__init__(msg)
-
-
-class MergeConflictError(SCMError):
-    pass
 
 
 class InvalidRemoteSCMRepo(SCMError):

--- a/dvc/scm/base.py
+++ b/dvc/scm/base.py
@@ -10,8 +10,7 @@ class SCMError(DvcException):
 
 
 class CloneError(SCMError):
-    def __init__(self, url, path):
-        super().__init__(f"Failed to clone repo '{url}' to '{path}'")
+    pass
 
 
 class RevError(SCMError):

--- a/dvc/scm/exceptions.py
+++ b/dvc/scm/exceptions.py
@@ -28,3 +28,10 @@ class AuthError(SCMError):
     def __init__(self, url: str) -> None:
         self.url = url
         super().__init__(f"HTTP Git authentication is not supported: '{url}'")
+
+
+class CloneError(SCMError):
+    def __init__(self, url: str, path: str) -> None:
+        self.url = url
+        self.path = path
+        super().__init__(f"Failed to clone repo '{url}' to '{path}'")

--- a/dvc/scm/exceptions.py
+++ b/dvc/scm/exceptions.py
@@ -35,3 +35,7 @@ class CloneError(SCMError):
         self.url = url
         self.path = path
         super().__init__(f"Failed to clone repo '{url}' to '{path}'")
+
+
+class RevError(SCMError):
+    pass

--- a/dvc/scm/exceptions.py
+++ b/dvc/scm/exceptions.py
@@ -6,3 +6,13 @@ class GitHookAlreadyExists(SCMError):
     def __init__(self, name: str) -> None:
         self.name = name
         super().__init__(f"Hook '{name}' already exists")
+
+
+class FileNotInRepoError(SCMError):
+    """Thrown when trying to find .gitignore for a file that is not in a scm
+    repository.
+    """
+
+
+class MergeConflictError(SCMError):
+    pass

--- a/dvc/scm/exceptions.py
+++ b/dvc/scm/exceptions.py
@@ -16,3 +16,15 @@ class FileNotInRepoError(SCMError):
 
 class MergeConflictError(SCMError):
     pass
+
+
+class InvalidRemote(SCMError):
+    def __init__(self, url: str) -> None:
+        self.url = url
+        super().__init__(f"'{url}' is not a valid Git remote or URL")
+
+
+class AuthError(SCMError):
+    def __init__(self, url: str) -> None:
+        self.url = url
+        super().__init__(f"HTTP Git authentication is not supported: '{url}'")

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -11,7 +11,8 @@ from typing import Dict, Iterable, Optional, Tuple, Type
 from funcy import cached_property, first
 from pathspec.patterns import GitWildMatchPattern
 
-from dvc.scm.base import Base, FileNotInRepoError, RevError
+from dvc.scm.base import Base, RevError
+from dvc.scm.exceptions import FileNotInRepoError
 from dvc.utils import relpath
 from dvc.utils.fs import path_isin
 

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -12,11 +12,14 @@ from funcy import cached_property, first
 from pathspec.patterns import GitWildMatchPattern
 
 from dvc.scm.base import Base
-from dvc.scm.exceptions import FileNotInRepoError, RevError
+from dvc.scm.exceptions import (
+    FileNotInRepoError,
+    GitHookAlreadyExists,
+    RevError,
+)
 from dvc.utils import relpath
 from dvc.utils.fs import path_isin
 
-from ..exceptions import GitHookAlreadyExists
 from .backend.base import BaseGitBackend, NoGitBackendError
 from .backend.dulwich import DulwichBackend
 from .backend.gitpython import GitPythonBackend

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -11,8 +11,8 @@ from typing import Dict, Iterable, Optional, Tuple, Type
 from funcy import cached_property, first
 from pathspec.patterns import GitWildMatchPattern
 
-from dvc.scm.base import Base, RevError
-from dvc.scm.exceptions import FileNotInRepoError
+from dvc.scm.base import Base
+from dvc.scm.exceptions import FileNotInRepoError, RevError
 from dvc.utils import relpath
 from dvc.utils.fs import path_isin
 

--- a/dvc/scm/git/backend/base.py
+++ b/dvc/scm/git/backend/base.py
@@ -10,7 +10,7 @@ from typing import (
     Union,
 )
 
-from dvc.scm.base import SCMError
+from dvc.scm.exceptions import SCMError
 
 from ..objects import GitObject
 

--- a/dvc/scm/git/backend/dulwich/__init__.py
+++ b/dvc/scm/git/backend/dulwich/__init__.py
@@ -19,8 +19,7 @@ from typing import (
 from funcy import cached_property
 
 from dvc.progress import Tqdm
-from dvc.scm.base import SCMError
-from dvc.scm.exceptions import AuthError, InvalidRemote
+from dvc.scm.exceptions import AuthError, InvalidRemote, SCMError
 from dvc.utils import relpath
 
 from ...objects import GitObject

--- a/dvc/scm/git/backend/gitpython.py
+++ b/dvc/scm/git/backend/gitpython.py
@@ -17,8 +17,12 @@ from typing import (
 from funcy import ignore
 
 from dvc.progress import Tqdm
-from dvc.scm.base import SCMError
-from dvc.scm.exceptions import CloneError, MergeConflictError, RevError
+from dvc.scm.exceptions import (
+    CloneError,
+    MergeConflictError,
+    RevError,
+    SCMError,
+)
 from dvc.utils import fix_env, is_binary, relpath
 
 from ..objects import GitCommit, GitObject

--- a/dvc/scm/git/backend/gitpython.py
+++ b/dvc/scm/git/backend/gitpython.py
@@ -17,7 +17,8 @@ from typing import (
 from funcy import ignore
 
 from dvc.progress import Tqdm
-from dvc.scm.base import CloneError, MergeConflictError, RevError, SCMError
+from dvc.scm.base import CloneError, RevError, SCMError
+from dvc.scm.exceptions import MergeConflictError
 from dvc.utils import fix_env, is_binary, relpath
 
 from ..objects import GitCommit, GitObject

--- a/dvc/scm/git/backend/gitpython.py
+++ b/dvc/scm/git/backend/gitpython.py
@@ -17,8 +17,8 @@ from typing import (
 from funcy import ignore
 
 from dvc.progress import Tqdm
-from dvc.scm.base import RevError, SCMError
-from dvc.scm.exceptions import MergeConflictError, CloneError
+from dvc.scm.base import SCMError
+from dvc.scm.exceptions import CloneError, MergeConflictError, RevError
 from dvc.utils import fix_env, is_binary, relpath
 
 from ..objects import GitCommit, GitObject

--- a/dvc/scm/git/backend/gitpython.py
+++ b/dvc/scm/git/backend/gitpython.py
@@ -17,8 +17,8 @@ from typing import (
 from funcy import ignore
 
 from dvc.progress import Tqdm
-from dvc.scm.base import CloneError, RevError, SCMError
-from dvc.scm.exceptions import MergeConflictError
+from dvc.scm.base import RevError, SCMError
+from dvc.scm.exceptions import MergeConflictError, CloneError
 from dvc.utils import fix_env, is_binary, relpath
 
 from ..objects import GitCommit, GitObject

--- a/dvc/scm/git/backend/pygit2.py
+++ b/dvc/scm/git/backend/pygit2.py
@@ -17,7 +17,8 @@ from typing import (
 
 from funcy import cached_property
 
-from dvc.scm.base import MergeConflictError, RevError, SCMError
+from dvc.scm.base import RevError, SCMError
+from dvc.scm.exceptions import MergeConflictError
 from dvc.utils import relpath
 
 from ..objects import GitCommit, GitObject

--- a/dvc/scm/git/backend/pygit2.py
+++ b/dvc/scm/git/backend/pygit2.py
@@ -17,8 +17,7 @@ from typing import (
 
 from funcy import cached_property
 
-from dvc.scm.base import SCMError
-from dvc.scm.exceptions import MergeConflictError, RevError
+from dvc.scm.exceptions import MergeConflictError, RevError, SCMError
 from dvc.utils import relpath
 
 from ..objects import GitCommit, GitObject

--- a/dvc/scm/git/backend/pygit2.py
+++ b/dvc/scm/git/backend/pygit2.py
@@ -17,8 +17,8 @@ from typing import (
 
 from funcy import cached_property
 
-from dvc.scm.base import RevError, SCMError
-from dvc.scm.exceptions import MergeConflictError
+from dvc.scm.base import SCMError
+from dvc.scm.exceptions import MergeConflictError, RevError
 from dvc.utils import relpath
 
 from ..objects import GitCommit, GitObject

--- a/dvc/scm/git/stash.py
+++ b/dvc/scm/git/stash.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Optional
 
-from dvc.scm.base import SCMError
+from dvc.scm.exceptions import SCMError
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/scm/test_git.py
+++ b/tests/unit/scm/test_git.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from dvc.scm.base import SCMError
+from dvc.scm.exceptions import SCMError
 
 
 # Behaves the same as SCM but will test against all supported Git backends.

--- a/tests/unit/scm/test_git.py
+++ b/tests/unit/scm/test_git.py
@@ -344,7 +344,7 @@ def test_commit_no_verify(tmp_dir, scm, git, hook):
 
 @pytest.mark.parametrize("squash", [True, False])
 def test_merge(tmp_dir, scm, git, squash):
-    from dvc.scm.base import MergeConflictError
+    from dvc.scm.exceptions import MergeConflictError
 
     if git.test_backend == "dulwich":
         pytest.skip()
@@ -399,7 +399,7 @@ def test_checkout_index(tmp_dir, scm, git):
     "strategy, expected", [("ours", "baz"), ("theirs", "bar")]
 )
 def test_checkout_index_conflicts(tmp_dir, scm, git, strategy, expected):
-    from dvc.scm.base import MergeConflictError
+    from dvc.scm.exceptions import MergeConflictError
 
     if git.test_backend == "dulwich":
         pytest.skip()

--- a/tests/unit/scm/test_git.py
+++ b/tests/unit/scm/test_git.py
@@ -422,7 +422,7 @@ def test_checkout_index_conflicts(tmp_dir, scm, git, strategy, expected):
 
 
 def test_resolve_rev(tmp_dir, scm, make_tmp_dir, git):
-    from dvc.scm.base import RevError
+    from dvc.scm.exceptions import RevError
 
     if git.test_backend == "dulwich":
         pytest.skip()


### PR DESCRIPTION
This PR splits scm-related exceptions into two kinds:
1. Internal scm exceptions that are in `dvc.scm.exceptions` and likely going to be available as `scmrepo.exceptions`.
2. External DVC-related exceptions in `dvc.scm.base` that is required for UI and dvc's API to work.
   This will be available in `dvc.scm` when we migrate.

So, due to 2, there are some exceptions with the same name in both 1 and 2, but they serve a different purpose and are just reraised from one to another.

This PR is still incomplete, in that we have to decide what to do with raised `SCMError` exceptions. As DVC is unaware of these exceptions, places where we are checking for `DvcException` or where we just exit from the `main`, it will throw errors with:
```
Having any troubles? Hit us up at https://dvc.org/support, we are always happy to help!
```

There may definitely be some UI issues with this breakage, which we need to discuss. The easiest path forward that I see is to make these changes and fix them in the future as we find them.

The other way would require us to go through chains of API calls where we raise `dvc.scm.exceptions.SCMError` and catch those and reraise those as `dvc.scm.base.SCMError`.

