### PR TITLE
odb: move verify option to config

### DIFF
--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -79,13 +79,13 @@ REMOTE_COMMON = {
     "checksum_jobs": All(Coerce(int), Range(1)),
     "jobs": All(Coerce(int), Range(1)),
     Optional("no_traverse"): Bool,  # obsoleted
-    "verify": Bool,
 }
 LOCAL_COMMON = {
     "type": supported_cache_type,
     Optional("protected", default=False): Bool,  # obsoleted
     "shared": All(Lower, Choices("group")),
     Optional("slow_link_warning", default=True): Bool,
+    Optional("verify", default=False): Bool,
 }
 HTTP_COMMON = {
     "auth": All(Lower, Choices("basic", "digest", "custom")),
@@ -95,6 +95,7 @@ HTTP_COMMON = {
     "ask_password": Bool,
     "ssl_verify": Any(Bool, str),
     "method": str,
+    Optional("verify", default=False): Bool,
 }
 WEBDAV_COMMON = {
     "user": str,
@@ -105,6 +106,7 @@ WEBDAV_COMMON = {
     "key_path": str,
     "timeout": Coerce(int),
     "ssl_verify": Any(Bool, str),
+    Optional("verify", default=False): Bool,
 }
 
 SCHEMA = {
@@ -158,11 +160,13 @@ SCHEMA = {
                     "cache_regions": bool,
                     "read_timeout": Coerce(int),
                     "connect_timeout": Coerce(int),
+                    Optional("verify", default=False): Bool,
                     **REMOTE_COMMON,
                 },
                 "gs": {
                     "projectname": str,
                     "credentialpath": str,
+                    Optional("verify", default=False): Bool,
                     **REMOTE_COMMON,
                 },
                 "ssh": {
@@ -175,6 +179,7 @@ SCHEMA = {
                     "timeout": Coerce(int),
                     "gss_auth": Bool,
                     "allow_agent": Bool,
+                    Optional("verify", default=False): Bool,
                     **REMOTE_COMMON,
                 },
                 "hdfs": {"user": str, "kerb_ticket": str, **REMOTE_COMMON},
@@ -185,6 +190,7 @@ SCHEMA = {
                     "ssl_verify": Any(Bool, str),
                     "token": str,
                     "use_https": Bool,
+                    Optional("verify", default=False): Bool,
                     **REMOTE_COMMON,
                 },
                 "azure": {
@@ -200,12 +206,14 @@ SCHEMA = {
                     "exclude_visual_studio_code_credential": Bool,
                     "exclude_shared_token_cache_credential": Bool,
                     "exclude_managed_identity_credential": Bool,
+                    Optional("verify", default=False): Bool,
                     **REMOTE_COMMON,
                 },
                 "oss": {
                     "oss_key_id": str,
                     "oss_key_secret": str,
                     "oss_endpoint": str,
+                    Optional("verify", default=True): Bool,
                     **REMOTE_COMMON,
                 },
                 "gdrive": {
@@ -216,6 +224,7 @@ SCHEMA = {
                     "gdrive_service_account_user_email": str,
                     "gdrive_service_account_json_file_path": str,
                     Optional("gdrive_trash_only", default=False): Bool,
+                    Optional("verify", default=True): Bool,
                     **REMOTE_COMMON,
                 },
                 "http": {**HTTP_COMMON, **REMOTE_COMMON},

--- a/dvc/objects/db/__init__.py
+++ b/dvc/objects/db/__init__.py
@@ -8,18 +8,10 @@ if TYPE_CHECKING:
 
 def get_odb(fs, fs_path, **config):
     from .base import ObjectDB
-    from .gdrive import GDriveObjectDB
     from .local import LocalObjectDB
-    from .oss import OSSObjectDB
 
     if fs.scheme == Schemes.LOCAL:
         return LocalObjectDB(fs, fs_path, **config)
-
-    if fs.scheme == Schemes.GDRIVE:
-        return GDriveObjectDB(fs, fs_path, **config)
-
-    if fs.scheme == Schemes.OSS:
-        return OSSObjectDB(fs, fs_path, **config)
 
     return ObjectDB(fs, fs_path, **config)
 

--- a/dvc/objects/db/gdrive.py
+++ b/dvc/objects/db/gdrive.py
@@ -1,5 +1,0 @@
-from .base import ObjectDB
-
-
-class GDriveObjectDB(ObjectDB):
-    DEFAULT_VERIFY = True

--- a/dvc/objects/db/oss.py
+++ b/dvc/objects/db/oss.py
@@ -1,9 +1,0 @@
-from .base import ObjectDB
-
-
-class OSSObjectDB(ObjectDB):
-    """
-    Temporary extra verification
-    """
-
-    DEFAULT_VERIFY = True

--- a/tests/func/test_config.py
+++ b/tests/func/test_config.py
@@ -239,6 +239,7 @@ def test_merging_two_levels(dvc):
     assert dvc.config["remote"]["test"] == {
         "url": "ssh://example.com",
         "password": "1",
+        "verify": False,
     }
 
 

--- a/tests/func/test_remote.py
+++ b/tests/func/test_remote.py
@@ -239,6 +239,7 @@ def test_remote_modify_local_on_repo_config(tmp_dir, dvc):
     assert dvc.config["remote"]["myremote"] == {
         "url": "http://example.com/path",
         "user": "xxx",
+        "verify": False,
     }
 
 


### PR DESCRIPTION
These options are part of the default config for each particular remote.
Plugins will define their default config on their own, but for now, we keep
those in one config schema.