### PR TITLE
gs: Allow reading proxy config from env 

### DIFF
--- a/dvc/fs/gs.py
+++ b/dvc/fs/gs.py
@@ -17,6 +17,7 @@ class GSFileSystem(ObjectFileSystem):
         login_info = {"consistency": None}
         login_info["project"] = config.get("projectname")
         login_info["token"] = config.get("credentialpath")
+        login_info["session_kwargs"] = {"trust_env": True}
         return login_info
 
     @wrap_prop(threading.Lock())

--- a/tests/unit/fs/test_gs.py
+++ b/tests/unit/fs/test_gs.py
@@ -1,0 +1,7 @@
+from dvc.fs import GSFileSystem
+
+
+def test_gs_trust_env():
+    gs = GSFileSystem()
+    session = gs.fs._session
+    assert session.trust_env


### PR DESCRIPTION
We were not passing `trust_env` to aiohttp:

https://docs.aiohttp.org/en/stable/client_advanced.html#proxy-support

Discord context: https://discord.com/channels/485586884165107732/968618527990906900