### PR TITLE
repo: use fs instead of scm

### DIFF
--- a/dvc/fs/repo.py
+++ b/dvc/fs/repo.py
@@ -177,8 +177,7 @@ class RepoFileSystem(FileSystem):  # pylint:disable=abstract-method
             if self._is_dvc_repo(d):
                 repo = self.repo_factory(
                     d,
-                    scm=self._main_repo.scm,
-                    rev=self._main_repo.get_rev(),
+                    fs=self._main_repo.fs,
                     repo_factory=self.repo_factory,
                 )
                 self._dvcfss[repo.root_dir] = DvcFileSystem(repo=repo)

--- a/tests/unit/repo/test_repo.py
+++ b/tests/unit/repo/test_repo.py
@@ -120,9 +120,9 @@ def test_branch_config(tmp_dir, scm):
     scm.checkout("master")
 
     with pytest.raises(NotDvcRepoError):
-        Repo(scm=scm, rev="master").close()
+        Repo(rev="master").close()
 
-    dvc = Repo(scm=scm, rev="branch")
+    dvc = Repo(rev="branch")
     try:
         assert dvc.config["remote"]["branch"]["url"] == "/some/path"
     finally:

--- a/tests/unit/test_external_repo.py
+++ b/tests/unit/test_external_repo.py
@@ -36,8 +36,7 @@ def test_hook_is_called(tmp_dir, erepo_dir, mocker):
             [
                 call(
                     path,
-                    scm=repo.scm,
-                    rev=repo.get_rev(),
+                    fs=repo.fs,
                     repo_factory=repo.repo_fs.repo_factory,
                 )
                 for path in paths


### PR DESCRIPTION
SCM is used for both reading and writing operations, but in the former case -
as filesystem and in the latter - as actual scm/git. So we should distinguish
those and use fs directly, which follows the overall philosophy of being able
to use Repo on any fs.

Keeping `rev=` option for `Repo` because it is a very convenient way to get
repo instance from local path but for particular branch/tag/etc.

Pre-requisite for git/dvc/repofs refactorings.
