### PR TITLE
fs: test_links: create destination directory first

### DIFF
--- a/dvc/fs/utils.py
+++ b/dvc/fs/utils.py
@@ -153,6 +153,7 @@ def test_links(
     from_fs.makedirs(from_fs.path.parent(from_file))
     with from_fs.open(from_file, "wb") as fobj:
         fobj.write(b"test")
+    to_fs.makedirs(to_fs.path.parent(to_file))
 
     ret = []
     try:


### PR DESCRIPTION
`dvc.fs.utils.test_links()` fails with a CacheLinkError if the target `to_path` does not already exist, as is the case when "abc.dvc" exists (referring to a directory object) and we try to run "dvc pull abc/def". To avoid this issue, fully create `to_path` before attempting to create a link in it.

Example error log which this should fix:
```
2022-01-08 00:58:31,286 ERROR: failed to pull data from the cloud - No possible cache link types for '/<REPO>/<OBJECT>/<SUBDIR>'. See <https://dvc.org/doc/user-guide/troubleshooting#cache-types> for more information.
------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/dvc/command/data_sync.py", line 30, in run
    stats = self.repo.pull(
  File "/usr/local/lib/python3.8/dist-packages/dvc/repo/__init__.py", line 49, in wrapper
    return f(repo, *args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/dvc/repo/pull.py", line 40, in pull
    stats = self.checkout(
  File "/usr/local/lib/python3.8/dist-packages/dvc/repo/__init__.py", line 49, in wrapper
    return f(repo, *args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/dvc/repo/checkout.py", line 98, in checkout
    result = stage.checkout(
  File "/usr/local/lib/python3.8/dist-packages/funcy/decorators.py", line 45, in wrapper
    return deco(call, *dargs, **dkwargs)
  File "/usr/local/lib/python3.8/dist-packages/dvc/stage/decorators.py", line 36, in rwlocked
    return call()
  File "/usr/local/lib/python3.8/dist-packages/funcy/decorators.py", line 66, in __call__
    return self._func(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.8/dist-packages/dvc/stage/__init__.py", line 572, in checkout
    key, outs = self._checkout(
  File "/usr/local/lib/python3.8/dist-packages/dvc/stage/__init__.py", line 584, in _checkout
    result = out.checkout(**kwargs)
  File "/usr/local/lib/python3.8/dist-packages/dvc/output.py", line 756, in checkout
    modified = checkout(
  File "/usr/local/lib/python3.8/dist-packages/dvc/objects/checkout.py", line 241, in checkout
    _checkout(
  File "/usr/local/lib/python3.8/dist-packages/dvc/objects/checkout.py", line 164, in _checkout
    raise CacheLinkError([fs_path])
dvc.exceptions.CacheLinkError: No possible cache link types for '/<REPO>/<OBJECT>/<SUBDIR>'. See <https://dvc.org/doc/user-guide/troubleshooting#cache-types> for more information.

```