### PR TITLE
dvcfile: preserve 'remote' on add and commit

### DIFF
--- a/dvc/output.py
+++ b/dvc/output.py
@@ -670,6 +670,9 @@ class Output:
         if self.live:
             ret[self.PARAM_LIVE] = self.live
 
+        if self.remote:
+            ret[self.PARAM_REMOTE] = self.remote
+
         return ret
 
     def verify_metric(self):

--- a/dvc/repo/imp_url.py
+++ b/dvc/repo/imp_url.py
@@ -24,7 +24,7 @@ def imp_url(
     jobs=None,
 ):
     from dvc.dvcfile import Dvcfile
-    from dvc.stage import Stage, create_stage, restore_meta
+    from dvc.stage import Stage, create_stage, restore_fields
 
     out = resolve_output(url, out)
     path, wdir, out = resolve_paths(
@@ -58,7 +58,7 @@ def imp_url(
         outs=[out],
         erepo=erepo,
     )
-    restore_meta(stage)
+    restore_fields(stage)
 
     if desc:
         stage.outs[0].desc = desc

--- a/dvc/repo/stage.py
+++ b/dvc/repo/stage.py
@@ -157,7 +157,12 @@ class StageLoad:
             stage_data: Stage data to create from
                 (see create_stage and loads_from for more information)
         """
-        from dvc.stage import PipelineStage, Stage, create_stage, restore_meta
+        from dvc.stage import (
+            PipelineStage,
+            Stage,
+            create_stage,
+            restore_fields,
+        )
         from dvc.stage.exceptions import InvalidStageName
         from dvc.stage.utils import (
             is_valid_name,
@@ -190,7 +195,7 @@ class StageLoad:
             new_index = self.repo.index.add(stage)
             new_index.check_graph()
 
-        restore_meta(stage)
+        restore_fields(stage)
         return stage
 
     def from_target(

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -95,7 +95,7 @@ def create_stage(cls, repo, path, external=False, **kwargs):
     return stage
 
 
-def restore_meta(stage):
+def restore_fields(stage):
     from .exceptions import StageNotFound
 
     if not stage.dvcfile.exists():
@@ -113,10 +113,12 @@ def restore_meta(stage):
     stage.meta = old.meta
     stage.desc = old.desc
 
-    old_desc = {out.def_path: out.desc for out in old.outs}
+    old_fields = {out.def_path: (out.desc, out.remote) for out in old.outs}
 
     for out in stage.outs:
-        out.desc = old_desc.get(out.def_path, None)
+        out_fields = old_fields.get(out.def_path, None)
+        if out_fields:
+            out.desc, out.remote = out_fields
 
 
 class Stage(params.StageParams):

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -894,7 +894,7 @@ def test_add_with_cache_link_error(tmp_dir, dvc, mocker, capsys):
     }
 
 
-def test_add_preserve_meta(tmp_dir, dvc):
+def test_add_preserve_fields(tmp_dir, dvc):
     text = textwrap.dedent(
         """\
         # top comment
@@ -902,11 +902,11 @@ def test_add_preserve_meta(tmp_dir, dvc):
         outs:
         - path: foo # out comment
           desc: out desc
+          remote: testremote
         meta: some metadata
     """
     )
     tmp_dir.gen("foo.dvc", text)
-
     tmp_dir.dvc_gen("foo", "foo")
     assert (tmp_dir / "foo.dvc").read_text() == textwrap.dedent(
         """\
@@ -915,6 +915,7 @@ def test_add_preserve_meta(tmp_dir, dvc):
         outs:
         - path: foo # out comment
           desc: out desc
+          remote: testremote
           md5: acbd18db4cc2f85cedef654fccc4a4d8
           size: 3
         meta: some metadata

--- a/tests/func/test_commit.py
+++ b/tests/func/test_commit.py
@@ -1,4 +1,5 @@
 import os
+import textwrap
 
 import pytest
 
@@ -37,6 +38,36 @@ def test_commit_force(tmp_dir, dvc):
 
     dvc.commit(stage.path, force=True)
     assert dvc.status([stage.path]) == {}
+
+
+def test_commit_preserve_fields(tmp_dir, dvc):
+    text = textwrap.dedent(
+        """\
+        # top comment
+        desc: top desc
+        outs:
+        - path: foo # out comment
+          desc: out desc
+          remote: testremote
+        meta: some metadata
+    """
+    )
+    tmp_dir.gen("foo.dvc", text)
+    tmp_dir.dvc_gen("foo", "foo", commit=False)
+    dvc.commit("foo")
+    assert (tmp_dir / "foo.dvc").read_text() == textwrap.dedent(
+        """\
+        # top comment
+        desc: top desc
+        outs:
+        - path: foo # out comment
+          desc: out desc
+          remote: testremote
+          md5: acbd18db4cc2f85cedef654fccc4a4d8
+          size: 3
+        meta: some metadata
+    """
+    )
 
 
 @pytest.mark.parametrize("run_kw", [{"single_stage": True}, {"name": "copy"}])


### PR DESCRIPTION
Fixes partially #7356 -- `dvc move` doesn't preserve many fields (description, remote, comments) but looks like a more involved change.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
