### PR TITLE
scm: unified progress reporting in a structured way

### DIFF
--- a/dvc/repo/experiments/executor/local.py
+++ b/dvc/repo/experiments/executor/local.py
@@ -85,12 +85,14 @@ class TempDirExecutor(BaseLocalExecutor):
     def _init_git(self, scm: "Git", branch: Optional[str] = None, **kwargs):
         from dulwich.repo import Repo as DulwichRepo
 
+        from ..utils import push_refspec
+
         DulwichRepo.init(os.fspath(self.root_dir))
 
         refspec = f"{EXEC_NAMESPACE}/"
-        scm.push_refspec(self.git_url, refspec, refspec, **kwargs)
+        push_refspec(scm, self.git_url, refspec, refspec, **kwargs)
         if branch:
-            scm.push_refspec(self.git_url, branch, branch, **kwargs)
+            push_refspec(scm, self.git_url, branch, branch, **kwargs)
             self.scm.set_ref(EXEC_BRANCH, branch, symbolic=True)
         elif self.scm.get_ref(EXEC_BRANCH):
             self.scm.remove_ref(EXEC_BRANCH)

--- a/dvc/repo/experiments/executor/ssh.py
+++ b/dvc/repo/experiments/executor/ssh.py
@@ -104,6 +104,8 @@ class SSHExecutor(BaseExecutor):
         return kwargs
 
     def _init_git(self, scm: "Git", branch: Optional[str] = None, **kwargs):
+        from ..utils import push_refspec
+
         with self.sshfs() as fs:
             fs.makedirs(self.root_dir)
             self._ssh_cmd(fs, "git init .")
@@ -120,9 +122,9 @@ class SSHExecutor(BaseExecutor):
             # (see https://github.com/iterative/dvc/issues/6508)
             kwargs.update(self._git_client_args(fs))
             refspec = f"{EXEC_NAMESPACE}/"
-            scm.push_refspec(self.git_url, refspec, refspec, **kwargs)
+            push_refspec(scm, self.git_url, refspec, refspec, **kwargs)
             if branch:
-                scm.push_refspec(self.git_url, branch, branch, **kwargs)
+                push_refspec(scm, self.git_url, branch, branch, **kwargs)
                 self._ssh_cmd(fs, f"git symbolic-ref {EXEC_BRANCH} {branch}")
             else:
                 self._ssh_cmd(

--- a/dvc/repo/experiments/pull.py
+++ b/dvc/repo/experiments/pull.py
@@ -31,9 +31,17 @@ def pull(
 
     refspec = f"{exp_ref}:{exp_ref}"
     logger.debug("git pull experiment '%s' -> '%s'", git_remote, refspec)
-    repo.scm.fetch_refspecs(
-        git_remote, [refspec], force=force, on_diverged=on_diverged
-    )
+
+    from dvc.scm import TqdmGit
+
+    with TqdmGit(desc="Fetching git refs") as pbar:
+        repo.scm.fetch_refspecs(
+            git_remote,
+            [refspec],
+            force=force,
+            on_diverged=on_diverged,
+            progress=pbar.update_git,
+        )
 
     if pull_cache:
         _pull_cache(repo, exp_ref, **kwargs)

--- a/dvc/repo/experiments/push.py
+++ b/dvc/repo/experiments/push.py
@@ -37,14 +37,19 @@ def push(
 
     refname = str(exp_ref)
     logger.debug("git push experiment '%s' -> '%s'", exp_ref, git_remote)
-    push_refspec(
-        repo.scm,
-        git_remote,
-        refname,
-        refname,
-        force=force,
-        on_diverged=on_diverged,
-    )
+
+    from dvc.scm import TqdmGit
+
+    with TqdmGit(desc="Pushing git refs") as pbar:
+        push_refspec(
+            repo.scm,
+            git_remote,
+            refname,
+            refname,
+            force=force,
+            on_diverged=on_diverged,
+            progress=pbar.update_git,
+        )
 
     if push_cache:
         _push_cache(repo, exp_ref, **kwargs)

--- a/dvc/repo/experiments/remove.py
+++ b/dvc/repo/experiments/remove.py
@@ -80,8 +80,17 @@ def _remove_commited_exps(
         if not remote:
             remove_exp_refs(repo.scm, remove_list)
         else:
+            from dvc.scm import TqdmGit
+
             for ref_info in remove_list:
-                push_refspec(repo.scm, remote, None, str(ref_info))
+                with TqdmGit(desc="Pushing git refs") as pbar:
+                    push_refspec(
+                        repo.scm,
+                        remote,
+                        None,
+                        str(ref_info),
+                        progress=pbar.update_git,
+                    )
     return remain_list
 
 

--- a/dvc/scm/git/backend/base.py
+++ b/dvc/scm/git/backend/base.py
@@ -15,6 +15,8 @@ from dvc.scm.exceptions import SCMError
 from ..objects import GitObject
 
 if TYPE_CHECKING:
+    from dvc.scm.progress import GitProgressEvent
+
     from ..objects import GitCommit
 
 
@@ -49,6 +51,7 @@ class BaseGitBackend(ABC):
         to_path: str,
         rev: Optional[str] = None,
         shallow_branch: Optional[str] = None,
+        progress: Callable[["GitProgressEvent"], None] = None,
     ):
         pass
 
@@ -197,6 +200,7 @@ class BaseGitBackend(ABC):
         dest: str,
         force: bool = False,
         on_diverged: Optional[Callable[[str, str], bool]] = None,
+        progress: Callable[["GitProgressEvent"], None] = None,
         **kwargs,
     ):
         """Push refspec to a remote Git repo.
@@ -223,6 +227,7 @@ class BaseGitBackend(ABC):
         refspecs: Iterable[str],
         force: Optional[bool] = False,
         on_diverged: Optional[Callable[[str, str], bool]] = None,
+        progress: Callable[["GitProgressEvent"], None] = None,
         **kwargs,
     ):
         """Fetch refspecs from a remote Git repo.

--- a/dvc/scm/git/backend/pygit2.py
+++ b/dvc/scm/git/backend/pygit2.py
@@ -27,8 +27,8 @@ logger = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
+    from dvc.scm.progress import GitProgressEvent
     from dvc.types import StrPath
-
 
 # NOTE: constant from libgit2 git2/checkout.h
 # This can be removed after next pygit2 release:
@@ -153,6 +153,7 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
         to_path: str,
         rev: Optional[str] = None,
         shallow_branch: Optional[str] = None,
+        progress: Callable[["GitProgressEvent"], None] = None,
     ):
         raise NotImplementedError
 
@@ -374,6 +375,7 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
         dest: str,
         force: bool = False,
         on_diverged: Optional[Callable[[str, str], bool]] = None,
+        progress: Callable[["GitProgressEvent"], None] = None,
         **kwargs,
     ):
         raise NotImplementedError
@@ -384,6 +386,7 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
         refspecs: Iterable[str],
         force: Optional[bool] = False,
         on_diverged: Optional[Callable[[str, str], bool]] = None,
+        progress: Callable[["GitProgressEvent"], None] = None,
         **kwargs,
     ):
         raise NotImplementedError

--- a/dvc/scm/progress.py
+++ b/dvc/scm/progress.py
@@ -1,0 +1,73 @@
+from typing import NamedTuple, Optional, Union
+
+from funcy import compose
+
+
+def code2desc(op_code):
+    from git import RootUpdateProgress as OP
+
+    ops = {
+        OP.COUNTING: "Counting",
+        OP.COMPRESSING: "Compressing",
+        OP.WRITING: "Writing",
+        OP.RECEIVING: "Receiving",
+        OP.RESOLVING: "Resolving",
+        OP.FINDING_SOURCES: "Finding sources",
+        OP.CHECKING_OUT: "Checking out",
+        OP.CLONE: "Cloning",
+        OP.FETCH: "Fetching",
+        OP.UPDWKTREE: "Updating working tree",
+        OP.REMOVE: "Removing",
+        OP.PATHCHANGE: "Changing path",
+        OP.URLCHANGE: "Changing URL",
+        OP.BRANCHCHANGE: "Changing branch",
+    }
+    return ops.get(op_code & OP.OP_MASK, "")
+
+
+class GitProgressEvent(NamedTuple):
+    phase: str = ""
+    completed: Optional[int] = None
+    total: Optional[int] = None
+    message: str = ""
+
+    @classmethod
+    def parsed_from_gitpython(
+        cls,
+        op_code,
+        cur_count,
+        max_count=None,
+        message="",  # pylint: disable=redefined-outer-name
+    ):
+        return cls(code2desc(op_code), cur_count, max_count, message)
+
+
+class GitProgressReporter:
+    def __init__(self, fn) -> None:
+        from git.util import CallableRemoteProgress
+
+        self._reporter = CallableRemoteProgress(self.wrap_fn(fn))
+
+    def __call__(self, msg: Union[str, bytes]) -> None:
+        self._reporter._parse_progress_line(
+            msg.decode("ascii").strip() if isinstance(msg, bytes) else msg
+        )
+
+    @staticmethod
+    def wrap_fn(fn):
+        return compose(fn, GitProgressEvent.parsed_from_gitpython)
+
+
+if __name__ == "__main__":
+    message = """
+Cloning into 'dvcyaml-schema'...
+remote: Enumerating objects: 76, done.
+remote: Counting objects: 100% (76/76), done.
+remote: Compressing objects: 100% (56/56), done.
+remote: Total 76 (delta 30), reused 38 (delta 9), pack-reused 0
+Receiving objects: 100% (76/76), 24.83 KiB | 89.00 KiB/s, done.
+Resolving deltas: 100% (30/30), done."""
+
+    reporter = GitProgressReporter(print)
+    for line in message.splitlines():
+        reporter(line)

--- a/tests/func/test_external_repo.py
+++ b/tests/func/test_external_repo.py
@@ -140,7 +140,9 @@ def test_shallow_clone_branch(erepo_dir):
             with repo.open_by_relpath("file") as fd:
                 assert fd.read() == "branch"
 
-        mock_clone.assert_called_with(url, ANY, shallow_branch="branch")
+        mock_clone.assert_called_with(
+            url, ANY, shallow_branch="branch", progress=ANY
+        )
         _, shallow = CLONES[url]
         assert shallow
 
@@ -166,7 +168,9 @@ def test_shallow_clone_tag(erepo_dir):
             with repo.open_by_relpath("file") as fd:
                 assert fd.read() == "foo"
 
-        mock_clone.assert_called_with(url, ANY, shallow_branch="v1")
+        mock_clone.assert_called_with(
+            url, ANY, shallow_branch="v1", progress=ANY
+        )
         _, shallow = CLONES[url]
         assert shallow
 


### PR DESCRIPTION
This adds a support for reporting progress from Git in a structured
format. The gitpython already provides somewhat structured progress
reporting, dulwich on the other hand only provides git-like line
messages.

As gitpython uses git binary, it already parse this line format
in a structured way. This PR makes dulwich use the same machinery
to unify progress reporting for both dulwich and gitpython python.

This does add a dependency on gitpython even on dulwich backend,
so I am iffy if we should do this.

The alternative is to translate gitpython's progress reports to
string, and just use string messages as progress reports on both
dulwich and gitpython.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
