### PR TITLE
ignore: move debug statetement to the proper location

### DIFF
--- a/dvc/repo/scm_context.py
+++ b/dvc/repo/scm_context.py
@@ -75,13 +75,13 @@ class SCMContext:
 
         from dvc.scm import SCMError
 
-        logger.debug("Adding '%s' to gitignore file.", path)
         try:
             gitignore_file = self.scm.ignore(path)
         except FileNotInRepoError as exc:
             raise SCMError(str(exc))
 
         if gitignore_file:
+            logger.debug("Added '%s' to gitignore file.", path)
             self.track_file(relpath(gitignore_file))
             return self.ignored_paths.append(path)
 


### PR DESCRIPTION
The "adding %s to gitignore" debug statement was always being run because of the `_ignore()` call in `dvc/repo/__init__.py:207`


thanks @pared 