### PR TITLE
diff: fix missing key bug (#6720)

### DIFF
--- a/dvc/commands/diff.py
+++ b/dvc/commands/diff.py
@@ -128,7 +128,7 @@ class CmdDiff(CmdBase):
             show_hash = self.args.show_hash
             hide_missing = self.args.b_rev or self.args.hide_missing
             if hide_missing:
-                del diff["not in cache"]
+                diff.pop("not in cache", None)
 
             for key, entries in diff.items():
                 entries = sorted(

--- a/tests/unit/command/test_diff.py
+++ b/tests/unit/command/test_diff.py
@@ -204,20 +204,31 @@ def test_diff_show_markdown_and_hash(mocker, show_hash):
     mock_show_markdown.assert_called_once_with(diff, show_hash, False)
 
 
-def test_no_changes(mocker, capsys):
-    args = parse_args(["diff", "--json"])
+@pytest.mark.parametrize(
+    "opts",
+    (
+        [],
+        ["a_rev", "b_rev"],
+        ["--targets", "."],
+        ["--hide-missing"],
+    ),
+)
+@pytest.mark.parametrize(
+    "show, expected",
+    (
+        ([], ""),
+        (["--json"], "{}"),
+        (["--md"], "| Status   | Path   |\n|----------|--------|"),
+    ),
+)
+def test_no_changes(mocker, capsys, opts, show, expected):
+    args = parse_args(["diff", *opts, *show])
     cmd = args.func(args)
     mocker.patch("dvc.repo.Repo.diff", return_value={})
 
     assert 0 == cmd.run()
     out, _ = capsys.readouterr()
-    assert "{}" in out
-
-    args = parse_args(["diff"])
-    cmd = args.func(args)
-    assert 0 == cmd.run()
-    out, _ = capsys.readouterr()
-    assert not out
+    assert expected == out.strip()
 
 
 def test_show_markdown(capsys):


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [N/A] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

`dvc diff` fails when there is no diff and `hide_missing` is true (`hide_missing` is implied when comparing two revisions) because `CmdDiff.run` tries to delete the `not in cache` info from an empty dict. It seemed easy enough to fix.

Not sure if we need a test for this. Couldn't find any relevant ones specific to the `CmdDiff` logic.