### PR TITLE
exp remove: refactor exp utils

### DIFF
--- a/dvc/repo/experiments/pull.py
+++ b/dvc/repo/experiments/pull.py
@@ -4,7 +4,7 @@ from dvc.exceptions import DvcException, InvalidArgumentError
 from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
 
-from .utils import exp_commits, resolve_exp_ref
+from .utils import exp_commits, resolve_name
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +14,8 @@ logger = logging.getLogger(__name__)
 def pull(
     repo, git_remote, exp_name, *args, force=False, pull_cache=False, **kwargs
 ):
-    exp_ref = resolve_exp_ref(repo.scm, exp_name, git_remote)
+    exp_ref_dict = resolve_name(repo.scm, exp_name, git_remote)
+    exp_ref = exp_ref_dict[exp_name]
     if not exp_ref:
         raise InvalidArgumentError(
             f"Experiment '{exp_name}' does not exist in '{git_remote}'"

--- a/dvc/repo/experiments/push.py
+++ b/dvc/repo/experiments/push.py
@@ -4,7 +4,7 @@ from dvc.exceptions import DvcException, InvalidArgumentError
 from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
 
-from .utils import exp_commits, push_refspec, resolve_exp_ref
+from .utils import exp_commits, push_refspec, resolve_name
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +20,8 @@ def push(
     push_cache=False,
     **kwargs,
 ):
-    exp_ref = resolve_exp_ref(repo.scm, exp_name)
+    exp_ref_dict = resolve_name(repo.scm, exp_name)
+    exp_ref = exp_ref_dict[exp_name]
     if not exp_ref:
         raise InvalidArgumentError(
             f"'{exp_name}' is not a valid experiment name"

--- a/dvc/repo/experiments/remove.py
+++ b/dvc/repo/experiments/remove.py
@@ -6,7 +6,7 @@ from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
 from dvc.scm import RevError
 
-from .utils import exp_refs, push_refspec, remove_exp_refs, resolve_exp_ref
+from .utils import exp_refs, push_refspec, remove_exp_refs, resolve_name
 
 logger = logging.getLogger(__name__)
 
@@ -69,9 +69,8 @@ def _remove_commited_exps(
 ) -> List[str]:
     remain_list = []
     remove_list = []
-    for exp_name in exp_names:
-        ref_info = resolve_exp_ref(repo.scm, exp_name, remote)
-
+    ref_info_dict = resolve_name(repo.scm, exp_names, remote)
+    for exp_name, ref_info in ref_info_dict.items():
         if ref_info:
             remove_list.append(ref_info)
         else:

--- a/tests/unit/repo/experiments/test_utils.py
+++ b/tests/unit/repo/experiments/test_utils.py
@@ -2,7 +2,7 @@ import pytest
 
 from dvc.exceptions import InvalidArgumentError
 from dvc.repo.experiments.base import EXPS_NAMESPACE, ExpRefInfo
-from dvc.repo.experiments.utils import check_ref_format, resolve_exp_ref
+from dvc.repo.experiments.utils import check_ref_format, resolve_name
 
 
 def commit_exp_ref(tmp_dir, scm, file="foo", contents="foo", name="foo"):
@@ -17,13 +17,16 @@ def commit_exp_ref(tmp_dir, scm, file="foo", contents="foo", name="foo"):
 @pytest.mark.parametrize("name_only", [True, False])
 def test_resolve_exp_ref(tmp_dir, scm, git_upstream, name_only, use_url):
     ref, _ = commit_exp_ref(tmp_dir, scm)
-    ref_info = resolve_exp_ref(scm, "foo" if name_only else ref)
-    assert isinstance(ref_info, ExpRefInfo)
-    assert str(ref_info) == ref
+    name = "foo" if name_only else ref
+    result = resolve_name(scm, [name, "notexist"])
+    assert isinstance(result[name], ExpRefInfo)
+    assert str(result[name]) == ref
+    assert result["notexist"] is None
 
     scm.push_refspec(git_upstream.url, ref, ref)
     remote = git_upstream.url if use_url else git_upstream.remote
-    remote_ref_info = resolve_exp_ref(scm, "foo" if name_only else ref, remote)
+    name = "foo" if name_only else ref
+    remote_ref_info = resolve_name(scm, [name], remote)[name]
     assert isinstance(remote_ref_info, ExpRefInfo)
     assert str(remote_ref_info) == ref
 


### PR DESCRIPTION
fix #7196 

Refactor exp_ref_by_name in `dvc/repo/experiments/utils.py`.

In previous the exp_ref_by_name walk throught all of the references to
match only one exp name. This makes multi exp name seeking to be a job
of `O(mn)` complexity, Walking though the exp ref and return all of the
exp ref with greatly reduce this complexity to `O(n)`

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
