### PR TITLE
exp show: Include `deps` and `outs`.

### DIFF
--- a/dvc/commands/experiments/show.py
+++ b/dvc/commands/experiments/show.py
@@ -39,14 +39,17 @@ def _update_names(names, items):
 def _collect_names(all_experiments, **kwargs):
     metric_names = defaultdict(dict)
     param_names = defaultdict(dict)
+    deps_names = set()
 
     for _, experiments in all_experiments.items():
         for exp_data in experiments.values():
             exp = exp_data.get("data", {})
             _update_names(metric_names, exp.get("metrics", {}).items())
             _update_names(param_names, exp.get("params", {}).items())
+            for dep_name in exp.get("deps", {}):
+                deps_names.add(dep_name)
 
-    return metric_names, param_names
+    return metric_names, param_names, deps_names
 
 
 experiment_types = {
@@ -64,6 +67,7 @@ def _collect_rows(
     experiments,
     metric_names,
     param_names,
+    deps_names,
     precision=DEFAULT_PRECISION,
     sort_by=None,
     sort_order=None,
@@ -150,7 +154,11 @@ def _collect_rows(
             precision,
             fill_value=fill_value,
         )
-
+        for dep in deps_names:
+            hash_info = exp.get("deps", {}).get(dep, {}).get("hash")
+            if hash_info is not None:
+                hash_info = hash_info[:7]
+            row.append(hash_info or fill_value)
         yield row
 
 
@@ -245,6 +253,7 @@ def experiments_table(
     metric_names,
     param_headers,
     param_names,
+    deps_names,
     sort_by=None,
     sort_order=None,
     precision=DEFAULT_PRECISION,
@@ -256,7 +265,8 @@ def experiments_table(
     from dvc.compare import TabularData
 
     td = TabularData(
-        lconcat(headers, metric_headers, param_headers), fill_value=fill_value
+        lconcat(headers, metric_headers, param_headers, deps_names),
+        fill_value=fill_value,
     )
     for base_rev, experiments in all_experiments.items():
         rows = _collect_rows(
@@ -264,6 +274,7 @@ def experiments_table(
             experiments,
             metric_names,
             param_names,
+            deps_names,
             sort_by=sort_by,
             sort_order=sort_order,
             precision=precision,
@@ -310,7 +321,7 @@ def show_experiments(
 ):
     from funcy.seqs import flatten as flatten_list
 
-    metric_names, param_names = _collect_names(all_experiments)
+    metric_names, param_names, deps_names = _collect_names(all_experiments)
 
     headers = [
         "Experiment",
@@ -335,6 +346,7 @@ def show_experiments(
         metric_names,
         param_headers,
         param_names,
+        deps_names,
         kwargs.get("sort_by"),
         kwargs.get("sort_order"),
         kwargs.get("precision"),
@@ -359,14 +371,22 @@ def show_experiments(
         )
         td.drop(*merge_headers[1:])
 
-    headers = {"metrics": metric_headers, "params": param_headers}
+    headers = {
+        "metrics": metric_headers,
+        "params": param_headers,
+        "deps": deps_names,
+    }
     styles = {
         "Experiment": {"no_wrap": True, "header_style": "black on grey93"},
         "Created": {"header_style": "black on grey93"},
         "State": {"header_style": "black on grey93"},
         "Executor": {"header_style": "black on grey93"},
     }
-    header_bg_colors = {"metrics": "cornsilk1", "params": "light_cyan1"}
+    header_bg_colors = {
+        "metrics": "cornsilk1",
+        "params": "light_cyan1",
+        "deps": "plum2",
+    }
     styles.update(
         {
             header: {

--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -39,6 +39,16 @@ def _collect_experiment_commit(
         if params:
             res["params"] = params
 
+        res["deps"] = {
+            dep.def_path: {
+                "hash": dep.hash_info.value,
+                "size": dep.meta.size,
+                "nfiles": dep.meta.nfiles,
+            }
+            for dep in repo.index.deps
+            if type(dep).__name__ != "ParamsDependency" and dep.is_in_repo
+        }
+
         res["queued"] = stash
         if running is not None and exp_rev in running:
             res["running"] = True


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [X] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

https://github.com/iterative/dvc.org/pull/3220

---

Use `repo.index.deps` / `repo.index.outs` to collect dependencies / outputss associated with each experiment.

Closes #6434

## What's considered a dep

Currently, anything in `repo.index.deps` that is not a param dependency or an imported `.dvc` (because if the `.dvc` is used in the pipeline it would be a duplicated column). 

Studio filters git tracked files but I think that showing those files (i.e. `src` deps) is also valuable.

I think that more complicated internal filtering (i.e. considering removing intermediate deps) it's not worthy and problematic when considering all use cases. 

The table can get noisy but we provide the `--only-changed` flag (we could consider making it the default) and new improved filtering  #7141 that should make it easy to customize the table.

## JSON output

For `--json` output, this P.R. adds new `deps` and `outs` fields:

```json
{
        "baseline": {
            "data": {
                "deps": {
                    "copy.py": {
                        "hash": "561f068574ab2a132d304dca3dd6510d",
                        "size": 310,
                        "nfiles": None,
                    }
                },
                "metrics": {"metrics.yaml": {"data": {"foo": 1}}},
                "outs": {
                    "model.pkl": {
                        "hash": "fb7792b6596fd12502dd132c0aba0568",
                        "size": 2000,
                        "nfiles": None,
                    }
                },
                "params": {"params.yaml": {"data": {"foo": 1}}},
                "queued": False,
                "running": False,
                "executor": None,
                "timestamp": None,
            }
        }
    }
```

## Table

For the table, it creates a new type of colored columns and shows the `hash` (let the debate begin).

After some testing, it looks like the optimal value for showing in the data column highly varies between use cases. 

Given the limitations of the CLI, I opted for showing `hash` as it's the value that allows, IMO, to easily identify differences between rows.

From example-get-started:

- `dvc exp show --only-changed`

<img width="1286" alt="Captura de pantalla 2021-12-22 a las 20 11 16" src="https://user-images.githubusercontent.com/12677733/147143974-5aee816f-b252-4d97-9b15-bdbc15412b4f.png">

- `dvc exp show --all-branches --only-changed`

<img width="1629" alt="Captura de pantalla 2021-12-22 a las 20 11 45" src="https://user-images.githubusercontent.com/12677733/147144080-b35b2d11-dacb-460b-99ce-f9ee865db8ed.png">

Some deps might not be relevant, filtering with #7141 :

- ` dvc exp show --all-branches --only-changed --drop '.+prepared|model'`

<img width="1327" alt="Captura de pantalla 2021-12-22 a las 20 15 31" src="https://user-images.githubusercontent.com/12677733/147144396-2f4bf07d-3f33-4fd3-be6d-f30d1cdcf953.png">




