### PR TITLE
data/objects: reduce log levels in dvc-objects and dvc-data

### DIFF
--- a/dvc/data/gc.py
+++ b/dvc/data/gc.py
@@ -1,8 +1,8 @@
 def gc(odb, used, jobs=None, cache_odb=None, shallow=True):
-    from dvc.data.tree import Tree
     from dvc.objects.errors import ObjectDBPermissionError
 
     from ._progress import QueryingProgress
+    from .tree import Tree
 
     if odb.read_only:
         raise ObjectDBPermissionError("Cannot gc read-only ODB")

--- a/dvc/data/status.py
+++ b/dvc/data/status.py
@@ -160,7 +160,6 @@ def compare_status(
     src: "ObjectDB",
     dest: "ObjectDB",
     obj_ids: Iterable["HashInfo"],
-    log_missing: bool = True,
     check_deleted: bool = True,
     src_index: Optional["ObjectDBIndexBase"] = None,
     dest_index: Optional["ObjectDBIndexBase"] = None,
@@ -189,19 +188,9 @@ def compare_status(
     else:
         src_exists = dest_exists
         src_missing = set()
-    result = CompareStatusResult(
+    return CompareStatusResult(
         src_exists & dest_exists,
         src_missing & dest_missing,
         src_exists - dest_exists,
         dest_exists - src_exists,
     )
-    if log_missing and result.missing:
-        missing_desc = "\n".join(
-            f"name: {hash_info.obj_name}, {hash_info}"
-            for hash_info in result.missing
-        )
-        logger.warning(
-            "Some of the cache files do not exist neither locally "
-            f"nor on remote. Missing cache files:\n{missing_desc}"
-        )
-    return result

--- a/dvc/data/tree.py
+++ b/dvc/data/tree.py
@@ -153,7 +153,7 @@ class Tree(HashFile):
             raise ObjectFormatError(f"{obj} is corrupted") from exc
 
         if not isinstance(raw, list):
-            logger.error(
+            logger.debug(
                 "dir cache file format error '%s' [skipping the file]",
                 obj.fs_path,
             )

--- a/dvc/objects/db.py
+++ b/dvc/objects/db.py
@@ -197,7 +197,7 @@ class ObjectDB:
         try:
             obj.check(self, check_hash=check_hash)
         except ObjectFormatError:
-            logger.warning("corrupted cache file '%s'.", obj.fs_path)
+            logger.debug("corrupted cache file '%s'.", obj.fs_path)
             with suppress(FileNotFoundError):
                 self.fs.remove(obj.fs_path)
             raise


### PR DESCRIPTION
Also introduces a `validate_status` kwarg in `data.transfer`,
which is used in DVC to log for missing version info. Just leaving as is was making some tests flaky in DVC, so I had to engineer this hack. 🥲 

We still have two warnings:

https://github.com/iterative/dvc/blob/82dc67d8909611048ab6839a68475d4c659516ac/dvc/data/checkout.py#L264-L267
https://github.com/iterative/dvc/blob/82dc67d8909611048ab6839a68475d4c659516ac/dvc/objects/fs/implementations/gdrive.py#L149-L154

I have left them out, and was not able to figure out some way to avoid these.