### PR TITLE
render.match: Skip errored revisions in `get_files`

### DIFF
--- a/dvc/render/match.py
+++ b/dvc/render/match.py
@@ -10,8 +10,12 @@ if TYPE_CHECKING:
 
 
 def get_files(plots_data: Dict) -> List:
-    values = dpath.util.values(plots_data, ["*", "*"])
-    return sorted({key for submap in values for key in submap.keys()})
+    files = set()
+    for rev in plots_data.keys():
+        for file in plots_data[rev].get("data", {}).keys():
+            files.add(file)
+    sorted_files = sorted(files)
+    return sorted_files
 
 
 def group_by_filename(plots_data: Dict) -> Dict:

--- a/tests/unit/render/test_match.py
+++ b/tests/unit/render/test_match.py
@@ -1,8 +1,20 @@
 from dvc.render.match import (
+    get_files,
     group_by_filename,
     match_renderers,
     squash_plots_properties,
 )
+
+
+def test_get_files_on_error():
+    plots_data = {
+        "v2": {"error": "ERROR"},
+        "v1": {
+            "data": {"file.json": {"data": [{"y": 2}, {"y": 3}], "props": {}}}
+        },
+    }
+    files = get_files(plots_data)
+    assert files == ["file.json"]
 
 
 def test_group_by_filename():


### PR DESCRIPTION
Introduced in #7409 
