### PR TITLE
exp show: lockless behavior

### DIFF
--- a/dvc/commands/experiments/show.py
+++ b/dvc/commands/experiments/show.py
@@ -480,6 +480,7 @@ class CmdExperimentsShow(CmdBase):
                 num=self.args.num,
                 sha_only=self.args.sha,
                 param_deps=self.args.param_deps,
+                fetch_running=self.args.fetch_running,
             )
         except DvcException:
             logger.exception("failed to show experiments")
@@ -644,5 +645,11 @@ def add_parser(experiments_subparsers, parent_parser):
         action="store_true",
         default=False,
         help="Open the Parallel Coordinates Plot directly in the browser.",
+    )
+    experiments_show_parser.add_argument(
+        "--no-fetch",
+        dest="fetch_running",
+        action="store_false",
+        help=argparse.SUPPRESS,
     )
     experiments_show_parser.set_defaults(func=CmdExperimentsShow)

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -742,7 +742,7 @@ class Experiments:
             return self.stash_revs[rev].name
         return None
 
-    def get_running_exps(self) -> Dict[str, int]:
+    def get_running_exps(self, fetch_refs: bool = True) -> Dict[str, int]:
         """Return info for running experiments."""
         from dvc.scm import InvalidRemoteSCMRepo
         from dvc.utils.serialize import load_json
@@ -774,7 +774,7 @@ class Experiments:
                         result[rev] = info.asdict()
                 else:
                     result[rev] = info.asdict()
-                    if info.git_url:
+                    if info.git_url and fetch_refs:
 
                         def on_diverged(_ref: str, _checkpoint: bool):
                             return False

--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -1,14 +1,16 @@
 import logging
 from collections import OrderedDict, defaultdict
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
-from dvc.repo import Repo, locked  # pylint: disable=unused-import
 from dvc.repo.experiments.base import ExpRefInfo
 from dvc.repo.metrics.show import _gather_metrics
 from dvc.repo.params.show import _gather_params
 from dvc.scm import iter_revs
 from dvc.utils import error_handler, onerror_collect
+
+if TYPE_CHECKING:
+    from dvc.repo import Repo
 
 logger = logging.getLogger(__name__)
 
@@ -124,7 +126,6 @@ def _collect_experiment_branch(
     return res
 
 
-@locked
 def show(
     repo: "Repo",
     all_branches=False,

--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -136,6 +136,7 @@ def show(
     num=1,
     param_deps=False,
     onerror: Optional[Callable] = None,
+    fetch_running: bool = True,
 ):
 
     if onerror is None:
@@ -153,7 +154,7 @@ def show(
         iter_revs(repo.scm, revs, num, all_branches, all_tags, all_commits)
     )
 
-    running = repo.experiments.get_running_exps()
+    running = repo.experiments.get_running_exps(fetch_refs=fetch_running)
 
     for rev in found_revs:
         res[rev]["baseline"] = _collect_experiment_commit(

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -118,6 +118,7 @@ def test_experiments_show(dvc, scm, mocker):
         revs="foo",
         sha_only=True,
         param_deps=True,
+        fetch_running=True,
     )
 
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Closes https://github.com/iterative/dvc/issues/5739

- `exp show` no longer requires acquiring the repo lock
- Add internal use `--no-fetch` option to disable fetching of exp refs for temp/queue experiments
    - vscode extension triggers `exp show` on any changes to `refs/exps/...`, so `exp show` will end up triggering repeated calls to itself when fetching into `refs/exps`
    - After this change vscode can wait for the refs to be updated by the completed `exp run` and then only call `exp show --no-fetch` once at that time (so the infinite recursive calls should be resolved)

Note that using `--no-fetch` disables active ref update for checkpoint runs in vscode. Currently in DVC there is no way to automate updating these refs, so we implemented manual updates on any CLI `exp show` call. For CLI users there is no difference between automating it and doing it on `exp show`, either way the `exp show` UI will reflect the proper current checkpoint status.

Based on the discussion with @mattseddon this was not a formally supported use case in the vscode extension anyways, so this behavior change should not make a major difference right now. After the dvc-task queueing changes, we will be able to properly implement automatically fetching those refs when needed in DVC, and at that point we should end up with parity between the dvc CLI and vscode wrt checkpoint updating.

One potential temporary workaround to allow the checkpoint updating would be for vscode to schedule a periodic `exp show` call (without `--no-fetch`) to force refreshing everything. The scheduled call would end up triggering the file watcher when it updates the checkpoint exp refs, but as long as the file watcher was setup so that it only triggers `exp show --no-fetch`, it would still avoid the infinite recursive calls.