### PR TITLE
exp run: support naive remote execution via `--machine`

### DIFF
--- a/dvc/command/base.py
+++ b/dvc/command/base.py
@@ -57,3 +57,13 @@ class CmdBaseNoRepo(CmdBase):
 
     def do_run(self):
         return self.run()
+
+
+def fix_plumbing_subparsers(subparsers):
+    # metavar needs to be explicitly set in order to hide plumbing subcommands
+    # from the 'positional arguments' choices list
+    # see: https://bugs.python.org/issue22848
+    cmds = [
+        cmd for cmd, parser in subparsers.choices.items() if parser.add_help
+    ]
+    subparsers.metavar = "{{{}}}".format(",".join(cmds))

--- a/dvc/command/experiments/__init__.py
+++ b/dvc/command/experiments/__init__.py
@@ -1,10 +1,15 @@
 import argparse
 
-from dvc.command.base import append_doc_link, fix_subparsers
+from dvc.command.base import (
+    append_doc_link,
+    fix_plumbing_subparsers,
+    fix_subparsers,
+)
 from dvc.command.experiments import (
     apply,
     branch,
     diff,
+    exec_run,
     gc,
     init,
     ls,
@@ -19,6 +24,7 @@ SUB_COMMANDS = [
     apply,
     branch,
     diff,
+    exec_run,
     gc,
     init,
     ls,
@@ -51,3 +57,4 @@ def add_parser(subparsers, parent_parser):
     fix_subparsers(experiments_subparsers)
     for cmd in SUB_COMMANDS:
         cmd.add_parser(experiments_subparsers, parent_parser)
+    fix_plumbing_subparsers(experiments_subparsers)

--- a/dvc/command/experiments/exec_run.py
+++ b/dvc/command/experiments/exec_run.py
@@ -1,0 +1,41 @@
+import logging
+
+from dvc.command.base import CmdBaseNoRepo
+
+logger = logging.getLogger(__name__)
+
+
+class CmdExecutorRun(CmdBaseNoRepo):
+    """Run an experiment executor."""
+
+    def run(self):
+        from dvc.repo.experiments.executor.base import (
+            BaseExecutor,
+            ExecutorInfo,
+        )
+        from dvc.utils.serialize import load_json
+
+        info = ExecutorInfo.from_dict(load_json(self.args.infofile))
+        BaseExecutor.reproduce(
+            info=info,
+            rev="",
+            queue=None,
+            log_level=logger.getEffectiveLevel(),
+        )
+        return 0
+
+
+def add_parser(experiments_subparsers, parent_parser):
+    EXEC_RUN_HELP = "Run an experiment executor."
+    exec_run_parser = experiments_subparsers.add_parser(
+        "exec-run",
+        parents=[parent_parser],
+        description=EXEC_RUN_HELP,
+        add_help=False,
+    )
+    exec_run_parser.add_argument(
+        "--infofile",
+        help="Path to executor info file",
+        default=None,
+    )
+    exec_run_parser.set_defaults(func=CmdExecutorRun)

--- a/dvc/command/experiments/exec_run.py
+++ b/dvc/command/experiments/exec_run.py
@@ -21,6 +21,7 @@ class CmdExecutorRun(CmdBaseNoRepo):
             rev="",
             queue=None,
             log_level=logger.getEffectiveLevel(),
+            infofile=self.args.infofile,
         )
         return 0
 

--- a/dvc/command/experiments/run.py
+++ b/dvc/command/experiments/run.py
@@ -38,6 +38,7 @@ class CmdExperimentsRun(CmdRepro):
             checkpoint_resume=self.args.checkpoint_resume,
             reset=self.args.reset,
             tmp_dir=self.args.tmp_dir,
+            machine=self.args.machine,
             **self._repro_kwargs,
         )
 
@@ -129,4 +130,13 @@ def _add_run_common(parser):
             "Run this experiment in a separate temporary directory instead of "
             "your workspace."
         ),
+    )
+    parser.add_argument(
+        "--machine",
+        default=None,
+        help=argparse.SUPPRESS,
+        # help=(
+        #     "Run this experiment on the specified 'dvc machine' instance."
+        # )
+        # metavar="<name>",
     )

--- a/dvc/config.py
+++ b/dvc/config.py
@@ -266,7 +266,12 @@ class Config(dict):
                     "key_path": func,
                 }
             },
-            "machine": {str: {"startup_script": func}},
+            "machine": {
+                str: {
+                    "startup_script": func,
+                    "setup_script": func,
+                }
+            },
         }
         return Schema(dirs_schema, extra=ALLOW_EXTRA)(conf)
 

--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -257,6 +257,7 @@ SCHEMA = {
             "instance_gpu": Lower,
             "ssh_private": str,
             "startup_script": str,
+            "setup_script": str,
         },
     },
     # section for experimental features

--- a/dvc/machine/__init__.py
+++ b/dvc/machine/__init__.py
@@ -37,6 +37,8 @@ sudo wget https://dvc.org/deb/dvc.list
 sudo apt-get update
 sudo apt-get install --yes dvc
 popd
+
+sudo echo "OK" > /var/log/dvc-machine-init.log
 """
 
 
@@ -188,6 +190,7 @@ class MachineManager:
         else:
             startup_script = DEFAULT_STARTUP_SCRIPT
         config["startup_script"] = startup_script
+        config.pop("setup_script", None)
         return backend.create(**config)
 
     def destroy(self, name: Optional[str]):
@@ -215,3 +218,7 @@ class MachineManager:
     def get_executor_kwargs(self, name: Optional[str]):
         config, backend = self.get_config_and_backend(name)
         return backend.get_executor_kwargs(**config)
+
+    def get_setup_script(self, name: Optional[str]) -> Optional[str]:
+        config, _backend = self.get_config_and_backend(name)
+        return config.get("setup_script")

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -31,11 +31,12 @@ from .executor.base import (
     BaseExecutor,
     ExecutorInfo,
 )
-from .executor.manager import (
-    BaseExecutorManager,
+from .executor.manager.base import BaseExecutorManager
+from .executor.manager.local import (
     TempDirExecutorManager,
     WorkspaceExecutorManager,
 )
+from .executor.manager.ssh import SSHExecutorManager
 from .utils import exp_refs_by_rev
 
 logger = logging.getLogger(__name__)
@@ -386,6 +387,7 @@ class Experiments:
         tmp_dir: bool = False,
         checkpoint_resume: Optional[str] = None,
         reset: bool = False,
+        machine: Optional[str] = None,
         **kwargs,
     ):
         """Reproduce and checkout a single experiment."""
@@ -395,7 +397,7 @@ class Experiments:
         if reset:
             self.reset_checkpoints()
 
-        if not (queue or tmp_dir):
+        if not (queue or tmp_dir or machine):
             staged, _, _ = self.scm.status()
             if staged:
                 logger.warning(
@@ -429,12 +431,15 @@ class Experiments:
             return [stash_rev]
         if tmp_dir or queue:
             manager_cls: Type = TempDirExecutorManager
+        elif machine:
+            manager_cls = SSHExecutorManager
         else:
             manager_cls = WorkspaceExecutorManager
         results = self._reproduce_revs(
             revs=[stash_rev],
             keep_stash=False,
             manager_cls=manager_cls,
+            machine=machine,
         )
         exp_rev = first(results)
         if exp_rev is not None:
@@ -590,6 +595,7 @@ class Experiments:
         revs: Optional[Iterable] = None,
         keep_stash: Optional[bool] = True,
         manager_cls: Type = TempDirExecutorManager,
+        machine: Optional[str] = None,
         **kwargs,
     ) -> Mapping[str, str]:
         """Reproduce the specified experiments.
@@ -631,6 +637,7 @@ class Experiments:
             os.path.join(self.repo.tmp_dir, EXEC_TMP_DIR),
             self.repo,
             to_run,
+            machine_name=machine,
         )
         try:
             exec_results = {}

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -672,7 +672,7 @@ class Experiments:
             dict mapping stash revs to the successfully executed experiments
             for each stash rev.
         """
-        return manager.exec_queue(**kwargs)
+        return manager.exec_queue(self.repo, **kwargs)
 
     def check_baseline(self, exp_rev):
         baseline_sha = self.repo.scm.get_rev()
@@ -747,6 +747,8 @@ class Experiments:
         from dvc.scm import InvalidRemoteSCMRepo
         from dvc.utils.serialize import load_json
 
+        from .executor.local import TempDirExecutor
+
         result = {}
         pid_dir = os.path.join(
             self.repo.tmp_dir,
@@ -777,10 +779,10 @@ class Experiments:
                         def on_diverged(_ref: str, _checkpoint: bool):
                             return False
 
+                        executor = TempDirExecutor.from_info(info)
                         try:
-                            for ref in BaseExecutor.fetch_exps(
+                            for ref in executor.fetch_exps(
                                 self.scm,
-                                info.git_url,
                                 on_diverged=on_diverged,
                             ):
                                 logger.debug(

--- a/dvc/repo/experiments/executor/local.py
+++ b/dvc/repo/experiments/executor/local.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
     from dvc.repo import Repo
 
-    from ..base import ExpStashEntry
+    from ..base import ExpRefInfo, ExpStashEntry
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +48,11 @@ class BaseLocalExecutor(BaseExecutor):
         super().cleanup()
         self.scm.close()
         del self.scm
+
+    def collect_cache(
+        self, repo: "Repo", exp_ref: "ExpRefInfo", run_cache: bool = True
+    ):
+        """Collect DVC cache."""
 
 
 class TempDirExecutor(BaseLocalExecutor):
@@ -91,9 +96,9 @@ class TempDirExecutor(BaseLocalExecutor):
         with open(local_config, "w", encoding="utf-8") as fobj:
             fobj.write(f"[cache]\n    dir = {cache_dir}")
 
-    def init_cache(self, dvc: "Repo", rev: str, run_cache: bool = True):
-        """Initialize DVC (cache)."""
-        self._config(dvc.odb.local.cache_dir)
+    def init_cache(self, repo: "Repo", rev: str, run_cache: bool = True):
+        """Initialize DVC cache."""
+        self._config(repo.odb.local.cache_dir)
 
     def cleanup(self):
         super().cleanup()
@@ -152,7 +157,7 @@ class WorkspaceExecutor(BaseLocalExecutor):
         elif scm.get_ref(EXEC_BRANCH):
             self.scm.remove_ref(EXEC_BRANCH)
 
-    def init_cache(self, dvc: "Repo", rev: str, run_cache: bool = True):
+    def init_cache(self, repo: "Repo", rev: str, run_cache: bool = True):
         pass
 
     def cleanup(self):

--- a/dvc/repo/experiments/executor/local.py
+++ b/dvc/repo/experiments/executor/local.py
@@ -91,7 +91,11 @@ class TempDirExecutor(BaseLocalExecutor):
         self.scm.merge(merge_rev, squash=True, commit=False)
 
     def _config(self, cache_dir):
-        local_config = os.path.join(self.dvc_dir, "config.local")
+        local_config = os.path.join(
+            self.root_dir,
+            self.dvc_dir,
+            "config.local",
+        )
         logger.debug("Writing experiments local config '%s'", local_config)
         with open(local_config, "w", encoding="utf-8") as fobj:
             fobj.write(f"[cache]\n    dir = {cache_dir}")

--- a/dvc/repo/experiments/executor/manager/base.py
+++ b/dvc/repo/experiments/executor/manager/base.py
@@ -7,9 +7,8 @@ from typing import TYPE_CHECKING, Deque, Dict, Generator, Optional, Tuple, Type
 
 from dvc.proc.manager import ProcessManager
 
-from ..base import (
+from ...base import (
     EXEC_BASELINE,
-    EXEC_BRANCH,
     EXEC_HEAD,
     EXEC_MERGE,
     CheckpointExistsError,
@@ -17,8 +16,8 @@ from ..base import (
     ExpRefInfo,
     ExpStashEntry,
 )
-from .base import EXEC_PID_DIR, BaseExecutor
-from .local import TempDirExecutor, WorkspaceExecutor
+from ..base import EXEC_PID_DIR, BaseExecutor
+from ..local import TempDirExecutor, WorkspaceExecutor
 
 if TYPE_CHECKING:
     from scmrepo.git import Git
@@ -37,6 +36,7 @@ class BaseExecutorManager(ABC, Mapping):
         self,
         scm: "Git",
         wdir: str,
+        **kwargs,
     ):
         from dvc.utils.fs import makedirs
 
@@ -74,8 +74,8 @@ class BaseExecutorManager(ABC, Mapping):
         import json
         from urllib.parse import urlparse
 
-        from .base import ExecutorInfo
-        from .ssh import SSHExecutor
+        from ..base import ExecutorInfo
+        from ..ssh import SSHExecutor
 
         def make_executor(info: "ExecutorInfo"):
             if info.git_url:
@@ -116,6 +116,16 @@ class BaseExecutorManager(ABC, Mapping):
         **kwargs,
     ):
         manager = cls(scm, wdir)
+        manager._enqueue_stash_entries(scm, repo, to_run, **kwargs)
+        return manager
+
+    def _enqueue_stash_entries(
+        self,
+        scm: "Git",
+        repo: "Repo",
+        to_run: Dict[str, ExpStashEntry],
+        **kwargs,
+    ):
         try:
             for stash_rev, entry in to_run.items():
                 scm.set_ref(EXEC_HEAD, entry.head_rev)
@@ -128,17 +138,16 @@ class BaseExecutorManager(ABC, Mapping):
                 #   EXEC_MERGE - the unmerged changes (from our stash)
                 #       to be reproduced
                 #   EXEC_BASELINE - the baseline commit for this experiment
-                executor = cls.EXECUTOR_CLS.from_stash_entry(
+                executor = self.EXECUTOR_CLS.from_stash_entry(
                     repo,
                     stash_rev,
                     entry,
                     **kwargs,
                 )
-                manager.enqueue(stash_rev, executor)
+                self.enqueue(stash_rev, executor)
         finally:
             for ref in (EXEC_HEAD, EXEC_MERGE, EXEC_BASELINE):
                 scm.remove_ref(ref)
-        return manager
 
     def exec_queue(self, jobs: Optional[int] = 1, detach: bool = False):
         """Run dvc repro for queued executors in parallel."""
@@ -260,92 +269,3 @@ class BaseExecutorManager(ABC, Mapping):
         except KeyError:
             pass
         remove(os.path.join(self.pid_dir, rev))
-
-
-class TempDirExecutorManager(BaseExecutorManager):
-    EXECUTOR_CLS = TempDirExecutor
-
-
-class WorkspaceExecutorManager(BaseExecutorManager):
-    EXECUTOR_CLS = WorkspaceExecutor
-
-    @classmethod
-    def from_stash_entries(
-        cls,
-        scm: "Git",
-        wdir: str,
-        repo: "Repo",
-        to_run: Dict[str, ExpStashEntry],
-        **kwargs,
-    ):
-        manager = cls(scm, wdir)
-        try:
-            assert len(to_run) == 1
-            for stash_rev, entry in to_run.items():
-                scm.set_ref(EXEC_HEAD, entry.head_rev)
-                scm.set_ref(EXEC_MERGE, stash_rev)
-                scm.set_ref(EXEC_BASELINE, entry.baseline_rev)
-
-                executor = cls.EXECUTOR_CLS.from_stash_entry(
-                    repo,
-                    stash_rev,
-                    entry,
-                    **kwargs,
-                )
-                manager.enqueue(stash_rev, executor)
-        finally:
-            for ref in (EXEC_MERGE,):
-                scm.remove_ref(ref)
-        return manager
-
-    def _collect_executor(self, executor, exec_result) -> Dict[str, str]:
-        results = {}
-        exp_rev = self.scm.get_ref(EXEC_BRANCH)
-        if exp_rev:
-            logger.debug("Collected experiment '%s'.", exp_rev[:7])
-            results[exp_rev] = exec_result.exp_hash
-        return results
-
-    def exec_queue(self, jobs: Optional[int] = 1, detach: bool = False):
-        """Run a single WorkspaceExecutor.
-
-        Workspace execution is done within the main DVC process
-        (rather than in multiprocessing context)
-        """
-        from dvc.exceptions import DvcException
-        from dvc.stage.monitor import CheckpointKilledError
-
-        assert len(self._queue) == 1
-        assert not detach
-        result: Dict[str, Dict[str, str]] = defaultdict(dict)
-        rev, executor = self._queue.popleft()
-
-        exec_name = "workspace"
-        infofile = self.get_infofile_path(exec_name)
-        try:
-            exec_result = executor.reproduce(
-                info=executor.info,
-                rev=rev,
-                infofile=infofile,
-                log_level=logger.getEffectiveLevel(),
-            )
-            if not exec_result.exp_hash:
-                raise DvcException(
-                    f"Failed to reproduce experiment '{rev[:7]}'"
-                )
-            if exec_result.ref_info:
-                result[rev].update(
-                    self._collect_executor(executor, exec_result)
-                )
-        except CheckpointKilledError:
-            # Checkpoint errors have already been logged
-            return {}
-        except DvcException:
-            raise
-        except Exception as exc:
-            raise DvcException(
-                f"Failed to reproduce experiment '{rev[:7]}'"
-            ) from exc
-        finally:
-            self.cleanup_executor(exec_name, executor)
-        return result

--- a/dvc/repo/experiments/executor/manager/local.py
+++ b/dvc/repo/experiments/executor/manager/local.py
@@ -56,7 +56,7 @@ class WorkspaceExecutorManager(BaseExecutorManager):
                 scm.remove_ref(ref)
         return manager
 
-    def _collect_executor(self, executor, exec_result) -> Dict[str, str]:
+    def _collect_executor(self, repo, executor, exec_result) -> Dict[str, str]:
         results = {}
         exp_rev = self.scm.get_ref(EXEC_BRANCH)
         if exp_rev:
@@ -64,7 +64,9 @@ class WorkspaceExecutorManager(BaseExecutorManager):
             results[exp_rev] = exec_result.exp_hash
         return results
 
-    def exec_queue(self, jobs: Optional[int] = 1, detach: bool = False):
+    def exec_queue(
+        self, repo: "Repo", jobs: Optional[int] = 1, detach: bool = False
+    ):
         """Run a single WorkspaceExecutor.
 
         Workspace execution is done within the main DVC process
@@ -93,7 +95,7 @@ class WorkspaceExecutorManager(BaseExecutorManager):
                 )
             if exec_result.ref_info:
                 result[rev].update(
-                    self._collect_executor(executor, exec_result)
+                    self._collect_executor(repo, executor, exec_result)
                 )
         except CheckpointKilledError:
             # Checkpoint errors have already been logged

--- a/dvc/repo/experiments/executor/manager/local.py
+++ b/dvc/repo/experiments/executor/manager/local.py
@@ -1,0 +1,109 @@
+import logging
+from collections import defaultdict
+from typing import TYPE_CHECKING, Dict, Optional
+
+from ...base import (
+    EXEC_BASELINE,
+    EXEC_BRANCH,
+    EXEC_HEAD,
+    EXEC_MERGE,
+    ExpStashEntry,
+)
+from ..local import TempDirExecutor, WorkspaceExecutor
+from .base import BaseExecutorManager
+
+if TYPE_CHECKING:
+    from scmrepo.git import Git
+
+    from dvc.repo import Repo
+
+logger = logging.getLogger(__name__)
+
+
+class TempDirExecutorManager(BaseExecutorManager):
+    EXECUTOR_CLS = TempDirExecutor
+
+
+class WorkspaceExecutorManager(BaseExecutorManager):
+    EXECUTOR_CLS = WorkspaceExecutor
+
+    @classmethod
+    def from_stash_entries(
+        cls,
+        scm: "Git",
+        wdir: str,
+        repo: "Repo",
+        to_run: Dict[str, ExpStashEntry],
+        **kwargs,
+    ):
+        manager = cls(scm, wdir)
+        try:
+            assert len(to_run) == 1
+            for stash_rev, entry in to_run.items():
+                scm.set_ref(EXEC_HEAD, entry.head_rev)
+                scm.set_ref(EXEC_MERGE, stash_rev)
+                scm.set_ref(EXEC_BASELINE, entry.baseline_rev)
+
+                executor = cls.EXECUTOR_CLS.from_stash_entry(
+                    repo,
+                    stash_rev,
+                    entry,
+                    **kwargs,
+                )
+                manager.enqueue(stash_rev, executor)
+        finally:
+            for ref in (EXEC_MERGE,):
+                scm.remove_ref(ref)
+        return manager
+
+    def _collect_executor(self, executor, exec_result) -> Dict[str, str]:
+        results = {}
+        exp_rev = self.scm.get_ref(EXEC_BRANCH)
+        if exp_rev:
+            logger.debug("Collected experiment '%s'.", exp_rev[:7])
+            results[exp_rev] = exec_result.exp_hash
+        return results
+
+    def exec_queue(self, jobs: Optional[int] = 1, detach: bool = False):
+        """Run a single WorkspaceExecutor.
+
+        Workspace execution is done within the main DVC process
+        (rather than in multiprocessing context)
+        """
+        from dvc.exceptions import DvcException
+        from dvc.stage.monitor import CheckpointKilledError
+
+        assert len(self._queue) == 1
+        assert not detach
+        result: Dict[str, Dict[str, str]] = defaultdict(dict)
+        rev, executor = self._queue.popleft()
+
+        exec_name = "workspace"
+        infofile = self.get_infofile_path(exec_name)
+        try:
+            exec_result = executor.reproduce(
+                info=executor.info,
+                rev=rev,
+                infofile=infofile,
+                log_level=logger.getEffectiveLevel(),
+            )
+            if not exec_result.exp_hash:
+                raise DvcException(
+                    f"Failed to reproduce experiment '{rev[:7]}'"
+                )
+            if exec_result.ref_info:
+                result[rev].update(
+                    self._collect_executor(executor, exec_result)
+                )
+        except CheckpointKilledError:
+            # Checkpoint errors have already been logged
+            return {}
+        except DvcException:
+            raise
+        except Exception as exc:
+            raise DvcException(
+                f"Failed to reproduce experiment '{rev[:7]}'"
+            ) from exc
+        finally:
+            self.cleanup_executor(exec_name, executor)
+        return result

--- a/dvc/repo/experiments/executor/manager/ssh.py
+++ b/dvc/repo/experiments/executor/manager/ssh.py
@@ -62,7 +62,7 @@ class SSHExecutorManager(BaseExecutorManager):
     def get_infofile_path(self, name: str) -> str:
         return f"{name}{BaseExecutor.INFOFILE_EXT}"
 
-    def _exec_attached(self, jobs: Optional[int] = 1):
+    def _exec_attached(self, repo: "Repo", jobs: Optional[int] = 1):
         from dvc.exceptions import DvcException
         from dvc.stage.monitor import CheckpointKilledError
 
@@ -90,7 +90,7 @@ class SSHExecutorManager(BaseExecutorManager):
                 )
             if exec_result.ref_info:
                 result[rev].update(
-                    self._collect_executor(executor, exec_result)
+                    self._collect_executor(repo, executor, exec_result)
                 )
         except CheckpointKilledError:
             # Checkpoint errors have already been logged

--- a/dvc/repo/experiments/executor/manager/ssh.py
+++ b/dvc/repo/experiments/executor/manager/ssh.py
@@ -1,0 +1,109 @@
+import logging
+import posixpath
+from collections import defaultdict
+from typing import TYPE_CHECKING, Callable, Dict, Generator, Optional, Tuple
+
+from ...base import ExpStashEntry
+from ..base import BaseExecutor
+from ..ssh import SSHExecutor, _sshfs
+from .base import BaseExecutorManager
+
+if TYPE_CHECKING:
+    from scmrepo.git import Git
+
+    from dvc.repo import Repo
+
+logger = logging.getLogger(__name__)
+
+
+class SSHExecutorManager(BaseExecutorManager):
+    EXECUTOR_CLS = SSHExecutor
+
+    def __init__(
+        self,
+        scm: "Git",
+        wdir: str,
+        host: Optional[str] = None,
+        port: Optional[int] = None,
+        username: Optional[str] = None,
+        fs_factory: Optional[Callable] = None,
+        **kwargs,
+    ):
+        assert host
+        super().__init__(scm, wdir, **kwargs)
+        self.host = host
+        self.port = port
+        self.username = username
+        self._fs_factory = fs_factory
+
+    def _load_infos(self) -> Generator[Tuple[str, "BaseExecutor"], None, None]:
+        # TODO: load existing infos using sshfs
+        yield from []
+
+    @classmethod
+    def from_stash_entries(
+        cls,
+        scm: "Git",
+        wdir: str,
+        repo: "Repo",
+        to_run: Dict[str, ExpStashEntry],
+        **kwargs,
+    ):
+        machine_name: Optional[str] = kwargs.get("machine_name", None)
+        manager = cls(
+            scm, wdir, **repo.machine.get_executor_kwargs(machine_name)
+        )
+        manager._enqueue_stash_entries(scm, repo, to_run, **kwargs)
+        return manager
+
+    def sshfs(self):
+        return _sshfs(self._fs_factory, host=self.host, port=self.port)
+
+    def get_infofile_path(self, name: str) -> str:
+        return f"{name}{BaseExecutor.INFOFILE_EXT}"
+
+    def _exec_attached(self, jobs: Optional[int] = 1):
+        from dvc.exceptions import DvcException
+        from dvc.stage.monitor import CheckpointKilledError
+
+        assert len(self._queue) == 1
+        result: Dict[str, Dict[str, str]] = defaultdict(dict)
+        rev, executor = self._queue.popleft()
+        info = executor.info
+        infofile = posixpath.join(
+            info.root_dir,
+            info.dvc_dir,
+            "tmp",
+            self.get_infofile_path(rev),
+        )
+        try:
+            exec_result = executor.reproduce(
+                info=executor.info,
+                rev=rev,
+                infofile=infofile,
+                log_level=logger.getEffectiveLevel(),
+                fs_factory=self._fs_factory,
+            )
+            if not exec_result.exp_hash:
+                raise DvcException(
+                    f"Failed to reproduce experiment '{rev[:7]}'"
+                )
+            if exec_result.ref_info:
+                result[rev].update(
+                    self._collect_executor(executor, exec_result)
+                )
+        except CheckpointKilledError:
+            # Checkpoint errors have already been logged
+            return {}
+        except DvcException:
+            raise
+        except Exception as exc:
+            raise DvcException(
+                f"Failed to reproduce experiment '{rev[:7]}'"
+            ) from exc
+        finally:
+            self.cleanup_executor(rev, executor)
+        return result
+
+    def cleanup_executor(self, rev: str, executor: "BaseExecutor"):
+        executor.cleanup()

--- a/dvc/repo/experiments/executor/ssh.py
+++ b/dvc/repo/experiments/executor/ssh.py
@@ -1,5 +1,7 @@
 import logging
+import os
 import posixpath
+import sys
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Callable, Iterable, Optional
 
@@ -14,12 +16,13 @@ from dvc.repo.experiments.base import (
     EXEC_NAMESPACE,
 )
 
-from .base import BaseExecutor
+from .base import BaseExecutor, ExecutorInfo, ExecutorResult
 
 if TYPE_CHECKING:
+    from multiprocessing import Queue
+
     from scmrepo.git import Git
 
-    from dvc.machine import MachineManager
     from dvc.repo import Repo
 
     from ..base import ExpRefInfo, ExpStashEntry
@@ -41,6 +44,7 @@ class SSHExecutor(BaseExecutor):
 
     WARN_UNTRACKED = True
     QUIET = True
+    SETUP_SCRIPT_FILENAME = "exec-setup.sh"
 
     def __init__(
         self,
@@ -49,6 +53,7 @@ class SSHExecutor(BaseExecutor):
         port: Optional[int] = None,
         username: Optional[str] = None,
         fs_factory: Optional[Callable] = None,
+        setup_script: Optional[str] = None,
         **kwargs,
     ):
         assert host
@@ -59,6 +64,7 @@ class SSHExecutor(BaseExecutor):
         self.username = username
         self._fs_factory = fs_factory
         self._repo_abspath = ""
+        self._setup_script = setup_script
 
     @classmethod
     def gen_dirname(cls, name: Optional[str] = None):
@@ -74,14 +80,15 @@ class SSHExecutor(BaseExecutor):
         entry: "ExpStashEntry",
         **kwargs,
     ):
-        manager: "MachineManager" = kwargs.pop("manager")
         machine_name: Optional[str] = kwargs.pop("machine_name", None)
         executor = cls._from_stash_entry(
             repo,
             stash_rev,
             entry,
             cls.gen_dirname(entry.name),
-            **manager.get_executor_kwargs(machine_name),
+            location=machine_name,
+            **repo.machine.get_executor_kwargs(machine_name),
+            setup_script=repo.machine.get_setup_script(machine_name),
         )
         logger.debug("Init SSH executor for host '%s'", executor.host)
         return executor
@@ -151,6 +158,24 @@ class SSHExecutor(BaseExecutor):
             merge_rev = scm.get_ref(EXEC_MERGE)
             self._ssh_cmd(fs, f"git merge --squash --no-commit {merge_rev}")
 
+            if self._setup_script:
+                self._init_setup_script(fs)
+
+    @classmethod
+    def _setup_script_path(cls, dvc_dir: str):
+        return posixpath.join(
+            dvc_dir,
+            "tmp",
+            cls.SETUP_SCRIPT_FILENAME,
+        )
+
+    def _init_setup_script(self, fs: "SSHFileSystem"):
+        assert self._repo_abspath
+        script_path = self._setup_script_path(
+            posixpath.join(self._repo_abspath, self.dvc_dir)
+        )
+        fs.upload(self._setup_script, script_path)
+
     def _ssh_cmd(self, sshfs, cmd, chdir=None, **kwargs):
         working_dir = chdir or self.root_dir
         return sshfs.fs.execute(f"cd {working_dir};{cmd}", **kwargs)
@@ -179,11 +204,10 @@ class SSHExecutor(BaseExecutor):
     @contextmanager
     def get_odb(self):
         from dvc.data.db import ODBManager, get_odb
-        from dvc.repo import Repo
 
         cache_path = posixpath.join(
             self._repo_abspath,
-            Repo.DVC_DIR,
+            self.dvc_dir,
             ODBManager.CACHE_DIR,
         )
 
@@ -194,3 +218,68 @@ class SSHExecutor(BaseExecutor):
         with self.sshfs() as fs:
             kwargs.update(self._git_client_args(fs))
             return super().fetch_exps(*args, **kwargs)
+
+    @classmethod
+    def reproduce(
+        cls,
+        info: "ExecutorInfo",
+        rev: str,
+        queue: Optional["Queue"] = None,
+        infofile: Optional[str] = None,
+        log_errors: bool = True,
+        log_level: Optional[int] = None,
+        **kwargs,
+    ) -> "ExecutorResult":
+        """Reproduce an experiment on a remote machine over SSH.
+
+        Internally uses 'dvc exp exec-run' over SSH.
+        """
+        import json
+        import time
+        from tempfile import TemporaryFile
+
+        from asyncssh import ProcessError
+
+        fs_factory: Optional[Callable] = kwargs.pop("fs_factory", None)
+        if log_errors and log_level is not None:
+            cls._set_log_level(log_level)
+
+        with _sshfs(fs_factory) as fs:
+            while not fs.exists("/var/log/dvc-machine-init.log"):
+                logger.info(
+                    "Waiting for dvc-machine startup script to complete..."
+                )
+                time.sleep(5)
+            logger.info(
+                "Reproducing experiment on '%s'", fs.fs_args.get("host")
+            )
+            with TemporaryFile(mode="w+", encoding="utf-8") as fobj:
+                json.dump(info.asdict(), fobj)
+                fobj.seek(0)
+                fs.upload_fobj(fobj, infofile)
+            cmd = ["source ~/.profile"]
+            script_path = cls._setup_script_path(info.dvc_dir)
+            if fs.exists(posixpath.join(info.root_dir, script_path)):
+                cmd.extend(
+                    [f"pushd {info.root_dir}", f"source {script_path}", "popd"]
+                )
+            exec_cmd = f"dvc exp exec-run --infofile {infofile}"
+            if log_level is not None:
+                if log_level <= logging.TRACE:  # type: ignore[attr-defined]
+                    exec_cmd += " -vv"
+                elif log_level <= logging.DEBUG:
+                    exec_cmd += " -v"
+            cmd.append(exec_cmd)
+            try:
+                sys.stdout.flush()
+                sys.stderr.flush()
+                stdout = os.dup(sys.stdout.fileno())
+                stderr = os.dup(sys.stderr.fileno())
+                fs.fs.execute("; ".join(cmd), stdout=stdout, stderr=stderr)
+                with fs.open(infofile) as fobj:
+                    result_info = ExecutorInfo.from_dict(json.load(fobj))
+                if result_info.result_hash:
+                    return result_info.result
+            except ProcessError:
+                pass
+            return ExecutorResult(None, None, False)

--- a/dvc/repo/experiments/pull.py
+++ b/dvc/repo/experiments/pull.py
@@ -48,7 +48,16 @@ def pull(
         _pull_cache(repo, exp_ref, **kwargs)
 
 
-def _pull_cache(repo, exp_ref, dvc_remote=None, jobs=None, run_cache=False):
+def _pull_cache(
+    repo,
+    exp_ref,
+    dvc_remote=None,
+    jobs=None,
+    run_cache=False,
+    odb=None,
+):
     revs = list(exp_commits(repo.scm, [exp_ref]))
     logger.debug("dvc fetch experiment '%s'", exp_ref)
-    repo.fetch(jobs=jobs, remote=dvc_remote, run_cache=run_cache, revs=revs)
+    repo.fetch(
+        jobs=jobs, remote=dvc_remote, run_cache=run_cache, revs=revs, odb=odb
+    )

--- a/dvc/repo/pull.py
+++ b/dvc/repo/pull.py
@@ -1,7 +1,11 @@
 import logging
+from typing import TYPE_CHECKING, Optional
 
 from dvc.repo import locked
 from dvc.utils import glob_targets
+
+if TYPE_CHECKING:
+    from dvc.objects.db.base import ObjectDB
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +24,7 @@ def pull(
     all_commits=False,
     run_cache=False,
     glob=False,
+    odb: Optional["ObjectDB"] = None,
 ):
     if isinstance(targets, str):
         targets = [targets]
@@ -36,6 +41,7 @@ def pull(
         with_deps=with_deps,
         recursive=recursive,
         run_cache=run_cache,
+        odb=odb,
     )
     stats = self.checkout(
         targets=expanded_targets,

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -129,6 +129,7 @@ def test_experiments_run(dvc, scm, mocker):
         "tmp_dir": False,
         "checkpoint_resume": None,
         "reset": False,
+        "machine": None,
     }
     default_arguments.update(repro_arguments)
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Related to https://github.com/iterative/dvc/issues/6267

- Adds `dvc exp run --machine` for running an experiment on the specified `dvc machine` instance
- Adds machine `setup_script` config option for runtime environment setup (this is separate from the existing `startup_script` which installs system packages at machine boot/startup).

Note: Until the next release, in order to actually use `dvc exp run --machine` you will need to override the default `startup_script` to install DVC from source with your own script:
```
#!/bin/bash
sudo add-apt-repository --yes ppa:deadsnakes/ppa 
sudo apt-get update
# NOTE: deadsnakes PPA python requires debian/ubuntu python3-pip
sudo apt-get install --yes python3.9 python3.9-dev python3.9-venv python3-pip
sudo -u ubuntu python3.9 -m pip install --upgrade pip --user
sudo -u ubuntu python3.9 -m pip install --upgrade setuptools --user
sudo -u ubuntu python3.9 -m pip install "git+https://github.com/iterative/dvc.git@refs/pull/7173/head#egg=dvc[all]" --user
echo "OK" | sudo tee /var/log/dvc-machine-init.log
```
Once this PR is merged you can drop the specific `refs/pull/...` from the pip install command. Also note that you have to install some python yourself, the system python in the default CML machine image is python 3.6 which is no longer supported in DVC.

[![asciicast](https://asciinema.org/a/CZlzGB8deBR6c3uniRErmSSIq.svg)](https://asciinema.org/a/CZlzGB8deBR6c3uniRErmSSIq)