### PR TITLE
deps: remove requests-kerberos from `webdhfs`; provide it via `webdhfs_kerberos`.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -78,10 +78,6 @@ install_requires =
     scmrepo==0.0.6
 
 [options.extras_require]
-# gssapi should not be included in all_remotes, because it doesn't have wheels
-# for linux and mac, so it will fail to compile if user doesn't have all the
-# requirements, including kerberos itself. Once all the wheels are available,
-# we can start shipping it by default.
 all =
     %(azure)s
     %(gdrive)s
@@ -108,11 +104,15 @@ s3 = s3fs[boto3]>=2021.11.1
 ssh =
     bcrypt
     sshfs[bcrypt]>=2021.11.2
+# gssapi should not be included in all_remotes, because it doesn't have wheels
+# for Linux, so it will fail to compile if user doesn't have all the
+# requirements, including kerberos itself.
 ssh_gssapi = sshfs[gssapi]>=2021.11.2
 webdav = webdav4>=0.9.3
 # not to break `dvc[webhdfs]`
 webhdfs =
-    requests-kerberos==0.14.0
+# requests-kerberos requires krb5 & gssapi, which does not provide wheels Linux
+webdhfs_kerberos = requests-kerberos==0.14.0
 terraform = tpi[ssh]>=2.1.0
 tests =
     %(terraform)s


### PR DESCRIPTION
`krb5` does not provide wheels for Linux and Windows and needs to install system libraries for the wheel to be built/installed. This fails `dvc[all]` and `dvc[webhdfs]` installations in Linux and on Windows.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
