### PR TITLE
exp init: create output dirs

### DIFF
--- a/dvc/commands/experiments/init.py
+++ b/dvc/commands/experiments/init.py
@@ -61,7 +61,7 @@ class CmdExperimentsInit(CmdBase):
             }
         )
 
-        initialized_stage, initialized_deps = init(
+        initialized_stage, initialized_deps, initialized_out_dirs = init(
             self.repo,
             name=self.args.name,
             type=self.args.type,
@@ -70,13 +70,18 @@ class CmdExperimentsInit(CmdBase):
             interactive=self.args.interactive,
             force=self.args.force,
         )
-        self._post_init_display(initialized_stage, initialized_deps)
+        self._post_init_display(
+            initialized_stage, initialized_deps, initialized_out_dirs
+        )
         if self.args.run:
             self.repo.experiments.run(targets=[initialized_stage.addressing])
         return 0
 
     def _post_init_display(
-        self, stage: "PipelineStage", new_deps: List["Dependency"]
+        self,
+        stage: "PipelineStage",
+        new_deps: List["Dependency"],
+        new_out_dirs: List[str],
     ) -> None:
         from dvc.utils import humanize
 
@@ -84,6 +89,12 @@ class CmdExperimentsInit(CmdBase):
         if new_deps:
             deps_paths = humanize.join(map(path_fmt, new_deps))
             ui.write(f"Creating dependencies: {deps_paths}", styled=True)
+
+        if new_out_dirs:
+            out_dirs_paths = humanize.join(map(path_fmt, new_out_dirs))
+            ui.write(
+                f"Creating output directories: {out_dirs_paths}", styled=True
+            )
 
         ui.write(
             f"Creating [b]{self.args.name}[/b] stage in [green]dvc.yaml[/]",

--- a/tests/func/experiments/test_init.py
+++ b/tests/func/experiments/test_init.py
@@ -496,3 +496,24 @@ def test_init_with_live_and_metrics_plots_provided(
     }
     assert (tmp_dir / "src").is_dir()
     assert (tmp_dir / "data").is_dir()
+
+
+def test_gen_output_dirs(tmp_dir, dvc):
+    init(
+        dvc,
+        defaults=CmdExperimentsInit.DEFAULTS,
+        overrides={
+            "cmd": "cmd",
+            "models": "models/predict.h5",
+            "metrics": "eval/scores.json",
+            "plots": "eval/plots",
+            "live": "eval/live",
+        },
+    )
+
+    assert (tmp_dir / "models").is_dir()
+    assert (tmp_dir / "eval").is_dir()
+    assert (tmp_dir / "eval/plots").is_dir()
+    assert (tmp_dir / "eval/live").is_dir()
+    assert not (tmp_dir / "models/predict.h5").exists()
+    assert not (tmp_dir / "eval/scores.json").exists()


### PR DESCRIPTION
Related to https://github.com/iterative/dvc/pull/7740#issuecomment-1127631757.

This PR creates output directories (but not any files) during `dvc exp init`, which accomplishes:
1. Avoiding errors when trying to Git-ignore those outputs.
2. Making it easier for users to generate outputs without needing to generate the parent directories.

```console
$ dvc exp init --metrics eval.json --plots eval/scalars --models models/predict.h5 python train.py
Creating dependencies: src, data and params.yaml
Creating output directories: eval/scalars and models
Creating train stage in dvc.yaml

Ensure your experiment command creates eval.json, eval/scalars and models/predict.h5.
You can now run your experiment using "dvc exp run".
```
