### PR TITLE
tests: make xfail-marked-tests to be strict by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ addopts = "-ra"
 markers = [
     "needs_internet: Might need network access for the tests",
 ]
+xfail_strict = true
 
 [tool.mypy]
 # Error output

--- a/tests/func/test_import_url.py
+++ b/tests/func/test_import_url.py
@@ -254,11 +254,6 @@ def test_import_url_to_remote_invalid_combinations(dvc):
         dvc.imp_url("s3://bucket/foo", no_exec=True, to_remote=True)
 
 
-empty_xfail = pytest.mark.xfail(
-    reason="https://github.com/iterative/dvc/issues/5521"
-)
-
-
 def test_import_url_to_remote_status(tmp_dir, dvc, local_cloud, local_remote):
     local_cloud.gen("foo", "foo")
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
