### PR TITLE
TqdmCallback: minor fixup, check for None explicitly

### DIFF
--- a/dvc/fs/_callback.py
+++ b/dvc/fs/_callback.py
@@ -108,7 +108,9 @@ class TqdmCallback(FsspecCallback):
         from dvc.progress import Tqdm
 
         return self._stack.enter_context(
-            self._progress_bar or Tqdm(**self._tqdm_kwargs)
+            self._progress_bar
+            if self._progress_bar is not None
+            else Tqdm(**self._tqdm_kwargs)
         )
 
     def __enter__(self):


### PR DESCRIPTION
Tqdm supports `__bool__()`, so we should really use `is not None` test
rather than boolean check. This is not used anywhere right now, but
I'd prefer to be correct here.

