### PR TITLE
fs: rename DvcFileSystem to DataFileSystem

### DIFF
--- a/dvc/fs/data.py
+++ b/dvc/fs/data.py
@@ -14,7 +14,7 @@ if typing.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class _DvcFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
+class _DataFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
     """DVC repo fs.
 
     Args:
@@ -178,7 +178,7 @@ class _DvcFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
         raise NotImplementedError
 
 
-class DvcFileSystem(FileSystem):
+class DataFileSystem(FileSystem):
     scheme = "local"
 
     PARAM_CHECKSUM = "md5"
@@ -189,7 +189,7 @@ class DvcFileSystem(FileSystem):
     @wrap_prop(threading.Lock())
     @cached_property
     def fs(self):
-        return _DvcFileSystem(**self.fs_args)
+        return _DataFileSystem(**self.fs_args)
 
     def isdvc(self, path, **kwargs):
         return self.fs.isdvc(path, **kwargs)

--- a/dvc/fs/repo.py
+++ b/dvc/fs/repo.py
@@ -10,7 +10,7 @@ from funcy import cached_property, wrap_prop, wrap_with
 
 from ._callback import DEFAULT_CALLBACK
 from .base import FileSystem
-from .dvc import DvcFileSystem
+from .data import DataFileSystem
 from .path import Path
 
 if TYPE_CHECKING:
@@ -70,7 +70,7 @@ class _RepoFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
         repo: DVC or git repo.
         subrepos: traverse to subrepos (by default, it ignores subrepos)
         repo_factory: A function to initialize subrepo with, default is Repo.
-        kwargs: Additional keyword arguments passed to the `DvcFileSystem()`.
+        kwargs: Additional keyword arguments passed to the `DataFileSystem()`.
     """
 
     root_marker = "/"
@@ -124,11 +124,11 @@ class _RepoFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
         key = self._get_key(self.repo.root_dir)
         self._subrepos_trie[key] = repo
 
-        self._dvcfss = {}
-        """Keep a dvcfs instance of each repo."""
+        self._datafss = {}
+        """Keep a datafs instance of each repo."""
 
         if hasattr(repo, "dvc_dir"):
-            self._dvcfss[key] = DvcFileSystem(repo=repo)
+            self._datafss[key] = DataFileSystem(repo=repo)
 
     def _get_key(self, path):
         parts = self.repo.fs.path.relparts(path, self.repo.root_dir)
@@ -245,7 +245,7 @@ class _RepoFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
                     scm=self.repo.scm,
                     repo_factory=self.repo_factory,
                 )
-                self._dvcfss[key] = DvcFileSystem(repo=repo)
+                self._datafss[key] = DataFileSystem(repo=repo)
             self._subrepos_trie[key] = repo
 
     def _is_dvc_repo(self, dir_path):
@@ -263,7 +263,7 @@ class _RepoFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
     ) -> Tuple[
         Optional[FileSystem],
         Optional[str],
-        Optional[DvcFileSystem],
+        Optional[DataFileSystem],
         Optional[str],
     ]:
         """
@@ -286,7 +286,7 @@ class _RepoFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
             dvc_parts = dvc_parts[1:]
 
         key = self._get_key(repo.root_dir)
-        dvc_fs = self._dvcfss.get(key)
+        dvc_fs = self._datafss.get(key)
         if dvc_fs:
             dvc_path = dvc_fs.path.join(*dvc_parts) if dvc_parts else ""
         else:

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -484,10 +484,10 @@ class Repo:
         return self.DVC_DIR in path_parts
 
     @cached_property
-    def dvcfs(self):
-        from dvc.fs.dvc import DvcFileSystem
+    def datafs(self):
+        from dvc.fs.data import DataFileSystem
 
-        return DvcFileSystem(repo=self)
+        return DataFileSystem(repo=self)
 
     @cached_property
     def repo_fs(self):
@@ -504,11 +504,11 @@ class Repo:
     @contextmanager
     def open_by_relpath(self, path, remote=None, mode="r", encoding=None):
         """Opens a specified resource as a file descriptor"""
-        from dvc.fs.dvc import DvcFileSystem
+        from dvc.fs.data import DataFileSystem
         from dvc.fs.repo import RepoFileSystem
 
         if os.path.isabs(path):
-            fs = DvcFileSystem(repo=self, workspace="local")
+            fs = DataFileSystem(repo=self, workspace="local")
             fs_path = path
         else:
             fs = RepoFileSystem(repo=self, subrepos=True)

--- a/dvc/repo/get.py
+++ b/dvc/repo/get.py
@@ -52,9 +52,9 @@ def get(url, path, out=None, rev=None, jobs=None):
         ) as repo:
 
             if os.path.isabs(path):
-                from dvc.fs.dvc import DvcFileSystem
+                from dvc.fs.data import DataFileSystem
 
-                fs = DvcFileSystem(repo=repo, workspace="local")
+                fs = DataFileSystem(repo=repo, workspace="local")
                 fs_path = path
             else:
                 fs = repo.repo_fs


### PR DESCRIPTION
Current naming for `DvcFileSystem` and `RepoFileSystem` is confusing, because
dvc is not only about data and it is much more natural to expect something
named `dvcfs` to include complete view for your whole repo (including git
files), which is what `repofs` is doing right now.

`DvcFileSystem` can provide a view not only for the repo data, but also for
external data (e.g. local external outputs). So it makes more sense to call
it a `DataFileSystem`, since it really represents the data management side
of dvc.

`RepoFileSystem` will be renamed into `DvcFileSystem` separately, to not
make this even more confusing.

Pre-requisite for #5162