### PR TITLE
repofs: base on fsspec

### DIFF
--- a/dvc/api.py
+++ b/dvc/api.py
@@ -22,17 +22,14 @@ def get_url(path, repo=None, rev=None, remote=None):
         with reraise(FileNotFoundError, PathMissingError(path, repo)):
             info = _repo.repo_fs.info(path)
 
-        if not info["isdvc"]:
+        dvc_info = info.get("dvc_info")
+        if not dvc_info:
             raise OutputNotFoundError(path, repo)
 
-        cloud = info["repo"].cloud
-        _, _, dvc_fs, dvc_path = _repo.repo_fs._get_fs_pair(path)
+        dvc_repo = info["repo"]
+        md5 = dvc_info["md5"]
 
-        if not os.path.isabs(path):
-            dvc_path = dvc_path.replace("\\", "/")
-
-        md5 = info["repo"].dvcfs.info(dvc_path)["md5"]
-        return cloud.get_url_for(remote, checksum=md5)
+        return dvc_repo.cloud.get_url_for(remote, checksum=md5)
 
 
 def open(  # noqa, pylint: disable=redefined-builtin

--- a/dvc/api.py
+++ b/dvc/api.py
@@ -19,15 +19,14 @@ def get_url(path, repo=None, rev=None, remote=None):
     directory in the remote storage.
     """
     with Repo.open(repo, rev=rev, subrepos=True, uninitialized=True) as _repo:
-        fs_path = _repo.fs.path.join(_repo.root_dir, path)
         with reraise(FileNotFoundError, PathMissingError(path, repo)):
-            info = _repo.repo_fs.info(fs_path)
+            info = _repo.repo_fs.info(path)
 
         if not info["isdvc"]:
             raise OutputNotFoundError(path, repo)
 
         cloud = info["repo"].cloud
-        dvc_path = _repo.fs.path.relpath(fs_path, info["repo"].root_dir)
+        _, _, dvc_fs, dvc_path = _repo.repo_fs._get_fs_pair(path)
 
         if not os.path.isabs(path):
             dvc_path = dvc_path.replace("\\", "/")

--- a/dvc/data/reference.py
+++ b/dvc/data/reference.py
@@ -30,7 +30,6 @@ class ReferenceHashFile(HashFile):
         checksum: Optional[str] = None,
         **kwargs,
     ):
-        from dvc.fs.repo import RepoFileSystem
         super().__init__(fs_path, fs, hash_info, **kwargs)
         self.checksum = checksum or fs.checksum(fs_path)
 
@@ -53,8 +52,6 @@ class ReferenceHashFile(HashFile):
         return self.fs.checksum(self.fs_path)
 
     def to_bytes(self):
-        from dvc.fs.repo import RepoFileSystem
-
         # NOTE: dumping reference FS's this way is insecure, as the
         # fully parsed remote FS config will include credentials
         #
@@ -75,7 +72,7 @@ class ReferenceHashFile(HashFile):
     @classmethod
     def from_bytes(cls, data: bytes, fs_cache: Optional[dict] = None):
         from dvc.fs import get_fs_cls
-        from dvc.fs.repo import RepoFileSystem
+        from dvc.fs.repo import RepoFileSystem, _RepoFileSystem
 
         try:
             dict_ = pickle.loads(data)
@@ -92,7 +89,7 @@ class ReferenceHashFile(HashFile):
         fs = fs_cache.get((scheme, config_pairs)) if fs_cache else None
         if not fs:
             config = dict(config_pairs)
-            if RepoFileSystem.PARAM_REPO_URL in config:
+            if _RepoFileSystem.PARAM_REPO_URL in config:
                 fs_cls = RepoFileSystem
             else:
                 fs_cls = get_fs_cls(config, scheme=scheme)

--- a/dvc/data/reference.py
+++ b/dvc/data/reference.py
@@ -30,6 +30,7 @@ class ReferenceHashFile(HashFile):
         checksum: Optional[str] = None,
         **kwargs,
     ):
+        from dvc.fs.repo import RepoFileSystem
         super().__init__(fs_path, fs, hash_info, **kwargs)
         self.checksum = checksum or fs.checksum(fs_path)
 
@@ -60,9 +61,6 @@ class ReferenceHashFile(HashFile):
         # ReferenceHashFiles should currently only be serialized in
         # memory and not to disk
         fs_path = self.fs_path
-        if isinstance(self.fs, RepoFileSystem):
-            fs_path = self.fs.path.relpath(fs_path, self.fs.root_dir)
-
         dict_ = {
             self.PARAM_PATH: fs_path,
             self.PARAM_HASH: self.hash_info,
@@ -95,11 +93,10 @@ class ReferenceHashFile(HashFile):
         if not fs:
             config = dict(config_pairs)
             if RepoFileSystem.PARAM_REPO_URL in config:
-                fs = RepoFileSystem(**config)
-                fs_path = fs.path.join(fs.root_dir, fs_path)
+                fs_cls = RepoFileSystem
             else:
                 fs_cls = get_fs_cls(config, scheme=scheme)
-                fs = fs_cls(**config)
+            fs = fs_cls(**config)
         return ReferenceHashFile(
             fs_path,
             fs,

--- a/dvc/dependency/repo.py
+++ b/dvc/dependency/repo.py
@@ -112,11 +112,14 @@ class RepoDependency(Dependency):
             if locked and self.def_repo.get(self.PARAM_REV_LOCK) is None:
                 self.def_repo[self.PARAM_REV_LOCK] = rev
 
-            path = os.path.abspath(os.path.join(repo.root_dir, self.def_path))
             if not obj_only:
                 try:
                     for odb, obj_ids in repo.used_objs(
-                        [path],
+                        [
+                            os.path.abspath(
+                                os.path.join(repo.root_dir, self.def_path)
+                            )
+                        ],
                         force=True,
                         jobs=kwargs.get("jobs"),
                         recursive=True,
@@ -132,7 +135,7 @@ class RepoDependency(Dependency):
             try:
                 staging, _, staged_obj = stage(
                     local_odb,
-                    path,
+                    self.def_path,
                     repo.repo_fs,
                     local_odb.fs.PARAM_CHECKSUM,
                 )
@@ -172,17 +175,17 @@ class RepoDependency(Dependency):
                 continue
             if (
                 obj.fs.repo_url in checked_urls
-                or obj.fs.root_dir in checked_urls
+                or obj.fs._root_dir in checked_urls
             ):
                 continue
             self_url = self.repo.url or self.repo.root_dir
             if (
                 obj.fs.repo_url is not None
                 and obj.fs.repo_url == self_url
-                or obj.fs.root_dir == self.repo.root_dir
+                or obj.fs._root_dir == self.repo.root_dir
             ):
                 raise CircularImportError(self, obj.fs.repo_url, self_url)
-            checked_urls.update([obj.fs.repo_url, obj.fs.root_dir])
+            checked_urls.update([obj.fs.repo_url, obj.fs._root_dir])
 
     def get_obj(self, filter_info=None, **kwargs):
         locked = kwargs.get("locked", True)

--- a/dvc/fs/fsspec_wrapper.py
+++ b/dvc/fs/fsspec_wrapper.py
@@ -91,7 +91,7 @@ class FSSpecWrapper(FileSystem):
         ...
 
     def ls(self, path, detail=False):
-        yield from self.fs.ls(path, detail=detail)
+        return self.fs.ls(path, detail=detail)
 
     def find(self, path, prefix=None):
         yield from self.fs.find(path)

--- a/dvc/fs/git.py
+++ b/dvc/fs/git.py
@@ -50,3 +50,6 @@ class GitFileSystem(FSSpecWrapper):  # pylint:disable=abstract-method
     @property
     def rev(self) -> str:
         return self.fs.rev
+
+    def ls(self, path, **kwargs):
+        return self.fs.ls(path, **kwargs) or []

--- a/dvc/fs/git.py
+++ b/dvc/fs/git.py
@@ -51,5 +51,5 @@ class GitFileSystem(FSSpecWrapper):  # pylint:disable=abstract-method
     def rev(self) -> str:
         return self.fs.rev
 
-    def ls(self, path, **kwargs):
-        return self.fs.ls(path, **kwargs) or []
+    def ls(self, path, detail=True, **kwargs):
+        return self.fs.ls(path, detail=detail, **kwargs) or []

--- a/dvc/fs/local.py
+++ b/dvc/fs/local.py
@@ -147,6 +147,9 @@ class LocalFileSystem(FileSystem):
     def info(self, path):
         return self.fs.info(path)
 
+    def ls(self, path, **kwargs):
+        return self.fs.ls(path, **kwargs)
+
     def put_file(
         self, from_file, to_info, callback=DEFAULT_CALLBACK, **kwargs
     ):

--- a/dvc/fs/path.py
+++ b/dvc/fs/path.py
@@ -81,8 +81,6 @@ class Path:
         return self.isin_or_eq(left, right) or self.isin(right, left)
 
     def relpath(self, path, start):
-        if not start:
-            return path
         return self.flavour.relpath(path, start=start)
 
     def relparts(self, path, base):

--- a/dvc/fs/path.py
+++ b/dvc/fs/path.py
@@ -81,7 +81,8 @@ class Path:
         return self.isin_or_eq(left, right) or self.isin(right, left)
 
     def relpath(self, path, start):
-        assert start
+        if not start:
+            return path
         return self.flavour.relpath(path, start=start)
 
     def relparts(self, path, base):

--- a/dvc/ignore.py
+++ b/dvc/ignore.py
@@ -303,7 +303,7 @@ class DvcIgnoreFilter:
             for root, _, files in self.walk(fs, path, **kwargs):
                 for file in files:
                     # NOTE: os.path.join is ~5.5 times slower
-                    yield f"{root}{os.sep}{file}"
+                    yield f"{root}{fs.sep}{file}"
         else:
             yield from fs.find(path)
 

--- a/dvc/output.py
+++ b/dvc/output.py
@@ -387,11 +387,6 @@ class Output:
         )
 
     @property
-    def repo_path(self):
-        assert self.is_in_repo
-        return relpath(self.fs_path, self.repo.root_dir)
-
-    @property
     def use_scm_ignore(self):
         if not self.is_in_repo:
             return False

--- a/dvc/output.py
+++ b/dvc/output.py
@@ -387,6 +387,11 @@ class Output:
         )
 
     @property
+    def repo_path(self):
+        assert self.is_in_repo
+        return relpath(self.fs_path, self.repo.root_dir)
+
+    @property
     def use_scm_ignore(self):
         if not self.is_in_repo:
             return False

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -482,7 +482,9 @@ class Repo:
     def repo_fs(self):
         from dvc.fs.repo import RepoFileSystem
 
-        return RepoFileSystem(self, subrepos=self.subrepos, **self._fs_conf)
+        return RepoFileSystem(
+            repo=self, subrepos=self.subrepos, **self._fs_conf
+        )
 
     @cached_property
     def index_db_dir(self):
@@ -493,7 +495,7 @@ class Repo:
         """Opens a specified resource as a file descriptor"""
         from dvc.fs.repo import RepoFileSystem
 
-        fs = RepoFileSystem(self, subrepos=True)
+        fs = RepoFileSystem(repo=self, subrepos=True)
         try:
             with fs.open(
                 path, mode=mode, encoding=encoding, remote=remote

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -494,7 +494,6 @@ class Repo:
         from dvc.fs.repo import RepoFileSystem
 
         fs = RepoFileSystem(self, subrepos=True)
-        path = self.fs.path.join(self.root_dir, path)
         try:
             with fs.open(
                 path, mode=mode, encoding=encoding, remote=remote

--- a/dvc/repo/diff.py
+++ b/dvc/repo/diff.py
@@ -24,7 +24,7 @@ def diff(self, a_rev="HEAD", b_rev=None, targets=None):
 
     from dvc.fs.repo import RepoFileSystem
 
-    repo_fs = RepoFileSystem(self)
+    repo_fs = RepoFileSystem(repo=self)
 
     b_rev = b_rev if b_rev else "workspace"
     results = {}
@@ -188,10 +188,11 @@ def _filter_missing(repo_fs, paths):
     for path in paths:
         try:
             info = repo_fs.info(path)
+            dvc_info = info.get("dvc_info")
             if (
-                info["isdvc"]
+                dvc_info
                 and info["type"] == "directory"
-                and not info["meta"].obj
+                and not dvc_info["meta"].obj
             ):
                 yield path
         except FileNotFoundError:

--- a/dvc/repo/get.py
+++ b/dvc/repo/get.py
@@ -49,9 +49,6 @@ def get(url, path, out=None, rev=None, jobs=None):
         with external_repo(
             url=url, rev=rev, cache_dir=tmp_dir, cache_types=cache_types
         ) as repo:
-            from_fs_path = os.path.abspath(os.path.join(repo.root_dir, path))
-            repo.repo_fs.download(
-                from_fs_path, os.path.abspath(out), jobs=jobs
-            )
+            repo.repo_fs.download(path, os.path.abspath(out), jobs=jobs)
     finally:
         remove(tmp_dir)

--- a/dvc/repo/ls.py
+++ b/dvc/repo/ls.py
@@ -60,11 +60,7 @@ def _ls(repo, fs_path, recursive=None, dvc_only=False):
 
     ret = {}
     for info in infos:
-        try:
-            _info = fs.info(info)
-        except FileNotFoundError:
-            # broken symlink
-            _info = {"type": "file", "isexec": False}
+        _info = fs.info(info)
 
         if _info.get("outs") or not dvc_only:
             path = (

--- a/dvc/repo/ls.py
+++ b/dvc/repo/ls.py
@@ -29,9 +29,7 @@ def ls(url, path=None, rev=None, recursive=None, dvc_only=False):
     from . import Repo
 
     with Repo.open(url, rev=rev, subrepos=True, uninitialized=True) as repo:
-        fs_path = repo.root_dir
-        if path:
-            fs_path = os.path.abspath(repo.fs.path.join(fs_path, path))
+        fs_path = path or ""
 
         ret = _ls(repo, fs_path, recursive, dvc_only)
 

--- a/dvc/repo/metrics/show.py
+++ b/dvc/repo/metrics/show.py
@@ -76,16 +76,15 @@ def _read_metric(path, fs, rev, **kwargs):
 
 
 def _read_metrics(repo, metrics, rev, onerror=None):
-    fs = RepoFileSystem(repo)
+    fs = RepoFileSystem(repo=repo)
 
     res = {}
     for metric in metrics:
-        fs_path = repo.fs.path.relpath(metric, repo.root_dir)
-        if not fs.isfile(fs_path):
+        if not fs.isfile(metric):
             continue
 
-        res[fs.path.relpath(metric, os.getcwd())] = _read_metric(
-            fs_path, fs, rev, onerror=onerror
+        res[os.path.relpath(metric, os.getcwd())] = _read_metric(
+            metric, fs, rev, onerror=onerror
         )
 
     return res

--- a/dvc/repo/metrics/show.py
+++ b/dvc/repo/metrics/show.py
@@ -80,11 +80,12 @@ def _read_metrics(repo, metrics, rev, onerror=None):
 
     res = {}
     for metric in metrics:
-        if not fs.isfile(metric):
+        fs_path = repo.fs.path.relpath(metric, repo.root_dir)
+        if not fs.isfile(fs_path):
             continue
 
         res[fs.path.relpath(metric, os.getcwd())] = _read_metric(
-            metric, fs, rev, onerror=onerror
+            fs_path, fs, rev, onerror=onerror
         )
 
     return res

--- a/dvc/repo/plots/__init__.py
+++ b/dvc/repo/plots/__init__.py
@@ -251,8 +251,8 @@ def _collect_plots(
         recursive=recursive,
     )
 
-    result = {plot.fs_path: _plot_props(plot) for plot in plots}
-    result.update({fs_path: {} for fs_path in fs_paths})
+    result = {relpath(plot.fs_path, repo.root_dir): _plot_props(plot) for plot in plots}
+    result.update({relpath(fs_path, repo.root_dir): {} for fs_path in fs_paths})
     return result
 
 

--- a/dvc/repo/plots/__init__.py
+++ b/dvc/repo/plots/__init__.py
@@ -106,7 +106,7 @@ class Plots:
     ):
         from dvc.fs.repo import RepoFileSystem
 
-        fs = RepoFileSystem(self.repo)
+        fs = RepoFileSystem(repo=self.repo)
         plots = _collect_plots(self.repo, targets, revision, recursive)
         res: Dict[str, Any] = {}
         for fs_path, rev_props in plots.items():
@@ -240,7 +240,7 @@ def _collect_plots(
     targets: List[str] = None,
     rev: str = None,
     recursive: bool = False,
-) -> Dict["List[str]", Dict]:
+) -> Dict[str, Dict]:
     from dvc.repo.collect import collect
 
     plots, fs_paths = collect(
@@ -251,8 +251,8 @@ def _collect_plots(
         recursive=recursive,
     )
 
-    result = {relpath(plot.fs_path, repo.root_dir): _plot_props(plot) for plot in plots}
-    result.update({relpath(fs_path, repo.root_dir): {} for fs_path in fs_paths})
+    result = {plot.fs_path: _plot_props(plot) for plot in plots}
+    result.update({fs_path: {} for fs_path in fs_paths})
     return result
 
 

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -63,7 +63,7 @@ def _get_stage_files(stage: "Stage") -> typing.Iterator[str]:
         if (
             not dep.use_scm_ignore
             and dep.is_in_repo
-            and not stage.repo.repo_fs.isdvc(dep.fs.path.relpath(dep.fs_path, stage.repo.root_dir))
+            and not stage.repo.repo_fs.isdvc(dep.fs_path)
         ):
             yield dep.fs_path
     for out in stage.outs:

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -63,7 +63,7 @@ def _get_stage_files(stage: "Stage") -> typing.Iterator[str]:
         if (
             not dep.use_scm_ignore
             and dep.is_in_repo
-            and not stage.repo.repo_fs.isdvc(dep.fs_path)
+            and not stage.repo.repo_fs.isdvc(dep.fs.path.relpath(dep.fs_path, stage.repo.root_dir))
         ):
             yield dep.fs_path
     for out in stage.outs:

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -332,6 +332,13 @@ def relpath(path, start=os.curdir):
     return os.path.relpath(path, start)
 
 
+def as_posix(path):
+    import ntpath
+    import posixpath
+
+    return path.replace(ntpath.sep, posixpath.sep)
+
+
 def env2bool(var, undefined=False):
     """
     undefined: return value if env var is unset

--- a/tests/func/experiments/test_checkpoints.py
+++ b/tests/func/experiments/test_checkpoints.py
@@ -32,9 +32,9 @@ def test_new_checkpoint(
         if rev == "workspace":
             continue
         fs = dvc.repo_fs
-        with fs.open((tmp_dir / "foo").fs_path) as fobj:
+        with fs.open("foo") as fobj:
             assert fobj.read().strip() == str(checkpoint_stage.iterations)
-        with fs.open((tmp_dir / "metrics.yaml").fs_path) as fobj:
+        with fs.open("metrics.yaml") as fobj:
             assert fobj.read().strip() == "foo: 2"
 
     if workspace:
@@ -81,9 +81,9 @@ def test_resume_checkpoint(
         if rev == "workspace":
             continue
         fs = dvc.repo_fs
-        with fs.open((tmp_dir / "foo").fs_path) as fobj:
+        with fs.open("foo") as fobj:
             assert fobj.read().strip() == str(2 * checkpoint_stage.iterations)
-        with fs.open((tmp_dir / "metrics.yaml").fs_path) as fobj:
+        with fs.open("metrics.yaml") as fobj:
             assert fobj.read().strip() == "foo: 2"
 
     if workspace:
@@ -112,9 +112,9 @@ def test_reset_checkpoint(
         if rev == "workspace":
             continue
         fs = dvc.repo_fs
-        with fs.open((tmp_dir / "foo").fs_path) as fobj:
+        with fs.open("foo") as fobj:
             assert fobj.read().strip() == str(checkpoint_stage.iterations)
-        with fs.open((tmp_dir / "metrics.yaml").fs_path) as fobj:
+        with fs.open("metrics.yaml") as fobj:
             assert fobj.read().strip() == "foo: 2"
 
     if workspace:
@@ -151,18 +151,18 @@ def test_resume_branch(tmp_dir, scm, dvc, checkpoint_stage, workspace):
         if rev == "workspace":
             continue
         fs = dvc.repo_fs
-        with fs.open((tmp_dir / "foo").fs_path) as fobj:
+        with fs.open("foo") as fobj:
             assert fobj.read().strip() == str(2 * checkpoint_stage.iterations)
-        with fs.open((tmp_dir / "metrics.yaml").fs_path) as fobj:
+        with fs.open("metrics.yaml") as fobj:
             assert fobj.read().strip() == "foo: 2"
 
     for rev in dvc.brancher([checkpoint_b]):
         if rev == "workspace":
             continue
         fs = dvc.repo_fs
-        with fs.open((tmp_dir / "foo").fs_path) as fobj:
+        with fs.open("foo") as fobj:
             assert fobj.read().strip() == str(2 * checkpoint_stage.iterations)
-        with fs.open((tmp_dir / "metrics.yaml").fs_path) as fobj:
+        with fs.open("metrics.yaml") as fobj:
             assert fobj.read().strip() == "foo: 100"
 
     with pytest.raises(MultipleBranchError):

--- a/tests/func/experiments/test_experiments.py
+++ b/tests/func/experiments/test_experiments.py
@@ -675,9 +675,9 @@ def test_modified_data_dep(tmp_dir, scm, dvc, workspace, params, target):
     for rev in dvc.brancher(revs=[exp]):
         if rev != exp:
             continue
-        with dvc.repo_fs.open((tmp_dir / "metrics.yaml").fs_path) as fobj:
+        with dvc.repo_fs.open("metrics.yaml") as fobj:
             assert fobj.read().strip() == params
-        with dvc.repo_fs.open((tmp_dir / "data").fs_path) as fobj:
+        with dvc.repo_fs.open("data") as fobj:
             assert fobj.read().strip() == "modified"
 
     if workspace:

--- a/tests/func/test_external_repo.py
+++ b/tests/func/test_external_repo.py
@@ -96,7 +96,7 @@ def test_pull_subdir_file(tmp_dir, erepo_dir):
     dest = tmp_dir / "file"
     with external_repo(os.fspath(erepo_dir)) as repo:
         repo.repo_fs.download(
-            os.path.join("subdir", "file"),
+            "subdir/file",
             os.fspath(dest),
         )
 

--- a/tests/func/test_external_repo.py
+++ b/tests/func/test_external_repo.py
@@ -96,7 +96,7 @@ def test_pull_subdir_file(tmp_dir, erepo_dir):
     dest = tmp_dir / "file"
     with external_repo(os.fspath(erepo_dir)) as repo:
         repo.repo_fs.download(
-            os.path.join(repo.root_dir, "subdir", "file"),
+            os.path.join("subdir", "file"),
             os.fspath(dest),
         )
 
@@ -192,7 +192,7 @@ def test_subrepos_are_ignored(tmp_dir, erepo_dir):
 
     with external_repo(os.fspath(erepo_dir)) as repo:
         repo.repo_fs.download(
-            os.path.join(repo.root_dir, "dir"),
+            "dir",
             os.fspath(tmp_dir / "out"),
         )
         expected_files = {"foo": "foo", "bar": "bar", ".gitignore": "/foo\n"}
@@ -206,7 +206,7 @@ def test_subrepos_are_ignored(tmp_dir, erepo_dir):
 
         staging, _, obj = stage(
             repo.odb.local,
-            os.path.join(repo.root_dir, "dir"),
+            "dir",
             repo.repo_fs,
             "md5",
             dvcignore=repo.dvcignore,
@@ -238,7 +238,7 @@ def test_subrepos_are_ignored_for_git_tracked_dirs(tmp_dir, erepo_dir):
 
     with external_repo(os.fspath(erepo_dir)) as repo:
         repo.repo_fs.download(
-            os.path.join(repo.root_dir, "dir"),
+            "dir",
             os.fspath(tmp_dir / "out"),
         )
         # subrepo files should not be here

--- a/tests/func/test_fs.py
+++ b/tests/func/test_fs.py
@@ -335,7 +335,7 @@ def test_callback_on_repo_fs(tmp_dir, dvc, scm):
 
     callback = fsspec.Callback()
     fs.download(
-        (tmp_dir / "dir").fs_path,
+        "dir",
         (tmp_dir / "dir2").fs_path,
         callback=callback,
     )
@@ -346,7 +346,7 @@ def test_callback_on_repo_fs(tmp_dir, dvc, scm):
 
     callback = fsspec.Callback()
     fs.download(
-        (tmp_dir / "dir" / "foo").fs_path,
+        os.path.join("dir", "foo"),
         (tmp_dir / "foo").fs_path,
         callback=callback,
     )
@@ -358,7 +358,7 @@ def test_callback_on_repo_fs(tmp_dir, dvc, scm):
 
     callback = fsspec.Callback()
     fs.download(
-        (tmp_dir / "dir" / "bar").fs_path,
+        os.path.join("dir", "bar"),
         (tmp_dir / "bar").fs_path,
         callback=callback,
     )

--- a/tests/func/test_ls.py
+++ b/tests/func/test_ls.py
@@ -578,5 +578,4 @@ def test_broken_symlink(tmp_dir, dvc):
             "isexec": False,
             "path": ".dvcignore",
         },
-        {"isout": False, "isdir": False, "isexec": False, "path": "link"},
     ]

--- a/tests/unit/fs/test_repo.py
+++ b/tests/unit/fs/test_repo.py
@@ -194,13 +194,13 @@ def test_walk(tmp_dir, dvc, dvcfiles, extra_expected):
     fs = RepoFileSystem(repo=dvc)
 
     expected = [
-        os.path.join(tmp_dir, "dir", "subdir1"),
-        os.path.join(tmp_dir, "dir", "subdir2"),
-        os.path.join(tmp_dir, "dir", "subdir1", "foo1"),
-        os.path.join(tmp_dir, "dir", "subdir1", "bar1"),
-        os.path.join(tmp_dir, "dir", "subdir2", "foo2"),
-        os.path.join(tmp_dir, "dir", "foo"),
-        os.path.join(tmp_dir, "dir", "bar"),
+        os.path.join("dir", "subdir1"),
+        os.path.join("dir", "subdir2"),
+        os.path.join("dir", "subdir1", "foo1"),
+        os.path.join("dir", "subdir1", "bar1"),
+        os.path.join("dir", "subdir2", "foo2"),
+        os.path.join("dir", "foo"),
+        os.path.join("dir", "bar"),
     ]
 
     actual = []
@@ -208,7 +208,7 @@ def test_walk(tmp_dir, dvc, dvcfiles, extra_expected):
         for entry in dirs + files:
             actual.append(os.path.join(root, entry))
 
-    expected += [os.path.join(tmp_dir, path) for path in extra_expected]
+    expected += [os.path.join(path) for path in extra_expected]
     assert set(actual) == set(expected)
     assert len(actual) == len(expected)
 
@@ -228,14 +228,15 @@ def test_walk_dirty(tmp_dir, dvc):
 
     fs = RepoFileSystem(repo=dvc)
     expected = [
-        os.path.join(tmp_dir, "dir", "subdir1"),
-        os.path.join(tmp_dir, "dir", "subdir2"),
-        os.path.join(tmp_dir, "dir", "subdir3"),
-        os.path.join(tmp_dir, "dir", "subdir1", "foo1"),
-        os.path.join(tmp_dir, "dir", "subdir1", "bar1"),
-        os.path.join(tmp_dir, "dir", "subdir2", "foo2"),
-        os.path.join(tmp_dir, "dir", "subdir3", "foo3"),
-        os.path.join(tmp_dir, "dir", "bar"),
+        os.path.join("dir", "subdir1"),
+        os.path.join("dir", "subdir2"),
+        os.path.join("dir", "subdir3"),
+        os.path.join("dir", "subdir1", "foo1"),
+        os.path.join("dir", "subdir1", "bar1"),
+        os.path.join("dir", "subdir2", "foo2"),
+        os.path.join("dir", "subdir3", "foo3"),
+        os.path.join("dir", "bar"),
+        os.path.join("dir", "foo"),
     ]
 
     actual = []
@@ -260,7 +261,7 @@ def test_walk_dirty_cached_dir(tmp_dir, scm, dvc):
         for entry in dirs + files:
             actual.append(os.path.join(root, entry))
 
-    assert actual == [(data / "bar").fs_path]
+    assert actual == [(data / "bar").fs_path, (data / "foo").fs_path]
 
 
 def test_walk_mixed_dir(tmp_dir, scm, dvc):
@@ -278,9 +279,9 @@ def test_walk_mixed_dir(tmp_dir, scm, dvc):
     fs = RepoFileSystem(repo=dvc)
 
     expected = [
-        os.path.join(tmp_dir, "dir", "foo"),
-        os.path.join(tmp_dir, "dir", "bar"),
-        os.path.join(tmp_dir, "dir", ".gitignore"),
+        os.path.join("dir", "foo"),
+        os.path.join("dir", "bar"),
+        os.path.join("dir", ".gitignore"),
     ]
     actual = []
     for root, dirs, files in fs.walk("dir"):

--- a/tests/unit/fs/test_repo.py
+++ b/tests/unit/fs/test_repo.py
@@ -261,7 +261,9 @@ def test_walk_dirty_cached_dir(tmp_dir, scm, dvc):
         for entry in dirs + files:
             actual.append(os.path.join(root, entry))
 
-    assert actual == [(data / "bar").fs_path, (data / "foo").fs_path]
+    expected = [(data / "foo").fs_path, (data / "bar").fs_path]
+    assert set(actual) == set(expected)
+    assert len(actual) == len(expected)
 
 
 def test_walk_mixed_dir(tmp_dir, scm, dvc):

--- a/tests/unit/fs/test_repo.py
+++ b/tests/unit/fs/test_repo.py
@@ -194,13 +194,13 @@ def test_walk(tmp_dir, dvc, dvcfiles, extra_expected):
     fs = RepoFileSystem(repo=dvc)
 
     expected = [
-        os.path.join("dir", "subdir1"),
-        os.path.join("dir", "subdir2"),
-        os.path.join("dir", "subdir1", "foo1"),
-        os.path.join("dir", "subdir1", "bar1"),
-        os.path.join("dir", "subdir2", "foo2"),
-        os.path.join("dir", "foo"),
-        os.path.join("dir", "bar"),
+        os.path.join(tmp_dir, "dir", "subdir1"),
+        os.path.join(tmp_dir, "dir", "subdir2"),
+        os.path.join(tmp_dir, "dir", "subdir1", "foo1"),
+        os.path.join(tmp_dir, "dir", "subdir1", "bar1"),
+        os.path.join(tmp_dir, "dir", "subdir2", "foo2"),
+        os.path.join(tmp_dir, "dir", "foo"),
+        os.path.join(tmp_dir, "dir", "bar"),
     ]
 
     actual = []
@@ -208,7 +208,7 @@ def test_walk(tmp_dir, dvc, dvcfiles, extra_expected):
         for entry in dirs + files:
             actual.append(os.path.join(root, entry))
 
-    expected += extra_expected
+    expected += [os.path.join(tmp_dir, path) for path in extra_expected]
     assert set(actual) == set(expected)
     assert len(actual) == len(expected)
 
@@ -228,14 +228,14 @@ def test_walk_dirty(tmp_dir, dvc):
 
     fs = RepoFileSystem(repo=dvc)
     expected = [
-        os.path.join("dir", "subdir1"),
-        os.path.join("dir", "subdir2"),
-        os.path.join("dir", "subdir3"),
-        os.path.join("dir", "subdir1", "foo1"),
-        os.path.join("dir", "subdir1", "bar1"),
-        os.path.join("dir", "subdir2", "foo2"),
-        os.path.join("dir", "subdir3", "foo3"),
-        os.path.join("dir", "bar"),
+        os.path.join(tmp_dir, "dir", "subdir1"),
+        os.path.join(tmp_dir, "dir", "subdir2"),
+        os.path.join(tmp_dir, "dir", "subdir3"),
+        os.path.join(tmp_dir, "dir", "subdir1", "foo1"),
+        os.path.join(tmp_dir, "dir", "subdir1", "bar1"),
+        os.path.join(tmp_dir, "dir", "subdir2", "foo2"),
+        os.path.join(tmp_dir, "dir", "subdir3", "foo3"),
+        os.path.join(tmp_dir, "dir", "bar"),
     ]
 
     actual = []
@@ -278,9 +278,9 @@ def test_walk_mixed_dir(tmp_dir, scm, dvc):
     fs = RepoFileSystem(repo=dvc)
 
     expected = [
-        os.path.join("dir", "foo"),
-        os.path.join("dir", "bar"),
-        os.path.join("dir", ".gitignore"),
+        os.path.join(tmp_dir, "dir", "foo"),
+        os.path.join(tmp_dir, "dir", "bar"),
+        os.path.join(tmp_dir, "dir", ".gitignore"),
     ]
     actual = []
     for root, dirs, files in fs.walk("dir"):

--- a/tests/unit/fs/test_repo_info.py
+++ b/tests/unit/fs/test_repo_info.py
@@ -61,7 +61,7 @@ def test_info_not_existing(repo_fs):
 def test_info_git_tracked_file(repo_fs, path):
     info = repo_fs.info(path)
 
-    assert info["repo"].root_dir == repo_fs.root_dir
+    assert info["repo"].root_dir == repo_fs._root_dir
     assert not info["isdvc"]
     assert info["type"] == "file"
     assert not info["isexec"]
@@ -80,7 +80,7 @@ def test_info_git_tracked_file(repo_fs, path):
 def test_info_dvc_tracked_file(repo_fs, path):
     info = repo_fs.info(path)
 
-    assert info["repo"].root_dir == repo_fs.root_dir
+    assert info["repo"].root_dir == repo_fs._root_dir
     assert info["isdvc"]
     assert info["type"] == "file"
     assert not info["isexec"]
@@ -90,7 +90,7 @@ def test_info_dvc_tracked_file(repo_fs, path):
 def test_info_git_only_dirs(repo_fs, path):
     info = repo_fs.info(path)
 
-    assert info["repo"].root_dir == repo_fs.root_dir
+    assert info["repo"].root_dir == repo_fs._root_dir
     assert not info["isdvc"]
     assert info["type"] == "directory"
     assert not info["isexec"]
@@ -98,9 +98,9 @@ def test_info_git_only_dirs(repo_fs, path):
 
 @pytest.mark.parametrize("path", [".", "models"])
 def test_info_git_dvc_mixed_dirs(repo_fs, path):
-    info = repo_fs.info(os.path.join(repo_fs.root_dir, path))
+    info = repo_fs.info(path)
 
-    assert info["repo"].root_dir == repo_fs.root_dir
+    assert info["repo"].root_dir == repo_fs._root_dir
     assert not info["isdvc"]
     assert info["type"] == "directory"
     assert not info["isexec"]
@@ -115,9 +115,9 @@ def test_info_git_dvc_mixed_dirs(repo_fs, path):
     ],
 )
 def test_info_dvc_only_dirs(repo_fs, path):
-    info = repo_fs.info(os.path.join(repo_fs.root_dir, path))
+    info = repo_fs.info(path)
 
-    assert info["repo"].root_dir == repo_fs.root_dir
+    assert info["repo"].root_dir == repo_fs._root_dir
     assert info["isdvc"]
     assert info["type"] == "directory"
     assert not info["isexec"]
@@ -135,7 +135,7 @@ def test_info_on_subrepos(make_tmp_dir, tmp_dir, dvc, scm, repo_fs):
         os.path.join("subrepo", "foo"),
         os.path.join("subrepo", "foobar"),
     ]:
-        info = repo_fs.info(tmp_dir / path)
+        info = repo_fs.info(path)
         assert info["repo"].root_dir == str(
             subrepo
         ), f"repo root didn't match for {path}"

--- a/tests/unit/test_external_repo.py
+++ b/tests/unit/test_external_repo.py
@@ -28,7 +28,7 @@ def test_hook_is_called(tmp_dir, erepo_dir, mocker):
     with external_repo(str(erepo_dir)) as repo:
         spy = mocker.spy(repo.repo_fs, "repo_factory")
 
-        list(repo.repo_fs.walk(repo.root_dir, ignore_subrepos=False))  # drain
+        list(repo.repo_fs.walk("", ignore_subrepos=False))  # drain
         assert spy.call_count == len(subrepos)
 
         paths = [os.path.join(repo.root_dir, path) for path in subrepo_paths]
@@ -65,7 +65,7 @@ def test_subrepo_is_constructed_properly(
     ) as repo:
         spy = mocker.spy(repo.repo_fs, "repo_factory")
 
-        list(repo.repo_fs.walk(repo.root_dir, ignore_subrepos=False))  # drain
+        list(repo.repo_fs.walk("", ignore_subrepos=False))  # drain
         assert spy.call_count == 1
         subrepo = spy.spy_return
 

--- a/tests/unit/test_external_repo.py
+++ b/tests/unit/test_external_repo.py
@@ -26,7 +26,7 @@ def test_hook_is_called(tmp_dir, erepo_dir, mocker):
             repo.dvc_gen("bar", "bar", commit=f"dvc add {repo}/bar")
 
     with external_repo(str(erepo_dir)) as repo:
-        spy = mocker.spy(repo.repo_fs, "repo_factory")
+        spy = mocker.spy(repo.repo_fs.fs, "repo_factory")
 
         list(repo.repo_fs.walk("", ignore_subrepos=False))  # drain
         assert spy.call_count == len(subrepos)
@@ -37,7 +37,7 @@ def test_hook_is_called(tmp_dir, erepo_dir, mocker):
                 call(
                     path,
                     fs=repo.fs,
-                    repo_factory=repo.repo_fs.repo_factory,
+                    repo_factory=repo.repo_fs.fs.repo_factory,
                 )
                 for path in paths
             ],
@@ -63,7 +63,7 @@ def test_subrepo_is_constructed_properly(
     with external_repo(
         str(tmp_dir), cache_dir=str(cache_dir), cache_types=["symlink"]
     ) as repo:
-        spy = mocker.spy(repo.repo_fs, "repo_factory")
+        spy = mocker.spy(repo.repo_fs.fs, "repo_factory")
 
         list(repo.repo_fs.walk("", ignore_subrepos=False))  # drain
         assert spy.call_count == 1


### PR DESCRIPTION
Initial migration to fsspec.

repofs is meant to only accept correct posix paths relative to the root of the repo, but I've left some logic to allow for abspath and ntpath support to have a bit more flexibility for users.

Future improvements:
* split repofs into overlayfs(fs + dvc) and subrepofs
* cleanup `__init__` logic

Fixes #7384