### PR TITLE
build: pin setuptools to <61

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=48", "wheel", "setuptools_scm[toml]>=6.3.1"]
+requires = ["setuptools>=48,<61", "wheel", "setuptools_scm[toml]>=6.3.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ classifiers =
 
 [options]
 setup_requires =
-    setuptools>=48
+    setuptools>=48,<61
     setuptools_scm[toml]>=6.3.1
     setuptools_scm_git_archive==1.1
 


### PR DESCRIPTION
A workaround for https://github.com/pypa/setuptools/issues/3196.

We had some benchmarks failure due to a new setuptools release `setuptools==61.0.0`. (eg: https://github.com/iterative/dvc/runs/5689488287?check_suite_focus=true#step:4:1777). Restricting that specific versions here temporarily.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
