### PR TITLE
fs: remove unused CHUNK_SIZE var

### DIFF
--- a/dvc/data/stage.py
+++ b/dvc/data/stage.py
@@ -32,7 +32,7 @@ def _upload_file(from_fs_path, fs, odb, upload_odb, callback=None):
 
     fs_path = upload_odb.fs.path
     tmp_info = fs_path.join(upload_odb.fs_path, tmp_fname())
-    with fs.open(from_fs_path, mode="rb", chunk_size=fs.CHUNK_SIZE) as stream:
+    with fs.open(from_fs_path, mode="rb") as stream:
         stream = HashedStreamReader(stream)
         size = fs.size(from_fs_path)
         with FsspecCallback.as_tqdm_callback(

--- a/dvc/fs/base.py
+++ b/dvc/fs/base.py
@@ -64,9 +64,6 @@ class FileSystem:
     TRAVERSE_THRESHOLD_SIZE = 500000
     CAN_TRAVERSE = True
 
-    # Needed for some providers, and http open()
-    CHUNK_SIZE = 64 * 1024 * 1024  # 64 MiB
-
     PARAM_CHECKSUM: ClassVar[Optional[str]] = None
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
There is no support for chunk_size kwarg in `fs.open`.
Also, `upload_fobj` is now able to figure out proper
chunk size from fileobj, so I don't think we need this on `_upload_file`.


