### PR TITLE
Add log statement to collect repo

### DIFF
--- a/dvc/repo/stage.py
+++ b/dvc/repo/stage.py
@@ -473,6 +473,8 @@ class StageLoad:
         for root, dirs, files in self.repo.dvcignore.walk(
             self.fs, self.repo.root_dir
         ):
+            logger.trace(  # type: ignore[attr-defined]
+                "Collect repo walking '%s'", root)
             dvcfile_filter = partial(is_dvcfile_and_not_ignored, root)
             for file in filter(dvcfile_filter, files):
                 file_path = os.path.join(root, file)

--- a/dvc/repo/stage.py
+++ b/dvc/repo/stage.py
@@ -474,7 +474,8 @@ class StageLoad:
             self.fs, self.repo.root_dir
         ):
             logger.trace(  # type: ignore[attr-defined]
-                "Collect repo walking '%s'", root)
+                "Collect repo walking '%s'", root
+            )
             dvcfile_filter = partial(is_dvcfile_and_not_ignored, root)
             for file in filter(dvcfile_filter, files):
                 file_path = os.path.join(root, file)


### PR DESCRIPTION
Minor change that adds a debugging log statement. This makes `dvc add -v` list the files it is walking, and makes it easier for a developer to find the folder that is making `dvc add` slow.

Motivating case: I was running `dvc add` on a directory, and it was taking a very long time (hours). The only info I got was that it was collecting stages, even after I ran it with a `-v`. I eventually realized there was a very large, nested folder that was not in my `.dvcignore` file, so `dvc add` was trying to walk that entire directory structure before it did anything else.

I would have realized this much quicker if `dvc add` had more info when `-v` was given. In fact, I wasn't originally sure what the issue was, I was tracking through the DVC code to see why `add` would be slow, and found this section where it walks the entire directory. I put a print statement in originally, but then thought that this might be more generally useful, so I changed it to a logging.debug statement and submitted this PR.

I don't _think_ a logging statement would add significant overhead here, but I didn't test it.