### PR TITLE
dvc.data: save and try loading raw dir objects

### DIFF
--- a/dvc/data/tree.py
+++ b/dvc/data/tree.py
@@ -140,7 +140,7 @@ class Tree(HashFile):
         return tree
 
     @classmethod
-    def load(cls, odb, hash_info):
+    def load(cls, odb, hash_info) -> "Tree":
         obj = odb.get(hash_info)
 
         try:

--- a/dvc/objects/hash_info.py
+++ b/dvc/objects/hash_info.py
@@ -41,3 +41,9 @@ class HashInfo:
         if not self:
             return False
         return self.value.endswith(HASH_DIR_SUFFIX)
+
+    def as_raw(self) -> "HashInfo":
+        assert self.value
+        return HashInfo(
+            self.name, self.value.rsplit(HASH_DIR_SUFFIX)[0], self.obj_name
+        )

--- a/tests/func/test_commit.py
+++ b/tests/func/test_commit.py
@@ -177,10 +177,13 @@ def test_commit_granular_dir(tmp_dir, dvc):
 
     cache = tmp_dir / ".dvc" / "cache"
 
-    assert set(cache.glob("*/*")) == set()
+    assert set(cache.glob("*/*")) == {
+        cache / "1a" / "ca2c799df82929bbdd976557975546",
+    }
 
     dvc.commit(os.path.join("data", "foo"))
     assert set(cache.glob("*/*")) == {
+        cache / "1a" / "ca2c799df82929bbdd976557975546",
         cache / "1a" / "ca2c799df82929bbdd976557975546.dir",
         cache / "ac" / "bd18db4cc2f85cedef654fccc4a4d8",
     }
@@ -188,6 +191,8 @@ def test_commit_granular_dir(tmp_dir, dvc):
 
     dvc.commit(os.path.join("data", "subdir"))
     assert set(cache.glob("*/*")) == {
+        cache / "26" / "d6b64d96a660707412f523e8184b5f",
+        cache / "1a" / "ca2c799df82929bbdd976557975546",
         cache / "1a" / "ca2c799df82929bbdd976557975546.dir",
         cache / "ac" / "bd18db4cc2f85cedef654fccc4a4d8",
         cache / "4c" / "e8d2a2cf314a52fa7f315ca37ca445",
@@ -197,6 +202,8 @@ def test_commit_granular_dir(tmp_dir, dvc):
 
     dvc.commit(os.path.join("data"))
     assert set(cache.glob("*/*")) == {
+        cache / "26" / "d6b64d96a660707412f523e8184b5f",
+        cache / "1a" / "ca2c799df82929bbdd976557975546",
         cache / "1a" / "ca2c799df82929bbdd976557975546.dir",
         cache / "ac" / "bd18db4cc2f85cedef654fccc4a4d8",
         cache / "4c" / "e8d2a2cf314a52fa7f315ca37ca445",

--- a/tests/func/test_external_repo.py
+++ b/tests/func/test_external_repo.py
@@ -219,6 +219,7 @@ def test_subrepos_are_ignored(tmp_dir, erepo_dir):
             hardlink=True,
         )
         assert set(cache_dir.glob("??/*")) == {
+            cache_dir / "e1" / "d9e8eae5374860ae025ec84cfd85c7",
             cache_dir / "e1" / "d9e8eae5374860ae025ec84cfd85c7.dir",
             cache_dir / "37" / "b51d194a7513e45b56f6524f2d51f2",
             cache_dir / "94" / "7d2b84e5aa88170e80dff467a5bfb6",

--- a/tests/func/test_gc.py
+++ b/tests/func/test_gc.py
@@ -20,13 +20,16 @@ class TestGC(TestDvcGit):
         super().setUp()
 
         self.dvc.add(self.FOO)
-        self.dvc.add(self.DATA_DIR)
+        stages = self.dvc.add(self.DATA_DIR)
+        raw_dir_hash = stages[0].outs[0].hash_info.as_raw().value
+
         self.good_cache = [
             self.dvc.odb.local.hash_to_path(md5)
             for md5 in self.dvc.odb.local.all()
+            if md5 != raw_dir_hash
         ]
 
-        self.bad_cache = []
+        self.bad_cache = [self.dvc.odb.local.hash_to_path(raw_dir_hash)]
         for i in ["123", "234", "345"]:
             path = os.path.join(self.dvc.odb.local.cache_dir, i[0:2], i[2:])
             self.create(path, i)
@@ -203,7 +206,7 @@ def test_gc_no_dir_cache(tmp_dir, dvc):
     with pytest.raises(CollectCacheError):
         dvc.gc(workspace=True)
 
-    assert _count_files(dvc.odb.local.cache_dir) == 4
+    assert _count_files(dvc.odb.local.cache_dir) == 5
     dvc.gc(force=True, workspace=True)
     assert _count_files(dvc.odb.local.cache_dir) == 2
 

--- a/tests/func/test_odb.py
+++ b/tests/func/test_odb.py
@@ -206,6 +206,9 @@ def test_shared_cache(tmp_dir, dvc, group):
     expected = {
         os.path.join(cache_dir, "17"): dir_mode,
         os.path.join(
+            cache_dir, "17", "4eaa1dd94050255b7b98a7e1924b31"
+        ): file_mode,
+        os.path.join(
             cache_dir, "17", "4eaa1dd94050255b7b98a7e1924b31.dir"
         ): file_mode,
         os.path.join(cache_dir, "97"): dir_mode,

--- a/tests/func/test_remote.py
+++ b/tests/func/test_remote.py
@@ -154,6 +154,9 @@ def test_dir_hash_should_be_key_order_agnostic(tmp_dir, dvc):
         _, _, obj = stage(dvc.odb.local, path, dvc.odb.local.fs, "md5")
         hash1 = obj.hash_info
 
+    # remove the raw dir obj to force building the tree on the next stage call
+    dvc.odb.local.fs.remove(dvc.odb.local.hash_to_path(hash1.as_raw().value))
+
     tree = Tree.from_list(
         [{"md5": "1", "relpath": "1"}, {"md5": "2", "relpath": "2"}]
     )

--- a/tests/unit/test_hashinfo.py
+++ b/tests/unit/test_hashinfo.py
@@ -1,0 +1,17 @@
+from dvc.objects.hash_info import HashInfo
+
+
+def test_as_raw():
+    hash_info = HashInfo(
+        "md5", "a1d0c6e83f027327d8461063f4ac58a6.dir", "objname"
+    )
+
+    raw = hash_info.as_raw()
+
+    assert hash_info.name == "md5"
+    assert hash_info.value == "a1d0c6e83f027327d8461063f4ac58a6.dir"
+    assert hash_info.obj_name == "objname"
+
+    assert raw.name == "md5"
+    assert raw.value == "a1d0c6e83f027327d8461063f4ac58a6"
+    assert raw.obj_name == "objname"


### PR DESCRIPTION
When staging a directory, always save a "raw dir object" to the odb. If the corresponding ".dir" object has not been added to the odb, `stage()` calls can load the tree from the raw dir object instead of rebuilding it by walking the directory.
This can lead to significant speed improvements when calling `dvc status` for modified directories.

Fixes #7390 