### PR TITLE
objects.fs: use getpass for prompts

### DIFF
--- a/dvc/objects/fs/implementations/http.py
+++ b/dvc/objects/fs/implementations/http.py
@@ -1,9 +1,9 @@
 import threading
+from getpass import getpass
 from typing import BinaryIO, Union
 
 from funcy import cached_property, memoize, wrap_with
 
-from dvc import prompt
 from dvc.scheme import Schemes
 
 from .._callback import DEFAULT_CALLBACK, FsspecCallback
@@ -13,10 +13,7 @@ from ..base import AnyFSPath, FileSystem
 @wrap_with(threading.Lock())
 @memoize
 def ask_password(host, user):
-    return prompt.password(
-        "Enter a password for "
-        "host '{host}' user '{user}'".format(host=host, user=user)
-    )
+    return getpass(f"Enter a password for host '{host}' user '{user}':\n")
 
 
 def make_context(ssl_verify):

--- a/dvc/objects/fs/implementations/ssh.py
+++ b/dvc/objects/fs/implementations/ssh.py
@@ -4,7 +4,6 @@ import threading
 
 from funcy import cached_property, memoize, silent, wrap_prop, wrap_with
 
-from dvc import prompt
 from dvc.scheme import Schemes
 
 from .._callback import DEFAULT_CALLBACK
@@ -17,11 +16,9 @@ DEFAULT_PORT = 22
 @wrap_with(threading.Lock())
 @memoize
 def ask_password(host, user, port):
-    return prompt.password(
+    return getpass.getpass(
         "Enter a private key passphrase or a password for "
-        "host '{host}' port '{port}' user '{user}'".format(
-            host=host, port=port, user=user
-        )
+        f"host '{host}' port '{port}' user '{user}':\n"
     )
 
 


### PR DESCRIPTION
Note that this will change the behaviour of DVC to always show
prompt even in --quiet mode, which is what we need.
Previously it'd prompt without any message.

I am trying to reduce dependency in DVC.
