### PR TITLE
fs.http: prevent hangs under some network conditions

### DIFF
--- a/dvc/fs/http.py
+++ b/dvc/fs/http.py
@@ -123,7 +123,7 @@ class HTTPFileSystem(NoDirectoriesMixin, FSSpecWrapper):
             total=None,
             connect=self.REQUEST_TIMEOUT,
             sock_connect=self.REQUEST_TIMEOUT,
-            sock_read=None,
+            sock_read=self.REQUEST_TIMEOUT,
         )
 
         return RetryClient(**kwargs)


### PR DESCRIPTION
When using an https remote (such as in the dvc-bench remote, see https://github.com/iterative/dvc-bench/issues/319), under certain situations, `dvc pull` would freeze and never return. Note that this did not happen 100% of the time, but often enough to make the bench CI always fail (note: CI was running a matrix strategy over ~12 workers, pulling a 25k file dataset on each).

Investigation pointed to network issues (as the issue could not be reproduced locally). I ended up tracking this to a connection being dropped/lost and `aiohttp` not realizing this. Due to our timeout defaults for `aiohttp.ClientSession`:
```python
aiohttp.ClientTimeout(
            total=None,
            connect=self.REQUEST_TIMEOUT,
            sock_connect=self.REQUEST_TIMEOUT,
            sock_read=None,
        )
```
(note that `sock_read=None`), `aiohttp` would keep trying to read from a dead socket thus hang.

By instantiating a `aiohttp.TCPConnector` with `enable_cleanup_closed=True`, the underlying transport is forcefully closed when the connection is lost, so that the request fails and `RetryClient` retries. 

Thanks @pared and @karajan1001 

fixes #7414 