### PR TITLE
dvc.objects: use stub ignore in dvc.objects/dvc.data

### DIFF
--- a/dvc/data/checkout.py
+++ b/dvc/data/checkout.py
@@ -1,10 +1,9 @@
 import logging
 from itertools import chain
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from dvc import prompt
 from dvc.exceptions import CacheLinkError, CheckoutError, ConfirmRemoveError
-from dvc.ignore import DvcIgnoreFilter
 from dvc.objects.fs._callback import FsspecCallback
 from dvc.objects.fs.generic import test_links, transfer
 
@@ -12,6 +11,9 @@ from .diff import ROOT
 from .diff import diff as odiff
 from .slow_link_detection import slow_link_guard  # type: ignore[attr-defined]
 from .stage import stage
+
+if TYPE_CHECKING:
+    from dvc.objects._ignore import Ignore
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +103,7 @@ def _diff(
     obj,
     cache,
     relink=False,
-    dvcignore: Optional[DvcIgnoreFilter] = None,
+    ignore: Optional["Ignore"] = None,
 ):
     old = None
     try:
@@ -111,7 +113,7 @@ def _diff(
             fs,
             obj.hash_info.name if obj else cache.fs.PARAM_CHECKSUM,
             dry_run=True,
-            dvcignore=dvcignore,
+            ignore=ignore,
         )
     except FileNotFoundError:
         pass
@@ -220,7 +222,7 @@ def checkout(
     progress_callback=None,
     relink=False,
     quiet=False,
-    dvcignore: Optional[DvcIgnoreFilter] = None,
+    ignore: Optional["Ignore"] = None,
     state=None,
 ):
     # if protocol(fs_path) not in ["local", cache.fs.protocol]:
@@ -232,7 +234,7 @@ def checkout(
         obj,
         cache,
         relink=relink,
-        dvcignore=dvcignore,
+        ignore=ignore,
     )
 
     failed = []

--- a/dvc/dependency/repo.py
+++ b/dvc/dependency/repo.py
@@ -72,7 +72,7 @@ class RepoDependency(Dependency):
             to.fs,
             obj,
             self.repo.odb.local,
-            dvcignore=None,
+            ignore=None,
             state=self.repo.state,
         )
 

--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -202,14 +202,6 @@ class FileMissingError(DvcException):
         )
 
 
-class DvcIgnoreInCollectedDirError(DvcException):
-    def __init__(self, ignore_dirname):
-        super().__init__(
-            ".dvcignore file should not be in collected dir path: "
-            "'{}'".format(ignore_dirname)
-        )
-
-
 class FileTransferError(DvcException):
     _METHOD = "transfer"
 

--- a/dvc/objects/_ignore.py
+++ b/dvc/objects/_ignore.py
@@ -1,0 +1,11 @@
+from typing import TYPE_CHECKING, Iterator, Protocol
+
+if TYPE_CHECKING:
+    from .fs.base import AnyFSPath, FileSystem
+
+
+class Ignore(Protocol):
+    def find(
+        self, fs: "FileSystem", path: "AnyFSPath"
+    ) -> Iterator["AnyFSPath"]:
+        ...

--- a/dvc/objects/utils.py
+++ b/dvc/objects/utils.py
@@ -4,11 +4,12 @@ import json
 from typing import TYPE_CHECKING, Tuple
 
 if TYPE_CHECKING:
+    from ._ignore import Ignore
     from .fs.base import AnyFSPath, FileSystem
 
 
 def get_mtime_and_size(
-    path: "AnyFSPath", fs: "FileSystem", dvcignore=None
+    path: "AnyFSPath", fs: "FileSystem", ignore: "Ignore" = None
 ) -> Tuple[str, int]:
     import nanotime
 
@@ -20,8 +21,8 @@ def get_mtime_and_size(
 
     size = 0
     files_mtimes = {}
-    if dvcignore:
-        walk_iterator = dvcignore.find(fs, path)
+    if ignore:
+        walk_iterator = ignore.find(fs, path)
     else:
         walk_iterator = fs.find(path)
     for file_path in walk_iterator:

--- a/dvc/output.py
+++ b/dvc/output.py
@@ -430,7 +430,7 @@ class Output:
             self.fs_path,
             self.fs,
             name,
-            dvcignore=self.dvcignore,
+            ignore=self.dvcignore,
             dry_run=not self.use_cache,
         )
         return obj.hash_info
@@ -552,7 +552,7 @@ class Output:
                 self.fs_path,
                 self.fs,
                 self.fs.PARAM_CHECKSUM,
-                dvcignore=self.dvcignore,
+                ignore=self.dvcignore,
                 dry_run=True,
             )
             self.hash_info = obj.hash_info
@@ -569,7 +569,7 @@ class Output:
             self.fs_path,
             self.fs,
             self.odb.fs.PARAM_CHECKSUM,
-            dvcignore=self.dvcignore,
+            ignore=self.dvcignore,
         )
         self.hash_info = self.obj.hash_info
 
@@ -597,7 +597,7 @@ class Output:
                     filter_info or self.fs_path,
                     self.fs,
                     self.odb.fs.PARAM_CHECKSUM,
-                    dvcignore=self.dvcignore,
+                    ignore=self.dvcignore,
                 )
                 otransfer(
                     staging,
@@ -612,7 +612,7 @@ class Output:
                 obj,
                 self.odb,
                 relink=True,
-                dvcignore=self.dvcignore,
+                ignore=self.dvcignore,
                 state=self.repo.state,
             )
             self.set_exec()
@@ -626,7 +626,7 @@ class Output:
             self.fs_path,
             self.fs,
             self.odb.fs.PARAM_CHECKSUM,
-            dvcignore=self.dvcignore,
+            ignore=self.dvcignore,
         )
         save_obj = save_obj.filter(prefix)
         checkout_obj = save_obj.get(self.odb, prefix)

--- a/dvc/repo/diff.py
+++ b/dvc/repo/diff.py
@@ -142,7 +142,7 @@ def _output_paths(repo, targets):
                     repo.odb.local.fs,
                     "md5",
                     dry_run=True,
-                    dvcignore=output.dvcignore,
+                    ignore=output.dvcignore,
                 )
                 hash_info = obj.hash_info
             else:

--- a/tests/func/test_external_repo.py
+++ b/tests/func/test_external_repo.py
@@ -209,7 +209,7 @@ def test_subrepos_are_ignored(tmp_dir, erepo_dir):
             "dir",
             repo.dvcfs,
             "md5",
-            dvcignore=repo.dvcignore,
+            ignore=repo.dvcignore,
         )
         transfer(
             staging,

--- a/tests/func/test_ignore.py
+++ b/tests/func/test_ignore.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from dvc.exceptions import DvcIgnoreInCollectedDirError
+from dvc.data.stage import IgnoreInCollectedDirError
 from dvc.ignore import DvcIgnore, DvcIgnorePatterns
 from dvc.objects.utils import get_mtime_and_size
 from dvc.output import OutputIsIgnoredError
@@ -87,7 +87,7 @@ def test_remove_file(tmp_dir, dvc):
 def test_dvcignore_in_out_dir(tmp_dir, dvc):
     tmp_dir.gen({"dir": {"foo": "foo", DvcIgnore.DVCIGNORE_FILE: ""}})
 
-    with pytest.raises(DvcIgnoreInCollectedDirError):
+    with pytest.raises(IgnoreInCollectedDirError):
         dvc.add("dir")
 
 

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -4,6 +4,7 @@ import pytest
 from funcy import raiser
 
 from dvc.cli import main
+from dvc.data.stage import IgnoreInCollectedDirError
 from dvc.objects.cache import DiskError
 from dvc.objects.fs.base import FileSystem, RemoteMissingDepsError
 
@@ -67,4 +68,19 @@ def test_remote_missing_deps_are_correctly_reported(
             "<https://github.com/iterative/dvc/issues>. "
             "Thank you!"
         )
+    assert expected in caplog.text
+
+
+def test_ignore_in_collected_dir_error_is_logged(tmp_dir, caplog, mocker):
+    error = IgnoreInCollectedDirError(".dvcignore", "dir")
+    mocker.patch(
+        "dvc.cli.parse_args",
+        return_value=Namespace(
+            func=raiser(error),
+            quiet=False,
+            verbose=True,
+        ),
+    )
+    assert main() == 255
+    expected = ".dvcignore file should not be in collected dir path: 'dir'"
     assert expected in caplog.text


### PR DESCRIPTION
This PR:
* defines a `Ignore` protocol in `dvc.objects`, that expects a `find` method.
  This will be used in dvc-data and dvc-objects instead of depending on dvc.ignore.
  dvcignore is expected to respect this protocol, which it does.
* renames `dvcignore` kwarg to `ignore` in `dvc-data` and `dvc-objects`.
* teaches dvc.cli that `IgnoreInCollectedError` is a known exception
   and is logged correctly and adds a test for the behaviour.

I am not happy that we need to hardcode `.dvcignore` in dvc-objects
but I don't see any easy way, since we always try to avoid
staging if the tree contains .dvcignore file, even if .dvcignore
is not passed.