### PR TITLE
plots: json: add datapoints to vega plots

### DIFF
--- a/dvc/render/data.py
+++ b/dvc/render/data.py
@@ -180,15 +180,14 @@ class Converter:
 def to_datapoints(data: Dict, props: Dict):
     converter = Converter(props)
 
-    datapoints = []
+    datapoints: Dict[str, List[Dict]] = {}
     for revision, rev_data in data.items():
+        datapoints[revision] = []
         for _, file_data in rev_data.get("data", {}).items():
             if "data" in file_data:
                 processed, final_props = converter.convert(
                     file_data.get("data")
                 )
 
-                Converter.update(processed, {REVISION_FIELD: revision})
-
-                datapoints.extend(processed)
+                datapoints[revision].extend(processed)
     return datapoints, final_props

--- a/dvc/render/utils.py
+++ b/dvc/render/utils.py
@@ -4,13 +4,9 @@ from typing import Dict, List
 import dpath.util
 
 
-def get_files(data: Dict) -> List:
-    files = set()
-    for rev in data.keys():
-        for file in data[rev].get("data", {}).keys():
-            files.add(file)
-    sorted_files = sorted(files)
-    return sorted_files
+def get_files(plots_data: Dict) -> List:
+    values = dpath.util.values(plots_data, ["*", "*"])
+    return sorted({key for submap in values for key in submap.keys()})
 
 
 def group_by_filename(plots_data: Dict) -> List[Dict]:
@@ -35,7 +31,6 @@ def match_renderers(plots_data, templates):
 
     renderers = []
     for group in group_by_filename(plots_data):
-
         plot_properties = squash_plots_properties(group)
         template = templates.load(plot_properties.get("template", None))
 

--- a/tests/unit/command/test_plots.py
+++ b/tests/unit/command/test_plots.py
@@ -276,6 +276,7 @@ def test_plots_diff_json(dvc, mocker, capsys):
             "HEAD~10",
             "HEAD~1",
             "--json",
+            "--split",
             "--targets",
             "plot.csv",
             "-o",
@@ -295,7 +296,7 @@ def test_plots_diff_json(dvc, mocker, capsys):
 
     assert cmd.run() == 0
 
-    show_json_mock.assert_called_once_with(renderers, "out")
+    show_json_mock.assert_called_once_with(renderers, "out", True)
 
     render_mock.assert_not_called()
 

--- a/tests/unit/render/test_data.py
+++ b/tests/unit/render/test_data.py
@@ -150,10 +150,12 @@ def test_to_datapoints():
 
     datapoints, resolved_properties = to_datapoints(input_data, props)
 
-    assert datapoints == [
-        {"v": 1, "v2": 0.1, "v3": 0.01, "rev": "revision"},
-        {"v": 2, "v2": 0.2, "v3": 0.02, "rev": "revision"},
-    ]
+    assert datapoints == {
+        "revision": [
+            {"v": 1, "v2": 0.1, "v3": 0.01},
+            {"v": 2, "v2": 0.2, "v3": 0.02},
+        ]
+    }
     assert resolved_properties == {
         "fields": {"v", "v2", "v3"},
         "x": "v2",

--- a/tests/unit/render/test_vega.py
+++ b/tests/unit/render/test_vega.py
@@ -341,6 +341,7 @@ def test_should_resolve_template(tmp_dir, dvc, template_path, target_name):
     )
 
 
+# TODO remove content checks
 def test_as_json(tmp_dir, scm, dvc):
     metric = [{"a": 1, "b": 2, "c": 3}, {"a": 2, "b": 3, "c": 4}]
     data = {"workspace": {"data": {"file.json": {"data": metric}}}}
@@ -355,3 +356,20 @@ def test_as_json(tmp_dir, scm, dvc):
     assert plot_as_json["type"] == "vega"
     assert plot_as_json["revisions"] == ["workspace"]
     assert plot_as_json["content"] == plot_content
+
+
+def test_as_json_split(tmp_dir, scm, dvc):
+    metric = [{"a": 1, "b": 2, "c": 3}, {"a": 2, "b": 3, "c": 4}]
+    data = {"workspace": {"data": {"file.json": {"data": metric}}}}
+    props = {"fields": {"b"}}
+
+    renderer = VegaRenderer(
+        data, template=dvc.plots.templates.load(), properties=props
+    )
+    plot_content = renderer.asdict(fill_data=False)
+    plot_as_json = first(json.loads(renderer.as_json(fill_data=False)))
+
+    assert plot_as_json["type"] == "vega"
+    assert plot_as_json["revisions"] == ["workspace"]
+    assert plot_as_json["content"] == plot_content
+    assert plot_as_json["datapoints"] == renderer._converted_data[0]


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Usage:

`dvc plots show/diff --json --split`

The results for `vega` will contain additional field `datapoints` and the template will not have the data filled (there will be `<DVC_METRIC_DATA>` in datapoints destination.)

As of now the `datapoints` field will exist no matter whether `--split` has been invoked or not. The only difference is that in case when not providing `--split`, the content of particular vega json will have the data filled.

cc @mattseddon 
