### PR TITLE
scm: move warning on unsupported index to scmcontext

### DIFF
--- a/dvc/repo/init.py
+++ b/dvc/repo/init.py
@@ -77,14 +77,18 @@ def init(root_dir=os.curdir, no_scm=False, force=False, subdir=False):
 
     proj.plots.templates.init()
 
-    scm.add(
-        [config.files["repo"], dvcignore, proj.plots.templates.templates_dir]
-    )
+    with proj.scm_context(autostage=True) as context:
+        files = [
+            config.files["repo"],
+            dvcignore,
+            proj.plots.templates.templates_dir,
+        ]
+        ignore_file = context.scm.ignore_file
+        if ignore_file:
+            files.extend([os.path.join(dvc_dir, ignore_file)])
+        proj.scm_context.track_file(files)
 
     logger.info("Initialized DVC repository.\n")
-
-    if scm.ignore_file:
-        scm.add([os.path.join(dvc_dir, scm.ignore_file)])
+    if not no_scm:
         logger.info("You can now commit the changes to git.\n")
-
     return proj

--- a/dvc/scm/exceptions.py
+++ b/dvc/scm/exceptions.py
@@ -39,3 +39,7 @@ class CloneError(SCMError):
 
 class RevError(SCMError):
     pass
+
+
+class UnsupportedIndexFormat(SCMError):
+    pass

--- a/dvc/scm/git/backend/gitpython.py
+++ b/dvc/scm/git/backend/gitpython.py
@@ -23,6 +23,7 @@ from dvc.scm.exceptions import (
     MergeConflictError,
     RevError,
     SCMError,
+    UnsupportedIndexFormat,
 )
 
 from ..objects import GitCommit, GitObject
@@ -220,15 +221,8 @@ class GitPythonBackend(BaseGitBackend):  # pylint:disable=abstract-method
                 self.git.add(*paths, update=True)
             else:
                 self.repo.index.add(paths)
-        except AssertionError:
-            msg = (
-                "failed to add '{}' to git. You can add those files "
-                "manually using `git add`. See "
-                "https://github.com/iterative/dvc/issues/610 for more "
-                "details.".format(str(paths))
-            )
-
-            logger.exception(msg)
+        except AssertionError as exc:
+            raise UnsupportedIndexFormat from exc
 
     def commit(self, msg: str, no_verify: bool = False):
         from git.exc import HookExecutionError


### PR DESCRIPTION
This PR:
1. Moves warning from scm to `SCMContext`. The `scm` throws a `UnsupportedIndexFormat` which is caught on `SCMContext.add` and is swallowed after a warning.
2. The warning message is improved, since we promote `autostage` these days (https://github.com/iterative/dvc/pull/6985).

```console
WARNING: failed to add, add manually using:

    git add .dvc/config .dvcignore .dvc/plots

See https://github.com/iterative/dvc/issues/610 for more details.
```

3. Make `Repo.init` use the same `scm_context` as the rest of the code does, and avoids using `scm.add` directly.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
