### PR TITLE
plots: image converter return absolute paths

### DIFF
--- a/dvc/render/convert.py
+++ b/dvc/render/convert.py
@@ -1,5 +1,4 @@
 import json
-import os
 from collections import defaultdict
 from typing import Dict, List, Union
 
@@ -67,7 +66,7 @@ def to_json(renderer, split: bool = False) -> List[Dict]:
             {
                 TYPE_KEY: renderer.TYPE,
                 REVISIONS_KEY: [datapoint.get(REVISION_FIELD)],
-                "url": os.path.abspath(datapoint.get(SRC_FIELD)),
+                "url": datapoint.get(SRC_FIELD),
             }
             for datapoint in renderer.datapoints
         ]

--- a/dvc/render/image_converter.py
+++ b/dvc/render/image_converter.py
@@ -45,7 +45,9 @@ class ImageConverter:
         if path:
             if not os.path.isdir(path):
                 os.makedirs(path, exist_ok=True)
-            src = self._write_image(path, revision, filename, data)
+            src = self._write_image(
+                os.path.abspath(path), revision, filename, data
+            )
         else:
             src = self._encode_image(data)
         datapoint = {

--- a/tests/integration/plots/test_json.py
+++ b/tests/integration/plots/test_json.py
@@ -67,13 +67,11 @@ def verify_image(tmp_dir, version, filename, content, html_path, json_result):
         tmp_dir / JSON_OUT / f"{version}_{filename}"
     ).read_bytes() == content
 
-    assert (
-        os.path.join("dvc_plots", "static", f"{version}_{filename}")
-        in html_content
-    )
+    assert os.path.join("static", f"{version}_{filename}") in html_content
 
     # there should be no absolute paths in produced HTML
-    assert str(tmp_dir) not in html_content
+    # TODO uncomment once dvc-render is adjusted
+    # assert str(tmp_dir) not in html_content
     assert (
         tmp_dir / "dvc_plots" / "static" / f"{version}_{filename}"
     ).read_bytes() == content

--- a/tests/unit/render/test_convert.py
+++ b/tests/unit/render/test_convert.py
@@ -205,8 +205,6 @@ def test_to_json_vega_split(mocker):
 
 
 def test_to_json_image(mocker):
-    import os
-
     image_renderer = mocker.MagicMock()
     image_renderer.TYPE = "image"
     image_renderer.datapoints = [
@@ -215,7 +213,7 @@ def test_to_json_image(mocker):
     ]
     result = to_json(image_renderer)
     assert result[0] == {
-        "url": os.path.abspath(image_renderer.datapoints[0].get(SRC_FIELD)),
+        "url": image_renderer.datapoints[0].get(SRC_FIELD),
         REVISIONS_KEY: [image_renderer.datapoints[0].get(REVISION_FIELD)],
         TYPE_KEY: image_renderer.TYPE,
     }


### PR DESCRIPTION
* [ ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

In #7549 we rolled back to the behavior of writing images, instead of encoding them. I made it DVC's responsibility to provide proper path to the renderer. However, without knowing where we create HTML, it is impossible to do that. We need to modify `dvc-render` to be able to evaluate relative paths of the images. Marking as WIP, as we need a fix on `dvc-render` side first and a release.
