### PR TITLE
dvc.objects: move hashing functions to dvc.objects

### DIFF
--- a/dvc/data/stream.py
+++ b/dvc/data/stream.py
@@ -3,9 +3,9 @@ import io
 
 from funcy import cached_property
 
+from dvc.objects.hash import dos2unix
 from dvc.objects.hash_info import HashInfo
 from dvc.objects.istextfile import DEFAULT_CHUNK_SIZE, istextblock
-from dvc.utils import dos2unix
 
 
 class HashedStreamReader(io.IOBase):

--- a/dvc/data/tree.py
+++ b/dvc/data/tree.py
@@ -7,8 +7,7 @@ from funcy import cached_property
 
 from dvc.objects.errors import ObjectFormatError
 from dvc.objects.file import HashFile
-
-from .stage import get_file_hash
+from dvc.objects.hash import hash_file
 
 if TYPE_CHECKING:
     from dvc.objects.db import ObjectDB
@@ -67,7 +66,7 @@ class Tree(HashFile):
         if hash_info:
             self.hash_info = hash_info
         else:
-            _, self.hash_info = get_file_hash(fs_path, memfs, "md5")
+            _, self.hash_info = hash_file(fs_path, memfs, "md5")
             assert self.hash_info.value
             self.hash_info.value += ".dir"
 

--- a/dvc/fs/dvc.py
+++ b/dvc/fs/dvc.py
@@ -41,7 +41,7 @@ def _ls(fs, path):
 
 
 def _merge_info(repo, fs_info, dvc_info):
-    from dvc.utils import is_exec
+    from dvc.fs.utils import is_exec
 
     ret = {"repo": repo}
 

--- a/dvc/fs/http.py
+++ b/dvc/fs/http.py
@@ -1,5 +1,5 @@
 import threading
-from typing import IO, Union
+from typing import BinaryIO, Union
 
 from funcy import cached_property, memoize, wrap_with
 
@@ -141,7 +141,7 @@ class HTTPFileSystem(FileSystem):
 
     def put_file(
         self,
-        from_file: Union[AnyFSPath, IO],
+        from_file: Union[AnyFSPath, BinaryIO],
         to_info: AnyFSPath,
         callback: FsspecCallback = DEFAULT_CALLBACK,
         size: int = None,

--- a/dvc/fs/utils.py
+++ b/dvc/fs/utils.py
@@ -1,0 +1,31 @@
+import os
+import stat
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .base import AnyFSPath
+
+
+def is_exec(mode: int) -> bool:
+    return bool(mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
+
+
+def relpath(path: "AnyFSPath", start: "AnyFSPath" = os.curdir) -> "AnyFSPath":
+    path = os.fspath(path)
+    start = os.path.abspath(os.fspath(start))
+
+    # Windows path on different drive than curdir doesn't have relpath
+    if os.name == "nt":
+        # Since python 3.8 os.realpath resolves network shares to their UNC
+        # path. So, to be certain that relative paths correctly captured,
+        # we need to resolve to UNC path first. We resolve only the drive
+        # name so that we don't follow any 'real' symlinks on the path
+        def resolve_network_drive_windows(path_to_resolve):
+            drive, tail = os.path.splitdrive(path_to_resolve)
+            return os.path.join(os.path.realpath(drive), tail)
+
+        path = resolve_network_drive_windows(os.path.abspath(path))
+        start = resolve_network_drive_windows(start)
+        if not os.path.commonprefix([start, path]):
+            return path
+    return os.path.relpath(path, start)

--- a/dvc/objects/cache.py
+++ b/dvc/objects/cache.py
@@ -57,5 +57,5 @@ class Cache(diskcache.Cache):
     ) -> None:
         settings.setdefault("disk_pickle_protocol", 4)
         super().__init__(
-            directory=directory, timeout=timeout, disk=Disk, **settings
+            directory=directory, timeout=timeout, disk=disk, **settings
         )

--- a/dvc/objects/file.py
+++ b/dvc/objects/file.py
@@ -65,10 +65,10 @@ class HashFile:
         self._check_hash(odb)
 
     def _check_hash(self, odb):
-        from dvc.data.stage import get_file_hash
-        from dvc.objects.errors import ObjectFormatError
+        from .errors import ObjectFormatError
+        from .hash import hash_file
 
-        _, actual = get_file_hash(
+        _, actual = hash_file(
             self.fs_path, self.fs, self.hash_info.name, odb.state
         )
 

--- a/dvc/objects/hash.py
+++ b/dvc/objects/hash.py
@@ -1,0 +1,136 @@
+import hashlib
+import logging
+from typing import TYPE_CHECKING, Any, BinaryIO, Dict, Tuple
+
+from dvc.fs._callback import DEFAULT_CALLBACK, FsspecCallback, TqdmCallback
+from dvc.fs.utils import is_exec
+
+from .hash_info import HashInfo
+from .istextfile import istextfile
+from .meta import Meta
+
+logger = logging.getLogger(__name__)
+
+
+if TYPE_CHECKING:
+    from dvc.fs.base import AnyFSPath, FileSystem
+
+    from .state import StateBase
+
+
+def _adapt_info(info: Dict[str, Any], scheme: str) -> Dict[str, Any]:
+    if scheme == "s3" and "ETag" in info:
+        info["etag"] = info["ETag"].strip('"')
+    elif scheme == "gs" and "etag" in info:
+        import base64
+
+        info["etag"] = base64.b64decode(info["etag"]).hex()
+    elif scheme.startswith("http") and (
+        "ETag" in info or "Content-MD5" in info
+    ):
+        info["checksum"] = info.get("ETag") or info.get("Content-MD5")
+    return info
+
+
+def dos2unix(data: bytes) -> bytes:
+    return data.replace(b"\r\n", b"\n")
+
+
+def _fobj_md5(
+    fobj: BinaryIO,
+    hash_md5: "hashlib._Hash",
+    binary: bool,
+    chunk_size: int = 2**20,
+) -> None:
+    while True:
+        data = fobj.read(chunk_size)
+        if not data:
+            break
+        chunk = data if binary else dos2unix(data)
+        hash_md5.update(chunk)
+
+
+def file_md5(
+    fname: "AnyFSPath",
+    fs: "FileSystem",
+    callback: "FsspecCallback" = DEFAULT_CALLBACK,
+) -> str:
+    """get the (md5 hexdigest, md5 digest) of a file"""
+
+    hash_md5 = hashlib.md5()
+    binary = not istextfile(fname, fs=fs)
+    size = fs.size(fname) or 0
+    callback.set_size(size)
+    with fs.open(fname, "rb") as fobj:
+        _fobj_md5(callback.wrap_attr(fobj), hash_md5, binary)
+    return hash_md5.hexdigest()
+
+
+def _hash_file(
+    fs_path: "AnyFSPath",
+    fs: "FileSystem",
+    name: str,
+    callback: "FsspecCallback" = DEFAULT_CALLBACK,
+) -> Tuple["str", Dict[str, Any]]:
+    info = _adapt_info(fs.info(fs_path), fs.scheme)
+
+    if name in info:
+        assert not info[name].endswith(".dir")
+        return info[name], info
+
+    if hasattr(fs, name):
+        func = getattr(fs, name)
+        return func(fs_path), info
+
+    if name == "md5":
+        return file_md5(fs_path, fs, callback=callback), info
+    raise NotImplementedError
+
+
+class LargeFileHashingCallback(TqdmCallback):
+    """Callback that only shows progress bar if self.size > LARGE_FILE_SIZE."""
+
+    LARGE_FILE_SIZE = 2**30
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("bytes", True)
+        super().__init__(*args, **kwargs)
+        self._logged = False
+
+    # TqdmCallback force renders progress bar on `set_size`.
+    set_size = FsspecCallback.set_size
+
+    def call(self, hook_name=None, **kwargs):
+        if self.size and self.size > self.LARGE_FILE_SIZE:
+            if not self._logged:
+                desc = self.progress_bar.desc
+                logger.info(
+                    f"Computing md5 for a large file '{desc}'. "
+                    "This is only done once."
+                )
+                self._logged = True
+            super().call()
+
+
+def hash_file(
+    fs_path: "AnyFSPath",
+    fs: "FileSystem",
+    name: str,
+    state: "StateBase" = None,
+    callback: "FsspecCallback" = None,
+) -> Tuple["Meta", "HashInfo"]:
+    if state:
+        meta, hash_info = state.get(fs_path, fs)
+        if hash_info:
+            return meta, hash_info
+
+    cb = callback or LargeFileHashingCallback(desc=fs_path)
+    with cb:
+        hash_value, info = _hash_file(fs_path, fs, name, callback=cb)
+    hash_info = HashInfo(name, hash_value)
+    if state:
+        assert ".dir" not in hash_info.value
+        state.save(fs_path, fs, hash_info)
+
+    meta = Meta(size=info["size"], isexec=is_exec(info.get("mode", 0)))
+    return meta, hash_info

--- a/dvc/objects/state.py
+++ b/dvc/objects/state.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 
 from dvc.fs.local import LocalFileSystem
 from dvc.fs.system import inode as get_inode
-from dvc.utils import relpath
+from dvc.fs.utils import relpath
 
 from .hash_info import HashInfo
 from .utils import get_mtime_and_size

--- a/tests/func/objects/test_hash.py
+++ b/tests/func/objects/test_hash.py
@@ -1,0 +1,16 @@
+from dvc.fs import LocalFileSystem
+from dvc.objects.hash import file_md5
+
+
+def test_file_md5(tmp_dir):
+    tmp_dir.gen("foo", "foo content")
+
+    fs = LocalFileSystem()
+    assert file_md5("foo", fs) == file_md5("foo", fs)
+
+
+def test_file_md5_crlf(tmp_dir):
+    fs = LocalFileSystem()
+    tmp_dir.gen("cr", b"a\nb\nc")
+    tmp_dir.gen("crlf", b"a\r\nb\r\nc")
+    assert file_md5("cr", fs) == file_md5("crlf", fs)

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -23,6 +23,7 @@ from dvc.exceptions import (
 )
 from dvc.fs import system
 from dvc.fs.local import LocalFileSystem
+from dvc.objects.hash import file_md5
 from dvc.objects.hash_info import HashInfo
 from dvc.output import (
     OutputAlreadyTrackedError,
@@ -35,7 +36,7 @@ from dvc.stage.exceptions import (
     StagePathNotFoundError,
 )
 from dvc.testing.test_workspace import TestAdd
-from dvc.utils import LARGE_DIR_SIZE, file_md5, relpath
+from dvc.utils import LARGE_DIR_SIZE, relpath
 from dvc.utils.fs import path_isin
 from dvc.utils.serialize import YAMLFileCorruptedError, load_yaml
 from tests.basic_env import TestDvc
@@ -378,7 +379,7 @@ class TestDoubleAddUnchanged(TestDvc):
 
 
 def test_should_update_state_entry_for_file_after_add(mocker, dvc, tmp_dir):
-    file_md5_counter = mocker.spy(dvc_module.data.stage, "file_md5")
+    file_md5_counter = mocker.spy(dvc_module.objects.hash, "file_md5")
     tmp_dir.gen("foo", "foo")
 
     ret = main(["config", "cache.type", "copy"])
@@ -409,7 +410,7 @@ def test_should_update_state_entry_for_file_after_add(mocker, dvc, tmp_dir):
 def test_should_update_state_entry_for_directory_after_add(
     mocker, dvc, tmp_dir
 ):
-    file_md5_counter = mocker.spy(dvc_module.data.stage, "file_md5")
+    file_md5_counter = mocker.spy(dvc_module.objects.hash, "file_md5")
 
     tmp_dir.gen({"data/data": "foo", "data/data_sub/sub_data": "foo"})
 

--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -149,7 +149,7 @@ def test_warn_on_outdated_stage(tmp_dir, dvc, local_remote, caplog):
 
 def test_hash_recalculation(mocker, dvc, tmp_dir, local_remote):
     tmp_dir.gen({"foo": "foo"})
-    test_file_md5 = mocker.spy(dvc_module.data.stage, "file_md5")
+    test_file_md5 = mocker.spy(dvc_module.objects.hash, "file_md5")
     ret = main(["config", "cache.type", "hardlink"])
     assert ret == 0
     ret = main(["add", "foo"])
@@ -211,7 +211,7 @@ def test_verify_hashes(
     remove("dir")
     remove(dvc.odb.local.cache_dir)
 
-    hash_spy = mocker.spy(dvc_module.data.stage, "file_md5")
+    hash_spy = mocker.spy(dvc_module.objects.hash, "file_md5")
 
     dvc.pull()
     assert hash_spy.call_count == 0

--- a/tests/func/test_install.py
+++ b/tests/func/test_install.py
@@ -6,7 +6,7 @@ import pytest
 from git import GitCommandError
 
 from dvc.exceptions import DvcException
-from dvc.utils import file_md5
+from dvc.objects.hash import file_md5
 from tests.func.parsing.test_errors import escape_ansi
 
 

--- a/tests/func/test_repro.py
+++ b/tests/func/test_repro.py
@@ -16,10 +16,11 @@ from dvc.exceptions import (
 )
 from dvc.fs import system
 from dvc.fs.local import LocalFileSystem
+from dvc.objects.hash import file_md5
 from dvc.output import Output
 from dvc.stage import Stage
 from dvc.stage.exceptions import StageFileDoesNotExistError
-from dvc.utils import file_md5, relpath
+from dvc.utils import relpath
 from dvc.utils.fs import remove
 from dvc.utils.serialize import dump_yaml, load_yaml
 from tests.basic_env import TestDvc

--- a/tests/func/test_run_single_stage.py
+++ b/tests/func/test_run_single_stage.py
@@ -20,6 +20,7 @@ from dvc.exceptions import (
     StagePathAsOutputError,
 )
 from dvc.fs import system
+from dvc.objects.hash import file_md5
 from dvc.output import Output, OutputIsStageFileError
 from dvc.repo import Repo as DvcRepo
 from dvc.stage import Stage
@@ -30,7 +31,6 @@ from dvc.stage.exceptions import (
     StagePathNotFoundError,
     StagePathOutsideError,
 )
-from dvc.utils import file_md5
 from dvc.utils.serialize import load_yaml
 from tests.basic_env import TestDvc, TestDvcGit
 

--- a/tests/func/test_state.py
+++ b/tests/func/test_state.py
@@ -1,10 +1,10 @@
 import os
 import re
 
+from dvc.objects.hash import file_md5
 from dvc.objects.hash_info import HashInfo
 from dvc.objects.state import State
 from dvc.repo import Repo
-from dvc.utils import file_md5
 
 
 def test_state(tmp_dir, dvc):

--- a/tests/func/test_utils.py
+++ b/tests/func/test_utils.py
@@ -4,14 +4,6 @@ import pytest
 
 from dvc import utils
 from dvc.exceptions import DvcException
-from dvc.fs.local import LocalFileSystem
-
-
-def test_file_md5_crlf(tmp_dir):
-    fs = LocalFileSystem()
-    tmp_dir.gen("cr", b"a\nb\nc")
-    tmp_dir.gen("crlf", b"a\r\nb\r\nc")
-    assert utils.file_md5("cr", fs) == utils.file_md5("crlf", fs)
 
 
 def test_dict_md5():

--- a/tests/unit/fs/test_data.py
+++ b/tests/unit/fs/test_data.py
@@ -232,9 +232,9 @@ def test_get_hash_dir(tmp_dir, dvc, mocker):
         {"dir": {"foo": "foo", "bar": "bar", "subdir": {"data": "data"}}}
     )
     fs = DataFileSystem(repo=dvc)
-    get_file_hash_spy = mocker.spy(dvc_module.data.stage, "get_file_hash")
+    hash_file_spy = mocker.spy(dvc_module.objects.hash, "hash_file")
     assert fs.info("dir")["md5"] == "8761c4e9acad696bee718615e23e22db.dir"
-    assert not get_file_hash_spy.called
+    assert not hash_file_spy.called
 
 
 def test_get_hash_granular(tmp_dir, dvc):

--- a/tests/unit/fs/test_dvc.py
+++ b/tests/unit/fs/test_dvc.py
@@ -576,8 +576,8 @@ def test_get_hash_mixed_dir(tmp_dir, scm, dvc):
 
 def test_get_hash_dirty_file(tmp_dir, dvc):
     from dvc.data import check
-    from dvc.data.stage import get_file_hash
     from dvc.objects.errors import ObjectFormatError
+    from dvc.objects.hash import hash_file
 
     tmp_dir.dvc_gen("file", "file")
     file_hash_info = HashInfo("md5", "8c7dd922ad47494fc02c388e12c00eac")
@@ -588,7 +588,7 @@ def test_get_hash_dirty_file(tmp_dir, dvc):
     clean_staging()
 
     # file is modified in workspace
-    # get_file_hash(file) should return workspace hash, not DVC cached hash
+    # hash_file(file) should return workspace hash, not DVC cached hash
     fs = DvcFileSystem(repo=dvc)
     assert fs.info("file").get("md5") is None
     staging, _, obj = stage(dvc.odb.local, "file", fs, "md5")
@@ -601,9 +601,9 @@ def test_get_hash_dirty_file(tmp_dir, dvc):
     with pytest.raises(ObjectFormatError):
         check(staging, obj)
 
-    # get_file_hash(file) should return DVC cached hash
+    # hash_file(file) should return DVC cached hash
     assert fs.info("file")["md5"] == file_hash_info.value
-    _, hash_info = get_file_hash("file", fs, "md5", state=dvc.state)
+    _, hash_info = hash_file("file", fs, "md5", state=dvc.state)
     assert hash_info == file_hash_info
 
     # tmp_dir/file can be staged even though it is missing in workspace since

--- a/tests/unit/utils/test_stream.py
+++ b/tests/unit/utils/test_stream.py
@@ -1,9 +1,9 @@
 import pytest
 
+from dvc.data.stream import HashedStreamReader
 from dvc.fs.local import LocalFileSystem
+from dvc.objects.hash import file_md5
 from dvc.objects.istextfile import DEFAULT_CHUNK_SIZE, istextfile
-from dvc.utils import file_md5
-from dvc.utils.stream import HashedStreamReader
 
 
 def test_hashed_stream_reader(tmp_dir):

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -3,10 +3,8 @@ import re
 
 import pytest
 
-from dvc.fs.local import LocalFileSystem
 from dvc.utils import (
     dict_sha256,
-    file_md5,
     fix_env,
     parse_target,
     relpath,
@@ -81,13 +79,6 @@ def test_fix_env_pyenv(path, orig):
         "PYENV_HOOK_PATH": "/some/hook/path",
     }
     assert fix_env(env)["PATH"] == orig
-
-
-def test_file_md5(tmp_dir):
-    tmp_dir.gen("foo", "foo content")
-
-    fs = LocalFileSystem()
-    assert file_md5("foo", fs) == file_md5("foo", fs)
 
 
 def test_tmp_fname():


### PR DESCRIPTION
- moves `get_hash_file`/`file_md5` into `dvc.objects.hash`
- move `HashedStreamReader` into `dvc.data.stream`
- `get_hash_file` renamed to `hash_file`
- copies `relpath` and `is_exec` to the `dvc.fs.utils`
- `hash_file` uses new fsspec-like callback
