### PR TITLE
bump pytest-docker to 0.11.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -130,7 +130,7 @@ tests =
     pytest-mock==3.7.0
     pytest-lazy-fixture==0.6.3
     # https://github.com/docker/docker-py/issues/2902
-    pytest-docker==0.10.3; python_version < '3.10' or sys_platform != 'win32'
+    pytest-docker==0.11.0; python_version < '3.10' or sys_platform != 'win32'
     flaky==3.7.0
     mock==4.0.3
     pytest-timeout==2.1.0


### PR DESCRIPTION
This adds support for pytest>7.
See https://github.com/avast/pytest-docker/pull/74.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
