### PR TITLE
exp: implement `celery_queue.shutdown(kill=...)`

### DIFF
--- a/dvc/repo/experiments/queue/base.py
+++ b/dvc/repo/experiments/queue/base.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass(frozen=True)
 class QueueEntry:
     dvc_root: str
     scm_root: str

--- a/dvc/repo/experiments/queue/local.py
+++ b/dvc/repo/experiments/queue/local.py
@@ -239,7 +239,7 @@ class LocalCeleryQueue(BaseStashQueue):
             raise UnresolvedExpNamesError(missing_rev)
 
         for queue_entry in to_kill:
-            self.proc.kill(queue_entry.name)
+            self.proc.kill(queue_entry.stash_rev)
 
     def _shutdown_handler(self, task_id: str = None, **kwargs):
         if task_id in self._shutdown_task_ids:
@@ -250,13 +250,14 @@ class LocalCeleryQueue(BaseStashQueue):
     def shutdown(self, kill: bool = False):
         from celery.signals import task_postrun
 
-        if kill:
-            raise NotImplementedError
         tasks = list(self._iter_active_tasks())
         if tasks:
             for task_id, _ in tasks:
                 self._shutdown_task_ids.add(task_id)
             task_postrun.connect()(self._shutdown_handler)
+            if kill:
+                for _, task_entry in tasks:
+                    self.proc.kill(task_entry.stash_rev)
         else:
             self.celery.control.shutdown()
 


### PR DESCRIPTION
1. Add some more unit test for `celery_queue.kill`
2. Implement `kill` argument for `celery_queue.shutdown`

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
