### PR TITLE
tests: clean repositories before each test runs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,14 @@ def enable_ui():
     ui.enable()
 
 
+@pytest.fixture(autouse=True)
+def clean_repos():
+    # pylint: disable=redefined-outer-name
+    from dvc.external_repo import clean_repos
+
+    clean_repos()
+
+
 @pytest.fixture(scope="session", autouse=True)
 def _close_pools():
     from dvc.fs.pool import close_pools


### PR DESCRIPTION
While investigating this failure: https://github.com/iterative/dvc/runs/4735592203?check_suite_focus=true#step:7:4910,
I noticed that we don't clean repos after each test runs, which meant that when some test later on called `main()` function, the function might try cleaning up multiple repositories at the end, which caused timeout for `exp init` tests.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
