### PR TITLE
dvc.data: use own internal error instead of DvcException

### DIFF
--- a/dvc/data/db/local.py
+++ b/dvc/data/db/local.py
@@ -7,7 +7,7 @@ from funcy import cached_property
 from shortuuid import uuid
 
 from dvc.objects.db import ObjectDB, noop, wrap_iter
-from dvc.objects.errors import ObjectFormatError
+from dvc.objects.errors import ObjectDBError, ObjectFormatError
 from dvc.objects.fs.system import umask
 from dvc.objects.fs.utils import copyfile, relpath, remove, walk_files
 from dvc.objects.hash_info import HashInfo
@@ -125,9 +125,7 @@ class LocalObjectDB(ObjectDB):
 
     def unprotect(self, fs_path):
         if not os.path.exists(fs_path):
-            from dvc.exceptions import DvcException
-
-            raise DvcException(
+            raise ObjectDBError(
                 f"can't unprotect non-existing data '{fs_path}'"
             )
 

--- a/dvc/data/transfer.py
+++ b/dvc/data/transfer.py
@@ -18,6 +18,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class TransferError(Exception):
+    def __init__(self, fails: int) -> None:
+        self.fails = fails
+        super().__init__(f"{fails} transfer failed")
+
+
 def _log_exceptions(func):
     @wraps(func)
     def wrapper(fs_path, *args, **kwargs):
@@ -64,8 +70,6 @@ def _do_transfer(
     cache_odb: Optional["ObjectDB"] = None,
     **kwargs: Any,
 ):
-    from dvc.exceptions import FileTransferError
-
     dir_ids, file_ids = split(lambda hash_info: hash_info.isdir, obj_ids)
     total_fails = 0
     succeeded_dir_objs = []
@@ -113,7 +117,7 @@ def _do_transfer(
     if total_fails:
         if src_index:
             src_index.clear()
-        raise FileTransferError(total_fails)
+        raise TransferError(total_fails)
 
     # index successfully pushed dirs
     if dest_index:

--- a/dvc/data/tree.py
+++ b/dvc/data/tree.py
@@ -21,6 +21,10 @@ class TreeError(Exception):
     pass
 
 
+class MergeError(Exception):
+    pass
+
+
 def _try_load(
     odbs: Iterable["ObjectDB"],
     hash_info: "HashInfo",
@@ -231,8 +235,6 @@ def du(odb, tree):
 
 def _diff(ancestor, other, allow_removed=False):
     from dictdiffer import diff
-
-    from dvc.exceptions import MergeError
 
     allowed = ["add"]
     if allow_removed:

--- a/dvc/output.py
+++ b/dvc/output.py
@@ -1027,6 +1027,7 @@ class Output:
             )
 
     def merge(self, ancestor, other):
+        from dvc.data.tree import MergeError as TreeMergeError
         from dvc.data.tree import du, merge
 
         assert other
@@ -1040,9 +1041,13 @@ class Output:
         self._check_can_merge(self)
         self._check_can_merge(other)
 
-        merged = merge(
-            self.odb, ancestor_info, self.hash_info, other.hash_info
-        )
+        try:
+            merged = merge(
+                self.odb, ancestor_info, self.hash_info, other.hash_info
+            )
+        except TreeMergeError as exc:
+            raise MergeError(str(exc)) from exc
+
         self.odb.add(merged.fs_path, merged.fs, merged.hash_info)
 
         self.hash_info = merged.hash_info

--- a/tests/func/test_remove.py
+++ b/tests/func/test_remove.py
@@ -3,8 +3,8 @@ import os
 import pytest
 
 from dvc.cli import main
-from dvc.exceptions import DvcException
 from dvc.fs import system
+from dvc.objects.errors import ObjectDBError
 from dvc.stage.exceptions import StageFileDoesNotExistError
 from dvc.utils.fs import remove
 from tests.utils import get_gitignore_content
@@ -47,7 +47,7 @@ def test_remove_broken_symlink(tmp_dir, dvc):
     remove(dvc.odb.local.cache_dir)
     assert system.is_symlink("foo")
 
-    with pytest.raises(DvcException):
+    with pytest.raises(ObjectDBError):
         dvc.remove(stage.addressing)
     assert os.path.lexists("foo")
     assert (tmp_dir / stage.relpath).exists()


### PR DESCRIPTION
transfer raises internal TransferError, merge raises internal MergeError
and local ODB raises ODBError on unprotect.
transfer's error is reraised to FileTransferError back in DataCloud.