### PR TITLE
exp: speed up repro execution with untracked directories in workspace

### DIFF
--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -196,7 +196,7 @@ class Experiments:
                             branch_name = ExpRefInfo.from_ref(branch).name
                         else:
                             branch_name = f"{resume_rev[:7]}"
-                        if self.scm.is_dirty():
+                        if self.scm.is_dirty(untracked_files=False):
                             logger.info(
                                 "Modified checkpoint experiment based on "
                                 "'%s' will be created",
@@ -398,7 +398,7 @@ class Experiments:
             self.reset_checkpoints()
 
         if not (queue or tmp_dir or machine):
-            staged, _, _ = self.scm.status()
+            staged, _, _ = self.scm.status(untracked_files="no")
             if staged:
                 logger.warning(
                     "Your workspace contains staged Git changes which will be "

--- a/dvc/repo/experiments/executor/base.py
+++ b/dvc/repo/experiments/executor/base.py
@@ -640,7 +640,7 @@ class BaseExecutor(ABC):
     ):
         """Commit stages as an experiment and return the commit SHA."""
         rev = scm.get_rev()
-        if not scm.is_dirty():
+        if not scm.is_dirty(untracked_files=False):
             logger.debug("No changes to commit")
             raise UnchangedExperimentError(rev)
 

--- a/dvc/repo/plots/diff.py
+++ b/dvc/repo/plots/diff.py
@@ -5,7 +5,7 @@ def _revisions(repo, revs, experiment):
         if baseline:
             revisions.append(baseline[:7])
     if len(revisions) <= 1:
-        if len(revisions) == 0 and repo.scm.is_dirty():
+        if len(revisions) == 0 and repo.scm.is_dirty(untracked_files=False):
             revisions.append("HEAD")
         revisions.append("workspace")
     return revisions


### PR DESCRIPTION
When large untracked directories are present in the workspace, a lot of time is spent collecting untracked files in `scm.status` and `scm.is_dirty` (which also calls `status`). `scmrepo==0.0.23` adds `untracked_files=no` flag which avoids collecting untracked files.


