### PR TITLE
scm: restructure scm

### DIFF
--- a/dvc/analytics.py
+++ b/dvc/analytics.py
@@ -84,8 +84,9 @@ def send(path):
 def _scm_in_use():
     from dvc.exceptions import NotDvcRepoError
     from dvc.repo import Repo
-    from dvc.scm import SCM, NoSCM
-    from dvc.scm.base import SCMError
+    from dvc.scm.noscm import NoSCM
+
+    from .scm import SCM, SCMError
 
     try:
         scm = SCM(root_dir=Repo.find_root())

--- a/dvc/dvcfile.py
+++ b/dvc/dvcfile.py
@@ -60,7 +60,7 @@ def is_lock_file(path):
 
 def is_git_ignored(repo, path):
     from dvc.fs.local import LocalFileSystem
-    from dvc.scm.base import NoSCMError
+    from dvc.scm import NoSCMError
 
     try:
         return isinstance(repo.fs, LocalFileSystem) and repo.scm.is_ignored(

--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -16,7 +16,7 @@ from dvc.exceptions import (
     PathMissingError,
 )
 from dvc.repo import Repo
-from dvc.scm import map_scm_exception
+from dvc.scm import CloneError, map_scm_exception
 from dvc.utils import relpath
 
 logger = logging.getLogger(__name__)
@@ -206,7 +206,6 @@ def _clone_default_branch(url, rev, for_write=False):
             clone_path = tempfile.mkdtemp("dvc-clone")
             if not for_write and rev and not Git.is_sha(rev):
                 # If rev is a tag or branch name try shallow clone first
-                from dvc.scm.base import CloneError
 
                 try:
                     git = clone(url, clone_path, shallow_branch=rev)

--- a/dvc/info.py
+++ b/dvc/info.py
@@ -10,7 +10,7 @@ from dvc.exceptions import NotDvcRepoError
 from dvc.fs import FS_MAP, get_fs_cls, get_fs_config
 from dvc.fs.utils import test_links
 from dvc.repo import Repo
-from dvc.scm.base import SCMError
+from dvc.scm import SCMError
 from dvc.utils import error_link
 from dvc.utils.pkg import PKG
 

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
     from dvc.repo.scm_context import SCMContext
     from dvc.scm import Base
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -91,9 +90,7 @@ class Repo:
     ):
         assert bool(scm) == bool(rev)
 
-        from dvc.scm import SCM
-        from dvc.scm.base import SCMError
-        from dvc.scm.git import Git
+        from dvc.scm import SCM, Base, Git, SCMError
         from dvc.utils.fs import makedirs
 
         dvc_dir = None
@@ -112,8 +109,6 @@ class Repo:
                 scm = SCM(root_dir or os.curdir)
             except SCMError:
                 scm = SCM(os.curdir, no_scm=True)
-
-            from dvc.scm import Base
 
             assert isinstance(scm, Base)
             root_dir = scm.root_dir
@@ -254,8 +249,7 @@ class Repo:
 
     @cached_property
     def scm(self):
-        from dvc.scm import SCM
-        from dvc.scm.base import SCMError
+        from dvc.scm import SCM, SCMError
 
         if self._scm:
             return self._scm

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -91,7 +91,7 @@ class Experiments:
 
     def __init__(self, repo):
         from dvc.lock import make_lock
-        from dvc.scm.base import NoSCMError
+        from dvc.scm import NoSCMError
 
         if repo.config["core"].get("no_scm", False):
             raise NoSCMError

--- a/dvc/repo/experiments/apply.py
+++ b/dvc/repo/experiments/apply.py
@@ -20,8 +20,7 @@ logger = logging.getLogger(__name__)
 @scm_context
 def apply(repo, rev, force=True, **kwargs):
     from dvc.repo.checkout import checkout as dvc_checkout
-    from dvc.scm import resolve_rev
-    from dvc.scm.base import RevError, SCMError
+    from dvc.scm import RevError, SCMError, resolve_rev
     from dvc.scm.exceptions import MergeConflictError
 
     exps = repo.experiments

--- a/dvc/repo/experiments/branch.py
+++ b/dvc/repo/experiments/branch.py
@@ -3,7 +3,7 @@ import logging
 from dvc.exceptions import InvalidArgumentError
 from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
-from dvc.scm.base import RevError
+from dvc.scm import RevError
 
 from .base import InvalidExpRevError
 from .utils import exp_refs_by_rev

--- a/dvc/repo/experiments/executor/base.py
+++ b/dvc/repo/experiments/executor/base.py
@@ -224,7 +224,7 @@ class BaseExecutor(ABC):
 
     @classmethod
     def _validate_remotes(cls, dvc: "Repo", git_remote: Optional[str]):
-        from dvc.scm.base import InvalidRemoteSCMRepo
+        from dvc.scm import InvalidRemoteSCMRepo
         from dvc.scm.exceptions import InvalidRemote
 
         if git_remote == dvc.root_dir:

--- a/dvc/repo/experiments/ls.py
+++ b/dvc/repo/experiments/ls.py
@@ -17,8 +17,7 @@ logger = logging.getLogger(__name__)
 @locked
 @scm_context
 def ls(repo, *args, rev=None, git_remote=None, all_=False, **kwargs):
-    from dvc.scm import resolve_rev
-    from dvc.scm.base import RevError
+    from dvc.scm import RevError, resolve_rev
     from dvc.scm.git import Git
 
     if rev:

--- a/dvc/repo/experiments/remove.py
+++ b/dvc/repo/experiments/remove.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from dvc.exceptions import InvalidArgumentError
 from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
-from dvc.scm.base import RevError
+from dvc.scm import RevError
 
 from .utils import exp_refs, push_refspec, remove_exp_refs, resolve_exp_ref
 

--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -120,8 +120,7 @@ def show(
         raise InvalidArgumentError(f"Invalid number of commits '{num}'")
 
     if revs is None:
-        from dvc.scm import resolve_rev
-        from dvc.scm.base import RevError
+        from dvc.scm import RevError, resolve_rev
 
         revs = []
         for n in range(num):

--- a/dvc/repo/experiments/utils.py
+++ b/dvc/repo/experiments/utils.py
@@ -52,7 +52,7 @@ def exp_refs_by_baseline(
 def iter_remote_refs(
     scm: "Git", url: str, base: Optional[str] = None, **kwargs
 ):
-    from dvc.scm.base import GitAuthError, InvalidRemoteSCMRepo
+    from dvc.scm import GitAuthError, InvalidRemoteSCMRepo
     from dvc.scm.exceptions import AuthError, InvalidRemote
 
     try:
@@ -72,8 +72,9 @@ def push_refspec(
     on_diverged: Optional[Callable[[str, str], bool]] = None,
     **kwargs,
 ):
-    from dvc.scm.base import GitAuthError
     from dvc.scm.exceptions import AuthError
+
+    from ...scm import GitAuthError
 
     try:
         return scm.push_refspec(

--- a/dvc/repo/init.py
+++ b/dvc/repo/init.py
@@ -5,8 +5,7 @@ from dvc.config import Config
 from dvc.exceptions import InitError, InvalidArgumentError
 from dvc.ignore import init as init_dvcignore
 from dvc.repo import Repo
-from dvc.scm import SCM
-from dvc.scm.base import SCMError
+from dvc.scm import SCM, SCMError
 from dvc.utils import relpath
 from dvc.utils.fs import remove
 

--- a/dvc/repo/metrics/show.py
+++ b/dvc/repo/metrics/show.py
@@ -7,7 +7,7 @@ from dvc.output import Output
 from dvc.repo import locked
 from dvc.repo.collect import StrPaths, collect
 from dvc.repo.live import summary_fs_path
-from dvc.scm.base import NoSCMError
+from dvc.scm import NoSCMError
 from dvc.utils import error_handler, errored_revisions, onerror_collect
 from dvc.utils.serialize import load_yaml
 

--- a/dvc/repo/params/show.py
+++ b/dvc/repo/params/show.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple
 from dvc.dependency.param import ParamsDependency
 from dvc.repo import locked
 from dvc.repo.collect import collect
-from dvc.scm.base import NoSCMError
+from dvc.scm import NoSCMError
 from dvc.stage import PipelineStage
 from dvc.ui import ui
 from dvc.utils import error_handler, errored_revisions, onerror_collect

--- a/dvc/repo/scm_context.py
+++ b/dvc/repo/scm_context.py
@@ -37,7 +37,7 @@ class SCMContext:
         return self.scm.add(self.files_to_track)
 
     def ignore(self, path: str) -> None:
-        from dvc.scm.base import SCMError
+        from dvc.scm import SCMError
         from dvc.scm.exceptions import FileNotInRepoError
 
         logger.debug("Adding '%s' to gitignore file.", path)
@@ -51,7 +51,7 @@ class SCMContext:
             return self.ignored_paths.append(path)
 
     def ignore_remove(self, path: str) -> None:
-        from dvc.scm.base import SCMError
+        from dvc.scm import SCMError
         from dvc.scm.exceptions import FileNotInRepoError
 
         logger.debug("Removing '%s' from gitignore file.", path)
@@ -67,8 +67,6 @@ class SCMContext:
     def __call__(
         self, autostage: bool = None, quiet: bool = None
     ) -> Iterator["SCMContext"]:
-        from dvc.scm import NoSCM
-
         try:
             yield self
         except Exception:
@@ -85,6 +83,8 @@ class SCMContext:
             autostage = self.autostage
         if quiet is None:
             quiet = self.quiet
+
+        from dvc.scm import NoSCM
 
         if autostage:
             self.track_changed_files()

--- a/dvc/scm/base.py
+++ b/dvc/scm/base.py
@@ -1,47 +1,13 @@
 """Manages source control systems (e.g. Git) in DVC."""
 
-import os
-
-from dvc.exceptions import DvcException
-
-
-class SCMError(DvcException):
-    """Base class for source control management errors."""
-
-
-class CloneError(SCMError):
-    pass
-
-
-class RevError(SCMError):
-    pass
-
-
-class NoSCMError(SCMError):
-    def __init__(self):
-        msg = (
-            "Only supported for Git repositories. If you're "
-            "seeing this error in a Git repo, try updating the DVC "
-            "configuration with `dvc config core.no_scm false`."
-        )
-        super().__init__(msg)
-
-
-class InvalidRemoteSCMRepo(SCMError):
-    pass
-
-
-class GitAuthError(SCMError):
-    def __init__(self, reason: str) -> None:
-        doc = "See https://dvc.org/doc//user-guide/troubleshooting#git-auth"
-        super().__init__(f"{reason}\n{doc}")
-
 
 class Base:
     """Base class for source control management driver implementations."""
 
-    def __init__(self, root_dir=os.curdir):
-        self._root_dir = os.path.realpath(root_dir)
+    def __init__(self, root_dir=None):
+        import os
+
+        self._root_dir = os.path.realpath(root_dir or os.curdir)
 
     @property
     def root_dir(self) -> str:

--- a/dvc/scm/noscm.py
+++ b/dvc/scm/noscm.py
@@ -1,0 +1,16 @@
+from .base import Base
+
+
+# Syntactic sugar to signal that this is an actual implementation for a DVC
+# project under no SCM control.
+class NoSCM(Base):
+    def __init__(
+        self,
+        root_dir: str = None,
+        _raise_not_implemented_as=NotImplementedError,
+    ):
+        super().__init__(root_dir=root_dir)
+        self._exc = _raise_not_implemented_as
+
+    def __getattr__(self, name):
+        raise self._exc

--- a/tests/func/experiments/test_checkpoints.py
+++ b/tests/func/experiments/test_checkpoints.py
@@ -10,7 +10,7 @@ from dvc.repo.experiments import MultipleBranchError
 from dvc.repo.experiments.base import EXEC_APPLY, EXEC_CHECKPOINT
 from dvc.repo.experiments.executor.base import BaseExecutor
 from dvc.repo.experiments.utils import exp_refs_by_rev
-from dvc.scm.base import InvalidRemoteSCMRepo
+from dvc.scm import InvalidRemoteSCMRepo
 
 
 @pytest.mark.parametrize("workspace", [True, False])

--- a/tests/func/experiments/test_experiments.py
+++ b/tests/func/experiments/test_experiments.py
@@ -386,7 +386,7 @@ def test_branch(tmp_dir, scm, dvc, exp_stage):
 
 def test_no_scm(tmp_dir):
     from dvc.repo import Repo as DvcRepo
-    from dvc.scm.base import NoSCMError
+    from dvc.scm import NoSCMError
 
     dvc = DvcRepo.init(no_scm=True)
 

--- a/tests/func/experiments/test_remote.py
+++ b/tests/func/experiments/test_remote.py
@@ -255,7 +255,7 @@ def test_push_pull_cache(
 
 
 def test_auth_error_list(tmp_dir, scm, dvc, http_auth_patch):
-    from dvc.scm.base import GitAuthError
+    from dvc.scm import GitAuthError
 
     with pytest.raises(
         GitAuthError,
@@ -265,7 +265,7 @@ def test_auth_error_list(tmp_dir, scm, dvc, http_auth_patch):
 
 
 def test_auth_error_pull(tmp_dir, scm, dvc, http_auth_patch):
-    from dvc.scm.base import GitAuthError
+    from dvc.scm import GitAuthError
 
     with pytest.raises(
         GitAuthError,
@@ -275,7 +275,7 @@ def test_auth_error_pull(tmp_dir, scm, dvc, http_auth_patch):
 
 
 def test_auth_error_push(tmp_dir, scm, dvc, exp_stage, http_auth_patch):
-    from dvc.scm.base import GitAuthError
+    from dvc.scm import GitAuthError
 
     results = dvc.experiments.run(exp_stage.addressing, params=["foo=2"])
     exp = first(results)

--- a/tests/func/test_diff.py
+++ b/tests/func/test_diff.py
@@ -13,7 +13,7 @@ def digest(text):
 
 
 def test_no_scm(tmp_dir, dvc):
-    from dvc.scm.base import NoSCMError
+    from dvc.scm import NoSCMError
 
     tmp_dir.dvc_gen("file", "text")
 

--- a/tests/func/test_ls.py
+++ b/tests/func/test_ls.py
@@ -7,7 +7,7 @@ import pytest
 
 from dvc.exceptions import PathMissingError
 from dvc.repo import Repo
-from dvc.scm.base import CloneError
+from dvc.scm import CloneError
 
 FS_STRUCTURE = {
     "README.md": "content",

--- a/tests/func/test_scm.py
+++ b/tests/func/test_scm.py
@@ -4,8 +4,7 @@ import sys
 import pytest
 from git import Repo
 
-from dvc.scm import SCM, Git, NoSCM
-from dvc.scm.base import SCMError
+from dvc.scm import SCM, Git, NoSCM, SCMError
 from dvc.system import System
 from tests.basic_env import TestGitSubmodule
 from tests.utils import get_gitignore_content


### PR DESCRIPTION
Makes it easier to decouple, we'd only need to rename
`dvc/scm/__init__.py` to `dvc/scm.py`.

As this reorder imports, this may be considered a minor breaking change.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
