### PR TITLE
objects.fs: use split in Path.name

### DIFF
--- a/dvc/objects/fs/path.py
+++ b/dvc/objects/fs/path.py
@@ -80,7 +80,7 @@ class Path:
         )
 
     def name(self, path):
-        return self.parts(path)[-1]
+        return self.flavour.basename(path)
 
     def suffix(self, path):
         name = self.name(path)


### PR DESCRIPTION
calling `parts()` to get name requires a lot of unnecessary splitting, which quickly adds up when dealing with large datasets.