### PR TITLE
fs: get rid of CallbackMixin in azure/gs/hdfs/webhdfs 

### DIFF
--- a/dvc/fs/azure.py
+++ b/dvc/fs/azure.py
@@ -10,7 +10,7 @@ from dvc.exceptions import DvcException
 from dvc.scheme import Schemes
 from dvc.utils import format_link
 
-from .fsspec_wrapper import CallbackMixin, ObjectFSWrapper
+from .fsspec_wrapper import ObjectFSWrapper
 
 logger = logging.getLogger(__name__)
 _DEFAULT_CREDS_STEPS = (
@@ -38,7 +38,7 @@ def _az_config():
 
 
 # pylint:disable=abstract-method
-class AzureFileSystem(CallbackMixin, ObjectFSWrapper):
+class AzureFileSystem(ObjectFSWrapper):
     scheme = Schemes.AZURE
     PARAM_CHECKSUM = "etag"
     REQUIRES = {

--- a/dvc/fs/gs.py
+++ b/dvc/fs/gs.py
@@ -5,10 +5,10 @@ from funcy import cached_property, wrap_prop
 from dvc.scheme import Schemes
 
 # pylint:disable=abstract-method
-from .fsspec_wrapper import CallbackMixin, ObjectFSWrapper
+from .fsspec_wrapper import ObjectFSWrapper
 
 
-class GSFileSystem(CallbackMixin, ObjectFSWrapper):
+class GSFileSystem(ObjectFSWrapper):
     scheme = Schemes.GS
     REQUIRES = {"gcsfs": "gcsfs"}
     PARAM_CHECKSUM = "etag"

--- a/dvc/fs/hdfs.py
+++ b/dvc/fs/hdfs.py
@@ -8,13 +8,13 @@ from funcy import cached_property, wrap_prop
 from dvc.scheme import Schemes
 from dvc.utils import fix_env
 
-from .fsspec_wrapper import CallbackMixin, FSSpecWrapper
+from .fsspec_wrapper import FSSpecWrapper
 
 CHECKSUM_REGEX = re.compile(r".*\t.*\t(?P<checksum>.*)")
 
 
 # pylint: disable=abstract-method
-class HDFSFileSystem(CallbackMixin, FSSpecWrapper):
+class HDFSFileSystem(FSSpecWrapper):
     scheme = Schemes.HDFS
     REQUIRES = {"fsspec": "fsspec", "pyarrow": "pyarrow"}
     PARAM_CHECKSUM = "checksum"

--- a/dvc/fs/webhdfs.py
+++ b/dvc/fs/webhdfs.py
@@ -5,10 +5,10 @@ from funcy import cached_property, wrap_prop
 from dvc.scheme import Schemes
 
 # pylint:disable=abstract-method
-from .fsspec_wrapper import CallbackMixin, FSSpecWrapper
+from .fsspec_wrapper import FSSpecWrapper
 
 
-class WebHDFSFileSystem(CallbackMixin, FSSpecWrapper):
+class WebHDFSFileSystem(FSSpecWrapper):
     scheme = Schemes.WEBHDFS
     REQUIRES = {"fsspec": "fsspec"}
     PARAM_CHECKSUM = "checksum"


### PR DESCRIPTION
No longer needed, as all of those filesystems already support callbacks.

Kudos @skshetry for pointing this out