### PR TITLE
scm: fix clone

### DIFF
--- a/dvc/scm.py
+++ b/dvc/scm.py
@@ -144,7 +144,7 @@ def clone(url: str, to_path: str, **kwargs):
         try:
             git = Git.clone(url, to_path, progress=pbar.update_git, **kwargs)
             if "shallow_branch" not in kwargs:
-                fetch_all_exps(git, "origin", progress=pbar.update_git)
+                fetch_all_exps(git, url, progress=pbar.update_git)
             return git
         except InternalCloneError as exc:
             raise CloneError(str(exc))


### PR DESCRIPTION
`fetch_all_exp()` in `clone()` was called with `url="origin"`, which resulted in the operation being performed with the remote URL defined in the cloned repo's config, which did not include any credentials initially provided to clone.

Fixes #7670
