### PR TITLE
exp show: throws an error with -n -1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -75,7 +75,7 @@ install_requires =
     aiohttp-retry>=2.4.5
     diskcache>=5.2.1
     jaraco.windows>=5.7.0; python_version < '3.8' and sys_platform == 'win32'
-    scmrepo==0.0.7
+    scmrepo==0.0.9
 
 [options.extras_require]
 all =

--- a/tests/unit/scm/test_scm.py
+++ b/tests/unit/scm/test_scm.py
@@ -36,6 +36,7 @@ def test_iter_revs(
     assert gen == {rev_root: [rev_root], rev_new: ["new"]}
     gen = iter_revs(scm, ["new"], 2)
     assert gen == {rev_new: ["new"], rev_old: [rev_old]}
+    scm.gitpython.repo.create_remote("upstream", "some_remote")
     gen = iter_revs(scm, ["other"], -1)
     assert gen == {
         rev_other: ["other"],


### PR DESCRIPTION
fix: #7434
exp show -n -1 will throw error on any repo with a remote repo setted.

1. Update new version of `scmrepo`
2. Update the unit test add a remote repo to the test case.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
