### PR TITLE
objects.fs: do not use format_link, DvcException and fix_env from DVC

### DIFF
--- a/dvc/fs/__init__.py
+++ b/dvc/fs/__init__.py
@@ -24,9 +24,10 @@ from dvc.objects.fs import (  # noqa: F401
     get_fs_config,
     system,
 )
-from dvc.objects.fs.base import (  # noqa: F401
-    AnyFSPath,
-    FileSystem,
+from dvc.objects.fs.base import AnyFSPath, FileSystem  # noqa: F401
+from dvc.objects.fs.errors import (  # noqa: F401
+    AuthError,
+    ConfigError,
     RemoteMissingDepsError,
 )
 from dvc.objects.fs.implementations.azure import AzureAuthError  # noqa: F401

--- a/dvc/objects/fs/base.py
+++ b/dvc/objects/fs/base.py
@@ -21,6 +21,7 @@ from funcy import cached_property
 
 from ..executors import ThreadPoolExecutor
 from ._callback import DEFAULT_CALLBACK, FsspecCallback
+from .errors import RemoteMissingDepsError
 
 if TYPE_CHECKING:
     from typing import BinaryIO, TextIO
@@ -48,23 +49,6 @@ class LinkError(OSError):
             errno.EPERM,
             f"{link} is not supported for {fs.protocol} by {type(fs)}",
             path,
-        )
-
-
-class RemoteMissingDepsError(Exception):
-    def __init__(
-        self,
-        fs: "FileSystem",
-        protocol: str,
-        url: str,
-        missing: List[str] = None,
-    ) -> None:
-        self.protocol = protocol
-        self.fs = fs
-        self.url = url
-        self.missing_deps = missing or []
-        super().__init__(
-            f"filesystem for '{protocol}': '{type(fs)}' missing dependencies"
         )
 
 

--- a/dvc/objects/fs/errors.py
+++ b/dvc/objects/fs/errors.py
@@ -1,0 +1,29 @@
+from typing import TYPE_CHECKING, List
+
+if TYPE_CHECKING:
+    from .base import FileSystem
+
+
+class AuthError(Exception):
+    pass
+
+
+class ConfigError(Exception):
+    pass
+
+
+class RemoteMissingDepsError(Exception):
+    def __init__(
+        self,
+        fs: "FileSystem",
+        protocol: str,
+        url: str,
+        missing: List[str] = None,
+    ) -> None:
+        self.protocol = protocol
+        self.fs = fs
+        self.url = url
+        self.missing_deps = missing or []
+        super().__init__(
+            f"filesystem for '{protocol}': '{type(fs)}' missing dependencies"
+        )

--- a/dvc/objects/fs/implementations/azure.py
+++ b/dvc/objects/fs/implementations/azure.py
@@ -6,10 +6,8 @@ from fsspec.asyn import fsspec_loop
 from fsspec.utils import infer_storage_options
 from funcy import cached_property, memoize, wrap_prop
 
-from dvc.exceptions import DvcException
-from dvc.utils import format_link
-
 from ..base import ObjectFileSystem
+from ..errors import AuthError
 
 logger = logging.getLogger(__name__)
 _DEFAULT_CREDS_STEPS = (
@@ -19,7 +17,7 @@ _DEFAULT_CREDS_STEPS = (
 )
 
 
-class AzureAuthError(DvcException):
+class AzureAuthError(AuthError):
     pass
 
 
@@ -91,9 +89,7 @@ class AzureFileSystem(ObjectFileSystem):
         if not (login_info["account_name"] or login_info["connection_string"]):
             raise AzureAuthError(
                 "Authentication to Azure Blob Storage requires either "
-                "account_name or connection_string.\nLearn more about "
-                "configuration settings at "
-                + format_link("https://man.dvc.org/remote/modify")
+                "account_name or connection_string."
             )
 
         any_secondary = any(
@@ -154,6 +150,5 @@ class AzureFileSystem(ObjectFileSystem):
         except (ValueError, AzureError) as e:
             raise AzureAuthError(
                 f"Authentication to Azure Blob Storage via {self.login_method}"
-                " failed.\nLearn more about configuration settings at"
-                f" {format_link('https://man.dvc.org/remote/modify')}"
+                " failed."
             ) from e

--- a/dvc/objects/fs/implementations/hdfs.py
+++ b/dvc/objects/fs/implementations/hdfs.py
@@ -1,15 +1,26 @@
 import os
 import re
 import subprocess
+import sys
 import threading
 
 from funcy import cached_property, wrap_prop
 
-from dvc.utils import fix_env
-
 from ..base import FileSystem
 
 CHECKSUM_REGEX = re.compile(r".*\t.*\t(?P<checksum>.*)")
+
+
+def fix_env():
+    env = os.environ.copy()
+    if getattr(sys, "frozen", False):
+        lp_key = "LD_LIBRARY_PATH"
+        lp_orig = env.get(lp_key + "_ORIG", None)
+        if lp_orig is not None:
+            env[lp_key] = lp_orig
+        else:
+            env.pop(lp_key, None)
+    return env
 
 
 # pylint: disable=abstract-method
@@ -58,7 +69,7 @@ class HDFSFileSystem(FileSystem):
 
         result = self._run_command(
             f"checksum {url}",
-            env=fix_env(os.environ),
+            env=fix_env(),
             user=self.fs_args.get("user"),
         )
         if result is None:

--- a/dvc/objects/fs/implementations/http.py
+++ b/dvc/objects/fs/implementations/http.py
@@ -6,6 +6,7 @@ from funcy import cached_property, memoize, wrap_with
 
 from .._callback import DEFAULT_CALLBACK, FsspecCallback
 from ..base import AnyFSPath, FileSystem
+from ..errors import ConfigError
 
 
 @wrap_with(threading.Lock())
@@ -41,8 +42,6 @@ class HTTPFileSystem(FileSystem):
     def _prepare_credentials(self, **config):
         import aiohttp
         from fsspec.asyn import fsspec_loop
-
-        from dvc.config import ConfigError
 
         credentials = {}
         client_kwargs = credentials.setdefault("client_kwargs", {})

--- a/dvc/objects/fs/implementations/s3.py
+++ b/dvc/objects/fs/implementations/s3.py
@@ -5,6 +5,8 @@ from collections import defaultdict
 from funcy import cached_property, wrap_prop
 
 from ..base import ObjectFileSystem
+from ..errors import ConfigError
+from ..utils import flatten, unflatten
 
 _AWS_CONFIG_PATH = os.path.join(os.path.expanduser("~"), ".aws", "config")
 
@@ -72,9 +74,6 @@ class S3FileSystem(ObjectFileSystem):
         return self._split_s3_config(s3_config)
 
     def _prepare_credentials(self, **config):
-        from dvc.config import ConfigError
-        from dvc.utils.flatten import flatten, unflatten
-
         login_info = defaultdict(dict)
 
         # credentials

--- a/dvc/objects/fs/utils.py
+++ b/dvc/objects/fs/utils.py
@@ -236,3 +236,15 @@ def human_readable_to_bytes(value: str) -> int:
 
     multiplier = MULTIPLIERS.get(suffix, 1)
     return int(value) * multiplier
+
+
+def flatten(d):
+    import flatten_dict
+
+    return flatten_dict.flatten(d, reducer="dot")
+
+
+def unflatten(d):
+    import flatten_dict
+
+    return flatten_dict.unflatten(d, splitter="dot")

--- a/tests/unit/fs/test_s3.py
+++ b/tests/unit/fs/test_s3.py
@@ -2,8 +2,7 @@ import os
 
 import pytest
 
-from dvc.config import ConfigError
-from dvc.fs import S3FileSystem
+from dvc.fs import ConfigError, S3FileSystem
 
 bucket_name = "bucket-name"
 prefix = "some/prefix"


### PR DESCRIPTION
* Introduce ConfigError and AuthError in dvc.objects.fs and raise it
  instead of dvc.config.ConfigError.
* Provide hints and links by catching those errors in dvc.cli.main,
  i.e decouple UI messages from filesystems for AuthError and
  ConfigError.
* Copy flatten/unflatten utils to dvc.objects.fs.utils.
* Avoid `format_link` and `fix_env` in filesystems.