### PR TITLE
Revert "build: pin setuptools to <61"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=48,<61", "wheel", "setuptools_scm[toml]>=6.3.1"]
+requires = ["setuptools>=48", "wheel", "setuptools_scm[toml]>=6.3.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ classifiers =
 
 [options]
 setup_requires =
-    setuptools>=48,<61
+    setuptools>=48
     setuptools_scm[toml]>=6.3.1
     setuptools_scm_git_archive==1.1
 


### PR DESCRIPTION
Reverts iterative/dvc#7502, now that setuptools==61.1.0 is released.