### PR TITLE
dvc.stage.cache: fix typo, was using src filesystem to transfer

### DIFF
--- a/dvc/stage/cache.py
+++ b/dvc/stage/cache.py
@@ -216,7 +216,7 @@ class StageCache:
         from dvc.fs.callbacks import Callback
 
         from_fs = from_odb.fs
-        to_fs = from_odb.fs
+        to_fs = to_odb.fs
         func = _log_exceptions(fs.generic.copy)
         runs = from_fs.path.join(from_odb.fs_path, "runs")
 

--- a/dvc/testing/test_run_cache.py
+++ b/dvc/testing/test_run_cache.py
@@ -1,0 +1,19 @@
+import shutil
+
+from .tmp_dir import TmpDir
+
+
+def test_push_pull(tmp_dir, dvc, remote):
+    tmp_dir.gen("foo", "foo")
+    stage = dvc.stage.add(
+        deps=["foo"], outs=["bar"], name="copy-foo-bar", cmd="cp foo bar"
+    )
+    dvc.reproduce(stage.addressing)
+    assert dvc.push(run_cache=True) == 2
+
+    stage_cache_dir = TmpDir(dvc.stage_cache.cache_dir)
+    expected = list(stage_cache_dir.rglob("*"))
+    shutil.rmtree(stage_cache_dir)
+
+    dvc.pull(run_cache=True)
+    assert list(stage_cache_dir.rglob("*")) == expected


### PR DESCRIPTION
Source filesystem was being used to transfer file to destination instead of the destination's filesystem.
This was working for LocalFileSystem as they work for any directories/path.
It's hard to test this these days, as we don't have remote tests inside dvc, so it was not caught.

Potentially fixes #7718.

* [x] Add a test.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
