### PR TITLE
dvc.objects.cache: set type in a more compatible way

### DIFF
--- a/dvc/data/db/index.py
+++ b/dvc/data/db/index.py
@@ -95,9 +95,7 @@ class ObjectDBIndex(ObjectDBIndexBase):
         self.index_dir = os.path.join(tmp_dir, self.INDEX_DIR, name)
         makedirs(self.index_dir, exist_ok=True)
         self.fs = LocalFileSystem()
-        cache = Cache(
-            self.index_dir, eviction_policy="none", disk_type="index"
-        )
+        cache = Cache(self.index_dir, eviction_policy="none", type="index")
         self.index = Index.fromcache(cache)
 
     def __iter__(self):

--- a/tests/unit/objects/test_cache.py
+++ b/tests/unit/objects/test_cache.py
@@ -17,7 +17,7 @@ def test_pickle_protocol_error(tmp_dir, disk_type):
     cache = Cache(
         directory,
         disk_pickle_protocol=pickle.HIGHEST_PROTOCOL + 1,
-        disk_type=disk_type,
+        type=disk_type,
     )
     with pytest.raises(DiskError) as exc, cache as cache:
         set_value(cache, "key", ("value1", "value2"))


### PR DESCRIPTION
It turns out that diskcache.Disk saves passed arguments to the database
and uses that all the time. So this means that we are not forward
compatible as it breaks moving from newer version of DVC to an older
one. We don't promise this, but this breaks our benchmarks which
are probably not isolated enough.

Regarding the use of cache, it is a bit iffy to extend it this way.
We only need this type for error messages (see https://error.dvc.org/pickle). We could consider removing
this, but since the error message is documented and it's not too hard
to extend this 😅, I decided to preserve the message.

Should fix failing test `test-pull` in https://github.com/iterative/dvc-bench/pull/347.
