### PR TITLE
config: Add ui.theme and use in exp show. 

### DIFF
--- a/dvc/command/experiments/show.py
+++ b/dvc/command/experiments/show.py
@@ -385,6 +385,7 @@ def show_experiments(
     csv=False,
     markdown=False,
     html=False,
+    theme=None,
     **kwargs,
 ):
     from funcy.seqs import flatten as flatten_list
@@ -440,9 +441,11 @@ def show_experiments(
             td.drop(col)
 
     row_styles = lmap(baseline_styler, td.column("typ"))
-    for n, row_style in enumerate(row_styles):
-        if n % 2 != 0:
-            row_style["style"] += " on grey23"
+    if theme:
+        for n, row_style in enumerate(row_styles):
+            if n % 2 != 0:
+                color = "grey85" if theme == "light" else "grey23"
+                row_style["style"] += f" on {color}"
 
     if not csv:
         merge_headers = ["Experiment", "rev", "typ", "parent"]
@@ -489,7 +492,7 @@ def show_experiments(
 
     td.render(
         pager=pager,
-        borders="horizontals",
+        borders="horizontals" if theme else True,
         rich_table=True,
         header_styles=styles,
         row_styles=row_styles,
@@ -570,6 +573,7 @@ class CmdExperimentsShow(CmdBase):
                 html=self.args.html,
                 out=self.args.out,
                 open=self.args.open,
+                theme=self.repo.config.get("ui", {}).get("theme", None),
             )
         return 0
 

--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -275,4 +275,7 @@ SCHEMA = {
         "plots": str,
         "live": str,
     },
+    "ui": {
+        Optional("theme", default=None): Any("light", "dark", None),
+    },
 }

--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -671,3 +671,34 @@ def test_show_parallel_coordinates(tmp_dir, dvc, scm, mocker):
     assert main(["exp", "show", "--html"]) == 0
     html_text = (tmp_dir / "dvc_plots" / "index.html").read_text()
     assert '{"label": "foobar", "values": [2.0, null, null]}' in html_text
+
+
+def test_show_theme(tmp_dir, scm, dvc, exp_stage, mocker):
+    from dvc.command.experiments import show
+    from dvc.ui import table
+    from dvc.utils.table import Table
+
+    show_experiments = mocker.spy(show, "show_experiments")
+    rich_table = mocker.spy(table, "rich_table")
+    add_row = mocker.spy(Table, "add_row")
+
+    assert main(["exp", "show"]) == 0
+    assert not show_experiments.call_args[1]["theme"]
+    assert add_row.call_args[1]["style"] == "bold"
+    assert rich_table.call_args[1]["borders"]
+
+    with dvc.config.edit() as conf:
+        conf["ui"]["theme"] = "light"
+
+    assert main(["exp", "show"]) == 0
+    assert show_experiments.call_args[1]["theme"]
+    assert add_row.call_args[1]["style"] == "bold on grey85"
+    assert rich_table.call_args[1]["borders"] == "horizontals"
+
+    with dvc.config.edit() as conf:
+        conf["ui"]["theme"] = "dark"
+
+    assert main(["exp", "show"]) == 0
+    assert show_experiments.call_args[1]["theme"]
+    assert add_row.call_args[1]["style"] == "bold on grey23"
+    assert rich_table.call_args[1]["borders"] == "horizontals"


### PR DESCRIPTION
* [X] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Closes #7194 


- Default

<img width="1034" alt="Captura de pantalla 2021-12-28 a las 10 42 47" src="https://user-images.githubusercontent.com/12677733/147553453-cab64d06-f999-465f-9f8e-bab43e1651b5.png">

<img width="871" alt="Captura de pantalla 2021-12-28 a las 10 46 23" src="https://user-images.githubusercontent.com/12677733/147553479-5391668b-04df-49b4-87ee-ff898a352277.png">


- `dvc config ui.theme light`:

<img width="1019" alt="Captura de pantalla 2021-12-28 a las 10 43 35" src="https://user-images.githubusercontent.com/12677733/147553503-bbf5d95b-b1fb-49ae-a27c-54fa8c51374a.png">

- `dvc config ui.theme dark`:

<img width="1015" alt="Captura de pantalla 2021-12-28 a las 10 43 17" src="https://user-images.githubusercontent.com/12677733/147553528-ae1009b2-7dfc-4fa3-a71e-2c52fcdd286b.png">


