### PR TITLE
exp: use celery threadpool worker instead of prefork

### DIFF
--- a/dvc/repo/experiments/queue/local.py
+++ b/dvc/repo/experiments/queue/local.py
@@ -94,7 +94,24 @@ class LocalCeleryQueue(BaseStashQueue):
     def worker(self) -> "TemporaryWorker":
         from dvc_task.worker import TemporaryWorker
 
-        return TemporaryWorker(self.celery, concurrency=1, timeout=10)
+        # NOTE: Use thread pool with concurrency 1 and disabled prefetch.
+        # Worker scaling should be handled by running additional workers,
+        # rather than increasing pool concurrency.
+        #
+        # We use "threads" over "solo" (inline single-threaded) execution so
+        # that we still have access to the control/broadcast API (which
+        # requires a separate message handling thread in the worker).
+        #
+        # Disabled prefetch ensures that each worker will can only schedule and
+        # execute up to one experiment at a time (and a worker cannot prefetch
+        # additional experiments from the queue).
+        return TemporaryWorker(
+            self.celery,
+            pool="threads",
+            concurrency=1,
+            prefetch_multiplier=1,
+            timeout=10,
+        )
 
     def spawn_worker(self):
         from dvc_task.proc.process import ManagedProcess

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ install_requires =
     jaraco.windows>=5.7.0; python_version < '3.8' and sys_platform == 'win32'
     scmrepo==0.0.18
     dvc-render==0.0.4
-    dvc-task@git+https://github.com/iterative/dvc-task.git@0.0.6
+    dvc-task@git+https://github.com/iterative/dvc-task.git@0.0.7
     dvclive>=0.7.2
 
 [options.extras_require]


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Use `threads` pool instead of the default `prefork` (multiprocessing) pool in the exp celery worker.

Since we are always using `concurrency=1` (and scaling via worker instances and not pool concurrency), and CPU intensive work (during exp pipeline stage repro) is still done in separate processes, it is safe for us to use threads over multiprocessing. This should be more stable since it allows us to avoid any celery multiprocessing related issues on windows.