### PR TITLE
scm: remove dvc specific message; add client kwarg

### DIFF
--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -165,7 +165,7 @@ class Experiments:
                 the human-readable name in the experiment branch ref. Has no
                 effect of branch is specified.
         """
-        with self.scm.detach_head() as orig_head:
+        with self.scm.detach_head(client="dvc") as orig_head:
             stash_head = orig_head
             if baseline_rev is None:
                 baseline_rev = orig_head
@@ -810,7 +810,7 @@ class Experiments:
         # `checkout --force` here will not lose any data (popping stash commit
         # will result in conflict between workspace params and stashed CLI
         # params, but we always want the stashed version).
-        with self.scm.detach_head(entry.rev, force=True):
+        with self.scm.detach_head(entry.rev, force=True, client="dvc"):
             rev = self.stash.pop()
             self.scm.set_ref(EXEC_BASELINE, entry.baseline_rev)
             if entry.branch:

--- a/dvc/scm/git/__init__.py
+++ b/dvc/scm/git/__init__.py
@@ -321,7 +321,12 @@ class Git(Base):
             commit = self.resolve_commit(parent)
 
     @contextmanager
-    def detach_head(self, rev: Optional[str] = None, force: bool = False):
+    def detach_head(
+        self,
+        rev: Optional[str] = None,
+        force: bool = False,
+        client: str = "scm",
+    ):
         """Context manager for performing detached HEAD SCM operations.
 
         Detaches and restores HEAD similar to interactive git rebase.
@@ -350,7 +355,7 @@ class Git(Base):
                 "HEAD",
                 orig_head,
                 symbolic=symbolic,
-                message=f"dvc: Restore HEAD to '{name}'",
+                message=f"{client}: Restore HEAD to '{name}'",
             )
             logger.debug("Restore HEAD to '%s'", name)
             self.reset()


### PR DESCRIPTION
This commit removes dvc specific message hardcoded in
scm.detach_head. Now that we are decoupling scm, we are
adding `client=` kwarg to be set by the caller.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
