### PR TITLE
params: allow tracking file

### DIFF
--- a/dvc/dependency/__init__.py
+++ b/dvc/dependency/__init__.py
@@ -47,16 +47,29 @@ def loads_from(stage, s_list, erepo=None):
 def _merge_params(s_list):
     d = defaultdict(list)
     default_file = ParamsDependency.DEFAULT_PARAMS_FILE
+
+    # figure out completely tracked params file, and ignore specific keys
+    wholly_tracked = set()
+    for key in s_list:
+        if not isinstance(key, dict):
+            continue
+        wholly_tracked.update(k for k, params in key.items() if not params)
+
     for key in s_list:
         if isinstance(key, str):
-            d[default_file].append(key)
+            if default_file not in wholly_tracked:
+                d[default_file].append(key)
             continue
+
         if not isinstance(key, dict):
             msg = "Only list of str/dict is supported. Got: "
             msg += f"'{type(key).__name__}'."
             raise ValueError(msg)
 
         for k, params in key.items():
+            if k in wholly_tracked:
+                d[k] = []
+                continue
             if not isinstance(params, list):
                 msg = "Expected list of params for custom params file "
                 msg += f"'{k}', got '{type(params).__name__}'."

--- a/dvc/repo/params/show.py
+++ b/dvc/repo/params/show.py
@@ -66,7 +66,9 @@ def _read_params(
 
     if deps:
         for param in params:
-            params_dict = error_handler(param.read_params_d)(onerror=onerror)
+            params_dict = error_handler(param.read_params)(
+                onerror=onerror, flatten=False
+            )
             if params_dict:
                 res[
                     repo.fs.path.relpath(param.fs_path, os.getcwd())

--- a/dvc/stage/serialize.py
+++ b/dvc/stage/serialize.py
@@ -90,18 +90,12 @@ def _serialize_params_keys(params):
     """
     keys = []
     for param_dep in sort_by_path(params):
-        dump = param_dep.dumpd()
-        path, params = dump[PARAM_PATH], dump[PARAM_PARAMS]
-        assert isinstance(params, (dict, list))
         # when on no_exec, params are not filled and are saved as list
-        k = sorted(params.keys() if isinstance(params, dict) else params)
-        if not k:
-            continue
-
-        if path == DEFAULT_PARAMS_FILE:
+        k = sorted(param_dep.params)
+        if k and param_dep.def_path == DEFAULT_PARAMS_FILE:
             keys = k + keys
         else:
-            keys.append({path: k})
+            keys.append({param_dep.def_path: k or None})
     return keys
 
 

--- a/tests/func/params/test_show.py
+++ b/tests/func/params/test_show.py
@@ -178,3 +178,17 @@ def test_log_errors(tmp_dir, scm, dvc, capsys, file, error_path):
         "DVC failed to load some parameters for following revisions: 'v1'."
         in error
     )
+
+
+@pytest.mark.parametrize("file", ["params.yaml", "other_params.yaml"])
+def test_show_without_targets_specified(tmp_dir, dvc, scm, file):
+    params_file = tmp_dir / file
+    data = {"foo": {"bar": "bar"}, "x": "0"}
+    params_file.dump(data)
+    dvc.stage.add(
+        name="test",
+        cmd=f"echo {file}",
+        params=[{file: None}],
+    )
+
+    assert dvc.params.show() == {"": {"data": {file: {"data": data}}}}

--- a/tests/func/test_status.py
+++ b/tests/func/test_status.py
@@ -137,3 +137,49 @@ def test_status_outputs(tmp_dir, dvc):
     assert dvc.status(targets=["alice"]) == {
         "alice_bob": [{"changed outs": {"alice": "modified"}}]
     }
+
+
+def test_params_without_targets(tmp_dir, dvc):
+    dvc.stage.add(
+        name="test", cmd="echo params.yaml", params=[{"params.yaml": None}]
+    )
+    assert dvc.status() == {
+        "test": [{"changed deps": {"params.yaml": "deleted"}}]
+    }
+
+    (tmp_dir / "params.yaml").touch()
+    assert dvc.status() == {"test": [{"changed deps": {"params.yaml": "new"}}]}
+
+    dvc.commit("test", force=True)
+    # make sure that we are able to keep track of "empty" contents
+    # and be able to distinguish between no-lock-entry and empty-lock-entry.
+    assert (tmp_dir / "dvc.lock").parse() == {
+        "schema": "2.0",
+        "stages": {
+            "test": {"cmd": "echo params.yaml", "params": {"params.yaml": {}}}
+        },
+    }
+    assert dvc.status() == {}
+
+    (tmp_dir / "params.yaml").dump({"foo": "foo", "bar": "bar"})
+    assert dvc.status() == {
+        "test": [
+            {"changed deps": {"params.yaml": {"bar": "new", "foo": "new"}}}
+        ]
+    }
+    dvc.commit("test", force=True)
+
+    (tmp_dir / "params.yaml").dump({"foo": "foobar", "lorem": "ipsum"})
+    assert dvc.status() == {
+        "test": [
+            {
+                "changed deps": {
+                    "params.yaml": {
+                        "bar": "deleted",
+                        "foo": "modified",
+                        "lorem": "new",
+                    }
+                }
+            }
+        ]
+    }

--- a/tests/unit/stage/test_serialize_pipeline_file.py
+++ b/tests/unit/stage/test_serialize_pipeline_file.py
@@ -100,6 +100,25 @@ def test_params_file_sorted(dvc):
     ]
 
 
+def test_params_file_without_targets(dvc):
+    params = [
+        "foo",
+        "bar",
+        {"params.yaml": None},
+        {"custom.yaml": ["wxyz", "pqrs", "baz"]},
+        {"a-file-of-params.yaml": None},
+        {"a-file-of-params.yaml": ["barr"]},
+    ]
+    stage = create_stage(
+        PipelineStage, dvc, outs=["bar"], deps=["foo"], params=params, **kwargs
+    )
+    assert to_pipeline_file(stage)["something"][stage.PARAM_PARAMS] == [
+        {"a-file-of-params.yaml": None},
+        {"custom.yaml": ["baz", "pqrs", "wxyz"]},
+        {"params.yaml": None},
+    ]
+
+
 @pytest.mark.parametrize(
     "typ, extra",
     [("plots", {"plot": True}), ("metrics", {"metric": True}), ("outs", {})],

--- a/tests/unit/stage/test_serialize_pipeline_lock.py
+++ b/tests/unit/stage/test_serialize_pipeline_lock.py
@@ -120,6 +120,25 @@ def test_lock_params_no_values_filled(dvc):
     assert to_single_stage_lockfile(stage) == {"cmd": "command"}
 
 
+@pytest.mark.parametrize(
+    "info, expected",
+    [
+        (None, {}),
+        ({}, {}),
+        ({"foo": "foo", "bar": "bar"}, {"bar": "bar", "foo": "foo"}),
+    ],
+)
+def test_lock_params_without_targets(dvc, info, expected):
+    stage = create_stage(
+        PipelineStage, dvc, params=[{"params.yaml": None}], **kwargs
+    )
+    stage.deps[0].fill_values(info)
+    assert to_single_stage_lockfile(stage) == {
+        "cmd": "command",
+        "params": {"params.yaml": OrderedDict(expected)},
+    }
+
+
 @pytest.mark.parametrize("typ", ["plots", "metrics", "outs"])
 def test_lock_outs(dvc, typ):
     stage = create_stage(PipelineStage, dvc, **{typ: ["input"]}, **kwargs)


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

(will create the docs after #7413)

The syntax for tracking files is:
```yaml
params:
 - params.yaml:
 - config.yaml:
```

Closes #4112 

[![asciicast](https://asciinema.org/a/PUVxnxZzJqe6RNjXipq0VXUNp.svg)](https://asciinema.org/a/PUVxnxZzJqe6RNjXipq0VXUNp)
