### PR TITLE
exp show: add `--rev` flag (#7152)

### DIFF
--- a/dvc/command/experiments/show.py
+++ b/dvc/command/experiments/show.py
@@ -532,8 +532,9 @@ class CmdExperimentsShow(CmdBase):
                 all_branches=self.args.all_branches,
                 all_tags=self.args.all_tags,
                 all_commits=self.args.all_commits,
-                sha_only=self.args.sha,
+                revs=self.args.rev,
                 num=self.args.num,
+                sha_only=self.args.sha,
                 param_deps=self.args.param_deps,
             )
         except DvcException:
@@ -605,13 +606,23 @@ def add_parser(experiments_subparsers, parent_parser):
         help="Show experiments derived from all Git commits.",
     )
     experiments_show_parser.add_argument(
+        "--rev",
+        type=str,
+        default=None,
+        help=(
+            "Show experiments derived from the specified revision. "
+            "Defaults to HEAD if none of `--rev`,`-a`,`-A`,`-T` is specified."
+        ),
+        metavar="<rev>",
+    )
+    experiments_show_parser.add_argument(
         "-n",
         "--num",
         type=int,
         default=1,
         dest="num",
         metavar="<num>",
-        help="Show the last `num` commits from HEAD.",
+        help="Show the last `num` commits from <rev>.",
     )
     experiments_show_parser.add_argument(
         "--no-pager",

--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -351,8 +351,9 @@ def test_show_multiple_commits(tmp_dir, scm, dvc, exp_stage):
     tmp_dir.scm_gen("file", "file", "commit")
     next_rev = scm.get_rev()
 
+    dvc.experiments.show(num=-1)
     with pytest.raises(InvalidArgumentError):
-        dvc.experiments.show(num=-1)
+        dvc.experiments.show(num=-2)
 
     expected = {"workspace", init_rev, next_rev}
     results = dvc.experiments.show(num=2)

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -99,6 +99,8 @@ def test_experiments_show(dvc, scm, mocker):
             "--param-deps",
             "-n",
             "1",
+            "--rev",
+            "foo",
         ]
     )
     assert cli_args.func == CmdExperimentsShow
@@ -113,8 +115,9 @@ def test_experiments_show(dvc, scm, mocker):
         all_tags=True,
         all_branches=True,
         all_commits=True,
-        sha_only=True,
         num=1,
+        revs="foo",
+        sha_only=True,
         param_deps=True,
     )
 

--- a/tests/unit/scm/test_scm.py
+++ b/tests/unit/scm/test_scm.py
@@ -1,0 +1,63 @@
+from dvc.repo.experiments import ExpRefInfo
+from dvc.scm import iter_revs
+
+
+def test_iter_revs(
+    tmp_dir,
+    scm,
+):
+    """
+    new         other
+     │            │
+    old (tag) ────┘
+     │
+    root
+    """
+    old = scm.active_branch()
+    tmp_dir.scm_gen("foo", "init", commit="init")
+    rev_root = scm.get_rev()
+    tmp_dir.scm_gen("foo", "old", commit="old")
+    rev_old = scm.get_rev()
+    scm.checkout("new", create_new=True)
+    tmp_dir.scm_gen("foo", "new", commit="new")
+    rev_new = scm.get_rev()
+    scm.checkout(old)
+    scm.tag("tag")
+    scm.checkout("other", create_new=True)
+    tmp_dir.scm_gen("foo", "other", commit="new")
+    rev_other = scm.get_rev()
+
+    ref = ExpRefInfo(rev_root, "exp1")
+    scm.set_ref(str(ref), rev_new)
+    ref = ExpRefInfo(rev_root, "exp2")
+    scm.set_ref(str(ref), rev_old)
+
+    gen = iter_revs(scm, [rev_root, "new"], 1)
+    assert gen == {rev_root: [rev_root], rev_new: ["new"]}
+    gen = iter_revs(scm, ["new"], 2)
+    assert gen == {rev_new: ["new"], rev_old: [rev_old]}
+    gen = iter_revs(scm, ["other"], -1)
+    assert gen == {
+        rev_other: ["other"],
+        rev_old: [rev_old],
+        rev_root: [rev_root],
+    }
+    gen = iter_revs(scm, ["tag"])
+    assert gen == {rev_old: ["tag"]}
+    gen = iter_revs(scm, all_branches=True)
+    assert gen == {rev_old: [old], rev_new: ["new"], rev_other: ["other"]}
+    gen = iter_revs(scm, all_tags=True)
+    assert gen == {rev_old: ["tag"]}
+    gen = iter_revs(scm, all_commits=True)
+    assert gen == {
+        rev_old: [rev_old],
+        rev_new: [rev_new],
+        rev_other: [rev_other],
+        rev_root: [rev_root],
+    }
+    gen = iter_revs(scm, all_experiments=True)
+    assert gen == {
+        rev_new: [rev_new],
+        rev_old: [rev_old],
+        rev_root: [rev_root],
+    }


### PR DESCRIPTION
fix: #7152
1. Add `--rev` flag to `dvc exp show`.
2. Add -1 support for `--num` flag`.
3. Extract revision solving to `utils`.
4. Update command unit test
5. Add a util unit test.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
