### PR TITLE
[WIP] exp run: support naive remote execution via `--machine`

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -623,6 +623,7 @@ class CmdExperimentsRun(CmdRepro):
             checkpoint_resume=self.args.checkpoint_resume,
             reset=self.args.reset,
             tmp_dir=self.args.tmp_dir,
+            machine=self.args.machine,
             **self._repro_kwargs,
         )
 
@@ -1550,4 +1551,13 @@ def _add_run_common(parser):
             "Run this experiment in a separate temporary directory instead of "
             "your workspace."
         ),
+    )
+    parser.add_argument(
+        "--machine",
+        default=None,
+        help=argparse.SUPPRESS,
+        # help=(
+        #     "Run this experiment on the specified 'dvc machine' instance."
+        # ),
+        # metavar="<name>",
     )

--- a/dvc/machine/__init__.py
+++ b/dvc/machine/__init__.py
@@ -29,7 +29,7 @@ RESERVED_NAMES = {"local", "localhost"}
 
 DEFAULT_STARTUP_SCRIPT = """#!/bin/bash
 sudo apt-get update
-sudo apt-get install --yes python3 python3-pip
+sudo apt-get install --yes python3 python3-pip python3-venv
 python3 -m pip install --upgrade pip
 
 pushd /etc/apt/sources.list.d

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -777,9 +777,8 @@ class Experiments:
                 raise CheckpointExistsError(ref_info.name)
             raise ExperimentExistsError(ref_info.name)
 
-        for ref in executor.fetch_exps(
+        for ref in executor.collect_exps(
             self.scm,
-            executor.git_url,
             force=exec_result.force,
             on_diverged=on_diverged,
         ):

--- a/dvc/repo/experiments/executor/base.py
+++ b/dvc/repo/experiments/executor/base.py
@@ -141,6 +141,10 @@ class BaseExecutor(ABC):
     def cleanup(self):
         pass
 
+    @property
+    def worker_kwargs(self):
+        return {}
+
     # TODO: come up with better way to stash repro arguments
     @staticmethod
     def pack_repro_args(path, *args, fs=None, extra=None, **kwargs):
@@ -161,8 +165,9 @@ class BaseExecutor(ABC):
             pickle.dump(data, fobj)
 
     @staticmethod
-    def unpack_repro_args(path):
-        with open(path, "rb") as fobj:
+    def unpack_repro_args(path, fs=None):
+        open_func = fs.open if fs else open
+        with open_func(path, "rb") as fobj:
             data = pickle.load(fobj)
         return data["args"], data["kwargs"]
 


### PR DESCRIPTION
* [ ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

WIP version of what was demo'd here:
[![asciicast](https://asciinema.org/a/zZJoVzT6oXmMH80GwYM3GyTwl.svg)](https://asciinema.org/a/zZJoVzT6oXmMH80GwYM3GyTwl)

Depending on what we decide to do regarding https://github.com/iterative/dvc/discussions/7002, it may make more sense to implement the (local) process management first and then come back to this, since the process management work will end up needing some `experiments.executor` reorganization