### PR TITLE
tests: several tests migrated unittest to pytest

### DIFF
--- a/tests/basic_env.py
+++ b/tests/basic_env.py
@@ -155,12 +155,6 @@ class TestDir(TestDirFixture, TestCase):
         TestCase.__init__(self, methodName)
 
 
-class TestGit(TestGitFixture, TestCase):
-    def __init__(self, methodName):
-        TestGitFixture.__init__(self)
-        TestCase.__init__(self, methodName)
-
-
 class TestDvc(TestDvcFixture, TestCase):
     def __init__(self, methodName):
         TestDvcFixture.__init__(self)

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -1,6 +1,5 @@
 from dataclasses import asdict
 from math import pi
-from unittest.mock import mock_open
 
 import pytest
 
@@ -219,7 +218,7 @@ def test_overwrite_with_setitem():
 def test_load_from(mocker):
     d = {"x": {"y": {"z": 5}, "lst": [1, 2, 3]}, "foo": "foo"}
     fs = mocker.Mock(
-        open=mock_open(read_data=dumps_yaml(d)),
+        open=mocker.mock_open(read_data=dumps_yaml(d)),
         **{"exists.return_value": True, "isdir.return_value": False},
     )
     file = "params.yaml"


### PR DESCRIPTION
Part of #1819

Changes:
1. Removed `TestGit` in `basic_env.py`.
2. Several `unittest.TestCase` subclasses in `func/test_odb.py` migrated to pytest: `TestCacheLoadBadDirCache`, `TestExternalCacheDir`, `TestSharedCacheDir`, `TestCacheLinkType`, `TestCmdCacheDir`
3. Several `unittest.TestCase` subclasses in `func/test_fs.py` migrated to pytest: `TestMtimeAndSize`, `TestContainsLink`,  

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

I have followed the checklit. 

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

This PR doesn't require documentation updates.


