### PR TITLE
deps: bump s3fs to >=2022.02.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -103,7 +103,7 @@ hdfs =
     fsspec[arrow]
 oss = ossfs>=2021.8.0
 s3 =
-    s3fs[boto3]>=2021.11.1
+    s3fs[boto3]>=2022.02.0
     aiobotocore[boto3]>2
 ssh =
     # due to https://github.com/python-poetry/poetry/issues/4683, we have to


### PR DESCRIPTION
The callbacks on _get_file/_put_file was only supported on >2022.02.0.
Fixes #7669.
See https://github.com/fsspec/s3fs/pull/590.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
