### PR TITLE
exp show: Add --drop and --keep args

### DIFF
--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -18,7 +18,6 @@ from dvc.repo.experiments.utils import exp_refs_by_rev
 from dvc.utils.fs import makedirs
 from dvc.utils.serialize import YAMLFileCorruptedError
 from tests.func.test_repro_multistage import COPY_SCRIPT
-from tests.utils import console_width
 
 
 def make_executor_info(**kwargs):
@@ -193,105 +192,12 @@ def test_show_checkpoint_branch(
     assert f"({branch_rev[:7]})" in cap.out
 
 
-@pytest.mark.parametrize(
-    "i_metrics,i_params,e_metrics,e_params,included,excluded",
-    [
-        (
-            "foo",
-            "foo",
-            None,
-            None,
-            ["foo"],
-            ["bar", "train/foo", "nested.foo"],
-        ),
-        (
-            None,
-            None,
-            "foo",
-            "foo",
-            ["bar", "train/foo", "nested.foo"],
-            ["foo"],
-        ),
-        (
-            "foo,bar",
-            "foo,bar",
-            None,
-            None,
-            ["foo", "bar"],
-            ["train/foo", "train/bar", "nested.foo", "nested.bar"],
-        ),
-        (
-            "metrics.yaml:foo,bar",
-            "params.yaml:foo,bar",
-            None,
-            None,
-            ["foo", "bar"],
-            ["train/foo", "train/bar", "nested.foo", "nested.bar"],
-        ),
-        (
-            "train/*",
-            "train/*",
-            None,
-            None,
-            ["train/foo", "train/bar"],
-            ["foo", "bar", "nested.foo", "nested.bar"],
-        ),
-        (
-            None,
-            None,
-            "train/*",
-            "train/*",
-            ["foo", "bar", "nested.foo", "nested.bar"],
-            ["train/foo", "train/bar"],
-        ),
-        (
-            "train/*",
-            "train/*",
-            "*foo",
-            "*foo",
-            ["train/bar"],
-            ["train/foo", "foo", "bar", "nested.foo", "nested.bar"],
-        ),
-        (
-            "nested.*",
-            "nested.*",
-            None,
-            None,
-            ["nested.foo", "nested.bar"],
-            ["foo", "bar", "train/foo", "train/bar"],
-        ),
-        (
-            None,
-            None,
-            "nested.*",
-            "nested.*",
-            ["foo", "bar", "train/foo", "train/bar"],
-            ["nested.foo", "nested.bar"],
-        ),
-        (
-            "*.*",
-            "*.*",
-            "*.bar",
-            "*.bar",
-            ["nested.foo"],
-            ["foo", "bar", "nested.bar", "train/foo", "train/bar"],
-        ),
-    ],
-)
 def test_show_filter(
     tmp_dir,
     scm,
     dvc,
     capsys,
-    i_metrics,
-    i_params,
-    e_metrics,
-    e_params,
-    included,
-    excluded,
 ):
-    from dvc.ui import ui
-
     capsys.readouterr()
 
     tmp_dir.gen("copy.py", COPY_SCRIPT)
@@ -324,26 +230,39 @@ def test_show_filter(
     )
     scm.commit("init")
 
-    command = ["exp", "show", "--no-pager", "--no-timestamp"]
-    if i_metrics is not None:
-        command.append(f"--include-metrics={i_metrics}")
-    if i_params is not None:
-        command.append(f"--include-params={i_params}")
-    if e_metrics is not None:
-        command.append(f"--exclude-metrics={e_metrics}")
-    if e_params is not None:
-        command.append(f"--exclude-params={e_params}")
-
-    with console_width(ui.rich_console, 255):
-        assert main(command) == 0
+    capsys.readouterr()
+    assert main(["exp", "show", "--drop=.*foo"]) == 0
     cap = capsys.readouterr()
+    for filtered in ["foo", "train/foo", "nested.foo"]:
+        assert f"params.yaml:{filtered}" not in cap.out
+        assert f"metrics.yaml:{filtered}" not in cap.out
 
-    for i in included:
-        assert f"params.yaml:{i}" in cap.out
-        assert f"metrics.yaml:{i}" in cap.out
-    for e in excluded:
-        assert f"params.yaml:{e}" not in cap.out
-        assert f"metrics.yaml:{e}" not in cap.out
+    capsys.readouterr()
+    assert main(["exp", "show", "--drop=.*foo", "--keep=.*train"]) == 0
+    cap = capsys.readouterr()
+    for filtered in ["foo", "nested.foo"]:
+        assert f"params.yaml:{filtered}" not in cap.out
+        assert f"metrics.yaml:{filtered}" not in cap.out
+    assert "params.yaml:train/foo" in cap.out
+    assert "metrics.yaml:train/foo" in cap.out
+
+    capsys.readouterr()
+    assert main(["exp", "show", "--drop=params.yaml:.*foo"]) == 0
+    cap = capsys.readouterr()
+    for filtered in ["foo", "train/foo", "nested.foo"]:
+        assert f"params.yaml:{filtered}" not in cap.out
+        assert f"metrics.yaml:{filtered}" in cap.out
+
+    capsys.readouterr()
+    assert main(["exp", "show", "--drop=Created"]) == 0
+    cap = capsys.readouterr()
+    assert "Created" not in cap.out
+
+    capsys.readouterr()
+    assert main(["exp", "show", "--drop=Created|Experiment"]) == 0
+    cap = capsys.readouterr()
+    assert "Created" not in cap.out
+    assert "Experiment" not in cap.out
 
 
 def test_show_multiple_commits(tmp_dir, scm, dvc, exp_stage):
@@ -589,17 +508,21 @@ def test_show_only_changed(tmp_dir, dvc, scm, capsys):
     capsys.readouterr()
     assert main(["exp", "show"]) == 0
     cap = capsys.readouterr()
-
     assert "bar" in cap.out
 
     capsys.readouterr()
     assert main(["exp", "show", "--only-changed"]) == 0
     cap = capsys.readouterr()
-
     assert "bar" not in cap.out
 
+    capsys.readouterr()
+    assert main(["exp", "show", "--only-changed", "--keep=.*bar"]) == 0
+    cap = capsys.readouterr()
+    assert "params.yaml:bar" in cap.out
+    assert "metrics.yaml:bar" in cap.out
 
-def test_show_parallel_coordinates(tmp_dir, dvc, scm, mocker):
+
+def test_show_parallel_coordinates(tmp_dir, dvc, scm, mocker, capsys):
     from dvc.commands.experiments import show
 
     webbroser_open = mocker.patch("webbrowser.open")
@@ -638,22 +561,20 @@ def test_show_parallel_coordinates(tmp_dir, dvc, scm, mocker):
     kwargs = show_experiments.call_args[1]
 
     html_text = (tmp_dir / "dvc_plots" / "index.html").read_text()
-    assert all(rev in html_text for rev in ["workspace", "master", "[exp-"])
+    assert all(rev in html_text for rev in ["workspace", "master"])
+    assert "[exp-" not in html_text
 
-    assert (
-        '{"label": "metrics.yaml:foo", "values": [2.0, 1.0, 2.0]}' in html_text
-    )
-    assert (
-        '{"label": "params.yaml:foo", "values": [2.0, 1.0, 2.0]}' in html_text
-    )
-    assert '"line": {"color": [2, 1, 0]' in html_text
+    assert '{"label": "metrics.yaml:foo", "values": [2.0, 1.0]}' in html_text
+    assert '{"label": "params.yaml:foo", "values": [2.0, 1.0]}' in html_text
+    assert '"line": {"color": [1, 0]' in html_text
     assert '"label": "metrics.yaml:bar"' not in html_text
+    assert '"label": "Created"' not in html_text
 
     assert main(["exp", "show", "--pcp", "--sort-by", "metrics.yaml:foo"]) == 0
     kwargs = show_experiments.call_args[1]
 
     html_text = (tmp_dir / "dvc_plots" / "index.html").read_text()
-    assert '"line": {"color": [2.0, 1.0, 2.0]' in html_text
+    assert '"line": {"color": [2.0, 1.0]' in html_text
 
     assert main(["exp", "show", "--pcp", "--out", "experiments"]) == 0
     kwargs = show_experiments.call_args[1]
@@ -670,3 +591,8 @@ def test_show_parallel_coordinates(tmp_dir, dvc, scm, mocker):
     assert main(["exp", "show", "--pcp"]) == 0
     html_text = (tmp_dir / "dvc_plots" / "index.html").read_text()
     assert '{"label": "foobar", "values": [2.0, null, null]}' in html_text
+
+    assert main(["exp", "show", "--pcp", "--drop", "foobar"]) == 0
+    html_text = (tmp_dir / "dvc_plots" / "index.html").read_text()
+    assert '"label": "Created"' not in html_text
+    assert '"label": "foobar"' not in html_text

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -790,7 +790,9 @@ def test_show_experiments_pcp(tmp_dir, mocker):
 
     show_experiments(all_experiments, pcp=True)
 
-    td.dropna.assert_called_with("rows", how="all")
+    td.drop.assert_called_with("Created")
+    td.dropna.assert_called_with("rows", how="all", subset=[])
+    td.drop_duplicates.assert_called_with("rows", subset=[])
 
     kwargs = td.to_parallel_coordinates.call_args[1]
 

--- a/tests/unit/test_tabular_data.py
+++ b/tests/unit/test_tabular_data.py
@@ -144,12 +144,28 @@ def test_fill_value():
 
 
 def test_drop():
-    td = TabularData(["col1", "col2", "col3"])
-    td.append(["foo", "bar", "baz"])
-    assert list(td) == [["foo", "bar", "baz"]]
+    td = TabularData(["col1", "col2", "col3", "other"])
+    td.append(["foo", "bar", "baz", "other_val"])
+    assert list(td) == [["foo", "bar", "baz", "other_val"]]
     td.drop("col2")
-    assert td.keys() == ["col1", "col3"]
-    assert list(td) == [["foo", "baz"]]
+    assert td.keys() == ["col1", "col3", "other"]
+    assert list(td) == [["foo", "baz", "other_val"]]
+
+
+def test_protected():
+    td = TabularData(["col1", "col2", "col3", "other"])
+    td.append(["foo", "bar", "baz", "other_val"])
+    td.protect("col1", "col2")
+
+    td.drop("col1", "col2", "col3", "other")
+    assert td.keys() == ["col1", "col2"]
+    assert list(td) == [["foo", "bar"]]
+
+    td.unprotect("col2")
+
+    td.drop("col1", "col2")
+    assert td.keys() == ["col1"]
+    assert list(td) == [["foo"]]
 
 
 def test_row_from_dict():
@@ -221,6 +237,20 @@ def test_dropna(axis, how, data, expected):
 
 
 @pytest.mark.parametrize(
+    "axis,expected",
+    [
+        ("cols", [["foo", ""], ["foo", ""], ["foo", "foobar"]]),
+        ("rows", [["foo", "bar", ""], ["foo", "bar", "foobar"]]),
+    ],
+)
+def test_dropna_subset(axis, expected):
+    td = TabularData(["col-1", "col-2", "col-3"])
+    td.extend([["foo"], ["foo", "bar"], ["foo", "bar", "foobar"]])
+    td.dropna(axis, subset=["col-1", "col-2"])
+    assert list(td) == expected
+
+
+@pytest.mark.parametrize(
     "axis,expected,ignore_empty",
     [
         (
@@ -263,29 +293,6 @@ def test_drop_duplicates(axis, expected, ignore_empty):
     assert list(td) == expected
 
 
-def test_drop_duplicates_ignore_empty():
-    td = TabularData(["col-1", "col-2", "col-3"], fill_value="-")
-    td.extend(
-        [["foo"], ["foo", "foo"], ["foo", "foo"], ["foo", "bar", "foobar"]]
-    )
-
-    assert list(td) == [
-        ["foo", "-", "-"],
-        ["foo", "foo", "-"],
-        ["foo", "foo", "-"],
-        ["foo", "bar", "foobar"],
-    ]
-
-    td.drop_duplicates("cols", ignore_empty=False)
-
-    assert list(td) == [
-        ["-", "-"],
-        ["foo", "-"],
-        ["foo", "-"],
-        ["bar", "foobar"],
-    ]
-
-
 def test_drop_duplicates_rich_text():
     from dvc.ui import ui
 
@@ -310,6 +317,51 @@ def test_drop_duplicates_rich_text():
     td.drop_duplicates("cols")
 
     assert list(td) == [["-"], ["foo"], ["foo"], ["bar"]]
+
+
+@pytest.mark.parametrize(
+    "axis,subset,expected",
+    [
+        (
+            "rows",
+            ["col-1"],
+            [["foo", "foo", "foo", "bar"]],
+        ),
+        (
+            "rows",
+            ["col-1", "col-3"],
+            [
+                ["foo", "foo", "foo", "bar"],
+                ["foo", "bar", "foobar", "bar"],
+            ],
+        ),
+        (
+            "cols",
+            ["col-1", "col-3"],
+            [
+                ["foo", "foo", "bar"],
+                ["bar", "foo", "bar"],
+                ["bar", "foobar", "bar"],
+            ],
+        ),
+    ],
+)
+def test_drop_duplicates_subset(axis, subset, expected):
+    td = TabularData(["col-1", "col-2", "col-3", "col-4"])
+    td.extend(
+        [
+            ["foo", "foo", "foo", "bar"],
+            ["foo", "bar", "foo", "bar"],
+            ["foo", "bar", "foobar", "bar"],
+        ]
+    )
+    assert list(td) == [
+        ["foo", "foo", "foo", "bar"],
+        ["foo", "bar", "foo", "bar"],
+        ["foo", "bar", "foobar", "bar"],
+    ]
+    td.drop_duplicates(axis, subset=subset)
+    assert list(td) == expected
 
 
 def test_dropna_invalid_axis():


### PR DESCRIPTION
* [X] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

---

- Removed `--include-metrics` / `--include-params` and
`--exclude-metrics` / `--exclude-params`.

- Removed `--no-timestamp`  (-> `--drop Created`)

- `--drop` and `--keep` operate directly on the table columns. 
  Support regex patterns.

- `--keep` does not perform any filtering. 
  It's only used to specify columns to keep despite the other filtering. 
  Previous `--include` behavior can be replicated with negative lookahead regex.

Closes #7079
Closes #7080
Closes #7083
Pre-requisite for #6434


---

Example:


<details>
<summary>`dvc exp show`</summary>

```
| Experiment              | Created      | loss    | accuracy   | train.batch_size   | train.hidden_units   | train.dropout   | train.num_epochs   | train.lr   | train.conv_activation   |
|-------------------------|--------------|---------|------------|--------------------|----------------------|-----------------|--------------------|------------|-------------------------|
| workspace               | -            | 0.31941 | 0.8997     | 128                | 64                   | 0.3             | 10                 | 0.01       | relu                    |
| main                    | Sep 14, 2021 | 0.26484 | 0.9038     | 128                | 64                   | 0.4             | 10                 | 0.001      | relu                    |
| ├── d599d35 [exp-4f1f0] | 06:12 PM     | 0.31941 | 0.8997     | 128                | 64                   | 0.3             | 10                 | 0.01       | relu                    |
| ├── c6d3ac6 [exp-eec4c] | 06:10 PM     | 0.24435 | 0.9135     | 128                | 64                   | 0.3             | 10                 | 0.001      | relu                    |
| └── 0d5e1ae [exp-25fae] | 06:03 PM     | 0.26133 | 0.9062     | 128                | 64                   | 0.4             | 10                 | 0.001      | relu                    |
```

</details>

<details>
<summary>`dvc exp show --only-changed`</summary>

```
| Experiment              | Created      | loss    | accuracy   | train.dropout   | train.lr   |
|-------------------------|--------------|---------|------------|-----------------|------------|
| workspace               | -            | 0.31941 | 0.8997     | 0.3             | 0.01       |
| main                    | Sep 14, 2021 | 0.26484 | 0.9038     | 0.4             | 0.001      |
| ├── d599d35 [exp-4f1f0] | 06:12 PM     | 0.31941 | 0.8997     | 0.3             | 0.01       |
| ├── c6d3ac6 [exp-eec4c] | 06:10 PM     | 0.24435 | 0.9135     | 0.3             | 0.001      |
| └── 0d5e1ae [exp-25fae] | 06:03 PM     | 0.26133 | 0.9062     | 0.4             | 0.001      |
```

</details>

</details>

<details>
<summary>`dvc exp show --only-changed --keep train.batch_size`</summary>

```
| Experiment              | Created      | loss    | accuracy   | train.batch_size   | train.dropout   | train.lr   |
|-------------------------|--------------|---------|------------|--------------------|-----------------|------------|
| workspace               | -            | 0.31941 | 0.8997     | 128                | 0.3             | 0.01       |
| main                    | Sep 14, 2021 | 0.26484 | 0.9038     | 128                | 0.4             | 0.001      |
| ├── d599d35 [exp-4f1f0] | 06:12 PM     | 0.31941 | 0.8997     | 128                | 0.3             | 0.01       |
| ├── c6d3ac6 [exp-eec4c] | 06:10 PM     | 0.24435 | 0.9135     | 128                | 0.3             | 0.001      |
| └── 0d5e1ae [exp-25fae] | 06:03 PM     | 0.26133 | 0.9062     | 128                | 0.4             | 0.001      |
```

</details>


<details>
<summary>`dvc exp show --drop train.*`</summary>

```
| Experiment              | Created      | loss    | accuracy   |
|-------------------------|--------------|---------|------------|
| workspace               | -            | 0.31941 | 0.8997     |
| main                    | Sep 14, 2021 | 0.26484 | 0.9038     |
| ├── d599d35 [exp-4f1f0] | 06:12 PM     | 0.31941 | 0.8997     |
| ├── c6d3ac6 [exp-eec4c] | 06:10 PM     | 0.24435 | 0.9135     |
| └── 0d5e1ae [exp-25fae] | 06:03 PM     | 0.26133 | 0.9062     |
```

</details>

<details>
<summary>`dvc exp show --drop train.* --keep train.dropout`</summary>

```
| Experiment              | Created      | loss    | accuracy   | train.dropout   |
|-------------------------|--------------|---------|------------|-----------------|
| workspace               | -            | 0.31941 | 0.8997     | 0.3             |
| main                    | Sep 14, 2021 | 0.26484 | 0.9038     | 0.4             |
| ├── d599d35 [exp-4f1f0] | 06:12 PM     | 0.31941 | 0.8997     | 0.3             |
| ├── c6d3ac6 [exp-eec4c] | 06:10 PM     | 0.24435 | 0.9135     | 0.3             |
| └── 0d5e1ae [exp-25fae] | 06:03 PM     | 0.26133 | 0.9062     | 0.4             |
```

</details>

<details>
<summary>`dvc exp show --only-changed --drop Created`</summary>

```
| Experiment              | loss    | accuracy   | train.dropout   | train.lr   |
|-------------------------|---------|------------|-----------------|------------|
| workspace               | 0.31941 | 0.8997     | 0.3             | 0.01       |
| main                    | 0.26484 | 0.9038     | 0.4             | 0.001      |
| ├── d599d35 [exp-4f1f0] | 0.31941 | 0.8997     | 0.3             | 0.01       |
| ├── c6d3ac6 [exp-eec4c] | 0.24435 | 0.9135     | 0.3             | 0.001      |
| └── 0d5e1ae [exp-25fae] | 0.26133 | 0.9062     | 0.4             | 0.001      |
```

</details>


For #7080

<details>
<summary>`dvc exp show --only-changed --drop Experiment --drop Created`</summary>

```
| loss    | accuracy   | train.dropout   | train.lr   |               
|---------|------------|-----------------|------------|
| 0.31941 | 0.8997     | 0.3             | 0.01       |
| 0.26484 | 0.9038     | 0.4             | 0.001      |
| 0.31941 | 0.8997     | 0.3             | 0.01       |
| 0.24435 | 0.9135     | 0.3             | 0.001      |
| 0.26133 | 0.9062     | 0.4             | 0.001      |
```