### PR TITLE
add abspath option to Output.is_in_repo

### DIFF
--- a/dvc/output.py
+++ b/dvc/output.py
@@ -388,8 +388,9 @@ class Output:
         if os.path.isabs(self.def_path):
             return False
 
-        return self.repo and path_isin(
-            os.path.realpath(self.fs_path), self.repo.root_dir
+        return self.repo and (
+            path_isin(os.path.realpath(self.fs_path), self.repo.root_dir)
+            or path_isin(os.path.abspath(self.fs_path), self.repo.root_dir)
         )
 
     @property

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -842,6 +842,22 @@ def test_add_symlink_file(tmp_dir, dvc):
     dvc.add(os.path.join("dir", "foo"))
 
 
+def test_add_symlink_file_pointing_out(make_tmp_dir, tmp_dir, dvc):
+    ext_dir = make_tmp_dir("dir")
+    ext_dir.gen({"foo": "foo"})
+    (tmp_dir / "foo").symlink_to(ext_dir / "foo")
+
+    dvc.add("foo")
+
+    assert (tmp_dir / "foo.dvc").exists()
+    assert (tmp_dir / ".dvc" / "cache").read_text() == {
+        "ac": {"bd18db4cc2f85cedef654fccc4a4d8": "foo"}
+    }
+    assert not (
+        tmp_dir / ".dvc" / "cache" / "ac" / "bd18db4cc2f85cedef654fccc4a4d8"
+    ).is_symlink()
+
+
 @pytest.mark.parametrize("external", [True, False])
 def test_add_symlink_dir(make_tmp_dir, tmp_dir, dvc, external):
     if external:


### PR DESCRIPTION
Just a very quick check for a fix for #7118 without downloading, running or linting anything, sorry if this distracting, I just didn't want to set up the environment on my new machine again and hoped the CI will resolve whether this breaks any tests.

* [ ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.
