### PR TITLE
fs.upload/download: simplify, remove unused kwargs, callbacks

### DIFF
--- a/dvc/data/stage.py
+++ b/dvc/data/stage.py
@@ -25,7 +25,8 @@ logger = logging.getLogger(__name__)
 _STAGING_MEMFS_PATH = "dvc-staging"
 
 
-def _upload_file(from_fs_path, fs, odb, upload_odb):
+def _upload_file(from_fs_path, fs, odb, upload_odb, callback=None):
+    from dvc.fs._callback import FsspecCallback
     from dvc.utils import tmp_fname
     from dvc.utils.stream import HashedStreamReader
 
@@ -34,9 +35,13 @@ def _upload_file(from_fs_path, fs, odb, upload_odb):
     with fs.open(from_fs_path, mode="rb", chunk_size=fs.CHUNK_SIZE) as stream:
         stream = HashedStreamReader(stream)
         size = fs.size(from_fs_path)
-        upload_odb.fs.upload(
-            stream, tmp_info, desc=fs_path.name(from_fs_path), total=size
-        )
+        with FsspecCallback.as_tqdm_callback(
+            callback,
+            desc=fs_path.name(from_fs_path),
+            bytes=True,
+            total=size,
+        ) as cb:
+            upload_odb.fs.upload(stream, tmp_info, size=size, callback=cb)
 
     odb.add(tmp_info, upload_odb.fs, stream.hash_info)
     meta = Meta(size=size)

--- a/dvc/fs/_callback.py
+++ b/dvc/fs/_callback.py
@@ -1,14 +1,15 @@
 from functools import wraps
-from typing import IO, TYPE_CHECKING, Optional, TypeVar, cast
+from typing import IO, TYPE_CHECKING, Any, Optional, TypeVar, cast
 
 import fsspec
-
-from dvc.progress import Tqdm
 
 if TYPE_CHECKING:
     from typing import Callable
 
     from typing_extensions import ParamSpec
+
+    from dvc.fs.base import FileSystem
+    from dvc.progress import Tqdm
 
     _P = ParamSpec("_P")
     _R = TypeVar("_R")
@@ -32,6 +33,39 @@ class FsspecCallback(fsspec.Callback):
 
         return wrapped
 
+    def wrap_and_branch(
+        self, fn: "Callable", fs: "FileSystem" = None
+    ) -> "Callable":
+        """
+        Wraps a function, and pass a new child callback to it.
+        When the function completes, we increment the parent callback by 1.
+        """
+        from .local import localfs
+
+        fs = fs or localfs
+        wrapped = self.wrap_fn(fn)
+
+        def make_callback(path1, path2):
+            # pylint: disable=assignment-from-none
+            child = self.branch(fs.path.name(path1), path2, {})
+            return self.as_callback(child)
+
+        @wraps(fn)
+        def func(path1, path2, **kwargs):
+            with make_callback(path1, path2) as callback:
+                return wrapped(path1, path2, callback=callback, **kwargs)
+
+        return func
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_args):
+        self.close()
+
+    def close(self):
+        """Handle here on exit."""
+
     @classmethod
     def as_callback(
         cls, maybe_callback: Optional["FsspecCallback"] = None
@@ -40,15 +74,32 @@ class FsspecCallback(fsspec.Callback):
             return DEFAULT_CALLBACK
         return maybe_callback
 
+    @classmethod
+    def as_tqdm_callback(
+        cls,
+        callback: Optional["FsspecCallback"] = None,
+        **tqdm_kwargs: Any,
+    ) -> "FsspecCallback":
+        return callback or TqdmCallback(**tqdm_kwargs)
+
 
 class NoOpCallback(FsspecCallback, fsspec.callbacks.NoOpCallback):
     pass
 
 
 class TqdmCallback(FsspecCallback):
-    def __init__(self, progress_bar):
-        self.progress_bar = progress_bar
+    def __init__(self, progress_bar: "Tqdm" = None, **tqdm_kwargs):
+        from dvc.progress import Tqdm
+
+        self.progress_bar = progress_bar or Tqdm(**tqdm_kwargs)
         super().__init__()
+
+    def __enter__(self):
+        self.progress_bar.__enter__()
+        return self
+
+    def close(self):
+        self.progress_bar.close()
 
     def set_size(self, size):
         if size is not None:
@@ -64,19 +115,8 @@ class TqdmCallback(FsspecCallback):
         self.progress_bar.update_to(value)
         super().absolute_update(value)
 
-
-def tdqm_or_callback_wrapped(
-    fobj, method, total, callback=None, **pbar_kwargs
-):
-    if callback:
-        from funcy import nullcontext
-        from tqdm.utils import CallbackIOWrapper
-
-        callback.set_size(total)
-        wrapper = CallbackIOWrapper(callback.relative_update, fobj, method)
-        return nullcontext(wrapper)
-
-    return Tqdm.wrapattr(fobj, method, total=total, bytes=True, **pbar_kwargs)
+    def branch(self, path_1: str, path_2: str, kwargs):
+        return TqdmCallback(bytes=True, total=-1, desc=path_1, **kwargs)
 
 
 DEFAULT_CALLBACK = NoOpCallback()

--- a/dvc/fs/utils.py
+++ b/dvc/fs/utils.py
@@ -48,7 +48,7 @@ def _copy(
 
     with from_fs.open(from_path, mode="rb") as fobj:
         size = from_fs.size(from_path)
-        return to_fs.upload(fobj, to_path, total=size)
+        return to_fs.upload(fobj, to_path, size=size)
 
 
 def _try_links(

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -135,11 +135,6 @@ class Tqdm(tqdm):
 
         return wrapped
 
-    def as_callback(self):
-        from dvc.fs._callback import TqdmCallback
-
-        return TqdmCallback(self)
-
     def close(self):
         self.postfix["info"] = ""
         # remove ETA (either unknown or zero); remove completed bar


### PR DESCRIPTION
1. This PR simplifies `fs.upload`/`fs.download`/`fs.download_file`.
2. Removes unused kwargs.
3. `download` uses `dvc.utils.threadpool.ThreadPoolExecutor` which
   supports canceling futures.
4. `download` for directories supports nested/branched callbacks
   and progress bars.

Closes #7412.
