### PR TITLE
dvcignore: use fs.path instead of os.path

### DIFF
--- a/dvc/fs/local.py
+++ b/dvc/fs/local.py
@@ -1,6 +1,8 @@
 import logging
 import os
 
+from funcy import cached_property
+
 from dvc.scheme import Schemes
 from dvc.system import System
 from dvc.utils import tmp_fname
@@ -25,6 +27,12 @@ class LocalFileSystem(FileSystem):
 
         super().__init__(**config)
         self.fs = LocalFS()
+
+    @cached_property
+    def path(self):
+        from .path import Path
+
+        return Path(self.sep, os.getcwd)
 
     def open(self, path, mode="r", encoding=None, **kwargs):
         return open(path, mode=mode, encoding=encoding)

--- a/dvc/fs/path.py
+++ b/dvc/fs/path.py
@@ -3,7 +3,11 @@ import posixpath
 
 
 class Path:
-    def __init__(self, sep):
+    def __init__(self, sep, getcwd=None):
+        def _getcwd():
+            return ""
+
+        self.getcwd = getcwd or _getcwd
         if sep == posixpath.sep:
             self.flavour = posixpath
         elif sep == ntpath.sep:
@@ -13,6 +17,23 @@ class Path:
 
     def join(self, *parts):
         return self.flavour.join(*parts)
+
+    def split(self, path):
+        return self.flavour.split(path)
+
+    def normpath(self, path):
+        return self.flavour.normpath(path)
+
+    def isabs(self, path):
+        return self.flavour.isabs(path)
+
+    def abspath(self, path):
+        if not self.isabs(path):
+            path = self.join(self.getcwd(), path)
+        return self.normpath(path)
+
+    def commonprefix(self, path):
+        return self.flavour.commonprefix(path)
 
     def parts(self, path):
         drive, path = self.flavour.splitdrive(path.rstrip(self.flavour.sep))
@@ -39,6 +60,9 @@ class Path:
 
     def parent(self, path):
         return self.flavour.dirname(path)
+
+    def dirname(self, path):
+        return self.parent(path)
 
     def parents(self, path):
         parts = self.parts(path)

--- a/tests/func/test_ignore.py
+++ b/tests/func/test_ignore.py
@@ -115,7 +115,8 @@ def test_ignore_collecting_dvcignores(tmp_dir, dvc, dname):
                 os.fspath(tmp_dir),
                 _to_pattern_info_list([os.path.basename(dname)]),
                 top_ignore_path,
-            )
+            ),
+            os.sep,
         )
         == dvcignore._get_trie_pattern(top_ignore_path)
         == dvcignore._get_trie_pattern(sub_dir_path)
@@ -140,7 +141,7 @@ def test_ignore_on_branch(tmp_dir, scm, dvc):
     }
 
     dvc.fs = GitFileSystem(scm=scm, rev="branch")
-    assert dvc.dvcignore.is_ignored_file(tmp_dir / "foo")
+    assert dvc.dvcignore.is_ignored_file((tmp_dir / "foo").fs_path)
 
 
 def test_match_nested(tmp_dir, dvc):
@@ -372,15 +373,15 @@ def test_pattern_trie_fs(tmp_dir, dvc):
         os.fspath(tmp_dir / "other"),
     )
 
-    assert DvcIgnorePatterns(*base_pattern) == ignore_pattern_top
-    assert DvcIgnorePatterns(*other_pattern) == ignore_pattern_other
+    assert DvcIgnorePatterns(*base_pattern, os.sep) == ignore_pattern_top
+    assert DvcIgnorePatterns(*other_pattern, os.sep) == ignore_pattern_other
     assert (
-        DvcIgnorePatterns(*first_pattern)
+        DvcIgnorePatterns(*first_pattern, os.sep)
         == ignore_pattern_first
         == ignore_pattern_middle
     )
     assert (
-        DvcIgnorePatterns(*second_pattern)
+        DvcIgnorePatterns(*second_pattern, os.sep)
         == ignore_pattern_second
         == ignore_pattern_bottom
     )

--- a/tests/unit/test_ignore.py
+++ b/tests/unit/test_ignore.py
@@ -7,7 +7,10 @@ from dvc.ignore import DvcIgnorePatterns
 
 
 def mock_dvcignore(dvcignore_path, patterns):
+    from dvc.fs.local import localfs
+
     fs = MagicMock()
+    fs.path = localfs.path
     with patch.object(fs, "open", mock_open(read_data="\n".join(patterns))):
         ignore_patterns = DvcIgnorePatterns.from_file(
             dvcignore_path, fs, "mocked"
@@ -195,7 +198,7 @@ def test_match_ignore_from_file(
 @pytest.mark.parametrize("omit_dir", [".git", ".hg", ".dvc"])
 def test_should_ignore_dir(omit_dir, sub_dir):
     root = os.path.join(os.path.sep, "walk", "dir", "root")
-    ignore = DvcIgnorePatterns([".git/", ".hg/", ".dvc/"], root)
+    ignore = DvcIgnorePatterns([".git/", ".hg/", ".dvc/"], root, os.sep)
 
     dirs = [omit_dir, "dir1", "dir2"]
     files = [omit_dir, "file1", "file2"]


### PR DESCRIPTION
We've been trying to avoid using `os.path.abspath` before, but we actually do need it in dvcignore for path normalization. So instead, we are introducing a primitive notion of `cwd` into our filesystems, that will be useful in other applications.

Note that even though fsspec doesn't officially support `cwd`, localfs does support it but in implicit manner, which requires us to have odd checks here and there around the code, which `Path.getcwd` will reduce in the future.