### PR TITLE
ui: remove `None` in CellT type

### DIFF
--- a/dvc/command/machine.py
+++ b/dvc/command/machine.py
@@ -241,6 +241,7 @@ class CmdMachineStatus(CmdBase):
         "instance_hdd_size",
         "instance_gpu",
     ]
+    FILL_VALUE = "-"
 
     def _add_row(
         self,
@@ -250,7 +251,11 @@ class CmdMachineStatus(CmdBase):
     ):
 
         if not all_status:
-            row = [name, None, "offline"]
+            row = [
+                name,
+                self.FILL_VALUE,
+                "offline",
+            ]  # back to `None` after #7167
             td.append(row)
         for i, status in enumerate(all_status, start=1):
             row = [name, f"num_{i}", "running" if status else "offline"]
@@ -264,7 +269,7 @@ class CmdMachineStatus(CmdBase):
             raise MachineDisabledError
 
         td = TabularData(
-            self.INSTANCE_FIELD + self.SHOWN_FIELD, fill_value="-"
+            self.INSTANCE_FIELD + self.SHOWN_FIELD, fill_value=self.FILL_VALUE
         )
 
         if self.args.name:

--- a/dvc/ui/table.py
+++ b/dvc/ui/table.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 SHOW_MAX_WIDTH = 1024
 
 
-CellT = Union[str, "RichText", None]  # RichText is mostly compatible with str
+CellT = Union[str, "RichText"]  # RichText is mostly compatible with str
 Row = Sequence[CellT]
 TableData = Sequence[Row]
 Headers = Sequence[str]


### PR DESCRIPTION
From https://github.com/iterative/dvc/pull/6893/files#r777784748
Table rendering does not support `None` for now, and we will change it
back after (#7167).

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
