### PR TITLE
exp remove: show removed experiments #7449

### DIFF
--- a/dvc/commands/experiments/remove.py
+++ b/dvc/commands/experiments/remove.py
@@ -4,6 +4,7 @@ import logging
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
 from dvc.exceptions import InvalidArgumentError
+from dvc.ui import ui
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +28,7 @@ class CmdExperimentsRemove(CmdBase):
 
         self.raise_error_if_all_disabled()
 
-        self.repo.experiments.remove(
+        removed_list = self.repo.experiments.remove(
             exp_names=self.args.experiment,
             all_commits=self.args.all_commits,
             rev=self.args.rev,
@@ -35,6 +36,8 @@ class CmdExperimentsRemove(CmdBase):
             queue=self.args.queue,
             git_remote=self.args.git_remote,
         )
+        removed = ",".join(removed_list)
+        ui.write(f"Removed experiments: {removed}")
 
         return 0
 


### PR DESCRIPTION
fix: #7449
`exp remove`: should show the experiments that were removed

1. experiment.remove now returns the experiment list been removed.
2. modify the functional test to these the returned list.
3. use ui to show the removed list.

Co-authored-by:

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

current behaviour
```bash
$ dvc exp remove aab2130 expqueue # revision and exp-name of queued experiments.
remove experiments: expqueue,aab2130
$ dvc exp remove --rev master
remove experiments: exp0.25,exp0.3
$ dvc exp remove --all
remove experiments: exp0.1,exp-0f3cc,exp0.5,exp0.15,exp0.4
```

