### PR TITLE
fs.gdrive: Fix GDRIVE_CREDENTIALS_DATA for service accounts

### DIFF
--- a/dvc/fs/gdrive.py
+++ b/dvc/fs/gdrive.py
@@ -109,11 +109,14 @@ class GDriveFileSystem(FSSpecWrapper):  # pylint:disable=abstract-method
         if (
             self._use_service_account
             and not self._service_account_json_file_path
+            and "GDRIVE_CREDENTIALS_DATA" not in os.environ
         ):
             raise DvcException(
                 "To use service account, set "
                 "`gdrive_service_account_json_file_path`, and optionally"
                 "`gdrive_service_account_user_email` in DVC config\n"
+                "You can also provide these using the GDRIVE_CREDENTIALS_DATA"
+                "environment variable.\n"
                 "Learn more at {}".format(
                     format_link("https://man.dvc.org/remote/modify")
                 )

--- a/dvc/fs/gdrive.py
+++ b/dvc/fs/gdrive.py
@@ -109,14 +109,12 @@ class GDriveFileSystem(FSSpecWrapper):  # pylint:disable=abstract-method
         if (
             self._use_service_account
             and not self._service_account_json_file_path
-            and "GDRIVE_CREDENTIALS_DATA" not in os.environ
+            and GDriveFileSystem.GDRIVE_CREDENTIALS_DATA not in os.environ
         ):
             raise DvcException(
                 "To use service account, set "
                 "`gdrive_service_account_json_file_path`, and optionally"
                 "`gdrive_service_account_user_email` in DVC config\n"
-                "You can also provide these using the GDRIVE_CREDENTIALS_DATA"
-                "environment variable.\n"
                 "Learn more at {}".format(
                     format_link("https://man.dvc.org/remote/modify")
                 )

--- a/tests/unit/remote/test_gdrive.py
+++ b/tests/unit/remote/test_gdrive.py
@@ -41,3 +41,11 @@ class TestRemoteGDrive:
         )
         with pytest.raises(GDriveAuthError):
             assert fs.fs
+
+    def test_service_account_using_env_var(self, dvc, monkeypatch):
+        monkeypatch.setenv(GDriveFileSystem.GDRIVE_CREDENTIALS_DATA, "foo")
+        GDriveFileSystem(
+            gdrive_credentials_tmp_dir=dvc.tmp_dir,
+            gdrive_use_service_account=True,
+            **self.CONFIG
+        )


### PR DESCRIPTION
`_validate_config()` had a bug: it would not take into account that Google
Drive credentials can also be passed using `GDRIVE_CREDENTIALS_DATA` as
documented here [1].

This patches the validation logic to also accept this environment variable as a
means to provide service account credentials.

Before, commands like `dvc push` would exit with:

```
ERROR: failed to push data to the cloud - To use service account, set
  `gdrive_service_account_json_file_path`, and
  optionally`gdrive_service_account_user_email` in DVC config
Learn more at <https://man.dvc.org/remote/modify>
```

[1]: https://dvc.org/doc/user-guide/setup-google-drive-remote#authorization

Thanks to @duijf for helping me diagnose.

Co-authored-by: Laurens Duijvesteijn <laurens@iterative.ai>