### PR TITLE
Raise informative missing s3 extra

### DIFF
--- a/dvc/output.py
+++ b/dvc/output.py
@@ -27,6 +27,7 @@ from .fs import get_cloud_fs
 from .fs.hdfs import HDFSFileSystem
 from .fs.local import LocalFileSystem
 from .fs.s3 import S3FileSystem
+from .fs.base import RemoteMissingDepsError
 from .hash_info import HashInfo
 from .istextfile import istextfile
 from .objects.errors import ObjectFormatError
@@ -871,6 +872,8 @@ class Output:
 
         try:
             self.get_dir_cache(jobs=jobs, remote=remote)
+        except RemoteMissingDepsError as ex:
+            raise ex
         except DvcException:
             logger.debug(f"failed to pull cache for '{self}'")
 

--- a/dvc/output.py
+++ b/dvc/output.py
@@ -24,10 +24,10 @@ from .data.stage import stage as ostage
 from .data.transfer import transfer as otransfer
 from .data.tree import Tree
 from .fs import get_cloud_fs
+from .fs.base import RemoteMissingDepsError
 from .fs.hdfs import HDFSFileSystem
 from .fs.local import LocalFileSystem
 from .fs.s3 import S3FileSystem
-from .fs.base import RemoteMissingDepsError
 from .hash_info import HashInfo
 from .istextfile import istextfile
 from .objects.errors import ObjectFormatError

--- a/dvc/output.py
+++ b/dvc/output.py
@@ -872,8 +872,8 @@ class Output:
 
         try:
             self.get_dir_cache(jobs=jobs, remote=remote)
-        except RemoteMissingDepsError as ex:
-            raise ex
+        except RemoteMissingDepsError:
+            raise
         except DvcException:
             logger.debug(f"failed to pull cache for '{self}'")
 

--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import shutil
-from unittest.mock import patch
 
 import pytest
 from flaky.flaky_decorator import flaky
@@ -10,7 +9,6 @@ import dvc as dvc_module
 from dvc.cli import main
 from dvc.data.db.local import LocalObjectDB
 from dvc.external_repo import clean_repos
-from dvc.fs.base import RemoteMissingDepsError
 from dvc.objects.db import ObjectDB
 from dvc.stage.exceptions import StageNotFound
 from dvc.testing.test_remote import (  # noqa, pylint: disable=unused-import
@@ -572,20 +570,3 @@ def test_target_remote(tmp_dir, dvc, make_remote):
         "6b18131dc289fd37006705affe961ef8.dir",
         "b8a9f715dbb64fd5c56e7783c6820a61",
     }
-
-
-def test_remote_missing_data_dir(tmp_dir, scm, dvc, make_remote):
-    tmp_dir.dvc_gen({"dir": {"subfile": "file2 content"}}, commit="add dir")
-    with dvc.config.edit() as conf:
-        conf["remote"]["s3"] = {"url": "s3://bucket/name"}
-        conf["core"] = {"remote": "s3"}
-
-    remove("dir")
-    remove(dvc.odb.local.cache_dir)
-
-    with patch(
-        "dvc.data_cloud.DataCloud.get_remote_odb",
-        side_effect=RemoteMissingDepsError("remote missing"),
-    ):
-        with pytest.raises(RemoteMissingDepsError):
-            dvc.pull()

--- a/tests/unit/output/test_output.py
+++ b/tests/unit/output/test_output.py
@@ -104,7 +104,7 @@ def test_get_used_objs(exists, expected_message, mocker, caplog):
     assert first(caplog.messages) == expected_message
 
 
-def test_remote_missing_data_dir(tmp_dir, scm, dvc, mocker):
+def test_remote_missing_depenency_on_dir_pull(tmp_dir, scm, dvc, mocker):
     tmp_dir.dvc_gen({"dir": {"subfile": "file2 content"}}, commit="add dir")
     with dvc.config.edit() as conf:
         conf["remote"]["s3"] = {"url": "s3://bucket/name"}

--- a/tests/unit/output/test_output.py
+++ b/tests/unit/output/test_output.py
@@ -5,9 +5,11 @@ import pytest
 from funcy import first
 from voluptuous import MultipleInvalid, Schema
 
+from dvc.fs.base import RemoteMissingDepsError
 from dvc.ignore import _no_match
 from dvc.output import CHECKSUM_SCHEMA, Output
 from dvc.stage import Stage
+from dvc.utils.fs import remove
 
 
 def test_save_missing(dvc, mocker):
@@ -100,3 +102,20 @@ def test_get_used_objs(exists, expected_message, mocker, caplog):
     with caplog.at_level(logging.WARNING, logger="dvc"):
         assert {} == output.get_used_objs()
     assert first(caplog.messages) == expected_message
+
+
+def test_remote_missing_data_dir(tmp_dir, scm, dvc, mocker):
+    tmp_dir.dvc_gen({"dir": {"subfile": "file2 content"}}, commit="add dir")
+    with dvc.config.edit() as conf:
+        conf["remote"]["s3"] = {"url": "s3://bucket/name"}
+        conf["core"] = {"remote": "s3"}
+
+    remove("dir")
+    remove(dvc.odb.local.cache_dir)
+
+    with mocker.patch(
+        "dvc.data_cloud.DataCloud.get_remote_odb",
+        side_effect=RemoteMissingDepsError("remote missing"),
+    ):
+        with pytest.raises(RemoteMissingDepsError):
+            dvc.pull()


### PR DESCRIPTION
As described in #6870 when s3 extra missing dvc does not always raise the informative message that it should be installed. This has to do with catching a generic DvcException and adding a debug message which I am overwriting here in that case to allow the Exception to propagate.

I am not sure this is the right place to catch the exception and additionally this might affect other cases as well which I am happy to address like non directory based hashes. Assuming this is the right place to catch the exception, happy to work on adding a test for this.

Fixes #6870 ? 

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
