### PR TITLE
TabularData: Simplify drop internals.

### DIFF
--- a/dvc/commands/experiments/show.py
+++ b/dvc/commands/experiments/show.py
@@ -391,7 +391,7 @@ def show_experiments(
     td.drop(*cols_to_drop)
 
     if pcp:
-        subset = [x for x in td.keys() if x != "Experiment"]
+        subset = {x for x in td.keys() if x != "Experiment"}
         td.dropna(
             "rows",
             how="all",

--- a/dvc/compare.py
+++ b/dvc/compare.py
@@ -137,13 +137,10 @@ class TabularData(MutableSequence[Sequence["CellT"]]):
         return len(self.columns), len(self)
 
     def drop(self, *col_names: str) -> None:
-        to_remove = set()
         for col in col_names:
             if not self.is_protected(col):
-                to_remove.add(col)
-        for col in to_remove:
-            self._keys.remove(col)
-            self._columns.pop(col)
+                self._keys.remove(col)
+                self._columns.pop(col)
 
     def rename(self, from_col_name: str, to_col_name: str) -> None:
         self._columns[to_col_name] = self._columns.pop(from_col_name)
@@ -215,7 +212,10 @@ class TabularData(MutableSequence[Sequence["CellT"]]):
         ]
 
     def dropna(
-        self, axis: str = "rows", how="any", subset: Optional[List] = None
+        self,
+        axis: str = "rows",
+        how="any",
+        subset: Optional[Iterable[str]] = None,
     ):
         if axis not in ["rows", "cols"]:
             raise ValueError(
@@ -266,7 +266,7 @@ class TabularData(MutableSequence[Sequence["CellT"]]):
     def drop_duplicates(
         self,
         axis: str = "rows",
-        subset: Optional[List] = None,
+        subset: Optional[Iterable[str]] = None,
         ignore_empty: bool = True,
     ):
         if axis not in ["rows", "cols"]:

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -791,8 +791,8 @@ def test_show_experiments_pcp(tmp_dir, mocker):
     show_experiments(all_experiments, pcp=True)
 
     td.drop.assert_called_with("Created")
-    td.dropna.assert_called_with("rows", how="all", subset=[])
-    td.drop_duplicates.assert_called_with("rows", subset=[])
+    td.dropna.assert_called_with("rows", how="all", subset=set())
+    td.drop_duplicates.assert_called_with("rows", subset=set())
 
     kwargs = td.to_parallel_coordinates.call_args[1]
 


### PR DESCRIPTION
Update `subset` type hint.

Leftover from #7141
