### PR TITLE
Suppress `--live-no-summary` help.

### DIFF
--- a/dvc/commands/stage.py
+++ b/dvc/commands/stage.py
@@ -214,7 +214,7 @@ def _add_common_args(parser):
         "--live-no-summary",
         action="store_true",
         default=False,
-        help="Signal dvclive logger to not dump latest metrics file.",
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--live-no-html",


### PR DESCRIPTION
Per https://github.com/iterative/dvclive/pull/217
