### PR TITLE
output: don't raise RemoteCacheRequiredError on instantiation, make it lazy

### DIFF
--- a/dvc/output.py
+++ b/dvc/output.py
@@ -326,9 +326,6 @@ class Output:
         self.desc = desc
 
         self.fs_path = self._parse_path(self.fs, fs_path)
-        if self.use_cache and self.odb is None:
-            raise RemoteCacheRequiredError(self.fs.scheme, self.fs_path)
-
         self.obj = None
         self.isexec = False if self.IS_DEPENDENCY else isexec
 
@@ -402,7 +399,10 @@ class Output:
 
     @property
     def odb(self):
-        return getattr(self.repo.odb, self.scheme)
+        odb = getattr(self.repo.odb, self.scheme)
+        if self.use_cache and odb is None:
+            raise RemoteCacheRequiredError(self.fs.scheme, self.fs_path)
+        return odb
 
     @property
     def cache_path(self):

--- a/tests/func/test_remote.py
+++ b/tests/func/test_remote.py
@@ -247,14 +247,15 @@ def test_external_dir_resource_on_no_cache(tmp_dir, dvc, tmp_path_factory):
     # https://github.com/iterative/dvc/issues/2647, is some situations
     # (external dir dependency) cache is required to calculate dir md5
     external_dir = tmp_path_factory.mktemp("external_dir")
-    (external_dir / "file").write_text("content")
+    file = external_dir / "file"
 
     dvc.odb.local = None
     with pytest.raises(RemoteCacheRequiredError):
         dvc.run(
-            cmd="echo hello world",
-            outs=[os.fspath(external_dir)],
-            single_stage=True,
+            cmd=f"echo content > {file}",
+            outs=[os.fspath(file)],
+            name="echo",
+            external=True,
         )
 
 


### PR DESCRIPTION
As the title says. Had to adjust tests as before we were raising this issue during instantiation which meant we were not checking for `external=True` there, but now stage validation takes priority and needs explicitly `external=True` for the test to work/make sense. 

This is backported from https://github.com/iterative/dvc/pull/6868.
