### PR TITLE
Revert "dvc ls: not raise PathMissingError on empty dir."

### DIFF
--- a/dvc/repo/ls.py
+++ b/dvc/repo/ls.py
@@ -31,10 +31,10 @@ def ls(url, path=None, rev=None, recursive=None, dvc_only=False):
     with Repo.open(url, rev=rev, subrepos=True, uninitialized=True) as repo:
         path = path or ""
 
-        if path and not repo.repo_fs.exists(path):
-            raise PathMissingError(path, repo, dvc_only=dvc_only)
-
         ret = _ls(repo.repo_fs, path, recursive, dvc_only)
+
+        if path and not ret:
+            raise PathMissingError(path, repo, dvc_only=dvc_only)
 
         ret_list = []
         for path, info in ret.items():

--- a/tests/func/test_ls.py
+++ b/tests/func/test_ls.py
@@ -150,20 +150,9 @@ def test_ls_repo_with_path_dir_dvc_only_empty(tmp_dir, dvc, scm):
     tmp_dir.scm_gen(FS_STRUCTURE, commit="init")
     tmp_dir.dvc_gen(DVC_STRUCTURE, commit="dvc")
     tmp_dir.scm_gen({"folder/.keep": "content"}, commit="add .keep")
-    tmp_dir.scm_gen({"empty_scm_folder/": {}}, commit="add scm empty")
-    tmp_dir.dvc_gen({"empty_dvc_folder": {}}, commit="empty dvc folder")
 
     with pytest.raises(PathMissingError):
-        Repo.ls(os.fspath(tmp_dir), path="not_exist_folder")
-
-    assert Repo.ls(os.fspath(tmp_dir), path="empty_scm_folder") == []
-
-    assert Repo.ls(os.fspath(tmp_dir), path="folder", dvc_only=True) == []
-
-    assert (
-        Repo.ls(os.fspath(tmp_dir), path="empty_dvc_folder", dvc_only=True)
-        == []
-    )
+        Repo.ls(os.fspath(tmp_dir), path="folder", dvc_only=True)
 
 
 def test_ls_repo_with_path_subdir(tmp_dir, dvc, scm):


### PR DESCRIPTION
```
2022-05-11T08:38:52.3563156Z ================================== FAILURES ===================================
2022-05-11T08:38:52.3563536Z ______________ test_ls_repo_with_removed_dvc_dir_with_path_file _______________
2022-05-11T08:38:52.3564566Z [gw0] win32 -- Python 3.8.10 C:\hostedtoolcache\windows\Python\3.8.10\x64\python.exe
2022-05-11T08:38:52.3564805Z 
2022-05-11T08:38:52.3565269Z tmp_dir = WindowsTmpDir('C:/Users/runneradmin/AppData/Local/Temp/pytest-of-runneradmin/pytest-0/popen-gw0/test_ls_repo_with_removed_dvc_3')
2022-05-11T08:38:52.3566004Z dvc = Repo: 'C:\Users\runneradmin\AppData\Local\Temp\pytest-of-runneradmin\pytest-0\popen-gw0\test_ls_repo_with_removed_dvc_3'
2022-05-11T08:38:52.3566746Z scm = Git: 'C:\Users\runneradmin\AppData\Local\Temp\pytest-of-runneradmin\pytest-0\popen-gw0\test_ls_repo_with_removed_dvc_3\.git'
2022-05-11T08:38:52.3567081Z 
2022-05-11T08:38:52.3567266Z     def test_ls_repo_with_removed_dvc_dir_with_path_file(tmp_dir, dvc, scm):
2022-05-11T08:38:52.3567593Z         create_dvc_pipeline(tmp_dir, dvc)
2022-05-11T08:38:52.3567820Z     
2022-05-11T08:38:52.3568051Z         path = os.path.join("out", "file")
2022-05-11T08:38:52.3568420Z >       files = Repo.ls(os.fspath(tmp_dir), path)
2022-05-11T08:38:52.3568613Z 
2022-05-11T08:38:52.3568748Z D:\a\dvc\dvc\tests\func\test_ls.py:295: 
2022-05-11T08:38:52.3569035Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
2022-05-11T08:38:52.3569195Z 
2022-05-11T08:38:52.3569654Z url = 'C:\\Users\\runneradmin\\AppData\\Local\\Temp\\pytest-of-runneradmin\\pytest-0\\popen-gw0\\test_ls_repo_with_removed_dvc_3'
2022-05-11T08:38:52.3570247Z path = 'out\\file', rev = None, recursive = None, dvc_only = False
2022-05-11T08:38:52.3570453Z 
2022-05-11T08:38:52.3570621Z     def ls(url, path=None, rev=None, recursive=None, dvc_only=False):
2022-05-11T08:38:52.3570974Z         """Methods for getting files and outputs for the repo.
2022-05-11T08:38:52.3571210Z     
2022-05-11T08:38:52.3571393Z         Args:
2022-05-11T08:38:52.3571607Z             url (str): the repo url
2022-05-11T08:38:52.3571901Z             path (str, optional): relative path into the repo
2022-05-11T08:38:52.3572226Z             rev (str, optional): SHA commit, branch or tag name
2022-05-11T08:38:52.3572632Z             recursive (bool, optional): recursively walk the repo
2022-05-11T08:38:52.3573744Z             dvc_only (bool, optional): show only DVC-artifacts
2022-05-11T08:38:52.3574047Z     
2022-05-11T08:38:52.3574215Z         Returns:
2022-05-11T08:38:52.3574428Z             list of `entry`
2022-05-11T08:38:52.3574627Z     
2022-05-11T08:38:52.3574804Z         Notes:
2022-05-11T08:38:52.3575045Z             `entry` is a dictionary with structure
2022-05-11T08:38:52.3575268Z             {
2022-05-11T08:38:52.3575473Z                 "path": str,
2022-05-11T08:38:52.3575694Z                 "isout": bool,
2022-05-11T08:38:52.3575911Z                 "isdir": bool,
2022-05-11T08:38:52.3576133Z                 "isexec": bool,
2022-05-11T08:38:52.3576338Z             }
2022-05-11T08:38:52.3576504Z         """
2022-05-11T08:38:52.3576704Z         from . import Repo
2022-05-11T08:38:52.3576900Z     
2022-05-11T08:38:52.3577322Z         with Repo.open(url, rev=rev, subrepos=True, uninitialized=True) as repo:
2022-05-11T08:38:52.3577647Z             path = path or ""
2022-05-11T08:38:52.3577834Z     
2022-05-11T08:38:52.3578080Z             if path and not repo.repo_fs.exists(path):
2022-05-11T08:38:52.3578523Z >               raise PathMissingError(path, repo, dvc_only=dvc_only)
2022-05-11T08:38:52.3579628Z E               dvc.exceptions.PathMissingError: The path 'out\file' does not exist in the target repository 'C:\Users\runneradmin\AppData\Local\Temp\pytest-of-runneradmin\pytest-0\popen-gw0\test_ls_repo_with_removed_dvc_3' neither as a DVC output nor as a Git-tracked file.
2022-05-11T08:38:52.3580164Z 
2022-05-11T08:38:52.3580315Z D:\a\dvc\dvc\dvc\repo\ls.py:35: PathMissingError
```

Reverts iterative/dvc#6120