### PR TITLE
bump pydrive: improves and fixes thread safety

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -94,7 +94,7 @@ azure =
     adlfs>=2021.10.0
     azure-identity>=1.4.0
     knack
-gdrive = pydrive2[fsspec]>=1.9.4
+gdrive = pydrive2[fsspec]>=1.10.1
 gs = gcsfs>=2021.11.1
 hdfs =
     # due to https://github.com/python-poetry/poetry/issues/4683, we have to


### PR DESCRIPTION
Bumping PyDrive2 after a critical fix here https://github.com/iterative/PyDrive2/pull/164

I haven't seen people complaining about this in DVC, but it's not that easy even to connect a random "push stalls after one hour" with this issues. In PyDrive2 MT was in bad shape and after one hour when token update is happening multiple threads were reading / writing the same file or potentially leaving locks locked (thus making other threads locked forever -> performance gradually was degrading or going down to 0).

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
