### PR TITLE
fs.put_file: don't require size to be passed

### DIFF
--- a/dvc/fs/base.py
+++ b/dvc/fs/base.py
@@ -318,7 +318,7 @@ class FileSystem:
         callback: FsspecCallback = DEFAULT_CALLBACK,
         **kwargs,
     ) -> None:
-        size = kwargs.pop("size")
+        size = kwargs.pop("size", None)
         if size:
             callback.set_size(size)
         if hasattr(from_file, "read"):

--- a/dvc/fs/base.py
+++ b/dvc/fs/base.py
@@ -316,9 +316,9 @@ class FileSystem:
         from_file: Union[AnyFSPath, IO],
         to_info: AnyFSPath,
         callback: FsspecCallback = DEFAULT_CALLBACK,
+        size: int = None,
         **kwargs,
     ) -> None:
-        size = kwargs.pop("size", None)
         if size:
             callback.set_size(size)
         if hasattr(from_file, "read"):


### PR DESCRIPTION
Before the function always expected the `size` kwarg to be passed (because it used `.pop()` instead of `.pop(..`, None)`), now it's part of a function signature which makes it clear it is an optional kwarg. 

The `size` kwarg may not always be passed, which would raise Exception here.