### PR TITLE
Add `getitem` to Index

### DIFF
--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -93,7 +93,7 @@ class Index:
 
     def __getitem__(self, item: str) -> "Stage":
         """Get a stage by its addressing attribute."""
-        for stage in self.stages:
+        for stage in self:
             if stage.addressing == item:
                 return stage
         raise KeyError(f"{item} - available stages are {self.stages}")

--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -92,7 +92,7 @@ class Index:
         yield from self.stages
 
     def __getitem__(self, item: str) -> "Stage":
-        """Get a Stage by its addressing attribute"""
+        """Get a stage by its addressing attribute."""
         for stage in self.stages:
             if stage.addressing == item:
                 return stage

--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -91,6 +91,13 @@ class Index:
     def __iter__(self) -> Iterator["Stage"]:
         yield from self.stages
 
+    def __getitem__(self, item: str) -> "Stage":
+        """Get a Stage by its addressing attribute"""
+        for stage in self.stages:
+            if stage.addressing == item:
+                return stage
+        raise KeyError(f"{item} - available stages are {self.stages}")
+
     def filter(self, filter_fn: Callable[["Stage"], bool]) -> "Index":
         stages_it = filter(filter_fn, self)
         return Index(self.repo, self.fs, stages=list(stages_it))

--- a/tests/func/test_repo_index.py
+++ b/tests/func/test_repo_index.py
@@ -291,3 +291,15 @@ def test_used_objs(tmp_dir, scm, dvc, run_copy, rev):
     assert index.used_objs("copy-foo-bar", with_deps=True) == {
         None: {expected_objs[0]}
     }
+
+
+def test_getitem(tmp_dir, dvc, run_copy):
+    (stage1,) = tmp_dir.dvc_gen("foo", "foo")
+    stage2 = run_copy("foo", "bar", name="copy-foo-bar")
+
+    index = Index(dvc)
+    assert index["foo.dvc"] == stage1
+    assert index["copy-foo-bar"] == stage2
+
+    with pytest.raises(KeyError):
+        _ = index["no-valid-stage-name"]


### PR DESCRIPTION
# Summary

 Allow access to a stage via `getitem` in addition to iterating over the Index.

It is currently possible to iterate over `dvc.repo.Index` but you can not get a `Stage` by its stagename.
This PR introduces `getitem` supporting the name of the Node as follows:

```py
index = Index()
stage: Stage = index["stagename"]
```

This can be handy for all operations attached to `Stage` such as looking at dependecies, etc.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.
