### PR TITLE
formatting/isort: consider dvc-render as a known first party for ordering imports

### DIFF
--- a/dvc/commands/plots.py
+++ b/dvc/commands/plots.py
@@ -38,9 +38,8 @@ class CmdPlots(CmdBase):
     def run(self):
         from pathlib import Path
 
-        from dvc_render import render_html
-
         from dvc.render.match import match_renderers
+        from dvc_render import render_html
 
         if self.args.show_vega:
             if not self.args.targets:

--- a/dvc/render/match.py
+++ b/dvc/render/match.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Dict, List, Optional
 
 import dpath.util
+
 from dvc_render import RENDERERS
 
 from .convert import to_datapoints

--- a/dvc/repo/plots/__init__.py
+++ b/dvc/repo/plots/__init__.py
@@ -196,9 +196,8 @@ class Plots:
             out.plot.pop(prop)
 
     def modify(self, path, props=None, unset=None):
-        from dvc_render.vega_templates import get_template
-
         from dvc.dvcfile import Dvcfile
+        from dvc_render.vega_templates import get_template
 
         props = props or {}
         template = props.get("template")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ exclude = '''
 
 [tool.isort]
 profile = "black"
-known_first_party = ["dvc", "dvc_data", "dvc_objects", "tests"]
+known_first_party = ["dvc", "dvc_data", "dvc_objects", "dvc_render", "tests"]
 line_length = 79
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
As per the title