### PR TITLE
exp queue: monitor queue status

### DIFF
--- a/dvc/commands/experiments/show.py
+++ b/dvc/commands/experiments/show.py
@@ -138,7 +138,7 @@ def _collect_rows(
         row_dict["Experiment"] = exp.get("name", "")
         row_dict["rev"] = name_rev
         row_dict["typ"] = typ
-        row_dict["Created"] = _format_time(
+        row_dict["Created"] = format_time(
             exp.get("timestamp"), fill_value, iso
         )
         row_dict["parent"] = parent
@@ -218,7 +218,7 @@ def _sort_exp(experiments, sort_path, sort_name, typ, reverse):
     return ret
 
 
-def _format_time(datetime_obj, fill_value=FILL_VALUE, iso=False):
+def format_time(datetime_obj, fill_value=FILL_VALUE, iso=False):
     if datetime_obj is None:
         return fill_value
 

--- a/dvc/commands/queue/__init__.py
+++ b/dvc/commands/queue/__init__.py
@@ -1,13 +1,15 @@
 import argparse
 
 from dvc.cli.utils import append_doc_link, fix_subparsers
-from dvc.commands.queue import kill, remove, start, stop
+from dvc.commands.queue import attach, kill, remove, start, status, stop
 
 SUB_COMMANDS = [
     remove,
     kill,
     start,
     stop,
+    attach,
+    status,
 ]
 
 

--- a/dvc/commands/queue/attach.py
+++ b/dvc/commands/queue/attach.py
@@ -1,0 +1,44 @@
+import argparse
+import logging
+
+from dvc.cli.command import CmdBase
+from dvc.cli.utils import append_doc_link
+
+logger = logging.getLogger(__name__)
+
+
+class CmdQueueAttach(CmdBase):
+    """Attach outputs of a exp task in queue."""
+
+    def run(self):
+        self.repo.experiments.celery_queue.attach(
+            rev=self.args.experiment,
+            encoding=self.args.encoding,
+        )
+
+        return 0
+
+
+def add_parser(queue_subparsers, parent_parser):
+    QUEUE_ATTACH_HELP = "Attach outputs of a experiment task in queue."
+    queue_attach_parser = queue_subparsers.add_parser(
+        "attach",
+        parents=[parent_parser],
+        description=append_doc_link(QUEUE_ATTACH_HELP, "queue/attach"),
+        help=QUEUE_ATTACH_HELP,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    queue_attach_parser.add_argument(
+        "-e",
+        "--encoding",
+        help=(
+            "Text encoding for redirected output. Defaults to"
+            "`locale.getpreferredencoding()`."
+        ),
+    )
+    queue_attach_parser.add_argument(
+        "experiment",
+        help="Experiments in queue to attach.",
+        metavar="<experiment>",
+    )
+    queue_attach_parser.set_defaults(func=CmdQueueAttach)

--- a/dvc/commands/queue/status.py
+++ b/dvc/commands/queue/status.py
@@ -1,0 +1,42 @@
+import argparse
+import logging
+from typing import List, Mapping, Optional
+
+from dvc.cli.command import CmdBase
+from dvc.cli.utils import append_doc_link
+from dvc.compare import TabularData
+
+from ..experiments.show import format_time
+
+logger = logging.getLogger(__name__)
+
+
+class CmdQueueStatus(CmdBase):
+    """Kill exp task in queue."""
+
+    def run(self):
+        result: List[
+            Mapping[str, Optional[str]]
+        ] = self.repo.experiments.celery_queue.status()
+        all_headers = ["Rev", "Name", "Created", "Status"]
+        td = TabularData(all_headers)
+        for exp in result:
+            created = format_time(exp.get("timestamp"))
+            td.append(
+                [exp["rev"], exp.get("name", ""), created, exp["status"]]
+            )
+        td.render()
+
+        return 0
+
+
+def add_parser(queue_subparsers, parent_parser):
+    QUEUE_STATUS_HELP = "List the status of the queue tasks and workers"
+    queue_status_parser = queue_subparsers.add_parser(
+        "status",
+        parents=[parent_parser],
+        description=append_doc_link(QUEUE_STATUS_HELP, "queue/status"),
+        help=QUEUE_STATUS_HELP,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    queue_status_parser.set_defaults(func=CmdQueueStatus)

--- a/dvc/repo/experiments/queue/local.py
+++ b/dvc/repo/experiments/queue/local.py
@@ -220,18 +220,14 @@ class LocalCeleryQueue(BaseStashQueue):
 
     def kill(self, revs: Collection[str]) -> None:
         to_kill: Set[QueueEntry] = set()
-        not_active: List[str] = []
         name_dict: Dict[
             str, Optional[QueueEntry]
-        ] = self.get_queue_entry_by_names(set(revs))
+        ] = self.match_queue_entry_by_name(set(revs), self.iter_active())
 
         missing_rev: List[str] = []
-        active_queue_entry = set(self.iter_active())
         for rev, queue_entry in name_dict.items():
             if queue_entry is None:
                 missing_rev.append(rev)
-            elif queue_entry not in active_queue_entry:
-                not_active.append(rev)
             else:
                 to_kill.add(queue_entry)
 
@@ -267,15 +263,11 @@ class LocalCeleryQueue(BaseStashQueue):
     ):
         from dvc.ui import ui
 
-        queue_entry: Optional[QueueEntry] = self.get_queue_entry_by_names(
-            {rev}
+        queue_entry: Optional[QueueEntry] = self.match_queue_entry_by_name(
+            {rev}, self.iter_active()
         ).get(rev)
         if queue_entry is None:
             raise UnresolvedExpNamesError([rev])
-        active_queue_entry = set(self.iter_active())
-        if queue_entry not in active_queue_entry:
-            ui.write("Cannot attach to an unstarted task")
-            return
         for line in self.proc.follow(queue_entry.stash_rev, encoding):
             ui.write(line)
 

--- a/dvc/repo/experiments/remove.py
+++ b/dvc/repo/experiments/remove.py
@@ -18,6 +18,7 @@ from .utils import (
 
 if TYPE_CHECKING:
     from dvc.repo import Repo
+    from dvc.repo.experiments.queue.local import LocalCeleryQueue
     from dvc.scm import Git
 
 
@@ -85,8 +86,10 @@ def _resolve_exp_by_name(
             commit_ref_dict[exp_ref] = exp_name
 
     if not git_remote:
-        _named_entries = (
-            repo.experiments.celery_queue.get_queue_entry_by_names(remained)
+        celery_queue: "LocalCeleryQueue" = repo.experiments.celery_queue
+
+        _named_entries = celery_queue.match_queue_entry_by_name(
+            remained, celery_queue.iter_queued(), celery_queue.iter_active()
         )
         for exp_name, entry in _named_entries.items():
             if entry is not None:

--- a/tests/unit/command/test_queue.py
+++ b/tests/unit/command/test_queue.py
@@ -1,7 +1,9 @@
 from dvc.cli import parse_args
+from dvc.commands.queue.attach import CmdQueueAttach
 from dvc.commands.queue.kill import CmdQueueKill
 from dvc.commands.queue.remove import CmdQueueRemove
 from dvc.commands.queue.start import CmdQueueStart
+from dvc.commands.queue.status import CmdQueueStatus
 from dvc.commands.queue.stop import CmdQueueStop
 
 
@@ -95,3 +97,43 @@ def test_experiments_stop(dvc, scm, mocker):
 
     assert cmd.run() == 0
     m.assert_called_once_with(kill=True)
+
+
+def test_experiments_status(dvc, scm, mocker):
+    cli_args = parse_args(
+        [
+            "queue",
+            "status",
+        ]
+    )
+    assert cli_args.func == CmdQueueStatus
+
+    cmd = cli_args.func(cli_args)
+    m = mocker.patch(
+        "dvc.repo.experiments.queue.local.LocalCeleryQueue.status",
+    )
+
+    assert cmd.run() == 0
+    m.assert_called_once_with()
+
+
+def test_experiments_attach(dvc, scm, mocker):
+    cli_args = parse_args(
+        [
+            "queue",
+            "attach",
+            "exp1",
+            "-e",
+            "utf8",
+        ]
+    )
+    assert cli_args.func == CmdQueueAttach
+
+    cmd = cli_args.func(cli_args)
+    m = mocker.patch(
+        "dvc.repo.experiments.queue.local.LocalCeleryQueue.attach",
+        return_value={},
+    )
+
+    assert cmd.run() == 0
+    m.assert_called_once_with(rev="exp1", encoding="utf8")


### PR DESCRIPTION
fix: #7590
1. Add two new command `queue status` and `queue attach`
2. Add unit test for the CLI

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Status is too complex for a CLI PR. Would implement this part later. 