### PR TITLE
dvc.objects: add callbacks for listing and estimating hashes

### DIFF
--- a/dvc/data/_progress.py
+++ b/dvc/data/_progress.py
@@ -1,0 +1,32 @@
+from dvc.progress import Tqdm
+
+
+class QueryingProgress(Tqdm):
+    def __init__(self, iterable=None, total=None, name=None, phase="Querying"):
+        msg_part = "cache in " + f"'{name}'" if name else "remote cache"
+        msg_fmt = "{phase} " + msg_part
+
+        self._estimating_msg = msg_fmt.format(phase="Estimating size of")
+        self._listing_msg = msg_fmt.format(phase="Querying")
+        super().__init__(
+            iterable=iterable,
+            desc=msg_fmt.format(phase=phase),
+            total=total,
+            unit="files",
+            unit_scale=False,
+            bar_format=self.BAR_FMT_DEFAULT,
+        )
+
+    def callback(self, phase, *args):
+        total = args[0] if args else self.total
+        completed = args[1] if len(args) > 1 else self.n
+        desc = self.desc
+        if phase == "estimating":
+            desc = self._estimating_msg
+        elif phase == "querying":
+            desc = self._listing_msg
+
+        if desc != self.desc:
+            # let Tqdm take care of when to update
+            self.set_description_str(desc, refresh=False)
+        self.update_to(completed, total)

--- a/dvc/data/db/local.py
+++ b/dvc/data/db/local.py
@@ -1,14 +1,14 @@
 import logging
 import os
 import stat
+from functools import partial
 
 from funcy import cached_property
 from shortuuid import uuid
 
 from dvc.hash_info import HashInfo
-from dvc.objects.db import ObjectDB
+from dvc.objects.db import ObjectDB, noop, wrap_iter
 from dvc.objects.errors import ObjectFormatError
-from dvc.progress import Tqdm
 from dvc.utils import relpath
 from dvc.utils.fs import copyfile, remove, umask, walk_files
 
@@ -60,15 +60,12 @@ class LocalObjectDB(ObjectDB):
         return f"{self.cache_path}{os.sep}{hash_[0:2]}{os.sep}{hash_[2:]}"
 
     def hashes_exist(
-        self, hashes, jobs=None, name=None
+        self, hashes, jobs=None, progress=noop
     ):  # pylint: disable=unused-argument
         ret = []
+        progress = partial(progress, "querying", len(hashes))
 
-        for hash_ in Tqdm(
-            hashes,
-            unit="file",
-            desc="Querying " + ("cache in " + name if name else "local cache"),
-        ):
+        for hash_ in wrap_iter(hashes, progress):
             hash_info = HashInfo(self.fs.PARAM_CHECKSUM, hash_)
             try:
                 self.check(hash_info)

--- a/dvc/data/gc.py
+++ b/dvc/data/gc.py
@@ -2,6 +2,8 @@ def gc(odb, used, jobs=None, cache_odb=None, shallow=True):
     from dvc.data.tree import Tree
     from dvc.objects.errors import ObjectDBPermissionError
 
+    from ._progress import QueryingProgress
+
     if odb.read_only:
         raise ObjectDBPermissionError("Cannot gc read-only ODB")
     if not cache_odb:
@@ -22,11 +24,9 @@ def gc(odb, used, jobs=None, cache_odb=None, shallow=True):
 
     removed = False
     # hashes must be sorted to ensure we always remove .dir files first
-    for hash_ in sorted(
-        odb.all(jobs, odb.fs_path),
-        key=_is_dir_hash,
-        reverse=True,
-    ):
+
+    hashes = QueryingProgress(odb.all(jobs), name=odb.fs_path)
+    for hash_ in sorted(hashes, key=_is_dir_hash, reverse=True):
         if hash_ in used_hashes:
             continue
         fs_path = odb.hash_to_path(hash_)

--- a/tests/unit/remote/test_base.py
+++ b/tests/unit/remote/test_base.py
@@ -26,7 +26,7 @@ def test_hashes_exist(object_exists, traverse, dvc):
     with mock.patch.object(odb, "_list_hashes", return_value=list(range(256))):
         hashes = set(range(1000))
         odb.hashes_exist(hashes)
-        object_exists.assert_called_with(hashes, None, None)
+        object_exists.assert_called_with(hashes, None)
         traverse.assert_not_called()
 
     odb.fs.CAN_TRAVERSE = True
@@ -47,7 +47,7 @@ def test_hashes_exist(object_exists, traverse, dvc):
         )
         assert max_hashes < 2048
         object_exists.assert_called_with(
-            frozenset(range(max_hashes, 1000)), None, None
+            frozenset(range(max_hashes, 1000)), None
         )
         traverse.assert_not_called()
 
@@ -63,7 +63,6 @@ def test_hashes_exist(object_exists, traverse, dvc):
             256 * pow(16, odb.fs.TRAVERSE_PREFIX_LEN),
             set(range(256)),
             jobs=None,
-            name=None,
         )
 
 


### PR DESCRIPTION
This PR gets rid of Tqdm progress bars inside `dvc.objects`.
Those are replaced with multi-phase callback in `hashes_exist`, and
simple callable that takes `completed` value in
`odb._estimate_remote_size()`.

The `odb.list_hashes_exists()` and `odb.all()` now return iterables,
hence the caller has the responsibility of handling progress.

This is now handled in `dvc.data` by using a custom `Tqdm` progressbar.
This is ugly and is temporary, but my motivation is to remove tqdm from dvc.objects
first. We can gradually get rid of these from `dvc.data` too, but
that requires more knowledge about `dvc.data` and involves more
design work. All in time, I guess. :)
