### PR TITLE
`plots`: Fix repo with removed plots

### DIFF
--- a/dvc/render/convert.py
+++ b/dvc/render/convert.py
@@ -52,14 +52,16 @@ def to_json(renderer, split: bool = False) -> List[Dict]:
             content = renderer.get_filled_template(skip_anchors=["data"])
         else:
             content = renderer.get_filled_template()
-        return [
-            {
-                TYPE_KEY: renderer.TYPE,
-                REVISIONS_KEY: sorted(grouped.keys()),
-                "content": json.loads(content),
-                "datapoints": grouped,
-            }
-        ]
+        if grouped:
+            return [
+                {
+                    TYPE_KEY: renderer.TYPE,
+                    REVISIONS_KEY: sorted(grouped.keys()),
+                    "content": json.loads(content),
+                    "datapoints": grouped,
+                }
+            ]
+        return []
     if renderer.TYPE == "image":
         return [
             {

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ install_requires =
     diskcache>=5.2.1
     jaraco.windows>=5.7.0; python_version < '3.8' and sys_platform == 'win32'
     scmrepo==0.0.18
-    dvc-render==0.0.4
+    dvc-render==0.0.5
     dvclive>=0.7.2
 
 [options.extras_require]

--- a/tests/integration/plots/test_json.py
+++ b/tests/integration/plots/test_json.py
@@ -235,12 +235,22 @@ def test_repo_with_plots(
         split_json_result,
     )
     verify_vega_props("confusion.json", json_result, **confusion_props)
+
+
+@pytest.mark.vscode
+def test_repo_with_removed_plots(tmp_dir, capsys, repo_with_plots):
     from dvc.utils.fs import remove
+
+    next(repo_with_plots())
 
     # even if there is no data, call should be successful
     remove(tmp_dir / ".dvc" / "cache")
     remove("linear.json")
     remove("confusion.json")
     remove("image.png")
-    call(capsys)
-    call(capsys, subcommand="diff")
+
+    for s in {"show", "diff"}:
+        _, json_result, split_json_result = call(capsys, subcommand=s)
+        for p in {"linear.json", "confusion.json", "image.png"}:
+            assert json_result[p] == []
+            assert split_json_result[p] == []


### PR DESCRIPTION
Changes in dvc-render 0.0.5 caused an error.

In https://github.com/iterative/dvc-render/pull/24 the behavior for get_filled_template changed to return an empty string. Previously it returned a valid dictionary with empty `data` field.

Updated `to_json` logic in `dvc` to not call `get_filled_template` at all if there are no `datapoints`.

