### PR TITLE
exp list: fix git_remote metavar

### DIFF
--- a/dvc/commands/experiments/ls.py
+++ b/dvc/commands/experiments/ls.py
@@ -59,6 +59,6 @@ def add_parser(experiments_subparsers, parent_parser):
             "If provided, experiments from the specified Git repository "
             " will be listed instead of local ones."
         ),
-        metavar="[<git_remote>]",
+        metavar="<git_remote>",
     )
     experiments_list_parser.set_defaults(func=CmdExperimentsList)


### PR DESCRIPTION
Before:

```console
$ dvc exp list --help
usage: dvc experiments list [-h] [-q | -v] [-A] [--rev <commit>] [-n <num>]
                            [--name-only]
                            [[<git_remote>]]

List local and remote experiments.
Documentation: <https://man.dvc.org/exp/list>

positional arguments:
  [<git_remote>]        Optional Git remote name or Git URL. If provided, experiments
                        from the specified Git repository will be listed instead of
                        local ones.
```

After:

```console
$ dvc exp list --help
usage: dvc experiments list [-h] [-q | -v] [-A] [--rev <commit>] [-n <num>]
                            [--name-only]
                            [<git_remote>]

List local and remote experiments.
Documentation: <https://man.dvc.org/exp/list>

positional arguments:
  <git_remote>          Optional Git remote name or Git URL. If provided, experiments
                        from the specified Git repository will be listed instead of
                        local ones.
```