### PR TITLE
exp init: create workspace structure by default, show workspace tree

### DIFF
--- a/dvc/commands/experiments/init.py
+++ b/dvc/commands/experiments/init.py
@@ -69,7 +69,6 @@ class CmdExperimentsInit(CmdBase):
         )
 
         text = ui.rich_text.assemble(
-            "\n" if self.args.interactive else "",
             "Created ",
             (self.args.name, "bright_blue"),
             " stage in ",

--- a/dvc/repo/experiments/init.py
+++ b/dvc/repo/experiments/init.py
@@ -226,7 +226,7 @@ def init_deps(stage: PipelineStage) -> None:
 
     if new_deps:
         paths = map("[green]{0}[/]".format, new_deps)
-        ui.write(f"Creating {humanize.join(paths)}", styled=True)
+        ui.write(f"Created {humanize.join(paths)}.", styled=True)
 
     # always create a file for params, detect file/folder based on extension
     # for other dependencies

--- a/dvc/repo/experiments/init.py
+++ b/dvc/repo/experiments/init.py
@@ -154,7 +154,7 @@ def init_interactive(
         styled=True,
     )
 
-    tree_label = "Experiment project structure:"
+    tree_label = "Using experiment project structure:"
     display_workspace_tree(workspace, tree_label, stderr=True)
     ret.update(
         compact(
@@ -329,7 +329,7 @@ def init(
             stage.dump(update_lock=False)
             stage.ignore_outs()
             if not interactive:
-                label = "Experiment project structure:"
+                label = "Using experiment project structure:"
                 display_workspace_tree(context, label)
             init_deps(stage, log=not interactive)
             if params:

--- a/tests/func/experiments/test_init.py
+++ b/tests/func/experiments/test_init.py
@@ -44,6 +44,8 @@ def test_init_simple(tmp_dir, scm, dvc, capsys):
             }
         }
     }
+    assert (tmp_dir / "data").read_text() == "data"
+    assert (tmp_dir / "src").is_dir()
 
 
 @pytest.mark.parametrize("interactive", [True, False])
@@ -142,6 +144,8 @@ def test_init_interactive_when_no_path_prompts_need_to_be_asked(
             }
         }
     }
+    assert (tmp_dir / "src").is_dir()
+    assert (tmp_dir / "data").is_dir()
 
 
 def test_when_params_is_omitted_in_interactive_mode(tmp_dir, scm, dvc):
@@ -164,6 +168,8 @@ def test_when_params_is_omitted_in_interactive_mode(tmp_dir, scm, dvc):
         }
     }
     assert not (tmp_dir / "dvc.lock").exists()
+    assert (tmp_dir / "script.py").read_text() == ""
+    assert (tmp_dir / "data").is_dir()
     scm._reset()
     assert scm.is_tracked("dvc.yaml")
     assert not scm.is_tracked("params.yaml")
@@ -194,6 +200,8 @@ def test_init_interactive_params_validation(tmp_dir, dvc, capsys):
             }
         }
     }
+    assert (tmp_dir / "script.py").read_text() == ""
+    assert (tmp_dir / "data").is_dir()
 
     out, err = capsys.readouterr()
     assert (
@@ -209,15 +217,7 @@ def test_init_interactive_params_validation(tmp_dir, dvc, capsys):
 
 
 def test_init_with_no_defaults_interactive(tmp_dir, dvc):
-    inp = io.StringIO(
-        "python script.py\n"
-        "script.py\n"
-        "data\n"
-        "model\n"
-        "n\n"
-        "metric\n"
-        "n\n"
-    )
+    inp = io.StringIO("script.py\n" "data\n" "model\n" "n\n" "metric\n" "n\n")
     init(
         dvc,
         defaults={},
@@ -229,12 +229,14 @@ def test_init_with_no_defaults_interactive(tmp_dir, dvc):
         "stages": {
             "train": {
                 "cmd": "python script.py",
-                "deps": ["python script.py", "script.py"],
+                "deps": ["data", "script.py"],
                 "metrics": [{"metric": {"cache": False}}],
-                "outs": ["data"],
+                "outs": ["model"],
             }
         }
     }
+    assert (tmp_dir / "script.py").read_text() == ""
+    assert (tmp_dir / "data").is_dir()
 
 
 @pytest.mark.parametrize(
@@ -258,9 +260,7 @@ def test_init_with_no_defaults_interactive(tmp_dir, dvc):
     ],
     ids=["non-interactive", "interactive"],
 )
-def test_init_interactive_default(
-    tmp_dir, scm, dvc, interactive, overrides, inp, capsys
-):
+def test_init_default(tmp_dir, scm, dvc, interactive, overrides, inp, capsys):
     (tmp_dir / "params.yaml").dump({"foo": {"bar": 1}})
 
     init(
@@ -284,6 +284,8 @@ def test_init_interactive_default(
         }
     }
     assert not (tmp_dir / "dvc.lock").exists()
+    assert (tmp_dir / "script.py").read_text() == ""
+    assert (tmp_dir / "data").is_dir()
     scm._reset()
     assert scm.is_tracked("dvc.yaml")
     assert scm.is_tracked("params.yaml")
@@ -292,9 +294,11 @@ def test_init_interactive_default(
     out, err = capsys.readouterr()
 
     if interactive:
-        assert "'script.py' does not exist in the workspace." in err
-        assert "'data' does not exist in the workspace." in err
-    assert not out
+        assert "'script.py' does not exist, the file will be created." in err
+        assert "'data' does not exist, the directory will be created." in err
+        assert not out
+        return
+    assert "Creating experiment project structure: " in out
 
 
 @pytest.mark.timeout(5, func_only=True)
@@ -365,6 +369,8 @@ def test_init_interactive_live(
         }
     }
     assert not (tmp_dir / "dvc.lock").exists()
+    assert (tmp_dir / "script.py").read_text() == ""
+    assert (tmp_dir / "data").is_dir()
     scm._reset()
     assert scm.is_tracked("dvc.yaml")
     assert scm.is_tracked("params.yaml")
@@ -372,10 +378,13 @@ def test_init_interactive_live(
     assert scm.is_ignored("models")
 
     out, err = capsys.readouterr()
+
     if interactive:
-        assert "'script.py' does not exist in the workspace." in err
-        assert "'data' does not exist in the workspace." in err
-    assert not out
+        assert "'script.py' does not exist, the file will be created." in err
+        assert "'data' does not exist, the directory will be created." in err
+        assert not out
+        return
+    assert "Creating experiment project structure: " in out
 
 
 @pytest.mark.parametrize(
@@ -410,6 +419,8 @@ def test_init_with_type_live_and_models_plots_provided(
             }
         }
     }
+    assert (tmp_dir / "src").is_dir()
+    assert (tmp_dir / "data").is_dir()
 
 
 @pytest.mark.parametrize(
@@ -443,3 +454,5 @@ def test_init_with_type_default_and_live_provided(
             }
         }
     }
+    assert (tmp_dir / "src").is_dir()
+    assert (tmp_dir / "data").is_dir()

--- a/tests/func/experiments/test_init.py
+++ b/tests/func/experiments/test_init.py
@@ -213,7 +213,7 @@ def test_init_interactive_params_validation(tmp_dir, dvc, capsys):
         "Please retry with an existing parameters file.\n"
         "Path to a parameters file [params.yaml, n to omit]:"
     ) in err
-    assert out == "Creating script.py\n"
+    assert out == "Created script.py.\n"
 
 
 def test_init_with_no_defaults_interactive(tmp_dir, dvc):
@@ -298,7 +298,7 @@ def test_init_default(tmp_dir, scm, dvc, interactive, overrides, inp, capsys):
         assert "'data' does not exist, the directory will be created." in err
     else:
         assert "Using experiment project structure: " in out
-    assert "Creating script.py and data" in out
+    assert "Created script.py and data" in out
 
 
 @pytest.mark.timeout(5, func_only=True)
@@ -384,7 +384,7 @@ def test_init_interactive_live(
         assert "'data' does not exist, the directory will be created." in err
     else:
         assert "Using experiment project structure: " in out
-    assert "Creating script.py and data" in out
+    assert "Created script.py and data" in out
 
 
 @pytest.mark.parametrize(

--- a/tests/func/experiments/test_init.py
+++ b/tests/func/experiments/test_init.py
@@ -298,7 +298,8 @@ def test_init_default(tmp_dir, scm, dvc, interactive, overrides, inp, capsys):
         assert "'data' does not exist, the directory will be created." in err
         assert not out
         return
-    assert "Creating experiment project structure: " in out
+    assert "Experiment project structure: " in out
+    assert "Creating script.py and data" in out
 
 
 @pytest.mark.timeout(5, func_only=True)
@@ -384,7 +385,8 @@ def test_init_interactive_live(
         assert "'data' does not exist, the directory will be created." in err
         assert not out
         return
-    assert "Creating experiment project structure: " in out
+    assert "Experiment project structure: " in out
+    assert "Creating script.py and data" in out
 
 
 @pytest.mark.parametrize(

--- a/tests/func/experiments/test_init.py
+++ b/tests/func/experiments/test_init.py
@@ -213,7 +213,7 @@ def test_init_interactive_params_validation(tmp_dir, dvc, capsys):
         "Please retry with an existing parameters file.\n"
         "Path to a parameters file [params.yaml, n to omit]:"
     ) in err
-    assert not out
+    assert out == "Creating script.py\n"
 
 
 def test_init_with_no_defaults_interactive(tmp_dir, dvc):
@@ -296,9 +296,8 @@ def test_init_default(tmp_dir, scm, dvc, interactive, overrides, inp, capsys):
     if interactive:
         assert "'script.py' does not exist, the file will be created." in err
         assert "'data' does not exist, the directory will be created." in err
-        assert not out
-        return
-    assert "Using experiment project structure: " in out
+    else:
+        assert "Using experiment project structure: " in out
     assert "Creating script.py and data" in out
 
 
@@ -383,9 +382,8 @@ def test_init_interactive_live(
     if interactive:
         assert "'script.py' does not exist, the file will be created." in err
         assert "'data' does not exist, the directory will be created." in err
-        assert not out
-        return
-    assert "Using experiment project structure: " in out
+    else:
+        assert "Using experiment project structure: " in out
     assert "Creating script.py and data" in out
 
 

--- a/tests/func/experiments/test_init.py
+++ b/tests/func/experiments/test_init.py
@@ -298,7 +298,7 @@ def test_init_default(tmp_dir, scm, dvc, interactive, overrides, inp, capsys):
         assert "'data' does not exist, the directory will be created." in err
         assert not out
         return
-    assert "Experiment project structure: " in out
+    assert "Using experiment project structure: " in out
     assert "Creating script.py and data" in out
 
 
@@ -385,7 +385,7 @@ def test_init_interactive_live(
         assert "'data' does not exist, the directory will be created." in err
         assert not out
         return
-    assert "Experiment project structure: " in out
+    assert "Using experiment project structure: " in out
     assert "Creating script.py and data" in out
 
 


### PR DESCRIPTION
This PR creates the workspace structure by default. That means that the `code` paths and `data` paths are created if they don't exist. If the path has any extension, the empty file will be created, otherwise, a directory is created. 

Initially, this was to be created for the defaults only, but I have added the magic everywhere, so this is applied to passed arguments, defaults or config values too.

Second thing that PR adds is this output so that users are aware of the changes and their workspace structure:
```
Creating experiment project structure:
├── data
├── metrics.json
├── models
├── params.yaml
├── plots
└── src
```

Closes #7137, closes #7138 and  closes #7139.