### PR TITLE
plots: grouping: stop using dpath.util.search

### DIFF
--- a/dvc/render/match.py
+++ b/dvc/render/match.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, Optional
 
 import dpath.util
 
@@ -10,20 +10,18 @@ if TYPE_CHECKING:
     from dvc.types import StrPath
 
 
-def get_files(plots_data: Dict) -> List:
-    files = set()
-    for rev in plots_data.keys():
-        for file in plots_data[rev].get("data", {}).keys():
-            files.add(file)
-    sorted_files = sorted(files)
-    return sorted_files
-
-
 def group_by_filename(plots_data: Dict) -> Dict:
-    files = get_files(plots_data)
-    grouped = {
-        file: dpath.util.search(plots_data, ["*", "*", file]) for file in files
-    }
+    grouped: Dict[str, Dict] = {}
+
+    for revision in plots_data.keys():
+        data = plots_data[revision].get("data", {})
+        for file in data.keys():
+            content = data.get(file)
+            if content:
+                dpath.util.new(
+                    grouped, [file, revision, "data", file], content
+                )
+
     return grouped
 
 

--- a/tests/func/test_live.py
+++ b/tests/func/test_live.py
@@ -6,7 +6,6 @@ import pytest
 from funcy import first
 
 from dvc import stage as stage_module
-from dvc.render.match import get_files
 
 pytest.importorskip("dvclive", reason="no dvclive")
 
@@ -122,7 +121,7 @@ def test_live_provides_metrics(tmp_dir, dvc, live_stage):
 
     assert (tmp_dir / "logs").is_dir()
     plots_data = dvc.plots.show()
-    files = get_files(plots_data)
+    files = list(plots_data["workspace"]["data"])
     assert os.path.join("logs", "scalars", "accuracy.tsv") in files
     assert os.path.join("logs", "scalars", "loss.tsv") in files
     assert os.path.join("logs", "images", "0", "image.jpg") in files

--- a/tests/unit/render/test_match.py
+++ b/tests/unit/render/test_match.py
@@ -1,20 +1,8 @@
 from dvc.render.match import (
-    get_files,
     group_by_filename,
     match_renderers,
     squash_plots_properties,
 )
-
-
-def test_get_files_on_error():
-    plots_data = {
-        "v2": {"error": "ERROR"},
-        "v1": {
-            "data": {"file.json": {"data": [{"y": 2}, {"y": 3}], "props": {}}}
-        },
-    }
-    files = get_files(plots_data)
-    assert files == ["file.json"]
 
 
 def test_group_by_filename():

--- a/tests/unit/test_plots.py
+++ b/tests/unit/test_plots.py
@@ -1,8 +1,6 @@
 import json
 import os
 
-from dvc.render.match import get_files
-
 
 def test_plots_order(tmp_dir, dvc):
     tmp_dir.gen(
@@ -28,9 +26,9 @@ def test_plots_order(tmp_dir, dvc):
             name="stage2",
         )
 
-    assert get_files(dvc.plots.show()) == [
+    assert list(dvc.plots.show()["workspace"]["data"]) == [
         "p.json",
+        os.path.join("sub", "p4.json"),
         "p1.json",
         os.path.join("sub", "p3.json"),
-        os.path.join("sub", "p4.json"),
     ]


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Seems like `dpath.util.search` is really slow. Tried modifying the code to stop using `search` and use `dpath.util.get` instead. There was a significant improvement (4x) but still seemed unreasonably long. Ended up implementing this method myself. 

We are still using `dpath.util.new` but its influence is orders of magnitude smaller than "reading" methods.

test repository:

```bash
#!/bin/bash

set -exu
pushd $TMPDIR

wsp=test_wspace
rep=test_repo

rm -rf $wsp && mkdir $wsp && pushd $wsp
main=$(pwd)

mkdir $rep && pushd $rep

git init
dvc init

echo "numpy" >> requirements.txt
pip install -r requirements.txt

git add -A
git commit -am "init"


echo -e "p: 1" > params.yaml

echo -e "from random import random
import numpy as np
import sys

num_files = int(sys.argv[1])
linspace_size = int(sys.argv[2])

def load_params():
    import yaml
    with open('params.yaml') as fd:
            return yaml.safe_load(fd)

params = load_params()
p = params['p']

def calc_metric(index):
    metric = np.power(np.linspace(0,1,linspace_size),p)

    if index % 2 == 0:
       metric = 1 - metric

    metric += np.random.random(linspace_size)/(index+1)
    result=[]
    for elem in list(metric):
        result.append({f'val_{index}': elem})
    return result

import json
if __name__ == '__main__':
    for i in range(num_files):
        metric = calc_metric(i)
        with open(f'metric_{i}.json', 'w') as fd:
            json.dump(metric, fd)
" > train.py

echo -e "
from subprocess import run
outputs = []
for i in range(40):
    outputs.append('--plots')
    outputs.append(f'metric_{i}.json')

run(['dvc', 'run', '-d', 'train.py', '--params', 'p', '-n', 'train'] + outputs + ['python train.py 40 1000'])
" > call_dvc.py

git add -A
git commit -am "initial"

python call_dvc.py

git add -A
git commit -am "initial"

echo -e "p: 3" > params.yaml
dvc repro
```

command: `time dvc plots diff`

Result for main:
`14.88s user 0.22s system 99% cpu 15.182 total`

Result for this change:
`1.33s user 0.22s system 95% cpu 1.627 total`

