### PR TITLE
fs.ossfs: remove unused var COPY_POLL_SECONDS

### DIFF
--- a/dvc/fs/oss.py
+++ b/dvc/fs/oss.py
@@ -16,7 +16,6 @@ class OSSFileSystem(ObjectFileSystem):
     scheme = Schemes.OSS
     REQUIRES = {"ossfs": "ossfs"}
     PARAM_CHECKSUM = "etag"
-    COPY_POLL_SECONDS = 5
     LIST_OBJECT_PAGE_SIZE = 100
 
     def _prepare_credentials(self, **config):


### PR DESCRIPTION
This var was never used. It came here when `OSSRemote` was introduced in #1961 by copying certain parts of `AzureRemote`.

https://github.com/iterative/dvc/blob/47400bba6f9de3345f1086fcd85948a071c32957/dvc/remote/azure.py#L42
https://github.com/iterative/dvc/blob/6882a781a4219559cff94a0d1dc6eb6144fb0a05/dvc/remote/azure.py#L97-L108
