### PR TITLE
dvcfs: detach from pipeline outputs

### DIFF
--- a/dvc/data/meta.py
+++ b/dvc/data/meta.py
@@ -1,6 +1,10 @@
 from collections import OrderedDict
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from dvc.objects.db import ObjectDB
+    from dvc.objects.file import HashFile
 
 
 @dataclass
@@ -12,6 +16,10 @@ class Meta:
     size: Optional[int] = field(default=None)
     nfiles: Optional[int] = field(default=None)
     isexec: Optional[bool] = field(default=False)
+
+    obj: Optional["HashFile"] = field(default=None)
+    odb: Optional["ObjectDB"] = field(default=None)
+    remote: Optional[str] = field(default=None)
 
     @classmethod
     def from_dict(cls, d):

--- a/dvc/data/stage.py
+++ b/dvc/data/stage.py
@@ -168,7 +168,7 @@ def _build_tree(fs_path, fs, name, **kwargs):
         assert key
         tree.add(key, meta, obj.hash_info)
 
-        tree_meta.size += meta.size
+        tree_meta.size += meta.size or 0
         tree_meta.nfiles += 1
 
     return tree_meta, tree

--- a/dvc/fs/repo.py
+++ b/dvc/fs/repo.py
@@ -479,14 +479,19 @@ class RepoFileSystem(FileSystem):  # pylint:disable=abstract-method
 
             fs_info = fs.info(path)
             fs_info["repo"] = dvc_fs.repo
-            fs_info["outs"] = dvc_info.get("outs", None) if dvc_info else None
             fs_info["isout"] = (
                 dvc_info.get("isout", False) if dvc_info else False
             )
+            fs_info["outs"] = dvc_info["outs"] if dvc_info else None
             fs_info["isdvc"] = dvc_info["isdvc"] if dvc_info else False
-            fs_info["isexec"] = (
-                dvc_info["isexec"] if dvc_info else is_exec(fs_info["mode"])
-            )
+            fs_info["meta"] = dvc_info.get("meta") if dvc_info else None
+
+            isexec = False
+            if dvc_info:
+                isexec = dvc_info["isexec"]
+            elif fs_info["type"] == "file":
+                isexec = is_exec(fs_info["mode"])
+            fs_info["isexec"] = isexec
             return fs_info
 
         except FileNotFoundError:

--- a/dvc/repo/diff.py
+++ b/dvc/repo/diff.py
@@ -190,10 +190,12 @@ def _filter_missing(repo_fs, paths):
     for path in paths:
         try:
             info = repo_fs.info(path)
-            if info["isdvc"]:
-                out = info["outs"][0]
-                if out.status().get(str(out)) == "not in cache":
-                    yield path
+            if (
+                info["isdvc"]
+                and info["type"] == "directory"
+                and not info["meta"].obj
+            ):
+                yield path
         except FileNotFoundError:
             pass
 

--- a/tests/func/objects/db/test_index.py
+++ b/tests/func/objects/db/test_index.py
@@ -16,7 +16,7 @@ def index(dvc, local_remote, mocker):
 def test_indexed_on_status(tmp_dir, dvc, index):
     foo = tmp_dir.dvc_gen({"foo": "foo content"})[0].outs[0]
     bar = tmp_dir.dvc_gen({"bar": {"baz": "baz content"}})[0].outs[0]
-    baz_hash = bar.obj.trie.get(("baz",))[1]
+    baz_hash = bar.obj._trie.get(("baz",))[1]
     clean_staging()
     dvc.push()
     index.clear()
@@ -30,7 +30,7 @@ def test_indexed_on_status(tmp_dir, dvc, index):
 def test_indexed_on_push(tmp_dir, dvc, index):
     foo = tmp_dir.dvc_gen({"foo": "foo content"})[0].outs[0]
     bar = tmp_dir.dvc_gen({"bar": {"baz": "baz content"}})[0].outs[0]
-    baz_hash = bar.obj.trie.get(("baz",))[1]
+    baz_hash = bar.obj._trie.get(("baz",))[1]
     clean_staging()
 
     dvc.push()

--- a/tests/func/test_ls.py
+++ b/tests/func/test_ls.py
@@ -473,14 +473,14 @@ def test_ls_granular(erepo_dir):
 
     entries = Repo.ls(os.fspath(erepo_dir), os.path.join("dir", "subdir"))
     assert entries == [
-        {"isout": False, "isdir": False, "isexec": False, "path": "bar"},
-        {"isout": False, "isdir": False, "isexec": False, "path": "foo"},
+        {"isout": True, "isdir": False, "isexec": False, "path": "bar"},
+        {"isout": True, "isdir": False, "isexec": False, "path": "foo"},
     ]
 
     entries = Repo.ls(os.fspath(erepo_dir), "dir")
     assert entries == [
-        {"isout": False, "isdir": False, "isexec": False, "path": "1"},
-        {"isout": False, "isdir": False, "isexec": False, "path": "2"},
+        {"isout": True, "isdir": False, "isexec": False, "path": "1"},
+        {"isout": True, "isdir": False, "isexec": False, "path": "2"},
         {"isout": False, "isdir": True, "isexec": False, "path": "subdir"},
     ]
 
@@ -500,18 +500,20 @@ def test_ls_target(erepo_dir, use_scm):
             commit="create dir",
         )
 
+    isout = not use_scm
+
     def _ls(path):
         return Repo.ls(os.fspath(erepo_dir), path)
 
     assert _ls(os.path.join("dir", "1")) == [
-        {"isout": False, "isdir": False, "isexec": False, "path": "1"}
+        {"isout": isout, "isdir": False, "isexec": False, "path": "1"}
     ]
     assert _ls(os.path.join("dir", "subdir", "foo")) == [
-        {"isout": False, "isdir": False, "isexec": False, "path": "foo"}
+        {"isout": isout, "isdir": False, "isexec": False, "path": "foo"}
     ]
     assert _ls(os.path.join("dir", "subdir")) == [
-        {"isdir": False, "isexec": 0, "isout": False, "path": "bar"},
-        {"isdir": False, "isexec": 0, "isout": False, "path": "foo"},
+        {"isdir": False, "isexec": 0, "isout": isout, "path": "bar"},
+        {"isdir": False, "isexec": 0, "isout": isout, "path": "foo"},
     ]
 
 

--- a/tests/func/test_remote.py
+++ b/tests/func/test_remote.py
@@ -271,7 +271,7 @@ def test_push_order(tmp_dir, dvc, tmp_path_factory, mocker, local_remote):
     # foo .dir file should be uploaded after bar
     odb = dvc.cloud.get_remote_odb("upstream")
     foo_path = odb.hash_to_path(foo.hash_info.value)
-    bar_path = odb.hash_to_path(foo.obj.trie[("bar",)][1].value)
+    bar_path = odb.hash_to_path(foo.obj._trie[("bar",)][1].value)
     paths = [args[3] for args, _ in mocked_upload.call_args_list]
     assert paths.index(foo_path) > paths.index(bar_path)
 

--- a/tests/unit/fs/test_repo.py
+++ b/tests/unit/fs/test_repo.py
@@ -321,7 +321,7 @@ def test_isdvc(tmp_dir, dvc):
     assert fs.isdvc("foo")
     assert not fs.isdvc("bar")
     assert fs.isdvc("dir")
-    assert not fs.isdvc(os.path.join("dir", "baz"))
+    assert fs.isdvc(os.path.join("dir", "baz"))
     assert fs.isdvc(os.path.join("dir", "baz"), recursive=True)
 
 

--- a/tests/unit/fs/test_repo_info.py
+++ b/tests/unit/fs/test_repo_info.py
@@ -65,38 +65,25 @@ def test_info_git_tracked_file(repo_fs, path):
     assert not info["isdvc"]
     assert info["type"] == "file"
     assert not info["isexec"]
-    assert not info["outs"]
 
 
 @pytest.mark.parametrize(
-    "path, outs",
+    "path",
     [
-        (os.path.join("data", "raw", "raw-1.csv"), ["data"]),
-        (os.path.join("data", "raw", "raw-2.csv"), ["data"]),
-        (
-            os.path.join("data", "processed", "processed-1.csv"),
-            ["data"],
-        ),
-        (
-            os.path.join("data", "processed", "processed-2.csv"),
-            ["data"],
-        ),
-        (
-            os.path.join("models", "transform.pickle"),
-            [os.path.join("models", "transform.pickle")],
-        ),
+        os.path.join("data", "raw", "raw-1.csv"),
+        os.path.join("data", "raw", "raw-2.csv"),
+        os.path.join("data", "processed", "processed-1.csv"),
+        os.path.join("data", "processed", "processed-2.csv"),
+        os.path.join("models", "transform.pickle"),
     ],
 )
-def test_info_dvc_tracked_file(repo_fs, path, outs):
+def test_info_dvc_tracked_file(repo_fs, path):
     info = repo_fs.info(path)
 
     assert info["repo"].root_dir == repo_fs.root_dir
     assert info["isdvc"]
     assert info["type"] == "file"
     assert not info["isexec"]
-    assert {out.fs_path for out in info["outs"]} == {
-        os.path.join(repo_fs.root_dir, out) for out in outs
-    }
 
 
 @pytest.mark.parametrize("path", ["src", os.path.join("src", "utils")])
@@ -106,28 +93,17 @@ def test_info_git_only_dirs(repo_fs, path):
     assert info["repo"].root_dir == repo_fs.root_dir
     assert not info["isdvc"]
     assert info["type"] == "directory"
-    assert info["isexec"]
-    assert not info["outs"]
+    assert not info["isexec"]
 
 
-@pytest.mark.parametrize(
-    "path, expected_outs",
-    [
-        (".", ["data", os.path.join("models", "transform.pickle")]),
-        ("models", [os.path.join("models", "transform.pickle")]),
-    ],
-)
-def test_info_git_dvc_mixed_dirs(repo_fs, path, expected_outs):
+@pytest.mark.parametrize("path", [".", "models"])
+def test_info_git_dvc_mixed_dirs(repo_fs, path):
     info = repo_fs.info(os.path.join(repo_fs.root_dir, path))
 
     assert info["repo"].root_dir == repo_fs.root_dir
     assert not info["isdvc"]
     assert info["type"] == "directory"
     assert not info["isexec"]
-
-    assert {out.fs_path for out in info["outs"]} == {
-        os.path.join(repo_fs.root_dir, out) for out in expected_outs
-    }
 
 
 @pytest.mark.parametrize(
@@ -145,9 +121,6 @@ def test_info_dvc_only_dirs(repo_fs, path):
     assert info["isdvc"]
     assert info["type"] == "directory"
     assert not info["isexec"]
-    assert {out.fs_path for out in info["outs"]} == {
-        os.path.join(repo_fs.root_dir, "data")
-    }
 
 
 def test_info_on_subrepos(make_tmp_dir, tmp_dir, dvc, scm, repo_fs):


### PR DESCRIPTION
Introducing simple repo tree that combines all workspaces into one structure,
and allows us to detach data representation from pipelines.

Pre-requisite for dvc-data extraction and using relpaths in dvcfs/repofs.
