### PR TITLE
plots: make templates generation explicit

### DIFF
--- a/dvc/repo/init.py
+++ b/dvc/repo/init.py
@@ -75,13 +75,10 @@ def init(root_dir=os.curdir, no_scm=False, force=False, subdir=False):
 
     proj = Repo(root_dir)
 
-    proj.plots.templates.init()
-
     with proj.scm_context(autostage=True) as context:
         files = [
             config.files["repo"],
             dvcignore,
-            proj.plots.templates.templates_dir,
         ]
         ignore_file = context.scm.ignore_file
         if ignore_file:


### PR DESCRIPTION
Fixes: #6389

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Changes in this PR:

- `.dvc/plots` will no longer be created upon `dvc init`
- user has to explicitly call `dvc plots templates` to create and populate `.dvc/plots`

TODO
- [ ] docs
