### PR TITLE
repro/exp run: display stage name instead of filepath on failure

### DIFF
--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -157,9 +157,9 @@ class InitError(DvcException):
 
 
 class ReproductionError(DvcException):
-    def __init__(self, dvc_file_name):
-        self.path = dvc_file_name
-        super().__init__(f"failed to reproduce '{dvc_file_name}'")
+    def __init__(self, name):
+        self.name = name
+        super().__init__(f"failed to reproduce '{name}'")
 
 
 class BadMetricError(DvcException):

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -218,7 +218,7 @@ def _reproduce_stages(
         except CheckpointKilledError:
             raise
         except Exception as exc:
-            raise ReproductionError(stage.relpath) from exc
+            raise ReproductionError(stage.addressing) from exc
 
     if on_unchanged is not None:
         on_unchanged(unchanged)

--- a/tests/func/experiments/test_experiments.py
+++ b/tests/func/experiments/test_experiments.py
@@ -97,7 +97,7 @@ def test_failed_exp(tmp_dir, scm, dvc, exp_stage, mocker, caplog):
 
     mocker.patch(
         "concurrent.futures.Future.exception",
-        return_value=ReproductionError(exp_stage.relpath),
+        return_value=ReproductionError(exp_stage.addressing),
     )
     with caplog.at_level(logging.ERROR):
         dvc.experiments.run(exp_stage.addressing, tmp_dir=True)


### PR DESCRIPTION
Before it used to say 'failed to reproduce dvc.yaml', which is now changed
to print 'failed to reproduce train' or something similar.

For stages that are in dvc.yaml in the current working directory, it will
just print the stage names. For stages in other dvc.yaml files, it'll print

in <relative_path>:<stage_name>.

```console
$ dvc exp run
ERROR: failed to reproduce 'train': [Errno 2] No such file or directory: '/private/var/folders/xh/trg29z296h70n109kwfk6g800000gn/T/tmp.fJbphlSG/data'
```
Related: https://github.com/iterative/dvc/issues/7137

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
