### PR TITLE
plots: update linear template so colors can be externally overwritten

### DIFF
--- a/dvc/repo/plots/templates/linear.json
+++ b/dvc/repo/plots/templates/linear.json
@@ -69,7 +69,7 @@
                 {
                     "mark": {
                         "type": "rule",
-                        "color": "gray"
+                        "stroke": "gray"
                     },
                     "encoding": {
                         "x": {


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

---

To keep things consistent when we display plots generated from default templates in the VS Code extension, we will be overwriting the default colors (in the same way that Studio does). From initial inspection, it appears that overwriting the colors of plots that are generated by the linear template gives a slightly unexpected result.  The vertical on-hover line gets drawn with the last color that I specify as an override:

![image](https://user-images.githubusercontent.com/37993418/149855009-f4ba319f-51a0-41ef-a346-3f54804d7d93.png)

After the change:

![image](https://user-images.githubusercontent.com/37993418/149855021-4abac6a9-2f90-4593-962e-cd429e96a2b4.png)

Let me know if you have any questions or concerns.

Thanks,
Matt