### PR TITLE
deps-dev: don't specify pygments explicitly

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -145,8 +145,6 @@ tests =
     google-cloud-storage==2.0.0
     dvclive[image]==0.4.6
     hdfs==2.6.0
-    # required by collective.checkdocs
-    Pygments==2.11.1
     collective.checkdocs==0.2
     pydocstyle==6.1.1
     # pylint requirements


### PR DESCRIPTION
pygments is a transitive dependency for us, from `rich` and here it was for `collective.checkdocs`.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
