### PR TITLE
fs.hdfs: skip port if not available

### DIFF
--- a/dvc/fs/hdfs.py
+++ b/dvc/fs/hdfs.py
@@ -27,9 +27,9 @@ class HDFSFileSystem(CallbackMixin, FSSpecWrapper):
 
     def unstrip_protocol(self, path: str) -> str:
         host = self.fs_args["host"]
-        port = self.fs_args["port"]
-        path = path.lstrip("/")
-        return f"hdfs://{host}:{port}/{path}"
+        port = self.fs_args.get("port")
+        netloc = host + (f":{port}" if port else "")
+        return "hdfs://" + netloc + "/" + path.lstrip("/")
 
     @staticmethod
     def _get_kwargs_from_urls(urlpath):

--- a/tests/unit/fs/test_hdfs.py
+++ b/tests/unit/fs/test_hdfs.py
@@ -1,0 +1,16 @@
+import pytest
+
+from dvc.fs import HDFSFileSystem
+
+
+@pytest.mark.parametrize(
+    "fs_args, expected_url",
+    [
+        ({"host": "example.com"}, "hdfs://example.com"),
+        ({"host": "example.com", "port": None}, "hdfs://example.com"),
+        ({"host": "example.com", "port": 8020}, "hdfs://example.com:8020"),
+    ],
+)
+def test_hdfs_unstrip_protocol(fs_args, expected_url):
+    fs = HDFSFileSystem(**fs_args)
+    assert fs.unstrip_protocol("/path") == expected_url + "/path"


### PR DESCRIPTION
See https://discord.com/channels/485586884165107732/485596304961962003/922875662694510663
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

### How to install/test
```console
pip install git+https://github.com/skshetry/dvc.git@fix-hdfs-unstrip#egg=dvc[hdfs]
```

cc @ashimko

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
