### PR TITLE
exp pull/push: better result handling in exp sharing(#7448)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -72,7 +72,7 @@ install_requires =
     aiohttp-retry>=2.4.5
     diskcache>=5.2.1
     jaraco.windows>=5.7.0; python_version < '3.8' and sys_platform == 'win32'
-    scmrepo==0.0.18
+    scmrepo==0.0.19
     dvc-render==0.0.5
     dvclive>=0.7.3
 

--- a/tests/func/experiments/test_remote.py
+++ b/tests/func/experiments/test_remote.py
@@ -3,7 +3,6 @@ import os
 import pytest
 from funcy import first
 
-from dvc.exceptions import DvcException
 from dvc.repo.experiments.utils import exp_refs_by_rev
 
 
@@ -81,8 +80,7 @@ def test_push_diverged(tmp_dir, scm, dvc, git_upstream, exp_stage):
 
     git_upstream.tmp_dir.scm.set_ref(str(ref_info), remote_rev)
 
-    with pytest.raises(DvcException):
-        dvc.experiments.push(git_upstream.remote, [ref_info.name])
+    assert dvc.experiments.push(git_upstream.remote, [ref_info.name]) == []
     assert git_upstream.tmp_dir.scm.get_ref(str(ref_info)) == remote_rev
 
     dvc.experiments.push(git_upstream.remote, [ref_info.name], force=True)
@@ -254,8 +252,7 @@ def test_pull_diverged(tmp_dir, scm, dvc, git_downstream, exp_stage):
     git_downstream.tmp_dir.scm.set_ref(str(ref_info), remote_rev)
 
     downstream_exp = git_downstream.tmp_dir.dvc.experiments
-    with pytest.raises(DvcException):
-        downstream_exp.pull(git_downstream.remote, ref_info.name)
+    assert downstream_exp.pull(git_downstream.remote, ref_info.name) == []
     assert git_downstream.tmp_dir.scm.get_ref(str(ref_info)) == remote_rev
 
     downstream_exp.pull(git_downstream.remote, ref_info.name, force=True)

--- a/tests/unit/repo/experiments/test_utils.py
+++ b/tests/unit/repo/experiments/test_utils.py
@@ -23,7 +23,7 @@ def test_resolve_exp_ref(tmp_dir, scm, git_upstream, name_only, use_url):
     assert str(result[name]) == ref
     assert result["notexist"] is None
 
-    scm.push_refspec(git_upstream.url, ref, ref)
+    scm.push_refspecs(git_upstream.url, f"{ref}:{ref}")
     remote = git_upstream.url if use_url else git_upstream.remote
     name = "foo" if name_only else ref
     remote_ref_info = resolve_name(scm, [name], remote)[name]


### PR DESCRIPTION
fix: #7448
Current we skip on those experiments which already existed on both sides, but
do not exclude them from the result list. And if we have diverged experiment,
pulling/pushing them will stop the current progress and raise an exception, but
didn't give any information on the condition of other experiments.

1. Change the exp pull and push to match the new API in `scmrepo`.
2. Handle sync status after `exp pull/push` finished.

Co-authored-by:

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Wait https://github.com/iterative/scmrepo/pull/59