### PR TITLE
objects.db: get rid of callbacks from internal _list_paths API

### DIFF
--- a/dvc/data/db/local.py
+++ b/dvc/data/db/local.py
@@ -78,7 +78,7 @@ class LocalObjectDB(ObjectDB):
 
         return ret
 
-    def _list_paths(self, prefix=None, progress_callback=None):
+    def _list_paths(self, prefix=None):
         assert self.fs_path is not None
         if prefix:
             fs_path = self.fs.path.join(self.fs_path, prefix[:2])
@@ -89,12 +89,7 @@ class LocalObjectDB(ObjectDB):
 
         # NOTE: use utils.fs walk_files since fs.walk_files will not follow
         # symlinks
-        if progress_callback:
-            for path in walk_files(fs_path):
-                progress_callback()
-                yield path
-        else:
-            yield from walk_files(fs_path)
+        yield from walk_files(fs_path)
 
     def _remove_unpacked_dir(self, hash_):
         hash_fs_path = self.hash_to_path(hash_)

--- a/tests/unit/remote/test_base.py
+++ b/tests/unit/remote/test_base.py
@@ -75,21 +75,15 @@ def test_list_hashes_traverse(_path_to_hash, list_hashes, dvc):
     size = 256 / odb.fs._JOBS * odb.fs.LIST_OBJECT_PAGE_SIZE
     list(odb._list_hashes_traverse(size, {0}))
     for i in range(1, 16):
-        list_hashes.assert_any_call(
-            prefix=f"{i:03x}", progress_callback=CallableOrNone
-        )
+        list_hashes.assert_any_call(f"{i:03x}")
     for i in range(1, 256):
-        list_hashes.assert_any_call(
-            prefix=f"{i:02x}", progress_callback=CallableOrNone
-        )
+        list_hashes.assert_any_call(f"{i:02x}")
 
     # default traverse (small remote)
     size -= 1
     list_hashes.reset_mock()
     list(odb._list_hashes_traverse(size - 1, {0}))
-    list_hashes.assert_called_with(
-        prefix=None, progress_callback=CallableOrNone
-    )
+    list_hashes.assert_called_with(None)
 
 
 def test_list_hashes(dvc):


### PR DESCRIPTION
This removes callback from internal APIs: `_list_paths`, `list_hashes`,
and `_hashes_with_limit`. These are all iterators and hence can just be
replaced by wrapping a progress bar over those iterators on the caller
side.

We still have progress bars in `hashes_exist`, `_estimate_remote_size`,
`_list_hashes_traverse` and `list_hashes_exists`, which should gradually
be lifted up and replaced.

I came over to this refactoring when investigating `webdav` issue in #7288, and noticed that `_list_paths` could be simpler.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
