### PR TITLE
s3: remove explicit dependency on aiobotocore; simplify constraints

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -104,9 +104,7 @@ gs = gcsfs>=2021.11.1
 hdfs =
     fsspec[arrow]
 oss = ossfs>=2021.8.0
-s3 =
-    s3fs>=2021.11.1
-    aiobotocore[boto3]>1.0.1
+s3 = s3fs[boto3]>=2021.11.1
 ssh =
     bcrypt
     sshfs[bcrypt]>=2021.11.2


### PR DESCRIPTION
Hoping to fix `dvc[s3]` installations in pipenv. Pipenv's resolver is in loop, backtracking ruamel.yaml from 0.17.17 to 0.17.11 continuously. I think this has to do more with `s3`'s dependency than `ruamel.yaml` as it only fails here. And, we are specifying dependency in 1.0.1 whereas aiobotocore has released 2.0 versions which is what is being installed, so it's redundant anyway. I am hopeful that this may help resolver with the simplification in constraints.

https://github.com/iterative/dvc-e2e/runs/4558989596?check_suite_focus=true#step:6:77
https://github.com/iterative/dvc-e2e/runs/4579223801?check_suite_focus=true

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
