### PR TITLE
exp list: add the new flags  (including -A/--all-commits) (#7153)

### DIFF
--- a/dvc/commands/experiments/__init__.py
+++ b/dvc/commands/experiments/__init__.py
@@ -58,3 +58,43 @@ def add_parser(subparsers, parent_parser):
     for cmd in SUB_COMMANDS:
         cmd.add_parser(experiments_subparsers, parent_parser)
     fix_plumbing_subparsers(experiments_subparsers)
+
+
+def add_rev_selection_flags(
+    experiments_subcmd_parser, command: str, default: bool = True
+):
+    experiments_subcmd_parser.add_argument(
+        "-A",
+        "--all-commits",
+        action="store_true",
+        default=False,
+        help=(
+            f"{command} all experiments in the repository "
+            "(overrides `--rev` and `--num`)."
+        ),
+    )
+    default_msg = " (HEAD by default)" if default else ""
+    msg = (
+        f"{command} experiments derived from the specified `<commit>` as "
+        f"baseline{default_msg}."
+    )
+    experiments_subcmd_parser.add_argument(
+        "--rev",
+        type=str,
+        default=None,
+        help=msg,
+        metavar="<commit>",
+    )
+    experiments_subcmd_parser.add_argument(
+        "-n",
+        "--num",
+        type=int,
+        default=1,
+        dest="num",
+        metavar="<num>",
+        help=(
+            f"{command} experiments from the `--rev` baseline and from `num` "
+            "commits before it (first parents). Give a negative value to "
+            "include all first-parent commits."
+        ),
+    )

--- a/dvc/commands/experiments/ls.py
+++ b/dvc/commands/experiments/ls.py
@@ -11,9 +11,10 @@ class CmdExperimentsList(CmdBase):
     def run(self):
         names_only = self.args.names_only
         exps = self.repo.experiments.ls(
+            all_commits=self.args.all_commits,
             rev=self.args.rev,
+            num=self.args.num,
             git_remote=self.args.git_remote,
-            all_=self.args.all,
         )
         for baseline in exps:
             tag = self.repo.scm.describe(baseline)
@@ -32,6 +33,7 @@ class CmdExperimentsList(CmdBase):
 
 
 def add_parser(experiments_subparsers, parent_parser):
+    from . import add_rev_selection_flags
 
     EXPERIMENTS_LIST_HELP = "List local and remote experiments."
     experiments_list_parser = experiments_subparsers.add_parser(
@@ -41,19 +43,7 @@ def add_parser(experiments_subparsers, parent_parser):
         help=EXPERIMENTS_LIST_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    experiments_list_parser.add_argument(
-        "--rev",
-        type=str,
-        default=None,
-        help=(
-            "List experiments derived from the specified revision. "
-            "Defaults to HEAD if neither `--rev` nor `--all` are specified."
-        ),
-        metavar="<rev>",
-    )
-    experiments_list_parser.add_argument(
-        "--all", action="store_true", help="List all experiments."
-    )
+    add_rev_selection_flags(experiments_list_parser, "List")
     experiments_list_parser.add_argument(
         "--names-only",
         action="store_true",

--- a/dvc/commands/experiments/show.py
+++ b/dvc/commands/experiments/show.py
@@ -515,6 +515,8 @@ class CmdExperimentsShow(CmdBase):
 
 
 def add_parser(experiments_subparsers, parent_parser):
+    from . import add_rev_selection_flags
+
     EXPERIMENTS_SHOW_HELP = "Print experiments."
     experiments_show_parser = experiments_subparsers.add_parser(
         "show",
@@ -523,6 +525,7 @@ def add_parser(experiments_subparsers, parent_parser):
         help=EXPERIMENTS_SHOW_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    add_rev_selection_flags(experiments_show_parser, "Show")
     experiments_show_parser.add_argument(
         "-a",
         "--all-branches",
@@ -536,32 +539,6 @@ def add_parser(experiments_subparsers, parent_parser):
         action="store_true",
         default=False,
         help="Show experiments derived from all Git tags.",
-    )
-    experiments_show_parser.add_argument(
-        "-A",
-        "--all-commits",
-        action="store_true",
-        default=False,
-        help="Show experiments derived from all Git commits.",
-    )
-    experiments_show_parser.add_argument(
-        "--rev",
-        type=str,
-        default=None,
-        help=(
-            "Show experiments derived from the specified revision. "
-            "Defaults to HEAD if none of `--rev`,`-a`,`-A`,`-T` is specified."
-        ),
-        metavar="<rev>",
-    )
-    experiments_show_parser.add_argument(
-        "-n",
-        "--num",
-        type=int,
-        default=1,
-        dest="num",
-        metavar="<num>",
-        help="Show the last `num` commits from <rev>.",
     )
     experiments_show_parser.add_argument(
         "--no-pager",

--- a/dvc/repo/experiments/ls.py
+++ b/dvc/repo/experiments/ls.py
@@ -3,49 +3,36 @@ from collections import defaultdict
 
 from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
+from dvc.scm import iter_revs
+from dvc.types import Optional
 
-from .utils import (
-    exp_refs,
-    exp_refs_by_baseline,
-    remote_exp_refs,
-    remote_exp_refs_by_baseline,
-)
+from .utils import exp_refs, exp_refs_by_baseline
 
 logger = logging.getLogger(__name__)
 
 
 @locked
 @scm_context
-def ls(repo, *args, rev=None, git_remote=None, all_=False, **kwargs):
-    from scmrepo.git import Git
-
-    from dvc.scm import RevError, resolve_rev
-
-    if rev:
-        try:
-            rev = resolve_rev(repo.scm, rev)
-        except RevError:
-            if not (git_remote and Git.is_sha(rev)):
-                # This could be a remote rev that has not been fetched yet
-                raise
-    elif not all_:
-        rev = repo.scm.get_rev()
-
+def ls(
+    repo,
+    rev: Optional[str] = None,
+    all_commits: bool = False,
+    num: int = 1,
+    git_remote: Optional[str] = None,
+):
     results = defaultdict(list)
-
-    if rev:
-        if git_remote:
-            gen = remote_exp_refs_by_baseline(repo.scm, git_remote, rev)
-        else:
-            gen = exp_refs_by_baseline(repo.scm, rev)
-        for info in gen:
-            results[rev].append(info.name)
-    elif all_:
-        if git_remote:
-            gen = remote_exp_refs(repo.scm, git_remote)
-        else:
-            gen = exp_refs(repo.scm)
+    if all_commits:
+        gen = exp_refs(repo.scm, git_remote)
         for info in gen:
             results[info.baseline_sha].append(info.name)
+        return results
+
+    rev = rev or "HEAD"
+
+    revs = iter_revs(repo.scm, [rev], num)
+    rev_set = set(revs.keys())
+    ref_info_dict = exp_refs_by_baseline(repo.scm, rev_set, git_remote)
+    for rev, ref_info_list in ref_info_dict.items():
+        results[rev] = [ref_info.name for ref_info in ref_info_list]
 
     return results

--- a/tests/func/experiments/test_experiments.py
+++ b/tests/func/experiments/test_experiments.py
@@ -479,7 +479,7 @@ def test_list(tmp_dir, scm, dvc, exp_stage):
         baseline_a: {ref_info_a.name, ref_info_b.name}
     }
 
-    exp_list = dvc.experiments.ls(all_=True)
+    exp_list = dvc.experiments.ls(all_commits=True)
     assert {key: set(val) for key, val in exp_list.items()} == {
         baseline_a: {ref_info_a.name, ref_info_b.name},
         baseline_c: {ref_info_c.name},

--- a/tests/func/experiments/test_remote.py
+++ b/tests/func/experiments/test_remote.py
@@ -132,12 +132,13 @@ def test_list_remote(tmp_dir, scm, dvc, git_downstream, exp_stage, use_url):
     downstream_exp = git_downstream.tmp_dir.dvc.experiments
     assert downstream_exp.ls(git_remote=remote) == {}
 
+    git_downstream.tmp_dir.scm.fetch_refspecs(remote, ["master:master"])
     exp_list = downstream_exp.ls(rev=baseline_a, git_remote=remote)
     assert {key: set(val) for key, val in exp_list.items()} == {
         baseline_a: {ref_info_a.name, ref_info_b.name}
     }
 
-    exp_list = downstream_exp.ls(all_=True, git_remote=remote)
+    exp_list = downstream_exp.ls(all_commits=True, git_remote=remote)
     assert {key: set(val) for key, val in exp_list.items()} == {
         baseline_a: {ref_info_a.name, ref_info_b.name},
         baseline_c: {ref_info_c.name},

--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -7,7 +7,6 @@ import pytest
 from funcy import first, get_in
 
 from dvc.cli import main
-from dvc.exceptions import InvalidArgumentError
 from dvc.repo.experiments.base import EXPS_STASH, ExpRefInfo
 from dvc.repo.experiments.executor.base import (
     EXEC_PID_DIR,
@@ -287,9 +286,7 @@ def test_show_multiple_commits(tmp_dir, scm, dvc, exp_stage):
     tmp_dir.scm_gen("file", "file", "commit")
     next_rev = scm.get_rev()
 
-    dvc.experiments.show(num=-1)
-    with pytest.raises(InvalidArgumentError):
-        dvc.experiments.show(num=-2)
+    dvc.experiments.show(num=-2)
 
     expected = {"workspace", init_rev, next_rev}
     results = dvc.experiments.show(num=2)

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -197,9 +197,11 @@ def test_experiments_list(dvc, scm, mocker):
             "experiments",
             "list",
             "origin",
+            "--all-commits",
+            "-n",
+            "-1",
             "--rev",
             "foo",
-            "--all",
             "--names-only",
         ]
     )
@@ -211,7 +213,11 @@ def test_experiments_list(dvc, scm, mocker):
     assert cmd.run() == 0
 
     m.assert_called_once_with(
-        cmd.repo, git_remote="origin", rev="foo", all_=True
+        cmd.repo,
+        git_remote="origin",
+        rev="foo",
+        all_commits=True,
+        num=-1,
     )
 
 


### PR DESCRIPTION
fix: #7153
Unify the flags in `exp list` to `exp show` (including -A/--all-commits
)
Wait #7152 and #7206

1. Add new `-A`,`-n` flags to `exp list` command.
2. Add unit test for the flag parse.
3. unify the revs retrive logic to `exp show`.
4. Add functional test for `exp list`

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
