### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -6,8 +6,13 @@ on:
   release:
     types: [released, prereleased]
   workflow_dispatch:
+permissions:
+  contents: read
+
 jobs:
   deb:
+    permissions:
+      contents: write  # for actions/upload-release-asset to upload release asset
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v3
@@ -39,6 +44,8 @@ jobs:
         asset_name: dvc_${{ github.event.release.tag_name }}_amd64.deb
         asset_content_type: binary/octet-stream
   rpm:
+    permissions:
+      contents: write  # for actions/upload-release-asset to upload release asset
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v3
@@ -70,6 +77,8 @@ jobs:
         asset_name: dvc-${{ github.event.release.tag_name }}-1.x86_64.rpm
         asset_content_type: binary/octet-stream
   osxpkg:
+    permissions:
+      contents: write  # for actions/upload-release-asset to upload release asset
     runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v3
@@ -104,6 +113,8 @@ jobs:
         asset_name: dvc-${{ github.event.release.tag_name }}.pkg
         asset_content_type: binary/octet-stream
   exe:
+    permissions:
+      contents: write  # for actions/upload-release-asset to upload release asset
     runs-on: windows-2019
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -80,6 +80,8 @@ jobs:
         file: ./coverage.xml
         fail_ci_if_error: false
   notify:
+    permissions:
+      contents: none
     if: github.ref == 'refs/heads/main' && failure()
     needs:
       - lint


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
