### PR TITLE
dvc.objects.hash: return a string of the hash instead of an integer

### DIFF
--- a/dvc/objects/hash.py
+++ b/dvc/objects/hash.py
@@ -80,7 +80,7 @@ def _hash_file(
 
     if hasattr(fs, name):
         func = getattr(fs, name)
-        return func(fs_path), info
+        return f"{func(fs_path):032x}", info
 
     if name == "md5":
         return file_md5(fs_path, fs, callback=callback), info


### PR DESCRIPTION
I got the following error, so I fixed in order to proceed with I was doing. 


```
...
...
  File "/stuff/src/dvc/dvc/output.py", line 548, in save                                                                                                                                                            
    _, self.meta, obj = ostage(                                                                                                                                                                                     
  File "/stuff/src/dvc/dvc/data/stage.py", line 364, in stage                                                                                                                                                       
    _, meta, obj = _stage_file(                                                                                                                                                                                     
  File "/stuff/src/dvc/dvc/data/stage.py", line 58, in _stage_file                                                                                                                                                  
    meta, hash_info = hash_file(fs_path, fs, name, state=state)                                                                                                                                                     
  File "/stuff/src/dvc/dvc/objects/hash.py", line 133, in hash_file                                                                                                                                                 
    assert ".dir" not in hash_info.value                                                                  
TypeError: argument of type 'int' is not iterable                                                   

```