### PR TITLE
dvc: use Trie instead of PathStringTrie

### DIFF
--- a/dvc/utils/collections.py
+++ b/dvc/utils/collections.py
@@ -1,10 +1,7 @@
 import inspect
-import os
 from collections.abc import Mapping
 from functools import wraps
 from typing import Callable, Dict, Iterable, List, TypeVar, Union
-
-from pygtrie import StringTrie as _StringTrie
 
 from dvc.exceptions import DvcException
 
@@ -15,14 +12,6 @@ class NewParamsFound(DvcException):
     def __init__(self, new_params: List, *args):
         self.new_params = new_params
         super().__init__("New params found during merge", *args)
-
-
-class PathStringTrie(_StringTrie):
-    """Trie based on platform-dependent separator for pathname components."""
-
-    def __init__(self, *args, **kwargs):
-        kwargs["separator"] = os.sep
-        super().__init__(*args, **kwargs)
 
 
 def apply_diff(src, dest):


### PR DESCRIPTION
PathStringTrie is error prone, as it gives you an illusion that you are working with paths, while it can't really handle important edge cases, which results in obscure bugs.

For example, when one sets `trie["/"] = "foo"`, we often expect `trie.longest_prefix("/path")` to return `"foo"`, while it is not actually like that, because `"/"` gets resolved into `("", "")` internal key, while `"/path"` is resolved into `("", "path")` and thus longest_prefix is `("",)`, which breaks our assumptions.

Instead, we should use regular `Trie` that doesn't create any illusions and forces user to be fully aware of his actions. We switched to `Trie`s long time ago in `scmrepo` and our data tree.

Additional logic change here is that our `Trie` is now based on the keys/paths relative to the repo root in both dvcignore and repofs, which saves us building additional nodes and making additional steps while traversing for long paths.