### PR TITLE
cli: support external commands available in PATH

### DIFF
--- a/dvc/commands/external.py
+++ b/dvc/commands/external.py
@@ -1,0 +1,22 @@
+import logging
+import os
+from typing import List
+
+from dvc.cli.command import CmdBaseNoRepo
+
+logger = logging.getLogger(__name__)
+
+
+class CmdExternal(CmdBaseNoRepo):
+    def exec(self, executable: str, args: List[str]) -> int:
+        import subprocess
+
+        return subprocess.call([executable, *args])
+
+    def run(self) -> int:
+        executable: str = self.args.executable
+        args: List[str] = self.args.args
+        cmd, _ = os.path.splitext(os.path.basename(executable))
+
+        logger.debug("exec: %s", " ".join([cmd, *args]))
+        return self.exec(executable, args)

--- a/tests/unit/command/test_external.py
+++ b/tests/unit/command/test_external.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import pytest
 
-from dvc.cli import DvcParserError, parse_args, main
+from dvc.cli import DvcParserError, main, parse_args
 from dvc.commands.external import CmdExternal
 from dvc.utils.fs import path_isin
 from dvc.utils.strictyaml import make_relpath

--- a/tests/unit/command/test_external.py
+++ b/tests/unit/command/test_external.py
@@ -1,0 +1,94 @@
+import os
+import shutil
+import stat
+import sys
+from dataclasses import dataclass
+
+import pytest
+
+from dvc.cli import DvcParserError, parse_args, main
+from dvc.commands.external import CmdExternal
+from dvc.utils.fs import path_isin
+from dvc.utils.strictyaml import make_relpath
+
+
+def append_paths(*paths, env="PATH"):
+    if env in os.environ:
+        paths = [*paths, os.environ[env]]
+    return os.pathsep.join(paths)
+
+
+@dataclass
+class ScriptInfo:
+    executable: str
+    script: str
+
+
+def make_executable_path(path):
+    # On Windows, if the executable path is in cwd, shutil.which returns
+    # ".\\rel" paths, otherwise, it returns an absolute path.
+    # On other platforms, it's always an absolute path.
+    abspath = os.path.abspath(path)
+    if os.name == "nt" and path_isin(abspath, os.getcwd()):
+        return make_relpath(path)
+    return abspath
+
+
+@pytest.fixture
+def make_external_cmd(tmp_dir, monkeypatch):
+    def make(cmd: str, contents: str) -> ScriptInfo:
+        monkeypatch.setenv("PATH", append_paths(str(tmp_dir)))
+
+        contents = f"#!{sys.executable}\n{contents}\n"
+        if os.name == "nt":
+            # Here, we create a batch file that invokes python script.
+            # `.BAT` files are usually in PATHEXT, but adding them explicitly
+            # just in case.
+            # We can just run this batch file without it's extension suffix
+            # later, we can do so after adding particular extension to PATHEXT.
+            monkeypatch.setenv("PATHEXT", append_paths(".BAT", "PATHEXT"))
+            script = tmp_dir / f"{cmd}.py"
+            script.write_text(contents, encoding="utf-8")
+
+            executable = script.with_suffix(".BAT")
+            executable.write_text(
+                f'@echo off\n"{sys.executable}" "{script}" %*\n'
+            )
+        else:
+            # We create a script without any extensions here, unlike in Windows
+            executable = script = tmp_dir / cmd
+            script.write_text(contents, encoding="utf-8")
+            script.chmod(script.stat().st_mode | stat.S_IEXEC)
+
+        assert shutil.which(cmd) == make_executable_path(executable)
+        return ScriptInfo(str(executable), str(script))
+
+    return make
+
+
+def test_parse_args_unknown_subcommand(caplog):
+    with pytest.raises(DvcParserError):
+        parse_args(["-v", "ext", "target", "--out", "out"])
+    assert "argument COMMAND: invalid choice: 'ext'" in caplog.text
+
+
+def test_parse_args(make_external_cmd):
+    cmd = make_external_cmd("dvc-ext", 'print("hello world!")')
+
+    ret = parse_args(["-v", "ext", "target", "--out", "out"])
+    assert ret.func is CmdExternal
+    assert ret.args == ["target", "--out", "out"]
+    assert ret.cmd == "ext"
+    assert ret.executable == make_executable_path(cmd.executable)
+    assert ret.verbose  # this should not be passed to cmd
+
+
+def test_external_cmd(make_external_cmd, caplog, capfd):
+    code = "import sys; print(sys.argv); sys.exit(1)"
+    cmd = make_external_cmd("dvc-ext", code)
+
+    assert main(["ext", "target", "--out", "out"]) == 1
+    assert "exec: dvc-ext target --out out" in caplog.text
+
+    output = capfd.readouterr()[0].strip().replace(r"\\", "\\")
+    assert output == rf"['{cmd.script}', 'target', '--out', 'out']"


### PR DESCRIPTION
This commit adds support for external commands that are available
in one of the directory set in PATH.
The executable should be in format of \'dvc-*\' format, should
have executable permissions and need to exist (duh). The suffix,
after 'dvc-' will be used as a subcommand name, and all tha arguments
after that subcommand will be passed to that external command.

Closes https://github.com/iterative/dvc/issues/6489.


### Motivation

1. This makes DVC extensible with new subcommands without having to modify DVC itself. This can help users to use
custom commands outside of DVC.

2. We may be able to maintain `dvclive` outside `dvc`. Although it's not clear if this will be enough, or if we need python-based plugins.

2. Users may be able to combine multiple dvc commands for their workflow or use it to set an alias. https://github.com/iterative/dvc/issues/7040.

3. We also lack plumbing/low-level commands that I always wanted to have, especially during debugging/development.
These commands could be modifying `dvc-objects` or manipulating `dvc.yaml`/`dvc.lock` files, or debugging pipelines workflow, etc. We have too many commands already, and we may not want to have more commands, that are niche.
This gives us the ability to share scripts among the team. See https://github.com/iterative/dvc/issues/1500.

This is not expected to be documented yet, we may try using it within the team and gather feedback first.

Other projects that support this mechanism:
- Git
- [Cargo](https://doc.rust-lang.org/cargo/reference/external-tools.html#custom-subcommands)


* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
