### PR TITLE
erepo: include exp refs in clones

### DIFF
--- a/dvc/repo/experiments/utils.py
+++ b/dvc/repo/experiments/utils.py
@@ -191,3 +191,16 @@ def check_ref_format(scm: "Git", ref: ExpRefInfo):
             f"Invalid exp name {ref.name}, the exp name must follow rules in "
             "https://git-scm.com/docs/git-check-ref-format"
         )
+
+
+def fetch_all_exps(scm: "Git", url: str, progress: Optional[Callable] = None):
+    refspecs = [
+        f"{ref}:{ref}"
+        for ref in iter_remote_refs(scm, url, base=EXPS_NAMESPACE)
+        if not (ref.startswith(EXEC_NAMESPACE) or ref == EXPS_STASH)
+    ]
+    scm.fetch_refspecs(
+        url,
+        refspecs,
+        progress=progress,
+    )

--- a/dvc/scm.py
+++ b/dvc/scm.py
@@ -101,9 +101,14 @@ class TqdmGit(Tqdm):
 def clone(url: str, to_path: str, **kwargs):
     from scmrepo.exceptions import CloneError as InternalCloneError
 
+    from dvc.repo.experiments.utils import fetch_all_exps
+
     with TqdmGit(desc="Cloning") as pbar:
         try:
-            return Git.clone(url, to_path, progress=pbar.update_git, **kwargs)
+            git = Git.clone(url, to_path, progress=pbar.update_git, **kwargs)
+            if "shallow_branch" not in kwargs:
+                fetch_all_exps(git, "origin", progress=pbar.update_git)
+            return git
         except InternalCloneError as exc:
             raise CloneError(str(exc))
 

--- a/tests/func/experiments/test_remote.py
+++ b/tests/func/experiments/test_remote.py
@@ -374,3 +374,20 @@ def test_auth_error_push(tmp_dir, scm, dvc, exp_stage, http_auth_patch):
         match=f"HTTP Git authentication is not supported: '{http_auth_patch}'",
     ):
         dvc.experiments.push(http_auth_patch, [ref_info.name])
+
+
+@pytest.mark.parametrize("use_ref", [True, False])
+def test_get(tmp_dir, scm, dvc, exp_stage, erepo_dir, use_ref):
+    from dvc.repo import Repo
+
+    results = dvc.experiments.run(exp_stage.addressing, params=["foo=2"])
+    exp_rev = first(results)
+    exp_ref = first(exp_refs_by_rev(scm, exp_rev))
+
+    with erepo_dir.chdir():
+        Repo.get(
+            str(tmp_dir),
+            "params.yaml",
+            rev=exp_ref.name if use_ref else exp_rev,
+        )
+        assert (erepo_dir / "params.yaml").read_text().strip() == "foo: 2"


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

- include exp refs when cloning/updating full (non-shallow) erepo clones
- add test for `dvc get --rev=<exp>`

Will fix #7169