### PR TITLE
debug: Add support for viztracer profiler.

### DIFF
--- a/dvc/_debug.py
+++ b/dvc/_debug.py
@@ -12,13 +12,13 @@ def viztracer_profile(
     max_stack_depth: int = -1,
 ):
     try:
-        from viztracer import VizTracer  # pylint: disable=import-error
+        import viztracer  # pylint: disable=import-error
     except ImportError:
         print("Failed to run profiler, viztracer is not installed")
         yield
         return
 
-    tracer = VizTracer(max_stack_depth=max_stack_depth)
+    tracer = viztracer.VizTracer(max_stack_depth=max_stack_depth)
 
     tracer.start()
     yield
@@ -126,12 +126,12 @@ def debugtools(args: "Namespace" = None, **kwargs):
             stack.enter_context(
                 yappi_profile(path=lambda: output.format(datetime.now()))
             )
-        if kw.get("viztracer"):
+        if kw.get("viztracer") or kw.get("viztracer_depth"):
             output = "viztracer.dvc-{0:%Y%m%d}_{0:%H%M%S}.json"
             stack.enter_context(
                 viztracer_profile(
                     path=lambda: output.format(datetime.now()),
-                    max_stack_depth=kw.get("max_stack_depth", -1),
+                    max_stack_depth=kw.get("viztracer_depth") or -1,
                 )
             )
         yield
@@ -149,7 +149,9 @@ def add_debugging_flags(parser):
     parser.add_argument(
         "--viztracer", action="store_true", default=False, help=SUPPRESS
     )
-    parser.add_argument("--max-stack-depth", default=-1, help=SUPPRESS)
+    parser.add_argument(
+        "--viztracer-depth", type=int, default=-1, help=SUPPRESS
+    )
     parser.add_argument("--cprofile-dump", help=SUPPRESS)
     parser.add_argument(
         "--pdb", action="store_true", default=False, help=SUPPRESS

--- a/dvc/_debug.py
+++ b/dvc/_debug.py
@@ -149,9 +149,7 @@ def add_debugging_flags(parser):
     parser.add_argument(
         "--viztracer", action="store_true", default=False, help=SUPPRESS
     )
-    parser.add_argument(
-        "--viztracer-depth", type=int, default=-1, help=SUPPRESS
-    )
+    parser.add_argument("--viztracer-depth", type=int, help=SUPPRESS)
     parser.add_argument("--cprofile-dump", help=SUPPRESS)
     parser.add_argument(
         "--pdb", action="store_true", default=False, help=SUPPRESS

--- a/dvc/_debug.py
+++ b/dvc/_debug.py
@@ -17,6 +17,7 @@ def viztracer_profile(
         print("Failed to run profiler, viztracer is not installed")
         yield
         return
+
     tracer = VizTracer(max_stack_depth=max_stack_depth)
 
     tracer.start()

--- a/tests/unit/command/test_debug.py
+++ b/tests/unit/command/test_debug.py
@@ -1,0 +1,38 @@
+from dvc.cli import main
+
+
+def test_viztracer(tmp_dir, dvc, mocker):
+    viztracer_profile = mocker.patch("dvc._debug.viztracer_profile")
+
+    assert main(["status", "--viztracer"]) == 0
+
+    args = viztracer_profile.call_args[1]
+    assert callable(args["path"])
+    assert args["max_stack_depth"] == -1
+
+    assert main(["status", "--viztracer", "--viztracer-depth", "5"]) == 0
+    args = viztracer_profile.call_args[1]
+    assert args["max_stack_depth"] == 5
+
+    assert main(["status", "--viztracer-depth", "2"]) == 0
+    args = viztracer_profile.call_args[1]
+    assert args["max_stack_depth"] == 2
+
+
+def test_viztracer_internal(tmp_dir, dvc, mocker):
+    import sys
+
+    viztracer = mocker.MagicMock()
+    sys.modules["viztracer"] = viztracer
+    from dvc import _debug
+
+    profile = mocker.spy(_debug, "viztracer_profile")
+    tracer = viztracer.VizTracer.return_value
+    assert main(["status", "--viztracer"]) == 0
+
+    args = viztracer.VizTracer.call_args[1]
+    assert args["max_stack_depth"] == -1
+
+    tracer.start.assert_called_once()
+    tracer.stop.assert_called_once()
+    tracer.save.assert_called_once_with(profile.call_args[1]["path"]())


### PR DESCRIPTION
Support https://github.com/gaogaotiantian/viztracer 

I have found it more visually pleasing for multi-thread stuff:

How to use:

- `pip install viztracer`
- `dvc add foo --viztracer --max-stack-depth 5`
- `vizviewer viztracer.dvc-{id}.json`

<img width="1792" alt="Captura de pantalla 2022-01-24 a las 21 36 49" src="https://user-images.githubusercontent.com/12677733/150861962-e1074571-d5f3-44d8-8577-140ebc0cc68a.png">
