### PR TITLE
fs: git: move isfile/walk to fsspec wrapper

### DIFF
--- a/dvc/fs/fsspec_wrapper.py
+++ b/dvc/fs/fsspec_wrapper.py
@@ -1,6 +1,15 @@
 import os
 import shutil
-from typing import IO, TYPE_CHECKING, Any, Dict, Iterator, Optional, overload
+from typing import (
+    IO,
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    Optional,
+    overload,
+)
 
 from funcy import cached_property
 from tqdm.utils import CallbackIOWrapper
@@ -49,20 +58,11 @@ class FSSpecWrapper(FileSystem):
         host filesystem"""
         return {}
 
-    def _isdir(self, path: AnyFSPath) -> bool:
+    def isdir(self, path: AnyFSPath) -> bool:
         return self.fs.isdir(path)
 
-    def isdir(self, path: AnyFSPath) -> bool:
-        try:
-            return self._isdir(path)
-        except FileNotFoundError:
-            return False
-
     def isfile(self, path: AnyFSPath) -> bool:
-        try:
-            return not self._isdir(path)
-        except FileNotFoundError:
-            return False
+        return self.fs.isfile(path)
 
     def is_empty(self, path: AnyFSPath) -> bool:
         entry = self.info(path)
@@ -145,6 +145,15 @@ class FSSpecWrapper(FileSystem):
                 length=getattr(fdest, "blocksize", None),  # type: ignore
             )
 
+    def walk(
+        self,
+        top: AnyFSPath,
+        topdown: bool = True,
+        onerror: Callable[[OSError], None] = None,
+        **kwargs: Any,
+    ):
+        return self.fs.walk(top, topdown=topdown, onerror=onerror, **kwargs)
+
 
 # pylint: disable=abstract-method
 class ObjectFSWrapper(FSSpecWrapper):
@@ -171,6 +180,18 @@ class ObjectFSWrapper(FSSpecWrapper):
             and entry["type"] == "file"
             and entry["name"].endswith("/")
         )
+
+    def isdir(self, path: AnyFSPath) -> bool:
+        try:
+            return self._isdir(path)
+        except FileNotFoundError:
+            return False
+
+    def isfile(self, path: AnyFSPath) -> bool:
+        try:
+            return not self._isdir(path)
+        except FileNotFoundError:
+            return False
 
     def find(self, path, prefix=None):
         if prefix:

--- a/dvc/fs/git.py
+++ b/dvc/fs/git.py
@@ -1,10 +1,10 @@
 import os
 import threading
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 from funcy import cached_property, wrap_prop
 
-from .fsspec_wrapper import AnyFSPath, FSSpecWrapper
+from .fsspec_wrapper import FSSpecWrapper
 
 if TYPE_CHECKING:
     from scmrepo.fs import GitFileSystem as FsspecGitFileSystem
@@ -50,15 +50,3 @@ class GitFileSystem(FSSpecWrapper):  # pylint:disable=abstract-method
     @property
     def rev(self) -> str:
         return self.fs.rev
-
-    def isfile(self, path: AnyFSPath) -> bool:
-        return self.fs.isfile(path)
-
-    def walk(
-        self,
-        top: AnyFSPath,
-        topdown: bool = True,
-        onerror: Callable[[OSError], None] = None,
-        **kwargs: Any,
-    ):
-        return self.fs.walk(top, topdown=topdown, onerror=onerror, **kwargs)


### PR DESCRIPTION
Helps us to concentrate all useful wrappers in one place so we could remove them later in one go.