### PR TITLE
exp show: remove a useless function

### DIFF
--- a/dvc/command/experiments/show.py
+++ b/dvc/command/experiments/show.py
@@ -517,14 +517,6 @@ def _format_json(item):
     return encode_exception(item)
 
 
-def _raise_error_if_all_disabled(**kwargs):
-    if not any(kwargs.values()):
-        raise InvalidArgumentError(
-            "Either of `-w|--workspace`, `-a|--all-branches`, `-T|--all-tags` "
-            "or `--all-commits` needs to be set."
-        )
-
-
 class CmdExperimentsShow(CmdBase):
     def run(self):
         try:


### PR DESCRIPTION
The function `_raise_error_if_all_disabled` is copyed wrongly to this
place during sub command refactoring. It used to be used in `exp gc`,
can be deleted from this function.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
