### PR TITLE
completion: fix dvc exp completion on zsh/bash

### DIFF
--- a/dvc/commands/completion.py
+++ b/dvc/commands/completion.py
@@ -31,7 +31,7 @@ _dvc_compgen_stages_and_files() {
 }
 
 _dvc_compgen_exps() {
-    local _dvc_exps=($(dvc exp list -q --all --names-only))
+    local _dvc_exps=($(dvc exp list -q --all-commits --names-only))
     compgen -W "${_dvc_exps[*]}" -- $1
 }
     """,
@@ -64,7 +64,7 @@ _dvc_compadd_stages_and_files() {
 }
 
 _dvc_compadd_exps() {
-    _describe 'experiments' "($(dvc exp list -q -a --names-only))"
+    _describe 'experiments' "($(dvc exp list -q --all-commits --names-only))"
 }
     """,
 }


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

`dvc exp list` does not have `--all` or `-a` flag.