### PR TITLE
dvc: detach gitfs from local paths

### DIFF
--- a/dvc/config.py
+++ b/dvc/config.py
@@ -89,6 +89,8 @@ class Config(dict):
         from dvc.fs.local import LocalFileSystem
 
         self.dvc_dir = dvc_dir
+        self.wfs = LocalFileSystem()
+        self.fs = fs or self.wfs
 
         if not dvc_dir:
             try:
@@ -98,10 +100,7 @@ class Config(dict):
             except NotDvcRepoError:
                 self.dvc_dir = None
         else:
-            self.dvc_dir = os.path.abspath(os.path.realpath(dvc_dir))
-
-        self.wfs = LocalFileSystem(url=self.dvc_dir)
-        self.fs = fs or self.wfs
+            self.dvc_dir = self.fs.path.abspath(self.fs.path.realpath(dvc_dir))
 
         self.load(validate=validate, config=config)
 
@@ -124,8 +123,8 @@ class Config(dict):
         }
 
         if self.dvc_dir is not None:
-            files["repo"] = os.path.join(self.dvc_dir, self.CONFIG)
-            files["local"] = os.path.join(self.dvc_dir, self.CONFIG_LOCAL)
+            files["repo"] = self.fs.path.join(self.dvc_dir, self.CONFIG)
+            files["local"] = self.fs.path.join(self.dvc_dir, self.CONFIG_LOCAL)
 
         return files
 

--- a/dvc/fs/git.py
+++ b/dvc/fs/git.py
@@ -1,4 +1,3 @@
-import os
 import threading
 from typing import TYPE_CHECKING, Any
 
@@ -15,7 +14,6 @@ if TYPE_CHECKING:
 class GitFileSystem(FileSystem):  # pylint:disable=abstract-method
     """Proxies the repo file access methods to Git objects"""
 
-    sep = os.sep
     scheme = "local"
 
     def __init__(
@@ -40,18 +38,16 @@ class GitFileSystem(FileSystem):  # pylint:disable=abstract-method
             }
         )
 
-    @cached_property
-    def path(self):
-        from .path import Path
-
-        return Path(self.sep, getcwd=os.getcwd)
-
     @wrap_prop(threading.Lock())
     @cached_property
     def fs(self) -> "FsspecGitFileSystem":
         from scmrepo.fs import GitFileSystem as FsspecGitFileSystem
 
         return FsspecGitFileSystem(**self.fs_args)
+
+    @cached_property
+    def path(self):
+        return self.fs.path
 
     @property
     def rev(self) -> str:

--- a/dvc/fs/local.py
+++ b/dvc/fs/local.py
@@ -182,7 +182,7 @@ class LocalFileSystem(FileSystem):
     def path(self):
         from .path import Path
 
-        return Path(self.sep, os.getcwd)
+        return Path(self.sep, getcwd=os.getcwd, realpath=os.path.realpath)
 
     def upload_fobj(self, fobj, to_info, **kwargs):
         self.makedirs(self.path.parent(to_info))

--- a/dvc/fs/path.py
+++ b/dvc/fs/path.py
@@ -3,17 +3,25 @@ import posixpath
 
 
 class Path:
-    def __init__(self, sep, getcwd=None):
+    def __init__(self, sep, getcwd=None, realpath=None):
         def _getcwd():
             return ""
 
         self.getcwd = getcwd or _getcwd
+        self.realpath = realpath or self.abspath
+
         if sep == posixpath.sep:
             self.flavour = posixpath
         elif sep == ntpath.sep:
             self.flavour = ntpath
         else:
             raise ValueError(f"unsupported separator '{sep}'")
+
+    def chdir(self, path):
+        def _getcwd():
+            return path
+
+        self.getcwd = _getcwd
 
     def join(self, *parts):
         return self.flavour.join(*parts)
@@ -104,15 +112,15 @@ class Path:
         # pylint: disable=arguments-out-of-order
         return self.isin_or_eq(left, right) or self.isin(right, left)
 
-    def relpath(self, path, start):
-        if not start:
+    def relpath(self, path, start=None):
+        if start is None:
             start = "."
         return self.flavour.relpath(
             self.abspath(path), start=self.abspath(start)
         )
 
-    def relparts(self, path, base):
-        return self.parts(self.relpath(path, base))
+    def relparts(self, path, start=None):
+        return self.parts(self.relpath(path, start=start))
 
     def as_posix(self, path):
         return path.replace(self.flavour.sep, posixpath.sep)

--- a/dvc/ignore.py
+++ b/dvc/ignore.py
@@ -35,7 +35,6 @@ class DvcIgnorePatterns(DvcIgnore):
         self.sep = sep
         self.pattern_list = pattern_list
         self.dirname = dirname
-        self.prefix = self.dirname + self.sep
 
         self.regex_pattern_list = [
             GitWildMatchPattern.pattern_to_regex(pattern_info.patterns)
@@ -74,10 +73,13 @@ class DvcIgnorePatterns(DvcIgnore):
     def _get_normalize_path(self, dirname, basename):
         # NOTE: `relpath` is too slow, so we have to assume that both
         # `dirname` and `self.dirname` are relative or absolute together.
+
+        prefix = self.dirname.rstrip(self.sep) + self.sep
+
         if dirname == self.dirname:
             path = basename
-        elif dirname.startswith(self.prefix):
-            rel = dirname[len(self.prefix) :]
+        elif dirname.startswith(prefix):
+            rel = dirname[len(prefix) :]
             # NOTE: `os.path.join` is ~x5.5 slower
             path = f"{rel}{self.sep}{basename}"
         else:
@@ -210,6 +212,7 @@ class DvcIgnoreFilter:
             new_pattern = DvcIgnorePatterns.from_file(path, self.fs, name)
             if old_pattern:
                 plist, prefix = merge_patterns(
+                    self.fs.path.flavour,
                     old_pattern.pattern_list,
                     old_pattern.dirname,
                     new_pattern.pattern_list,
@@ -259,6 +262,7 @@ class DvcIgnoreFilter:
         old_pattern = ignore_trie.longest_prefix(key).value
         if old_pattern:
             plist, prefix = merge_patterns(
+                self.fs.path.flavour,
                 old_pattern.pattern_list,
                 old_pattern.dirname,
                 new_pattern.pattern_list,

--- a/dvc/parsing/__init__.py
+++ b/dvc/parsing/__init__.py
@@ -18,7 +18,6 @@ from funcy import cached_property, collecting, first, isa, join, reraise
 
 from dvc.exceptions import DvcException
 from dvc.parsing.interpolate import ParseError
-from dvc.utils import relpath
 
 from .context import (
     Context,
@@ -135,19 +134,14 @@ def make_definition(
 
 class DataResolver:
     def __init__(self, repo: "Repo", wdir: str, d: dict):
-        from dvc.fs import LocalFileSystem
-
         self.fs = fs = repo.fs
 
         if os.path.isabs(wdir):
-            start = (
-                os.curdir if isinstance(fs, LocalFileSystem) else repo.root_dir
-            )
-            wdir = relpath(wdir, start)
+            wdir = fs.path.relpath(wdir)
             wdir = "" if wdir == os.curdir else wdir
 
         self.wdir = wdir
-        self.relpath = os.path.normpath(fs.path.join(self.wdir, "dvc.yaml"))
+        self.relpath = fs.path.normpath(fs.path.join(self.wdir, "dvc.yaml"))
 
         vars_ = d.get(VARS_KWD, [])
         check_interpolations(vars_, VARS_KWD, self.relpath)

--- a/dvc/parsing/context.py
+++ b/dvc/parsing/context.py
@@ -395,7 +395,7 @@ class Context(CtxDict):
 
     def merge_from(self, fs, item: str, wdir: str, overwrite=False):
         path, _, keys_str = item.partition(":")
-        path = os.path.normpath(fs.path.join(wdir, path))
+        path = fs.path.normpath(fs.path.join(wdir, path))
 
         select_keys = lfilter(bool, keys_str.split(",")) if keys_str else None
         if path in self.imports:

--- a/dvc/pathspec_math.py
+++ b/dvc/pathspec_math.py
@@ -2,7 +2,6 @@
 # Including changing base dir of path specification patterns and merging
 # of two path specification patterns with different base
 # All the operations follow the documents of `gitignore`
-import os
 from collections import namedtuple
 
 from pathspec.util import normalize_file
@@ -68,7 +67,7 @@ def _change_dirname(dirname, pattern_list, new_dirname):
     ]
 
 
-def merge_patterns(pattern_a, prefix_a, pattern_b, prefix_b):
+def merge_patterns(flavour, pattern_a, prefix_a, pattern_b, prefix_b):
     """
     Merge two path specification patterns.
 
@@ -81,7 +80,7 @@ def merge_patterns(pattern_a, prefix_a, pattern_b, prefix_b):
     if not pattern_b:
         return pattern_a, prefix_a
 
-    longest_common_dir = os.path.commonpath([prefix_a, prefix_b])
+    longest_common_dir = flavour.commonpath([prefix_a, prefix_b])
     new_pattern_a = _change_dirname(prefix_a, pattern_a, longest_common_dir)
     new_pattern_b = _change_dirname(prefix_b, pattern_b, longest_common_dir)
 

--- a/dvc/repo/brancher.py
+++ b/dvc/repo/brancher.py
@@ -31,7 +31,18 @@ def brancher(  # noqa: E302
 
     from dvc.fs.local import LocalFileSystem
 
+    repo_root_parts = ()
+    if self.fs.path.isin(self.root_dir, self.scm.root_dir):
+        repo_root_parts = self.fs.path.relparts(
+            self.root_dir, self.scm.root_dir
+        )
+
+    cwd_parts = ()
+    if self.fs.path.isin(self.fs.path.getcwd(), self.root_dir):
+        cwd_parts = self.fs.path.relparts(self.fs.path.getcwd(), self.root_dir)
+
     saved_fs = self.fs
+    saved_root = self.root_dir
 
     scm = self.scm
 
@@ -56,9 +67,16 @@ def brancher(  # noqa: E302
 
         for sha, names in found_revs.items():
             self.fs = GitFileSystem(scm=scm, rev=sha)
+            self.root_dir = self.fs.path.join("/", *repo_root_parts)
+
+            if cwd_parts:
+                cwd = self.fs.path.join("/", *cwd_parts)
+                self.fs.path.chdir(cwd)
+
             # ignore revs that don't contain repo root
             # (i.e. revs from before a subdir=True repo was init'ed)
             if self.fs.exists(self.root_dir):
                 yield sha if sha_only else ",".join(names)
     finally:
         self.fs = saved_fs
+        self.root_dir = saved_root

--- a/dvc/repo/collect.py
+++ b/dvc/repo/collect.py
@@ -31,7 +31,6 @@ def _collect_paths(
     rev: str = None,
 ) -> StrPaths:
     from dvc.fs.repo import RepoFileSystem
-    from dvc.utils import relpath
 
     fs = RepoFileSystem(repo=repo)
     fs_paths = [fs.from_os_path(target) for target in targets]
@@ -41,7 +40,7 @@ def _collect_paths(
         if recursive and fs.isdir(fs_path):
             target_paths.extend(fs.find(fs_path))
 
-        rel = relpath(fs_path)
+        rel = fs.path.relpath(fs_path)
         if not fs.exists(fs_path):
             if rev == "workspace" or rev == "":
                 logger.warning("'%s' was not found in current workspace.", rel)

--- a/dvc/stage/loader.py
+++ b/dvc/stage/loader.py
@@ -77,7 +77,7 @@ class StageLoader(Mapping):
         assert stage_data and isinstance(stage_data, dict)
 
         path, wdir = resolve_paths(
-            dvcfile.path, stage_data.get(Stage.PARAM_WDIR)
+            dvcfile.repo.fs, dvcfile.path, stage_data.get(Stage.PARAM_WDIR)
         )
         stage = loads_from(PipelineStage, dvcfile.repo, path, wdir, stage_data)
         stage.name = name
@@ -184,7 +184,9 @@ class SingleStageLoader(Mapping):
 
     @classmethod
     def load_stage(cls, dvcfile, d, stage_text):
-        path, wdir = resolve_paths(dvcfile.path, d.get(Stage.PARAM_WDIR))
+        path, wdir = resolve_paths(
+            dvcfile.repo.fs, dvcfile.path, d.get(Stage.PARAM_WDIR)
+        )
         stage = loads_from(Stage, dvcfile.repo, path, wdir, d)
         stage._stage_text = stage_text  # noqa, pylint:disable=protected-access
         stage.deps = dependency.loadd_from(

--- a/dvc/stage/utils.py
+++ b/dvc/stage/utils.py
@@ -210,10 +210,10 @@ def resolve_wdir(wdir, path):
     return pathlib.PurePath(rel_wdir).as_posix() if rel_wdir != "." else None
 
 
-def resolve_paths(path, wdir=None):
-    path = os.path.abspath(path)
+def resolve_paths(fs, path, wdir=None):
+    path = fs.path.abspath(path)
     wdir = wdir or os.curdir
-    wdir = os.path.abspath(os.path.join(os.path.dirname(path), wdir))
+    wdir = fs.path.abspath(fs.path.join(fs.path.dirname(path), wdir))
     return path, wdir
 
 

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -332,7 +332,7 @@ def relpath(path, start=os.curdir):
     return os.path.relpath(path, start)
 
 
-def as_posix(path):
+def as_posix(path: str) -> str:
     import ntpath
     import posixpath
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,7 +72,7 @@ install_requires =
     aiohttp-retry>=2.4.5
     diskcache>=5.2.1
     jaraco.windows>=5.7.0; python_version < '3.8' and sys_platform == 'win32'
-    scmrepo==0.0.19
+    scmrepo==0.0.22
     dvc-render==0.0.5
     dvclive>=0.7.3
 

--- a/tests/func/experiments/test_experiments.py
+++ b/tests/func/experiments/test_experiments.py
@@ -33,7 +33,7 @@ def test_new_simple(tmp_dir, scm, dvc, exp_stage, mocker, name, workspace):
 
     new_mock.assert_called_once()
     fs = scm.get_fs(exp)
-    with fs.open(tmp_dir / "metrics.yaml", mode="r", encoding="utf-8") as fobj:
+    with fs.open("metrics.yaml", mode="r", encoding="utf-8") as fobj:
         assert fobj.read().strip() == "foo: 2"
 
     if workspace:
@@ -75,7 +75,7 @@ def test_experiment_exists(tmp_dir, scm, dvc, exp_stage, mocker, workspace):
     exp = first(results)
 
     fs = scm.get_fs(exp)
-    with fs.open(tmp_dir / "metrics.yaml", mode="r", encoding="utf-8") as fobj:
+    with fs.open("metrics.yaml", mode="r", encoding="utf-8") as fobj:
         assert fobj.read().strip() == "foo: 3"
 
 
@@ -145,7 +145,7 @@ def test_modify_params(tmp_dir, scm, dvc, mocker, changes, expected):
 
     new_mock.assert_called_once()
     fs = scm.get_fs(exp)
-    with fs.open(tmp_dir / "metrics.yaml", mode="r") as fobj:
+    with fs.open("metrics.yaml", mode="r") as fobj:
         assert fobj.read().strip() == expected
 
 
@@ -263,9 +263,9 @@ def test_update_py_params(tmp_dir, scm, dvc):
     exp_a = first(results)
 
     fs = scm.get_fs(exp_a)
-    with fs.open(tmp_dir / "params.py", mode="r", encoding="utf-8") as fobj:
+    with fs.open("params.py", mode="r", encoding="utf-8") as fobj:
         assert fobj.read().strip() == "INT = 2"
-    with fs.open(tmp_dir / "metrics.py", mode="r", encoding="utf-8") as fobj:
+    with fs.open("metrics.py", mode="r", encoding="utf-8") as fobj:
         assert fobj.read().strip() == "INT = 2"
 
     tmp_dir.gen(
@@ -309,9 +309,9 @@ def test_update_py_params(tmp_dir, scm, dvc):
         return text.replace("\r\n", "\n")
 
     fs = scm.get_fs(exp_a)
-    with fs.open(tmp_dir / "params.py", mode="r", encoding="utf-8") as fobj:
+    with fs.open("params.py", mode="r", encoding="utf-8") as fobj:
         assert _dos2unix(fobj.read().strip()) == result
-    with fs.open(tmp_dir / "metrics.py", mode="r", encoding="utf-8") as fobj:
+    with fs.open("metrics.py", mode="r", encoding="utf-8") as fobj:
         assert _dos2unix(fobj.read().strip()) == result
 
     tmp_dir.gen("params.py", "INT = 1\n")
@@ -438,7 +438,7 @@ def test_untracked(tmp_dir, scm, dvc, caplog, workspace):
     assert fs.exists("dvc.yaml")
     assert fs.exists("dvc.lock")
     assert fs.exists("copy.py")
-    with fs.open(tmp_dir / "metrics.yaml", mode="r", encoding="utf-8") as fobj:
+    with fs.open("metrics.yaml", mode="r", encoding="utf-8") as fobj:
         assert fobj.read().strip() == "foo: 2"
 
 
@@ -515,8 +515,8 @@ def test_subdir(tmp_dir, scm, dvc, workspace):
 
     fs = scm.get_fs(exp)
     for fname in ["metrics.yaml", "dvc.lock"]:
-        assert fs.exists(subdir / fname)
-    with fs.open(subdir / "metrics.yaml", mode="r", encoding="utf-8") as fobj:
+        assert fs.exists(f"dir/{fname}")
+    with fs.open("dir/metrics.yaml", mode="r", encoding="utf-8") as fobj:
         assert fobj.read().strip() == "foo: 2"
 
     assert dvc.experiments.get_exact_name(exp) == ref_info.name
@@ -560,8 +560,8 @@ def test_subrepo(tmp_dir, scm, workspace):
 
     fs = scm.get_fs(exp)
     for fname in ["metrics.yaml", "dvc.lock"]:
-        assert fs.exists(subrepo / fname)
-    with fs.open(subrepo / "metrics.yaml", mode="r", encoding="utf-8") as fobj:
+        assert fs.exists(f"dir/repo/{fname}")
+    with fs.open("dir/repo/metrics.yaml", mode="r", encoding="utf-8") as fobj:
         assert fobj.read().strip() == "foo: 2"
 
     assert subrepo.dvc.experiments.get_exact_name(exp) == ref_info.name
@@ -582,9 +582,7 @@ def test_queue(tmp_dir, scm, dvc, exp_stage, mocker):
     metrics = set()
     for exp in results:
         fs = scm.get_fs(exp)
-        with fs.open(
-            tmp_dir / "metrics.yaml", mode="r", encoding="utf-8"
-        ) as fobj:
+        with fs.open("metrics.yaml", mode="r", encoding="utf-8") as fobj:
             metrics.add(fobj.read().strip())
     assert expected == metrics
 

--- a/tests/func/parsing/test_resolver.py
+++ b/tests/func/parsing/test_resolver.py
@@ -1,4 +1,3 @@
-import os
 from copy import deepcopy
 
 import pytest
@@ -71,13 +70,13 @@ def test_load_vars_from_file(tmp_dir, dvc):
 def test_load_vars_with_relpath(tmp_dir, scm, dvc):
     tmp_dir.scm_gen(DEFAULT_PARAMS_FILE, dumps_yaml(DATA), commit="add params")
 
-    subdir = tmp_dir / "subdir"
-    d = {"vars": [os.path.relpath(tmp_dir / DEFAULT_PARAMS_FILE, subdir)]}
-
     revisions = ["HEAD", "workspace"]
     for rev in dvc.brancher(revs=["HEAD"]):
         assert rev == revisions.pop()
-        resolver = DataResolver(dvc, subdir.fs_path, d)
+        d = {
+            "vars": [f"../{DEFAULT_PARAMS_FILE}"],
+        }
+        resolver = DataResolver(dvc, "subdir", d)
         assert resolver.context == deepcopy(DATA)
 
 

--- a/tests/func/test_fs.py
+++ b/tests/func/test_fs.py
@@ -198,7 +198,7 @@ def test_walk_dont_ignore_subrepos(tmp_dir, scm, dvc):
     get_dirs = itemgetter(1)
 
     assert set(get_dirs(next(dvc_fs.walk(path)))) == {".dvc", "subdir", ".git"}
-    assert set(get_dirs(next(scm_fs.walk(path)))) == {".dvc", "subdir"}
+    assert set(get_dirs(next(scm_fs.walk("/")))) == {".dvc", "subdir"}
 
 
 def test_fs_size(dvc, cloud):

--- a/tests/func/test_used_objs.py
+++ b/tests/func/test_used_objs.py
@@ -3,14 +3,6 @@ import os
 
 import pytest
 
-from dvc.exceptions import NoOutputOrStageError
-from dvc.stage.exceptions import StageFileDoesNotExistError
-
-gitfs_xfail = pytest.mark.xfail(
-    raises=(NoOutputOrStageError, StageFileDoesNotExistError),
-    reason="gitfs works on absolute paths only",
-)
-
 
 @pytest.mark.parametrize(
     "stage_wdir, cwd, target",
@@ -19,23 +11,21 @@ gitfs_xfail = pytest.mark.xfail(
         (os.curdir, os.curdir, "train"),
         (os.curdir, os.curdir, "dvc.yaml:train"),
         (os.curdir, "sub", os.path.join(os.pardir, "foo")),
-        pytest.param(
+        (
             os.curdir,
             "sub",
             os.path.join(os.pardir, "dvc.yaml:train"),
-            marks=gitfs_xfail,
         ),
         ("sub", os.curdir, os.path.join("sub", "foo")),
         ("sub", os.curdir, os.path.join("sub", "dvc.yaml:train")),
         ("sub", "sub", "foo"),
-        pytest.param("sub", "sub", "train", marks=gitfs_xfail),
-        pytest.param("sub", "sub", "dvc.yaml:train", marks=gitfs_xfail),
+        ("sub", "sub", "train"),
+        ("sub", "sub", "dvc.yaml:train"),
         ("sub", "dir", os.path.join(os.pardir, "sub", "foo")),
-        pytest.param(
+        (
             "sub",
             "dir",
             os.path.join(os.pardir, "sub", "dvc.yaml:train"),
-            marks=gitfs_xfail,
         ),
     ],
 )

--- a/tests/unit/stage/test_utils.py
+++ b/tests/unit/stage/test_utils.py
@@ -1,5 +1,6 @@
 import os
 
+from dvc.fs.local import localfs
 from dvc.stage.utils import resolve_paths
 
 
@@ -7,14 +8,16 @@ def test_resolve_paths():
     p = os.path.join("dir", "subdir")
     file_path = os.path.join(p, "dvc.yaml")
 
-    path, wdir = resolve_paths(path=file_path, wdir="dir")
+    path, wdir = resolve_paths(fs=localfs, path=file_path, wdir="dir")
     assert path == os.path.abspath(file_path)
     assert wdir == os.path.abspath(os.path.join(p, "dir"))
 
-    path, wdir = resolve_paths(path=file_path)
+    path, wdir = resolve_paths(fs=localfs, path=file_path)
     assert path == os.path.abspath(file_path)
     assert wdir == os.path.abspath(p)
 
-    path, wdir = resolve_paths(path=file_path, wdir="../../some-dir")
+    path, wdir = resolve_paths(
+        fs=localfs, path=file_path, wdir="../../some-dir"
+    )
     assert path == os.path.abspath(file_path)
     assert wdir == os.path.abspath("some-dir")

--- a/tests/unit/test_external_repo.py
+++ b/tests/unit/test_external_repo.py
@@ -31,12 +31,13 @@ def test_hook_is_called(tmp_dir, erepo_dir, mocker):
         list(repo.repo_fs.walk("", ignore_subrepos=False))  # drain
         assert spy.call_count == len(subrepos)
 
-        paths = [os.path.join(repo.root_dir, path) for path in subrepo_paths]
+        paths = ["/" + path.replace("\\", "/") for path in subrepo_paths]
         spy.assert_has_calls(
             [
                 call(
                     path,
                     fs=repo.fs,
+                    scm=repo.scm,
                     repo_factory=repo.repo_fs.fs.repo_factory,
                 )
                 for path in paths

--- a/tests/unit/test_ignore.py
+++ b/tests/unit/test_ignore.py
@@ -11,6 +11,7 @@ def mock_dvcignore(dvcignore_path, patterns):
 
     fs = MagicMock()
     fs.path = localfs.path
+    fs.sep = localfs.sep
     with patch.object(fs, "open", mock_open(read_data="\n".join(patterns))):
         ignore_patterns = DvcIgnorePatterns.from_file(
             dvcignore_path, fs, "mocked"


### PR DESCRIPTION
Our gitfs paths are currently tied to the local path in which the cloned
repository resides in, which results in a lot of hacky assumptions throughout
the code.

This PR detaches gitfs from local paths completely, making dvc work with a
proper fsspec gitfs implementation.

Part of #7543