### PR TITLE
scm: remove dependency from DvcException

### DIFF
--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -216,18 +216,6 @@ class DvcIgnoreInCollectedDirError(DvcException):
         )
 
 
-class GitHookAlreadyExistsError(DvcException):
-    def __init__(self, hook_name):
-        from dvc.utils import format_link
-
-        super().__init__(
-            "Hook '{}' already exists. Please refer to {} for more "
-            "info.".format(
-                hook_name, format_link("https://man.dvc.org/install")
-            )
-        )
-
-
 class FileTransferError(DvcException):
     _METHOD = "transfer"
 

--- a/dvc/repo/install.py
+++ b/dvc/repo/install.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING
 
+from dvc.exceptions import DvcException
+
 if TYPE_CHECKING:
     from dvc.repo import Repo
     from dvc.scm.git import Git
@@ -41,9 +43,17 @@ def pre_commit_install(scm: "Git") -> None:
 
 
 def install_hooks(scm: "Git") -> None:
+    from dvc.scm.exceptions import GitHookAlreadyExists
+    from dvc.utils import format_link
+
     hooks = ["post-checkout", "pre-commit", "pre-push"]
     for hook in hooks:
-        scm.verify_hook(hook)
+        try:
+            scm.verify_hook(hook)
+        except GitHookAlreadyExists as exc:
+            link = format_link("https://man.dvc.org/install")
+            raise DvcException(f"{exc}. Please refer to {link} for more info.")
+
     for hook in hooks:
         scm.install_hook(hook, f"exec dvc git-hook {hook} $@")
 

--- a/dvc/scm/exceptions.py
+++ b/dvc/scm/exceptions.py
@@ -1,0 +1,8 @@
+class SCMError(Exception):
+    """Base class for source control management errors."""
+
+
+class GitHookAlreadyExists(SCMError):
+    def __init__(self, name: str) -> None:
+        self.name = name
+        super().__init__(f"Hook '{name}' already exists")

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -11,11 +11,11 @@ from typing import Dict, Iterable, Optional, Tuple, Type
 from funcy import cached_property, first
 from pathspec.patterns import GitWildMatchPattern
 
-from dvc.exceptions import GitHookAlreadyExistsError
 from dvc.scm.base import Base, FileNotInRepoError, RevError
 from dvc.utils import relpath
 from dvc.utils.fs import path_isin
 
+from ..exceptions import GitHookAlreadyExists
 from .backend.base import BaseGitBackend, NoGitBackendError
 from .backend.dulwich import DulwichBackend
 from .backend.gitpython import GitPythonBackend
@@ -204,7 +204,7 @@ class Git(Base):
 
     def verify_hook(self, name):
         if (self.hooks_dir / name).exists():
-            raise GitHookAlreadyExistsError(name)
+            raise GitHookAlreadyExists(name)
 
     def install_hook(
         self, name: str, script: str, interpreter: str = "sh"

--- a/tests/func/test_install.py
+++ b/tests/func/test_install.py
@@ -5,8 +5,9 @@ import sys
 import pytest
 from git import GitCommandError
 
-from dvc.exceptions import GitHookAlreadyExistsError
+from dvc.exceptions import DvcException
 from dvc.utils import file_md5
+from tests.func.parsing.test_errors import escape_ansi
 
 
 @pytest.mark.skipif(
@@ -39,8 +40,13 @@ class TestInstall:
     def test_fail_if_hook_exists(self, scm, dvc):
         self._hook("post-checkout").write_text("hook content")
 
-        with pytest.raises(GitHookAlreadyExistsError):
+        with pytest.raises(DvcException) as exc_info:
             dvc.install()
+
+        assert escape_ansi(str(exc_info.value)) == (
+            "Hook 'post-checkout' already exists. "
+            "Please refer to <https://man.dvc.org/install> for more info."
+        )
 
     def test_pre_commit_hook(self, tmp_dir, scm, dvc, caplog):
         tmp_dir.dvc_gen("file", "file content", commit="create foo")


### PR DESCRIPTION
Also introduces `dvc.scm.exceptions.SCMError` which is going to be an internal exception which all of the exceptions in `scmrepo` are going to inherit from. `dvc.scm.base.SCMError` will be renamed in the future after we extract `scmrepo`.