### PR TITLE
stage/exp list: alias `--names-only` to `--name-only`

### DIFF
--- a/dvc/commands/experiments/ls.py
+++ b/dvc/commands/experiments/ls.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 class CmdExperimentsList(CmdBase):
     def run(self):
-        names_only = self.args.names_only
+        name_only = self.args.name_only
         exps = self.repo.experiments.ls(
             all_commits=self.args.all_commits,
             rev=self.args.rev,
@@ -23,10 +23,10 @@ class CmdExperimentsList(CmdBase):
                 if branch:
                     tag = branch.split("/")[-1]
             name = tag if tag else baseline[:7]
-            if not names_only:
+            if not name_only:
                 print(f"{name}:")
             for exp_name in exps[baseline]:
-                indent = "" if names_only else "\t"
+                indent = "" if name_only else "\t"
                 print(f"{indent}{exp_name}")
 
         return 0
@@ -45,6 +45,7 @@ def add_parser(experiments_subparsers, parent_parser):
     )
     add_rev_selection_flags(experiments_list_parser, "List")
     experiments_list_parser.add_argument(
+        "--name-only",
         "--names-only",
         action="store_true",
         help="Only output experiment names (without parent commits).",

--- a/dvc/commands/stage.py
+++ b/dvc/commands/stage.py
@@ -94,9 +94,7 @@ class CmdStageList(CmdBase):
         self.repo.stage_collection_error_handler = log_error
 
         stages = self._get_stages()
-        names_only = self.args.names_only
-
-        data = prepare_stages_data(stages, description=not names_only)
+        data = prepare_stages_data(stages, description=not self.args.name_only)
         ui.table(data.items())
 
         return 0
@@ -358,6 +356,7 @@ def add_parser(subparsers, parent_parser):
         help="List all stages inside the specified directory.",
     )
     stage_list_parser.add_argument(
+        "--name-only",
         "--names-only",
         action="store_true",
         default=False,

--- a/tests/unit/command/test_compat_flag.py
+++ b/tests/unit/command/test_compat_flag.py
@@ -31,11 +31,13 @@ def _id_gen(val) -> str:
         (["status", "--show-json"], "json"),
         (["plots", "show", "--show-json"], "json"),
         (["plots", "diff", "--show-json"], "json"),
+        (["exp", "list", "--names-only"], "name_only"),
+        (["stage", "list", "--names-only"], "name_only"),
     ],
     ids=_id_gen,
 )
 def test_backward_compat_flags(args, key):
-    """Test support for --show-csv/--show-json/--show-md flags."""
+    """Test support for flags kept for backward compatibility."""
     cli_args = parse_args(args)
     d = vars(cli_args)
     assert d[key] is True

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -201,7 +201,7 @@ def test_experiments_list(dvc, scm, mocker):
             "-1",
             "--rev",
             "foo",
-            "--names-only",
+            "--name-only",
         ]
     )
     assert cli_args.func == CmdExperimentsList


### PR DESCRIPTION
Fixes #7570.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

I think changing docs right now will make it more confusing, especially for users in old versions. So I'm proposing for not merging this for a few versions in https://github.com/iterative/dvc.org/pull/3453.

