### PR TITLE
exp init: refactor and simplify interactive mode

### DIFF
--- a/tests/func/experiments/test_init.py
+++ b/tests/func/experiments/test_init.py
@@ -5,7 +5,6 @@ import pytest
 
 from dvc.cli import main
 from dvc.commands.experiments.init import CmdExperimentsInit
-from dvc.exceptions import DvcException
 from dvc.repo.experiments.init import init
 from dvc.stage.exceptions import DuplicateStageName
 
@@ -93,21 +92,6 @@ def test_init_with_no_defaults_non_interactive(tmp_dir, scm, dvc):
     scm._reset()
     assert not (tmp_dir / "dvc.lock").exists()
     assert scm.is_tracked("dvc.yaml")
-
-
-def test_abort_confirmation(tmp_dir, dvc):
-    (tmp_dir / "param").dump({"foo": 1})
-    inp = io.StringIO("./script\nscript\ndata\nmodel\nparam\nmetric\nplt\nn")
-    with pytest.raises(DvcException) as exc:
-        init(
-            dvc,
-            interactive=True,
-            defaults=CmdExperimentsInit.DEFAULTS,
-            stream=inp,
-        )
-    assert str(exc.value) == "Aborting ..."
-    assert not (tmp_dir / "dvc.yaml").exists()
-    assert not (tmp_dir / "dvc.lock").exists()
 
 
 @pytest.mark.parametrize(
@@ -213,7 +197,7 @@ def test_init_interactive_params_validation(tmp_dir, dvc, capsys):
         "Please retry with an existing parameters file.\n"
         "Path to a parameters file [params.yaml, n to omit]:"
     ) in err
-    assert out == "Created script.py.\n"
+    assert "Created script.py." in out
 
 
 def test_init_with_no_defaults_interactive(tmp_dir, dvc):
@@ -296,8 +280,7 @@ def test_init_default(tmp_dir, scm, dvc, interactive, overrides, inp, capsys):
     if interactive:
         assert "'script.py' does not exist, the file will be created." in err
         assert "'data' does not exist, the directory will be created." in err
-    else:
-        assert "Using experiment project structure: " in out
+    assert "Using experiment project structure: " in out
     assert "Created script.py and data" in out
 
 
@@ -382,8 +365,7 @@ def test_init_interactive_live(
     if interactive:
         assert "'script.py' does not exist, the file will be created." in err
         assert "'data' does not exist, the directory will be created." in err
-    else:
-        assert "Using experiment project structure: " in out
+    assert "Using experiment project structure: " in out
     assert "Created script.py and data" in out
 
 


### PR DESCRIPTION
- Moves workspace tree for interactive mode after prompts. Previously
  this was displayed before the prompts.
- Remove the yaml contents and the confirmation prompt in an interactive
  mode.
- Simplify `init_interactive()`.

###### Before
```console
This command will guide you to set up a train stage in dvc.yaml.
See https://s.dvc.org/g/pipeline-files.

Command to execute: true

Enter the paths for dependencies and outputs of the command.
DVC assumes the following workspace structure:
├── data
├── metrics.json
├── models
├── params.yaml
├── plots
└── src

Path to a code file/directory [src, n to omit]:
'src' does not exist in the workspace. "exp run" may fail.
Path to a data file/directory [data, n to omit]:
'data' does not exist in the workspace. "exp run" may fail.
Path to a model file/directory [models, n to omit]:
Path to a parameters file [params.yaml, n to omit]:
Path to a metrics file [metrics.json, n to omit]:
Path to a plots file/directory [plots, n to omit]:
────────────────────────────────────────────────────────────────────────────────
train:
  cmd: 'true'
  deps:
  - data
  - src
  params:
  - foo
  outs:
  - models
  metrics:
  - metrics.json:
      cache: false
  plots:
  - plots:
      cache: false

Do you want to add the above contents to dvc.yaml? [Y/n]: y

Created src and data.
Created train stage in dvc.yaml. To run, use "dvc exp run".
See https://s.dvc.org/g/exp/run.
```

###### After
```console
This command will guide you to set up a train stage in dvc.yaml.
See https://s.dvc.org/g/pipeline-files.

Command to execute: true

Enter the paths for dependencies and outputs of the command.
Path to a code file/directory [src, n to omit]:
'src' does not exist, the directory will be created.
Path to a data file/directory [data, n to omit]:
'data' does not exist, the directory will be created.
Path to a model file/directory [models, n to omit]:
Path to a parameters file [params.yaml, n to omit]:
Path to a metrics file [metrics.json, n to omit]:
Path to a plots file/directory [plots, n to omit]:

Using experiment project structure:
├── data
├── metrics.json
├── models
├── params.yaml
├── plots
└── src

Created src and data.
Created train stage in dvc.yaml. To run, use "dvc exp run".
```

See https://github.com/iterative/dvc/pull/7331#issuecomment-1042136255.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
