### PR TITLE
plots: image: fix image to_json structure

### DIFF
--- a/dvc/render/convert.py
+++ b/dvc/render/convert.py
@@ -60,7 +60,7 @@ def to_json(renderer, split: bool = False) -> List[Dict]:
         return [
             {
                 TYPE_KEY: renderer.TYPE,
-                REVISIONS_KEY: datapoint.get(REVISION_FIELD),
+                REVISIONS_KEY: [datapoint.get(REVISION_FIELD)],
                 "url": datapoint.get(SRC_FIELD),
             }
             for datapoint in renderer.datapoints

--- a/tests/unit/render/test_convert.py
+++ b/tests/unit/render/test_convert.py
@@ -214,6 +214,6 @@ def test_to_json_image(mocker):
     result = to_json(image_renderer)
     assert result[0] == {
         "url": image_renderer.datapoints[0].get(SRC_FIELD),
-        REVISIONS_KEY: image_renderer.datapoints[0].get(REVISION_FIELD),
+        REVISIONS_KEY: [image_renderer.datapoints[0].get(REVISION_FIELD)],
         TYPE_KEY: image_renderer.TYPE,
     }


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

In recent rendering lib extraction (#7409) we changed the data type for images, from list to str.
We should keep the structure for `to_json` consistent, vscode relies on this. cc @mattseddon 