### PR TITLE
exp: implement internal queue.kill support(#7587)

### DIFF
--- a/dvc/repo/experiments/queue/local.py
+++ b/dvc/repo/experiments/queue/local.py
@@ -5,6 +5,7 @@ import time
 from collections import defaultdict
 from typing import (
     TYPE_CHECKING,
+    Collection,
     Dict,
     Generator,
     List,
@@ -20,7 +21,7 @@ from kombu.message import Message
 from dvc.daemon import daemonize
 from dvc.exceptions import DvcException
 
-from ..exceptions import ExpQueueEmptyError
+from ..exceptions import ExpQueueEmptyError, UnresolvedExpNamesError
 from ..executor.base import (
     EXEC_PID_DIR,
     EXEC_TMP_DIR,
@@ -201,6 +202,29 @@ class LocalCeleryQueue(BaseStashQueue):
                 pass
             time.sleep(1)
 
+    def kill(self, revs: Collection[str]) -> None:
+        to_kill: Set[QueueEntry] = set()
+        not_active: List[str] = []
+        name_dict: Dict[
+            str, Optional[QueueEntry]
+        ] = self.get_queue_entry_by_names(set(revs))
+
+        missing_rev: List[str] = []
+        active_queue_entry = set(self.iter_active())
+        for rev, queue_entry in name_dict.items():
+            if queue_entry is None:
+                missing_rev.append(rev)
+            elif queue_entry not in active_queue_entry:
+                not_active.append(rev)
+            else:
+                to_kill.add(queue_entry)
+
+        if missing_rev:
+            raise UnresolvedExpNamesError(missing_rev)
+
+        for queue_entry in to_kill:
+            self.proc.kill(queue_entry.name)
+
     def _shutdown_handler(self, task_id: str = None, **kwargs):
         if task_id in self._shutdown_task_ids:
             self._shutdown_task_ids.remove(task_id)
@@ -335,6 +359,9 @@ class WorkspaceQueue(BaseStashQueue):
         return results
 
     def get_result(self, entry: QueueEntry) -> Optional[ExecutorResult]:
+        raise NotImplementedError
+
+    def kill(self, revs: Collection[str]) -> None:
         raise NotImplementedError
 
     def shutdown(self, kill: bool = False):

--- a/tests/unit/repo/experiments/queue/test_local.py
+++ b/tests/unit/repo/experiments/queue/test_local.py
@@ -8,8 +8,8 @@ def test_shutdown_no_tasks(test_queue, mocker):
 
 
 @shared_task
-def _foo():
-    return "foo"
+def _foo(arg="foo"):
+    return arg
 
 
 def test_shutdown_active_tasks(test_queue, mocker):
@@ -35,3 +35,35 @@ def test_shutdown_active_tasks(test_queue, mocker):
     assert "foo" == result.get()
     assert result.id not in test_queue._shutdown_task_ids
     shutdown_spy.assert_called_once()
+
+
+def test_post_run_after_kill(test_queue, mocker):
+    import time
+
+    from celery import chain
+
+    sig_bar = test_queue.proc.run(
+        ["python3", "-c", "import time; time.sleep(5)"], name="bar"
+    )
+    result_bar = sig_bar.freeze()
+    sig_foo = _foo.s()
+    result_foo = sig_foo.freeze()
+    run_chain = chain(sig_bar, sig_foo)
+
+    run_chain.delay()
+    timeout = time.time() + 10
+
+    while True:
+        if result_bar.status == "RUNNING":
+            break
+        if time.time() > timeout:
+            raise AssertionError()
+
+    assert result_foo.status == "PENDING"
+    test_queue.proc.kill("bar")
+
+    while True:
+        if result_foo.status == "SUCCESS":
+            break
+        if time.time() > timeout:
+            raise AssertionError()


### PR DESCRIPTION
fix: #7587
1. Add implement kill method for local queue class
2. Add a test to make sure the following job will be success after the
   original job was killed.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
