### PR TITLE
Fix memory leak in Index.build_graph()

### DIFF
--- a/tests/func/test_repo_index.py
+++ b/tests/func/test_repo_index.py
@@ -24,7 +24,6 @@ def test_index(tmp_dir, scm, dvc, run_copy):
 
     assert index.outs_graph
     assert index.graph
-    assert index.build_graph()
     assert isinstance(index.outs_trie, Trie)
     assert index.identifier
     index.check_graph()
@@ -229,7 +228,7 @@ def test_unique_identifier(tmp_dir, dvc, scm, run_copy):
 
 def test_skip_graph_checks(dvc, mocker):
     # See https://github.com/iterative/dvc/issues/2671 for more info
-    mock_build_graph = mocker.spy(Index, "build_graph")
+    mock_build_graph = mocker.spy(Index.graph, "fget")
 
     # sanity check
     Index(dvc).check_graph()

--- a/tests/unit/repo/test_repo.py
+++ b/tests/unit/repo/test_repo.py
@@ -77,7 +77,9 @@ def test_locked(mocker):
 
 def test_skip_graph_checks(tmp_dir, dvc, mocker, run_copy):
     # See https://github.com/iterative/dvc/issues/2671 for more info
-    mock_build_graph = mocker.patch("dvc.repo.index.Index.build_graph")
+    from dvc.repo.index import Index
+
+    mock_build_graph = mocker.spy(Index.graph, "fget")
 
     # sanity check
     tmp_dir.gen("foo", "foo text")


### PR DESCRIPTION
`@memoize()` memory lives as long as decorated function lives, which is
permanent in this case. Since `self` is referenced as a memory key no
`Index` will ever be freed.

Changed to use `@cached_property` who's cache lives as long as the
parent instance.

**NOTE:** This is an issue for Studio since we are parsing many commits in a long running process. 