### PR TITLE
dvcfs: use paths relative to the repo root

### DIFF
--- a/dvc/api.py
+++ b/dvc/api.py
@@ -27,7 +27,8 @@ def get_url(path, repo=None, rev=None, remote=None):
             raise OutputNotFoundError(path, repo)
 
         cloud = info["repo"].cloud
-        md5 = info["repo"].dvcfs.info(fs_path)["md5"]
+        dvc_path = _repo.fs.path.relpath(fs_path, info["repo"].root_dir)
+        md5 = info["repo"].dvcfs.info(dvc_path)["md5"]
         return cloud.get_url_for(remote, checksum=md5)
 
 

--- a/tests/func/test_fs.py
+++ b/tests/func/test_fs.py
@@ -305,7 +305,7 @@ def test_download_callbacks_on_dvc_git_fs(tmp_dir, dvc, scm, fs_type):
 
     callback = fsspec.Callback()
     fs.download_file(
-        (tmp_dir / "file").fs_path,
+        "file",
         (tmp_dir / "file2").fs_path,
         callback=callback,
     )
@@ -317,7 +317,7 @@ def test_download_callbacks_on_dvc_git_fs(tmp_dir, dvc, scm, fs_type):
 
     callback = fsspec.Callback()
     fs.download(
-        (tmp_dir / "dir").fs_path,
+        "dir",
         (tmp_dir / "dir2").fs_path,
         callback=callback,
     )

--- a/tests/unit/fs/test_repo.py
+++ b/tests/unit/fs/test_repo.py
@@ -491,7 +491,7 @@ def test_repo_fs_no_subrepos(tmp_dir, dvc, scm):
     ]
 
     actual = []
-    for root, dirs, files in fs.walk(tmp_dir, dvcfiles=True):
+    for root, dirs, files in fs.walk(tmp_dir.fs_path, dvcfiles=True):
         for entry in dirs + files:
             actual.append(os.path.normpath(os.path.join(root, entry)))
 


### PR DESCRIPTION
Currently we use both absolute and relative (depend on cwd) paths, which is
terrible for an api, as their interpretation depends on external factors.
This PR makes dvcfs accept only paths relative to the repo root for regular
outputs and absolute paths for external outputs.

Pre-requisite for making repofs use same relative paths.

