### PR TITLE
[WIP] Sharing multiple experiments

### DIFF
--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -711,6 +711,7 @@ class CmdExperimentsList(CmdBase):
             git_remote=self.args.git_remote,
             all_=self.args.all,
             branch=self.args.branch,
+            max_count=self.args.max_count,
         )
         for baseline in exps:
             tag = self.repo.scm.describe(baseline)
@@ -745,6 +746,7 @@ class CmdExperimentsPush(CmdBase):
             all_=self.args.all,
             rev=self.args.rev,
             branch=self.args.branch,
+            max_count=self.args.max_count,
             force=self.args.force,
             push_cache=self.args.push_cache,
             dvc_remote=self.args.dvc_remote,
@@ -781,6 +783,7 @@ class CmdExperimentsPull(CmdBase):
             all_=self.args.all,
             rev=self.args.rev,
             branch=self.args.branch,
+            max_count=self.args.max_count,
             force=self.args.force,
             pull_cache=self.args.pull_cache,
             dvc_remote=self.args.dvc_remote,
@@ -922,6 +925,15 @@ filter_group.add_argument(
 )
 filter_group.add_argument(
     "--all", default=False, action="store_true", help="Affect all experiments."
+)
+parent_list_parser.add_argument(
+    "--max-count",
+    type=int,
+    default=1,
+    dest="max_count",
+    metavar="<max_count>",
+    help="Show the last `num` commits from `rev` or `branch` or HEAD. Set `-1`"
+    "to show the full history",
 )
 
 

--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -1381,7 +1381,10 @@ def add_parser(subparsers, parent_parser):
         metavar="<git_remote>",
     )
     experiments_pull_parser.add_argument(
-        "experiment", help="Experiment to pull.", metavar="<experiment>"
+        "experiment",
+        help="Experiments to pull.",
+        metavar="<experiments>",
+        nargs="+",
     )
     experiments_pull_parser.set_defaults(func=CmdExperimentsPull)
 

--- a/dvc/command/experiments.py
+++ b/dvc/command/experiments.py
@@ -1322,7 +1322,10 @@ def add_parser(subparsers, parent_parser):
         metavar="<git_remote>",
     )
     experiments_push_parser.add_argument(
-        "experiment", help="Experiment to push.", metavar="<experiment>"
+        "experiment",
+        help="Experiments to push.",
+        metavar="<experiments>",
+        nargs="+",
     ).complete = completion.EXPERIMENT
     experiments_push_parser.set_defaults(func=CmdExperimentsPush)
 

--- a/dvc/repo/experiments/base.py
+++ b/dvc/repo/experiments/base.py
@@ -4,6 +4,7 @@ from dvc.exceptions import DvcException, InvalidArgumentError
 
 # Experiment refs are stored according baseline git SHA:
 #   refs/exps/01/234abcd.../<exp_name>
+BRANCH_NAMESPACE = "refs/heads"
 EXPS_NAMESPACE = "refs/exps"
 EXPS_STASH = f"{EXPS_NAMESPACE}/stash"
 EXEC_NAMESPACE = f"{EXPS_NAMESPACE}/exec"

--- a/dvc/repo/experiments/branch.py
+++ b/dvc/repo/experiments/branch.py
@@ -5,7 +5,7 @@ from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
 from dvc.scm import RevError
 
-from .base import InvalidExpRevError
+from .base import BRANCH_NAMESPACE, InvalidExpRevError
 from .utils import exp_refs_by_rev
 
 logger = logging.getLogger(__name__)
@@ -44,7 +44,7 @@ def branch(repo, exp_rev, branch_name, *args, **kwargs):
     if not ref_info:
         raise InvalidExpRevError(exp_rev)
 
-    branch_ref = f"refs/heads/{branch_name}"
+    branch_ref = f"{BRANCH_NAMESPACE}/{branch_name}"
     if repo.scm.get_ref(branch_ref):
         raise InvalidArgumentError(
             f"Git branch '{branch_name}' already exists."

--- a/dvc/repo/experiments/exceptions.py
+++ b/dvc/repo/experiments/exceptions.py
@@ -1,0 +1,23 @@
+from dvc.exceptions import InvalidArgumentError
+from dvc.types import List
+
+
+class UnresolvedExpNamesError(InvalidArgumentError):
+    def __init__(
+        self, unresolved_list: List[str], *args, git_remote: str = None
+    ):
+        unresolved_names = ";".join(unresolved_list)
+        if not git_remote:
+            if len(unresolved_names) > 1:
+                super().__init__(
+                    f"'{unresolved_names}' are not valid experiment names"
+                )
+            else:
+                super().__init__(
+                    f"'{unresolved_names}' is not a valid experiment name"
+                )
+        else:
+            super().__init__(
+                f"Experiment '{unresolved_names}' does not exist "
+                f"in '{git_remote}'"
+            )

--- a/dvc/repo/experiments/ls.py
+++ b/dvc/repo/experiments/ls.py
@@ -19,11 +19,12 @@ def ls(
     git_remote: Optional[str] = None,
     all_: bool = False,
     branch: Optional[str] = None,
+    max_count: int = 1,
     **kwargs
 ):
     results = defaultdict(list)
     for info in get_exp_ref_from_variables(
-        repo.scm, rev, all_, branch, git_remote
+        repo.scm, rev, all_, branch, max_count, git_remote
     ):
         results[info.baseline_sha].append(info.name)
 

--- a/dvc/repo/experiments/ls.py
+++ b/dvc/repo/experiments/ls.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 
 from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
+from dvc.types import Optional
 
 from .utils import get_exp_ref_from_variables
 
@@ -11,9 +12,19 @@ logger = logging.getLogger(__name__)
 
 @locked
 @scm_context
-def ls(repo, *args, rev=None, git_remote=None, all_=False, **kwargs):
+def ls(
+    repo,
+    *args,
+    rev: Optional[str] = None,
+    git_remote: Optional[str] = None,
+    all_: bool = False,
+    branch: Optional[str] = None,
+    **kwargs
+):
     results = defaultdict(list)
-    for info in get_exp_ref_from_variables(repo.scm, rev, all_, git_remote):
+    for info in get_exp_ref_from_variables(
+        repo.scm, rev, all_, branch, git_remote
+    ):
         results[info.baseline_sha].append(info.name)
 
     return results

--- a/dvc/repo/experiments/pull.py
+++ b/dvc/repo/experiments/pull.py
@@ -23,6 +23,7 @@ def pull(
     all_: bool = False,
     rev: Optional[str] = None,
     branch: Optional[str] = None,
+    max_count: int = 1,
     force: bool = False,
     pull_cache: bool = False,
     **kwargs,
@@ -30,7 +31,7 @@ def pull(
     if not exp_names:
         exp_names = []
         for info in get_exp_ref_from_variables(
-            repo.scm, rev, all_, branch, git_remote
+            repo.scm, rev, all_, branch, max_count, git_remote
         ):
             exp_names.append(info.name)
 

--- a/dvc/repo/experiments/pull.py
+++ b/dvc/repo/experiments/pull.py
@@ -4,11 +4,11 @@ from dvc.exceptions import DvcException
 from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
 from dvc.scm import TqdmGit
-from dvc.types import List, Union
+from dvc.types import List, Optional, Union
 
 from .base import ExpRefInfo
 from .exceptions import UnresolvedExpNamesError
-from .utils import exp_commits, name2exp_ref
+from .utils import exp_commits, get_exp_ref_from_variables, name2exp_ref
 
 logger = logging.getLogger(__name__)
 
@@ -20,10 +20,19 @@ def pull(
     git_remote: str,
     exp_names: Union[List[str], str],
     *args,
+    all_: bool = False,
+    rev: Optional[str] = None,
     force: bool = False,
     pull_cache: bool = False,
     **kwargs,
 ):
+    if not exp_names:
+        exp_names = []
+        for info in get_exp_ref_from_variables(
+            repo.scm, rev, all_, git_remote
+        ):
+            exp_names.append(info.name)
+
     if isinstance(exp_names, str):
         exp_names = [exp_names]
     exp_ref_list, unresolved_exp_names = name2exp_ref(

--- a/dvc/repo/experiments/pull.py
+++ b/dvc/repo/experiments/pull.py
@@ -1,10 +1,14 @@
 import logging
 
-from dvc.exceptions import DvcException, InvalidArgumentError
+from dvc.exceptions import DvcException
 from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
+from dvc.scm import TqdmGit
+from dvc.types import List, Union
 
-from .utils import exp_commits, resolve_exp_ref
+from .base import ExpRefInfo
+from .exceptions import UnresolvedExpNamesError
+from .utils import exp_commits, name2exp_ref
 
 logger = logging.getLogger(__name__)
 
@@ -12,42 +16,60 @@ logger = logging.getLogger(__name__)
 @locked
 @scm_context
 def pull(
-    repo, git_remote, exp_name, *args, force=False, pull_cache=False, **kwargs
+    repo,
+    git_remote: str,
+    exp_names: Union[List[str], str],
+    *args,
+    force: bool = False,
+    pull_cache: bool = False,
+    **kwargs,
 ):
-    exp_ref = resolve_exp_ref(repo.scm, exp_name, git_remote)
-    if not exp_ref:
-        raise InvalidArgumentError(
-            f"Experiment '{exp_name}' does not exist in '{git_remote}'"
-        )
+    if isinstance(exp_names, str):
+        exp_names = [exp_names]
+    exp_ref_list, unresolved_exp_names = name2exp_ref(
+        repo.scm, exp_names, git_remote, **kwargs
+    )
+    if unresolved_exp_names:
+        raise UnresolvedExpNamesError(unresolved_exp_names)
 
+    _pull(repo, git_remote, exp_ref_list, force, pull_cache, **kwargs)
+
+
+def _pull_cache(repo, exp_ref, dvc_remote=None, jobs=None, run_cache=False):
+    revs = list(exp_commits(repo.scm, exp_ref))
+    logger.debug(f"dvc fetch experiment '{exp_ref}'")
+    repo.fetch(jobs=jobs, remote=dvc_remote, run_cache=run_cache, revs=revs)
+
+
+def _pull(
+    repo,
+    git_remote: str,
+    exp_refs: List[ExpRefInfo],
+    force: bool,
+    pull_cache: bool,
+    **kwargs,
+):
     def on_diverged(refname: str, rev: str) -> bool:
         if repo.scm.get_ref(refname) == rev:
             return True
+        exp_name = refname.split("/")[-1]
         raise DvcException(
             f"Local experiment '{exp_name}' has diverged from remote "
             "experiment with the same name. To override the local experiment "
             "re-run with '--force'."
         )
 
-    refspec = f"{exp_ref}:{exp_ref}"
-    logger.debug("git pull experiment '%s' -> '%s'", git_remote, refspec)
-
-    from dvc.scm import TqdmGit
+    refspec_list = [f"{exp_ref}:{exp_ref}" for exp_ref in exp_refs]
+    logger.debug(f"git pull experiment '{git_remote}' -> '{refspec_list}'")
 
     with TqdmGit(desc="Fetching git refs") as pbar:
         repo.scm.fetch_refspecs(
             git_remote,
-            [refspec],
+            refspec_list,
             force=force,
             on_diverged=on_diverged,
             progress=pbar.update_git,
         )
 
     if pull_cache:
-        _pull_cache(repo, exp_ref, **kwargs)
-
-
-def _pull_cache(repo, exp_ref, dvc_remote=None, jobs=None, run_cache=False):
-    revs = list(exp_commits(repo.scm, [exp_ref]))
-    logger.debug("dvc fetch experiment '%s'", exp_ref)
-    repo.fetch(jobs=jobs, remote=dvc_remote, run_cache=run_cache, revs=revs)
+        _pull_cache(repo, exp_refs, **kwargs)

--- a/dvc/repo/experiments/pull.py
+++ b/dvc/repo/experiments/pull.py
@@ -22,6 +22,7 @@ def pull(
     *args,
     all_: bool = False,
     rev: Optional[str] = None,
+    branch: Optional[str] = None,
     force: bool = False,
     pull_cache: bool = False,
     **kwargs,
@@ -29,7 +30,7 @@ def pull(
     if not exp_names:
         exp_names = []
         for info in get_exp_ref_from_variables(
-            repo.scm, rev, all_, git_remote
+            repo.scm, rev, all_, branch, git_remote
         ):
             exp_names.append(info.name)
 

--- a/dvc/repo/experiments/push.py
+++ b/dvc/repo/experiments/push.py
@@ -28,6 +28,7 @@ def push(
     all_: bool = False,
     rev: Optional[str] = None,
     branch: Optional[str] = None,
+    max_count: int = 1,
     force: bool = False,
     push_cache: bool = False,
     **kwargs,
@@ -35,7 +36,7 @@ def push(
     if not exp_names:
         exp_names = []
         for info in get_exp_ref_from_variables(
-            repo.scm, rev, all_, branch, None
+            repo.scm, rev, all_, branch, max_count, None
         ):
             exp_names.append(info.name)
 

--- a/dvc/repo/experiments/push.py
+++ b/dvc/repo/experiments/push.py
@@ -1,10 +1,14 @@
 import logging
 
-from dvc.exceptions import DvcException, InvalidArgumentError
+from dvc.exceptions import DvcException
 from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
+from dvc.scm import TqdmGit
+from dvc.types import List, Union
 
-from .utils import exp_commits, push_refspec, resolve_exp_ref
+from .base import ExpRefInfo
+from .exceptions import UnresolvedExpNamesError
+from .utils import exp_commits, name2exp_ref, push_refspec
 
 logger = logging.getLogger(__name__)
 
@@ -13,49 +17,61 @@ logger = logging.getLogger(__name__)
 @scm_context
 def push(
     repo,
-    git_remote,
-    exp_name: str,
+    git_remote: str,
+    exp_names: Union[List[str], str],
     *args,
-    force=False,
-    push_cache=False,
+    force: bool = False,
+    push_cache: bool = False,
     **kwargs,
 ):
-    exp_ref = resolve_exp_ref(repo.scm, exp_name)
-    if not exp_ref:
-        raise InvalidArgumentError(
-            f"'{exp_name}' is not a valid experiment name"
-        )
+    if isinstance(exp_names, str):
+        exp_names = [exp_names]
+    exp_ref_list, unresolved_exp_names = name2exp_ref(
+        repo.scm, exp_names, None, **kwargs
+    )
+    if unresolved_exp_names:
+        raise UnresolvedExpNamesError(unresolved_exp_names)
 
+    _push(repo, git_remote, exp_ref_list, force, push_cache, **kwargs)
+
+
+def _push_cache(repo, exp_refs, dvc_remote=None, jobs=None, run_cache=False):
+    revs = list(exp_commits(repo.scm, exp_refs))
+    logger.debug(f"dvc push experiment '{exp_refs}'")
+    repo.push(jobs=jobs, remote=dvc_remote, run_cache=run_cache, revs=revs)
+
+
+def _push(
+    repo,
+    git_remote: str,
+    exp_refs: List[ExpRefInfo],
+    force: bool,
+    push_cache: bool,
+    **kwargs,
+):
     def on_diverged(refname: str, rev: str) -> bool:
         if repo.scm.get_ref(refname) == rev:
             return True
+        exp_name = refname.split("/")[-1]
         raise DvcException(
             f"Local experiment '{exp_name}' has diverged from remote "
             "experiment with the same name. To override the remote experiment "
             "re-run with '--force'."
         )
 
-    refname = str(exp_ref)
-    logger.debug("git push experiment '%s' -> '%s'", exp_ref, git_remote)
+    logger.debug(f"git push experiment '{exp_refs}' -> '{git_remote}'")
 
-    from dvc.scm import TqdmGit
-
-    with TqdmGit(desc="Pushing git refs") as pbar:
-        push_refspec(
-            repo.scm,
-            git_remote,
-            refname,
-            refname,
-            force=force,
-            on_diverged=on_diverged,
-            progress=pbar.update_git,
-        )
+    for exp_ref in exp_refs:
+        with TqdmGit(desc="Pushing git refs") as pbar:
+            push_refspec(
+                repo.scm,
+                git_remote,
+                str(exp_ref),
+                str(exp_ref),
+                force=force,
+                on_diverged=on_diverged,
+                progress=pbar.update_git,
+            )
 
     if push_cache:
-        _push_cache(repo, exp_ref, **kwargs)
-
-
-def _push_cache(repo, exp_ref, dvc_remote=None, jobs=None, run_cache=False):
-    revs = list(exp_commits(repo.scm, [exp_ref]))
-    logger.debug("dvc push experiment '%s'", exp_ref)
-    repo.push(jobs=jobs, remote=dvc_remote, run_cache=run_cache, revs=revs)
+        _push_cache(repo, exp_refs, **kwargs)

--- a/dvc/repo/experiments/push.py
+++ b/dvc/repo/experiments/push.py
@@ -4,11 +4,16 @@ from dvc.exceptions import DvcException
 from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
 from dvc.scm import TqdmGit
-from dvc.types import List, Union
+from dvc.types import List, Optional, Union
 
 from .base import ExpRefInfo
 from .exceptions import UnresolvedExpNamesError
-from .utils import exp_commits, name2exp_ref, push_refspec
+from .utils import (
+    exp_commits,
+    get_exp_ref_from_variables,
+    name2exp_ref,
+    push_refspec,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -20,10 +25,17 @@ def push(
     git_remote: str,
     exp_names: Union[List[str], str],
     *args,
+    all_: bool = False,
+    rev: Optional[str] = None,
     force: bool = False,
     push_cache: bool = False,
     **kwargs,
 ):
+    if not exp_names:
+        exp_names = []
+        for info in get_exp_ref_from_variables(repo.scm, rev, all_, None):
+            exp_names.append(info.name)
+
     if isinstance(exp_names, str):
         exp_names = [exp_names]
     exp_ref_list, unresolved_exp_names = name2exp_ref(

--- a/dvc/repo/experiments/push.py
+++ b/dvc/repo/experiments/push.py
@@ -27,13 +27,16 @@ def push(
     *args,
     all_: bool = False,
     rev: Optional[str] = None,
+    branch: Optional[str] = None,
     force: bool = False,
     push_cache: bool = False,
     **kwargs,
 ):
     if not exp_names:
         exp_names = []
-        for info in get_exp_ref_from_variables(repo.scm, rev, all_, None):
+        for info in get_exp_ref_from_variables(
+            repo.scm, rev, all_, branch, None
+        ):
             exp_names.append(info.name)
 
     if isinstance(exp_names, str):

--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, Optional
 
 from dvc.exceptions import InvalidArgumentError
 from dvc.repo import locked
-from dvc.repo.experiments.base import ExpRefInfo
+from dvc.repo.experiments.base import BRANCH_NAMESPACE, ExpRefInfo
 from dvc.repo.experiments.executor.base import ExecutorInfo
 from dvc.repo.experiments.utils import fix_exp_head
 from dvc.repo.metrics.show import _gather_metrics
@@ -55,7 +55,7 @@ def _collect_experiment_commit(
             res["metrics"] = vals
 
         if not sha_only and rev != "workspace":
-            for refspec in ["refs/tags", "refs/heads"]:
+            for refspec in ["refs/tags", BRANCH_NAMESPACE]:
                 name = repo.scm.describe(rev, base=refspec)
                 if name:
                     break

--- a/dvc/repo/experiments/utils.py
+++ b/dvc/repo/experiments/utils.py
@@ -1,4 +1,4 @@
-from typing import Callable, Generator, Iterable, Optional, Set
+from typing import Callable, Generator, Iterable, List, Optional, Set, Tuple
 
 from scmrepo.git import Git
 
@@ -203,3 +203,20 @@ def check_ref_format(scm: "Git", ref: ExpRefInfo):
             f"Invalid exp name {ref.name}, the exp name must follow rules in "
             "https://git-scm.com/docs/git-check-ref-format"
         )
+
+
+def name2exp_ref(
+    scm: "Git",
+    exp_names: List[str],
+    git_remote: Optional[str] = None,
+    **kwargs,
+) -> Tuple[List[ExpRefInfo], List[str]]:
+    exp_ref_list: List[ExpRefInfo] = []
+    remain_list: List[str] = []
+    for exp_name in exp_names:
+        exp_ref = resolve_exp_ref(scm, exp_name, git_remote)
+        if not exp_ref:
+            remain_list.append(exp_name)
+        else:
+            exp_ref_list.append(exp_ref)
+    return exp_ref_list, remain_list

--- a/dvc/repo/experiments/utils.py
+++ b/dvc/repo/experiments/utils.py
@@ -227,6 +227,7 @@ def get_exp_ref_from_variables(
     rev: Optional[str],
     all_: bool,
     branch: Optional[str],
+    max_count: int,
     git_remote: Optional[str],
 ) -> Generator["ExpRefInfo", None, None]:
     from dvc.scm import RevError, resolve_rev
@@ -244,10 +245,15 @@ def get_exp_ref_from_variables(
         rev = scm.get_rev()
 
     if rev:
+        rev_list = scm.last_n_commits(rev, max_count=max_count)
         if git_remote:
-            yield from remote_exp_refs_by_baseline(scm, git_remote, rev)
+            for revision in rev_list:
+                yield from remote_exp_refs_by_baseline(
+                    scm, git_remote, revision
+                )
         else:
-            yield from exp_refs_by_baseline(scm, rev)
+            for revision in rev_list:
+                yield from exp_refs_by_baseline(scm, revision)
     elif all_:
         if git_remote:
             yield from remote_exp_refs(scm, git_remote)

--- a/dvc/repo/experiments/utils.py
+++ b/dvc/repo/experiments/utils.py
@@ -223,9 +223,15 @@ def name2exp_ref(
 
 
 def get_exp_ref_from_variables(
-    scm: "Git", rev: Optional[str], all_: bool, git_remote: Optional[str]
+    scm: "Git",
+    rev: Optional[str],
+    all_: bool,
+    branch: Optional[str],
+    git_remote: Optional[str],
 ) -> Generator["ExpRefInfo", None, None]:
     from dvc.scm import RevError, resolve_rev
+
+    rev = branch or rev
 
     if rev:
         try:

--- a/tests/func/experiments/test_remote.py
+++ b/tests/func/experiments/test_remote.py
@@ -164,6 +164,7 @@ def test_list_remote(tmp_dir, scm, dvc, git_downstream, exp_stage, use_url):
     downstream_exp = git_downstream.tmp_dir.dvc.experiments
     assert downstream_exp.ls(git_remote=remote) == {}
 
+    git_downstream.tmp_dir.scm.fetch_refspecs(str(tmp_dir), ["master:master"])
     exp_list = downstream_exp.ls(rev=baseline_a, git_remote=remote)
     assert {key: set(val) for key, val in exp_list.items()} == {
         baseline_a: {ref_info_a.name, ref_info_b.name}
@@ -233,6 +234,7 @@ def test_pull_all_and_rev(
         rev = baseline
 
     downstream_exp = git_downstream.tmp_dir.dvc.experiments
+    git_downstream.tmp_dir.scm.fetch_refspecs(str(tmp_dir), ["master:master"])
     downstream_exp.pull(git_downstream.remote, [], all_=all_, rev=rev)
     assert git_downstream.tmp_dir.scm.get_ref(str(ref_info1)) == exp1
     assert git_downstream.tmp_dir.scm.get_ref(str(ref_info2)) == exp2

--- a/tests/func/experiments/test_remote.py
+++ b/tests/func/experiments/test_remote.py
@@ -39,6 +39,38 @@ def test_push(tmp_dir, scm, dvc, git_upstream, exp_stage, use_url):
     assert git_upstream.tmp_dir.scm.get_ref(str(ref_info1)) == exp1
 
 
+@pytest.mark.parametrize(
+    "all_,rev,result3", [(True, False, True), (False, True, None)]
+)
+def test_push_all_and_rev(
+    tmp_dir, scm, dvc, git_upstream, exp_stage, all_, rev, result3
+):
+    remote = git_upstream.url
+    baseline = scm.get_rev()
+
+    results = dvc.experiments.run(exp_stage.addressing, params=["foo=1"])
+    exp1 = first(results)
+    ref_info1 = first(exp_refs_by_rev(scm, exp1))
+    results = dvc.experiments.run(exp_stage.addressing, params=["foo=2"])
+    exp2 = first(results)
+    ref_info2 = first(exp_refs_by_rev(scm, exp2))
+
+    scm.commit("new_baseline")
+
+    results = dvc.experiments.run(exp_stage.addressing, params=["foo=3"])
+    exp3 = first(results)
+    ref_info3 = first(exp_refs_by_rev(scm, exp3))
+
+    if rev:
+        rev = baseline
+    dvc.experiments.push(remote, [], all_=all_, rev=rev)
+    assert git_upstream.tmp_dir.scm.get_ref(str(ref_info1)) == exp1
+    assert git_upstream.tmp_dir.scm.get_ref(str(ref_info2)) == exp2
+    if result3:
+        result3 = exp3
+    assert git_upstream.tmp_dir.scm.get_ref(str(ref_info3)) == result3
+
+
 def test_push_diverged(tmp_dir, scm, dvc, git_upstream, exp_stage):
     git_upstream.tmp_dir.scm_gen("foo", "foo", commit="init")
     remote_rev = git_upstream.tmp_dir.scm.get_rev()
@@ -174,6 +206,39 @@ def test_pull(tmp_dir, scm, dvc, git_downstream, exp_stage, use_url):
 
     downstream_exp.pull(remote, [str(ref_info1)])
     assert git_downstream.tmp_dir.scm.get_ref(str(ref_info1)) == exp1
+
+
+@pytest.mark.parametrize(
+    "all_,rev,result3", [(True, False, True), (False, True, None)]
+)
+def test_pull_all_and_rev(
+    tmp_dir, scm, dvc, git_downstream, exp_stage, all_, rev, result3
+):
+    baseline = scm.get_rev()
+
+    results = dvc.experiments.run(exp_stage.addressing, params=["foo=1"])
+    exp1 = first(results)
+    ref_info1 = first(exp_refs_by_rev(scm, exp1))
+    results = dvc.experiments.run(exp_stage.addressing, params=["foo=2"])
+    exp2 = first(results)
+    ref_info2 = first(exp_refs_by_rev(scm, exp2))
+
+    scm.commit("new_baseline")
+
+    results = dvc.experiments.run(exp_stage.addressing, params=["foo=3"])
+    exp3 = first(results)
+    ref_info3 = first(exp_refs_by_rev(scm, exp3))
+
+    if rev:
+        rev = baseline
+
+    downstream_exp = git_downstream.tmp_dir.dvc.experiments
+    downstream_exp.pull(git_downstream.remote, [], all_=all_, rev=rev)
+    assert git_downstream.tmp_dir.scm.get_ref(str(ref_info1)) == exp1
+    assert git_downstream.tmp_dir.scm.get_ref(str(ref_info2)) == exp2
+    if result3:
+        result3 = exp3
+    assert git_downstream.tmp_dir.scm.get_ref(str(ref_info3)) == result3
 
 
 def test_pull_diverged(tmp_dir, scm, dvc, git_downstream, exp_stage):

--- a/tests/func/experiments/test_remote.py
+++ b/tests/func/experiments/test_remote.py
@@ -13,19 +13,30 @@ def test_push(tmp_dir, scm, dvc, git_upstream, exp_stage, use_url):
 
     remote = git_upstream.url if use_url else git_upstream.remote
     with pytest.raises(InvalidArgumentError):
-        dvc.experiments.push(remote, "foo")
+        dvc.experiments.push(remote, ["foo"])
+
+    results = dvc.experiments.run(exp_stage.addressing, params=["foo=1"])
+    exp1 = first(results)
+    ref_info1 = first(exp_refs_by_rev(scm, exp1))
 
     results = dvc.experiments.run(exp_stage.addressing, params=["foo=2"])
-    exp = first(results)
-    ref_info = first(exp_refs_by_rev(scm, exp))
+    exp2 = first(results)
+    ref_info2 = first(exp_refs_by_rev(scm, exp2))
 
-    dvc.experiments.push(remote, ref_info.name)
-    assert git_upstream.tmp_dir.scm.get_ref(str(ref_info)) == exp
+    results = dvc.experiments.run(exp_stage.addressing, params=["foo=3"])
+    exp3 = first(results)
+    ref_info3 = first(exp_refs_by_rev(scm, exp3))
 
-    git_upstream.tmp_dir.scm.remove_ref(str(ref_info))
+    dvc.experiments.push(remote, [ref_info1.name, ref_info2.name])
+    assert git_upstream.tmp_dir.scm.get_ref(str(ref_info1)) == exp1
+    assert git_upstream.tmp_dir.scm.get_ref(str(ref_info2)) == exp2
+    assert git_upstream.tmp_dir.scm.get_ref(str(ref_info3)) is None
 
-    dvc.experiments.push(remote, str(ref_info))
-    assert git_upstream.tmp_dir.scm.get_ref(str(ref_info)) == exp
+    git_upstream.tmp_dir.scm.remove_ref(str(ref_info1))
+    assert git_upstream.tmp_dir.scm.get_ref(str(ref_info1)) is None
+
+    dvc.experiments.push(remote, [ref_info1.name])
+    assert git_upstream.tmp_dir.scm.get_ref(str(ref_info1)) == exp1
 
 
 def test_push_diverged(tmp_dir, scm, dvc, git_upstream, exp_stage):
@@ -39,10 +50,10 @@ def test_push_diverged(tmp_dir, scm, dvc, git_upstream, exp_stage):
     git_upstream.tmp_dir.scm.set_ref(str(ref_info), remote_rev)
 
     with pytest.raises(DvcException):
-        dvc.experiments.push(git_upstream.remote, ref_info.name)
+        dvc.experiments.push(git_upstream.remote, [ref_info.name])
     assert git_upstream.tmp_dir.scm.get_ref(str(ref_info)) == remote_rev
 
-    dvc.experiments.push(git_upstream.remote, ref_info.name, force=True)
+    dvc.experiments.push(git_upstream.remote, [ref_info.name], force=True)
     assert git_upstream.tmp_dir.scm.get_ref(str(ref_info)) == exp
 
 
@@ -53,7 +64,7 @@ def test_push_checkpoint(tmp_dir, scm, dvc, git_upstream, checkpoint_stage):
     exp_a = first(results)
     ref_info_a = first(exp_refs_by_rev(scm, exp_a))
 
-    dvc.experiments.push(git_upstream.remote, ref_info_a.name, force=True)
+    dvc.experiments.push(git_upstream.remote, [ref_info_a.name], force=True)
     assert git_upstream.tmp_dir.scm.get_ref(str(ref_info_a)) == exp_a
 
     results = dvc.experiments.run(
@@ -64,7 +75,7 @@ def test_push_checkpoint(tmp_dir, scm, dvc, git_upstream, checkpoint_stage):
 
     tmp_dir.scm_gen("new", "new", commit="new")
 
-    dvc.experiments.push(git_upstream.remote, ref_info_b.name, force=True)
+    dvc.experiments.push(git_upstream.remote, [ref_info_b.name], force=True)
     assert git_upstream.tmp_dir.scm.get_ref(str(ref_info_b)) == exp_b
 
 
@@ -86,15 +97,15 @@ def test_push_ambiguous_name(tmp_dir, scm, dvc, git_upstream, exp_stage):
     exp_b = first(results)
     ref_info_b = first(exp_refs_by_rev(scm, exp_b))
 
-    dvc.experiments.push(remote, "foo")
+    dvc.experiments.push(remote, ["foo"])
     assert git_upstream.tmp_dir.scm.get_ref(str(ref_info_b)) == exp_b
 
     tmp_dir.scm_gen("new", "new 2", commit="new 2")
 
     with pytest.raises(InvalidArgumentError):
-        dvc.experiments.push(remote, "foo")
+        dvc.experiments.push(remote, ["foo"])
 
-    dvc.experiments.push(remote, str(ref_info_a))
+    dvc.experiments.push(remote, [str(ref_info_a)])
     assert git_upstream.tmp_dir.scm.get_ref(str(ref_info_a)) == exp_a
 
 
@@ -237,7 +248,7 @@ def test_push_pull_cache(
     exp = first(results)
     ref_info = first(exp_refs_by_rev(scm, exp))
 
-    dvc.experiments.push(remote, ref_info.name, push_cache=True)
+    dvc.experiments.push(remote, [ref_info.name], push_cache=True)
     for x in range(2, checkpoint_stage.iterations + 1):
         hash_ = digest(str(x))
         path = os.path.join(local_remote.url, hash_[:2], hash_[2:])
@@ -285,4 +296,4 @@ def test_auth_error_push(tmp_dir, scm, dvc, exp_stage, http_auth_patch):
         GitAuthError,
         match=f"HTTP Git authentication is not supported: '{http_auth_patch}'",
     ):
-        dvc.experiments.push(http_auth_patch, ref_info.name)
+        dvc.experiments.push(http_auth_patch, [ref_info.name])

--- a/tests/func/experiments/test_remove.py
+++ b/tests/func/experiments/test_remove.py
@@ -106,7 +106,7 @@ def test_remove_remote(tmp_dir, scm, dvc, exp_stage, git_upstream, use_url):
         exp_list.append(exp)
         ref_info = first(exp_refs_by_rev(scm, exp))
         ref_info_list.append(ref_info)
-        dvc.experiments.push(remote, ref_info.name)
+        dvc.experiments.push(remote, [ref_info.name])
         assert git_upstream.tmp_dir.scm.get_ref(str(ref_info)) == exp
 
     dvc.experiments.remove(

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -220,7 +220,8 @@ def test_experiments_push(dvc, scm, mocker):
             "experiments",
             "push",
             "origin",
-            "experiment",
+            "experiment1",
+            "experiment2",
             "--force",
             "--no-cache",
             "--remote",
@@ -240,7 +241,7 @@ def test_experiments_push(dvc, scm, mocker):
     m.assert_called_once_with(
         cmd.repo,
         "origin",
-        "experiment",
+        ["experiment1", "experiment2"],
         force=True,
         push_cache=False,
         dvc_remote="my-remote",

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -196,8 +196,6 @@ def test_experiments_list(dvc, scm, mocker):
             "experiments",
             "list",
             "origin",
-            "--rev",
-            "foo",
             "--all",
             "--names-only",
         ]
@@ -210,7 +208,7 @@ def test_experiments_list(dvc, scm, mocker):
     assert cmd.run() == 0
 
     m.assert_called_once_with(
-        cmd.repo, git_remote="origin", rev="foo", all_=True
+        cmd.repo, git_remote="origin", rev=None, all_=True
     )
 
 
@@ -243,11 +241,25 @@ def test_experiments_push(dvc, scm, mocker):
         "origin",
         ["experiment1", "experiment2"],
         force=True,
+        all_=False,
+        rev=None,
         push_cache=False,
         dvc_remote="my-remote",
         jobs=1,
         run_cache=True,
     )
+
+    cli_args = parse_args(
+        [
+            "experiments",
+            "push",
+            "origin",
+            "experiment1",
+            "--all",
+        ]
+    )
+    with pytest.raises(InvalidArgumentError):
+        cli_args.func(cli_args).run()
 
 
 def test_experiments_pull(dvc, scm, mocker):
@@ -256,7 +268,8 @@ def test_experiments_pull(dvc, scm, mocker):
             "experiments",
             "pull",
             "origin",
-            "experiment",
+            "--rev",
+            "bar",
             "--force",
             "--no-cache",
             "--remote",
@@ -276,7 +289,9 @@ def test_experiments_pull(dvc, scm, mocker):
     m.assert_called_once_with(
         cmd.repo,
         "origin",
-        ["experiment"],
+        [],
+        all_=False,
+        rev="bar",
         force=True,
         pull_cache=False,
         dvc_remote="my-remote",

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -208,7 +208,7 @@ def test_experiments_list(dvc, scm, mocker):
     assert cmd.run() == 0
 
     m.assert_called_once_with(
-        cmd.repo, git_remote="origin", rev=None, all_=True
+        cmd.repo, git_remote="origin", rev=None, all_=True, branch=None
     )
 
 
@@ -243,6 +243,7 @@ def test_experiments_push(dvc, scm, mocker):
         force=True,
         all_=False,
         rev=None,
+        branch=None,
         push_cache=False,
         dvc_remote="my-remote",
         jobs=1,
@@ -292,6 +293,7 @@ def test_experiments_pull(dvc, scm, mocker):
         [],
         all_=False,
         rev="bar",
+        branch=None,
         force=True,
         pull_cache=False,
         dvc_remote="my-remote",

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -208,7 +208,12 @@ def test_experiments_list(dvc, scm, mocker):
     assert cmd.run() == 0
 
     m.assert_called_once_with(
-        cmd.repo, git_remote="origin", rev=None, all_=True, branch=None
+        cmd.repo,
+        git_remote="origin",
+        rev=None,
+        all_=True,
+        branch=None,
+        max_count=1,
     )
 
 
@@ -244,6 +249,7 @@ def test_experiments_push(dvc, scm, mocker):
         all_=False,
         rev=None,
         branch=None,
+        max_count=1,
         push_cache=False,
         dvc_remote="my-remote",
         jobs=1,
@@ -277,6 +283,8 @@ def test_experiments_pull(dvc, scm, mocker):
             "my-remote",
             "--jobs",
             "1",
+            "--max-count",
+            "4",
             "--run-cache",
         ]
     )
@@ -295,6 +303,7 @@ def test_experiments_pull(dvc, scm, mocker):
         rev="bar",
         branch=None,
         force=True,
+        max_count=4,
         pull_cache=False,
         dvc_remote="my-remote",
         jobs=1,

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -276,7 +276,7 @@ def test_experiments_pull(dvc, scm, mocker):
     m.assert_called_once_with(
         cmd.repo,
         "origin",
-        "experiment",
+        ["experiment"],
         force=True,
         pull_cache=False,
         dvc_remote="my-remote",

--- a/tests/unit/repo/experiments/test_utils.py
+++ b/tests/unit/repo/experiments/test_utils.py
@@ -52,11 +52,13 @@ def test_run_check_ref_format(scm, name, result):
 
 @pytest.mark.parametrize("git_remote", [True, None])
 @pytest.mark.parametrize(
-    "all_,rev,branch,result",
+    "all_,rev,branch,max_count,result",
     [
-        (True, None, None, {"exp1", "exp2", "exp3", "exp4"}),
-        (None, True, None, {"exp1", "exp2"}),
-        (None, None, True, {"exp4"}),
+        (True, None, None, 1, {"exp1", "exp2", "exp3", "exp4"}),
+        (None, True, None, 1, {"exp1", "exp2"}),
+        (None, None, True, 1, {"exp4"}),
+        (None, None, True, 2, {"exp3", "exp4"}),
+        (None, None, True, -1, {"exp1", "exp2", "exp3", "exp4"}),
     ],
 )
 def test_get_exp_ref_from_variables(
@@ -67,6 +69,7 @@ def test_get_exp_ref_from_variables(
     all_,
     rev,
     branch,
+    max_count,
     result,
 ):
     tmp_dir.scm_gen("foo", "init", commit="init")
@@ -93,11 +96,15 @@ def test_get_exp_ref_from_variables(
     if branch:
         branch = "new"
 
-    gen = get_exp_ref_from_variables(scm, rev, all_, branch, git_remote)
+    gen = get_exp_ref_from_variables(
+        scm, rev, all_, branch, max_count, git_remote
+    )
     assert {exp_ref.name for exp_ref in gen} == result
 
     if branch:
         with pytest.raises(RevError):
             list(
-                get_exp_ref_from_variables(scm, rev, all_, "other", git_remote)
+                get_exp_ref_from_variables(
+                    scm, rev, all_, "other", max_count, git_remote
+                )
             )

--- a/tests/unit/repo/experiments/test_utils.py
+++ b/tests/unit/repo/experiments/test_utils.py
@@ -1,21 +1,29 @@
 import pytest
 
 from dvc.exceptions import InvalidArgumentError
-from dvc.repo.experiments.base import EXPS_NAMESPACE, ExpRefInfo
-from dvc.repo.experiments.utils import check_ref_format, resolve_exp_ref
+from dvc.repo.experiments.base import ExpRefInfo
+from dvc.repo.experiments.utils import (
+    check_ref_format,
+    get_exp_ref_from_variables,
+    resolve_exp_ref,
+)
 
 
 def commit_exp_ref(tmp_dir, scm, file="foo", contents="foo", name="foo"):
+    baseline_rev = scm.get_rev()
     tmp_dir.scm_gen(file, contents, commit="init")
     rev = scm.get_rev()
-    ref = "/".join([EXPS_NAMESPACE, "ab", "c123", name])
+    ref_info = ExpRefInfo(baseline_rev, name)
+    ref = str(ref_info)
     scm.gitpython.set_ref(ref, rev)
+    scm.checkout(baseline_rev)
     return ref, rev
 
 
 @pytest.mark.parametrize("use_url", [True, False])
 @pytest.mark.parametrize("name_only", [True, False])
 def test_resolve_exp_ref(tmp_dir, scm, git_upstream, name_only, use_url):
+    tmp_dir.scm_gen("foo", "init", commit="init")
     ref, _ = commit_exp_ref(tmp_dir, scm)
     ref_info = resolve_exp_ref(scm, "foo" if name_only else ref)
     assert isinstance(ref_info, ExpRefInfo)
@@ -39,3 +47,46 @@ def test_run_check_ref_format(scm, name, result):
     else:
         with pytest.raises(InvalidArgumentError):
             check_ref_format(scm, ref)
+
+
+@pytest.mark.parametrize("git_remote", [True, None])
+@pytest.mark.parametrize(
+    "all_,rev,result",
+    [
+        (True, None, {"exp1", "exp2", "exp3", "exp4"}),
+        (None, True, {"exp1", "exp2"}),
+    ],
+)
+def test_get_exp_ref_from_variables(
+    tmp_dir,
+    scm,
+    git_upstream,
+    git_remote,
+    all_,
+    rev,
+    result,
+):
+    tmp_dir.scm_gen("foo", "init", commit="init")
+    baseline1 = scm.get_rev()
+    ref_list = []
+    ref, _ = commit_exp_ref(tmp_dir, scm, contents="1", name="exp1")
+    ref_list.append(ref)
+    ref, _ = commit_exp_ref(tmp_dir, scm, contents="2", name="exp2")
+    ref_list.append(ref)
+    tmp_dir.scm_gen("foo", "init2", commit="init")
+    _ = scm.get_rev()
+    ref, _ = commit_exp_ref(tmp_dir, scm, contents="3", name="exp3")
+    ref_list.append(ref)
+    ref, _ = commit_exp_ref(tmp_dir, scm, contents="4", name="exp4")
+    ref_list.append(ref)
+
+    if rev:
+        rev = baseline1[:7]
+    if git_remote:
+        git_remote = git_upstream.url
+        for ref in ref_list:
+            scm.push_refspec(git_upstream.url, ref, ref)
+
+    gen = get_exp_ref_from_variables(scm, rev, all_, git_remote)
+
+    assert {exp_ref.name for exp_ref in gen} == result


### PR DESCRIPTION
fix #5489 
1. exp push/pull: accept multiple exp as input
2. exp push/pull: can accept the same arguments as the `exp ls` and work on exactly the same exps as shown in `ls`
3. add a new flag branch for branch name
4. add new argument max_count for history of a rev

wait for https://github.com/iterative/scmrepo/pull/13


* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
