### PR TITLE
fs.git: refactor GitFileSystem to be fsspec compliant

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: codespell
         args: 
           - --ignore-words-list
-          - ba,datas,fo,uptodate
+          - ba,datas,fo,uptodate,cachable
     repo: https://github.com/codespell-project/codespell
     rev: v2.1.0
   - hooks:

--- a/dvc/fs/scm.py
+++ b/dvc/fs/scm.py
@@ -1,0 +1,72 @@
+import os
+import threading
+from typing import TYPE_CHECKING, Any, Callable
+
+from funcy import cached_property, wrap_prop
+
+from .fsspec_wrapper import AnyFSPath, FSSpecWrapper
+
+if TYPE_CHECKING:
+    from dvc.fs.git import GitFileSystem as FsspecGitFileSystem
+    from dvc.scm.git import Git
+    from dvc.scm.git.objects import GitTrie
+
+
+class GitFileSystem(FSSpecWrapper):  # pylint:disable=abstract-method
+    """Proxies the repo file access methods to Git objects"""
+
+    sep = os.sep
+    scheme = "local"
+
+    def __init__(
+        self,
+        path: str = None,
+        rev: str = None,
+        scm: "Git" = None,
+        trie: "GitTrie" = None,
+        **kwargs: Any,
+    ) -> None:
+        from dvc.scm import resolve_rev
+
+        super().__init__()
+        self.fs_args.update(
+            {
+                "path": path,
+                "rev": rev,
+                "scm": scm,
+                "trie": trie,
+                "rev_resolver": resolve_rev,
+                **kwargs,
+            }
+        )
+
+    @wrap_prop(threading.Lock())
+    @cached_property
+    def fs(self) -> "FsspecGitFileSystem":
+        from dvc.fs.git import GitFileSystem as FsspecGitFileSystem
+
+        return FsspecGitFileSystem(**self.fs_args)
+
+    @property
+    def rev(self) -> str:
+        return self.fs.rev
+
+    def isexec(self, path: AnyFSPath) -> bool:
+        from dvc.utils import is_exec
+
+        try:
+            return is_exec(self.info(path)["mode"])
+        except FileNotFoundError:
+            return False
+
+    def isfile(self, path: AnyFSPath) -> bool:
+        return self.fs.isfile(path)
+
+    def walk(
+        self,
+        top: AnyFSPath,
+        topdown: bool = True,
+        onerror: Callable[[OSError], None] = None,
+        **kwargs: Any,
+    ):
+        return self.fs.walk(top, topdown=topdown, onerror=onerror, **kwargs)

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -90,13 +90,18 @@ class Repo:
     ):
         assert bool(scm) == bool(rev)
 
+        from dvc.fs.scm import GitFileSystem
         from dvc.scm import SCM, Base, Git, SCMError
         from dvc.utils.fs import makedirs
 
         dvc_dir = None
         tmp_dir = None
         try:
-            fs = scm.get_fs(rev) if isinstance(scm, Git) and rev else None
+            fs = (
+                GitFileSystem(scm=scm, rev=rev)
+                if isinstance(scm, Git) and rev
+                else None
+            )
             root_dir = self.find_root(root_dir, fs)
             dvc_dir = os.path.join(root_dir, self.DVC_DIR)
             tmp_dir = os.path.join(dvc_dir, "tmp")
@@ -157,6 +162,7 @@ class Repo:
         from dvc.config import Config
         from dvc.data_cloud import DataCloud
         from dvc.fs.local import LocalFileSystem
+        from dvc.fs.scm import GitFileSystem
         from dvc.lock import LockNoop, make_lock
         from dvc.objects.db import ODBManager
         from dvc.repo.live import Live
@@ -164,7 +170,7 @@ class Repo:
         from dvc.repo.params import Params
         from dvc.repo.plots import Plots
         from dvc.repo.stage import StageLoad
-        from dvc.scm import SCM
+        from dvc.scm import SCM, Git
         from dvc.stage.cache import StageCache
         from dvc.state import State, StateNoop
 
@@ -179,7 +185,8 @@ class Repo:
         )
 
         if scm:
-            self._fs = scm.get_fs(rev)
+            assert isinstance(scm, Git)
+            self._fs = GitFileSystem(scm=scm, rev=rev)
         else:
             self._fs = LocalFileSystem(url=self.root_dir)
 

--- a/dvc/repo/brancher.py
+++ b/dvc/repo/brancher.py
@@ -60,11 +60,12 @@ def brancher(  # noqa: E302
 
     try:
         if revs:
+            from dvc.fs.scm import GitFileSystem
             from dvc.scm import resolve_rev
 
             rev_resolver = partial(resolve_rev, scm)
             for sha, names in group_by(rev_resolver, revs).items():
-                self.fs = scm.get_fs(sha)
+                self.fs = GitFileSystem(scm=scm, rev=sha)
                 # ignore revs that don't contain repo root
                 # (i.e. revs from before a subdir=True repo was init'ed)
                 if self.fs.exists(self.root_dir):

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -17,6 +17,7 @@ from dvc.scm.exceptions import (
     GitHookAlreadyExists,
     RevError,
 )
+from dvc.scm.utils import relpath
 
 from .backend.base import BaseGitBackend, NoGitBackendError
 from .backend.dulwich import DulwichBackend
@@ -146,7 +147,7 @@ class Git(Base):
         assert os.path.isabs(path)
         assert os.path.isabs(ignore_file_dir)
 
-        entry = os.path.relpath(path, ignore_file_dir).replace(os.sep, "/")
+        entry = relpath(path, ignore_file_dir).replace(os.sep, "/")
         # NOTE: using '/' prefix to make path unambiguous
         if len(entry) > 0 and entry[0] != "/":
             entry = "/" + entry
@@ -257,12 +258,7 @@ class Git(Base):
     def get_fs(self, rev: str):
         from dvc.fs.git import GitFileSystem
 
-        from .objects import GitTrie
-
-        resolved = self.resolve_rev(rev)
-        tree_obj = self.pygit2.get_tree_obj(rev=resolved)
-        trie = GitTrie(tree_obj, resolved)
-        return GitFileSystem(self.root_dir, trie)
+        return GitFileSystem(scm=self, rev=rev)
 
     is_ignored = partialmethod(_backend_func, "is_ignored")
     add = partialmethod(_backend_func, "add")

--- a/dvc/scm/git/backend/dulwich/__init__.py
+++ b/dvc/scm/git/backend/dulwich/__init__.py
@@ -19,6 +19,7 @@ from typing import (
 from funcy import cached_property
 
 from dvc.scm.exceptions import AuthError, InvalidRemote, SCMError
+from dvc.scm.utils import relpath
 
 from ...objects import GitObject
 from ..base import BaseGitBackend
@@ -160,26 +161,24 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
                 # parent git repo root). We append path to root_dir here so
                 # that the result of relpath(path, root_dir) is actually the
                 # path relative to the submodule root.
-                fs_path = os.path.relpath(path, self.root_dir)
+                fs_path = relpath(path, self.root_dir)
                 for sm_path in self._submodules.values():
                     if fs_path.startswith(sm_path):
                         path = os.path.join(
                             self.root_dir,
-                            os.path.relpath(fs_path, sm_path),
+                            relpath(fs_path, sm_path),
                         )
                         break
             if os.path.isdir(path):
                 files.extend(
                     os.fsencode(
-                        os.path.relpath(
-                            os.path.join(root, fpath), self.root_dir
-                        )
+                        relpath(os.path.join(root, fpath), self.root_dir)
                     )
                     for root, _, fs in os.walk(path)
                     for fpath in fs
                 )
             else:
-                files.append(os.fsencode(os.path.relpath(path, self.root_dir)))
+                files.append(os.fsencode(relpath(path, self.root_dir)))
 
         # NOTE: this doesn't check gitignore, same as GitPythonBackend.add
         if update:
@@ -244,11 +243,7 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
         return untracked
 
     def is_tracked(self, path: str) -> bool:
-        rel = (
-            os.path.relpath(path, self.root_dir)
-            .replace(os.path.sep, "/")
-            .encode()
-        )
+        rel = relpath(path, self.root_dir).replace(os.path.sep, "/").encode()
         rel_dir = rel + b"/"
         for p in self.repo.open_index():
             if p == rel or p.startswith(rel_dir):
@@ -305,7 +300,7 @@ class DulwichBackend(BaseGitBackend):  # pylint:disable=abstract-method
     def is_ignored(self, path: "Union[str, os.PathLike[str]]") -> bool:
         # `is_ignored` returns `false` if excluded in `.gitignore` and
         # `None` if it's not mentioned at all. `True` if it is ignored.
-        relative_path = os.path.relpath(path, self.root_dir)
+        relative_path = relpath(path, self.root_dir)
         # if checking a directory, a trailing slash must be included
         if str(path)[-1] == os.sep:
             relative_path += os.sep

--- a/dvc/scm/git/backend/gitpython.py
+++ b/dvc/scm/git/backend/gitpython.py
@@ -24,6 +24,7 @@ from dvc.scm.exceptions import (
     RevError,
     SCMError,
 )
+from dvc.scm.utils import relpath
 
 from ..objects import GitCommit, GitObject
 from .base import BaseGitBackend
@@ -557,7 +558,7 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
     def reset(self, hard: bool = False, paths: Iterable[str] = None):
         if paths:
             paths_list: Optional[List[str]] = [
-                os.path.relpath(path, self.root_dir) for path in paths
+                relpath(path, self.root_dir) for path in paths
             ]
             if os.name == "nt":
                 paths_list = [
@@ -590,7 +591,7 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
         else:
             if paths:
                 paths_list: Optional[List[str]] = [
-                    os.path.relpath(path, self.root_dir) for path in paths
+                    relpath(path, self.root_dir) for path in paths
                 ]
                 if os.name == "nt":
                     paths_list = [

--- a/dvc/scm/git/backend/pygit2.py
+++ b/dvc/scm/git/backend/pygit2.py
@@ -18,6 +18,7 @@ from typing import (
 from funcy import cached_property
 
 from dvc.scm.exceptions import MergeConflictError, RevError, SCMError
+from dvc.scm.utils import relpath
 
 from ..objects import GitCommit, GitObject
 from .base import BaseGitBackend
@@ -282,7 +283,7 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
         raise NotImplementedError
 
     def is_ignored(self, path: "Union[str, os.PathLike[str]]") -> bool:
-        rel = os.path.relpath(path, self.root_dir)
+        rel = relpath(path, self.root_dir)
         if os.name == "nt":
             rel.replace("\\", "/")
         return self.repo.path_is_ignored(rel)
@@ -471,7 +472,7 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
         if paths is not None:
             tree = self.repo.revparse_single("HEAD").tree
             for path in paths:
-                rel = os.path.relpath(path, self.root_dir)
+                rel = relpath(path, self.root_dir)
                 if os.name == "nt":
                     rel = rel.replace("\\", "/")
                 obj = tree[rel]
@@ -510,7 +511,7 @@ class Pygit2Backend(BaseGitBackend):  # pylint:disable=abstract-method
         index = self.repo.index
         if paths:
             path_list: Optional[List[str]] = [
-                os.path.relpath(path, self.root_dir) for path in paths
+                relpath(path, self.root_dir) for path in paths
             ]
             if os.name == "nt":
                 path_list = [

--- a/dvc/scm/utils.py
+++ b/dvc/scm/utils.py
@@ -1,0 +1,22 @@
+import os
+
+
+def relpath(path, start=os.curdir):
+    path = os.fspath(path)
+    start = os.path.abspath(os.fspath(start))
+
+    # Windows path on different drive than curdir doesn't have relpath
+    if os.name == "nt":
+        # Since python 3.8 os.realpath resolves network shares to their UNC
+        # path. So, to be certain that relative paths correctly captured,
+        # we need to resolve to UNC path first. We resolve only the drive
+        # name so that we don't follow any 'real' symlinks on the path
+        def resolve_network_drive_windows(path_to_resolve):
+            drive, tail = os.path.splitdrive(path_to_resolve)
+            return os.path.join(os.path.realpath(drive), tail)
+
+        path = resolve_network_drive_windows(os.path.abspath(path))
+        start = resolve_network_drive_windows(start)
+        if not os.path.commonprefix([start, path]):
+            return path
+    return os.path.relpath(path, start)

--- a/tests/func/experiments/test_experiments.py
+++ b/tests/func/experiments/test_experiments.py
@@ -32,7 +32,7 @@ def test_new_simple(tmp_dir, scm, dvc, exp_stage, mocker, name, workspace):
 
     new_mock.assert_called_once()
     fs = scm.get_fs(exp)
-    with fs.open(tmp_dir / "metrics.yaml") as fobj:
+    with fs.open(tmp_dir / "metrics.yaml", mode="r", encoding="utf-8") as fobj:
         assert fobj.read().strip() == "foo: 2"
 
     if workspace:
@@ -74,7 +74,7 @@ def test_experiment_exists(tmp_dir, scm, dvc, exp_stage, mocker, workspace):
     exp = first(results)
 
     fs = scm.get_fs(exp)
-    with fs.open(tmp_dir / "metrics.yaml") as fobj:
+    with fs.open(tmp_dir / "metrics.yaml", mode="r", encoding="utf-8") as fobj:
         assert fobj.read().strip() == "foo: 3"
 
 
@@ -144,7 +144,7 @@ def test_modify_params(tmp_dir, scm, dvc, mocker, changes, expected):
 
     new_mock.assert_called_once()
     fs = scm.get_fs(exp)
-    with fs.open(tmp_dir / "metrics.yaml") as fobj:
+    with fs.open(tmp_dir / "metrics.yaml", mode="r") as fobj:
         assert fobj.read().strip() == expected
 
 
@@ -262,9 +262,9 @@ def test_update_py_params(tmp_dir, scm, dvc):
     exp_a = first(results)
 
     fs = scm.get_fs(exp_a)
-    with fs.open(tmp_dir / "params.py") as fobj:
+    with fs.open(tmp_dir / "params.py", mode="r", encoding="utf-8") as fobj:
         assert fobj.read().strip() == "INT = 2"
-    with fs.open(tmp_dir / "metrics.py") as fobj:
+    with fs.open(tmp_dir / "metrics.py", mode="r", encoding="utf-8") as fobj:
         assert fobj.read().strip() == "INT = 2"
 
     tmp_dir.gen(
@@ -308,9 +308,9 @@ def test_update_py_params(tmp_dir, scm, dvc):
         return text.replace("\r\n", "\n")
 
     fs = scm.get_fs(exp_a)
-    with fs.open(tmp_dir / "params.py") as fobj:
+    with fs.open(tmp_dir / "params.py", mode="r", encoding="utf-8") as fobj:
         assert _dos2unix(fobj.read().strip()) == result
-    with fs.open(tmp_dir / "metrics.py") as fobj:
+    with fs.open(tmp_dir / "metrics.py", mode="r", encoding="utf-8") as fobj:
         assert _dos2unix(fobj.read().strip()) == result
 
     tmp_dir.gen("params.py", "INT = 1\n")
@@ -437,7 +437,7 @@ def test_untracked(tmp_dir, scm, dvc, caplog, workspace):
     assert fs.exists("dvc.yaml")
     assert fs.exists("dvc.lock")
     assert fs.exists("copy.py")
-    with fs.open(tmp_dir / "metrics.yaml") as fobj:
+    with fs.open(tmp_dir / "metrics.yaml", mode="r", encoding="utf-8") as fobj:
         assert fobj.read().strip() == "foo: 2"
 
 
@@ -515,7 +515,7 @@ def test_subdir(tmp_dir, scm, dvc, workspace):
     fs = scm.get_fs(exp)
     for fname in ["metrics.yaml", "dvc.lock"]:
         assert fs.exists(subdir / fname)
-    with fs.open(subdir / "metrics.yaml") as fobj:
+    with fs.open(subdir / "metrics.yaml", mode="r", encoding="utf-8") as fobj:
         assert fobj.read().strip() == "foo: 2"
 
     assert dvc.experiments.get_exact_name(exp) == ref_info.name
@@ -560,7 +560,7 @@ def test_subrepo(tmp_dir, scm, workspace):
     fs = scm.get_fs(exp)
     for fname in ["metrics.yaml", "dvc.lock"]:
         assert fs.exists(subrepo / fname)
-    with fs.open(subrepo / "metrics.yaml") as fobj:
+    with fs.open(subrepo / "metrics.yaml", mode="r", encoding="utf-8") as fobj:
         assert fobj.read().strip() == "foo: 2"
 
     assert subrepo.dvc.experiments.get_exact_name(exp) == ref_info.name
@@ -581,7 +581,9 @@ def test_queue(tmp_dir, scm, dvc, exp_stage, mocker):
     metrics = set()
     for exp in results:
         fs = scm.get_fs(exp)
-        with fs.open(tmp_dir / "metrics.yaml") as fobj:
+        with fs.open(
+            tmp_dir / "metrics.yaml", mode="r", encoding="utf-8"
+        ) as fobj:
             metrics.add(fobj.read().strip())
     assert expected == metrics
 

--- a/tests/func/test_ignore.py
+++ b/tests/func/test_ignore.py
@@ -123,6 +123,8 @@ def test_ignore_collecting_dvcignores(tmp_dir, dvc, dname):
 
 
 def test_ignore_on_branch(tmp_dir, scm, dvc):
+    from dvc.fs.scm import GitFileSystem
+
     tmp_dir.scm_gen({"foo": "foo", "bar": "bar"}, commit="add files")
 
     with tmp_dir.branch("branch", new=True):
@@ -137,7 +139,7 @@ def test_ignore_on_branch(tmp_dir, scm, dvc):
         (tmp_dir / DvcIgnore.DVCIGNORE_FILE).fs_path,
     }
 
-    dvc.fs = scm.get_fs("branch")
+    dvc.fs = GitFileSystem(scm=scm, rev="branch")
     assert dvc.dvcignore.is_ignored_file(tmp_dir / "foo")
 
 


### PR DESCRIPTION
Also adds a wrapper for DVC to use as GitFileSystem in dvc.fs.scm.
This is temporary, and will be renamed back to dvc.fs.git after the
split.

Note that this filesystem is not fully compliant, it's only
meant to be compatible with our previous implementation.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
