### PR TITLE
plots: Pass `templates_dir` to `match_renderers`.

### DIFF
--- a/dvc/commands/plots.py
+++ b/dvc/commands/plots.py
@@ -75,7 +75,9 @@ class CmdPlots(CmdBase):
                 out if self.args.json else os.path.join(out, "static")
             )
             renderers = match_renderers(
-                plots_data=plots_data, out=renderers_out
+                plots_data=plots_data,
+                out=renderers_out,
+                templates_dir=self.repo.plots.templates_dir,
             )
 
             if self.args.show_vega:

--- a/dvc/render/match.py
+++ b/dvc/render/match.py
@@ -49,7 +49,7 @@ def match_renderers(
                 if out is not None:
                     plot_properties["out"] = out
                 if templates_dir is not None:
-                    plot_properties["templates_dir"] = templates_dir
+                    plot_properties["template_dir"] = templates_dir
                 datapoints, plot_properties = to_datapoints(
                     renderer_class, group, plot_properties
                 )

--- a/dvc/repo/plots/__init__.py
+++ b/dvc/repo/plots/__init__.py
@@ -228,7 +228,8 @@ class Plots:
 
     @cached_property
     def templates_dir(self):
-        return os.path.join(self.repo.dvc_dir, "plots")
+        if self.repo.dvc_dir:
+            return os.path.join(self.repo.dvc_dir, "plots")
 
 
 def _is_plot(out: "Output") -> bool:

--- a/tests/unit/command/test_plots.py
+++ b/tests/unit/command/test_plots.py
@@ -240,6 +240,36 @@ def test_plots_path_is_quoted_and_resolved_properly(
     assert expected_url in out
 
 
+def test_should_pass_template_dir(tmp_dir, dvc, mocker, capsys):
+    cli_args = parse_args(
+        [
+            "plots",
+            "diff",
+            "HEAD~1",
+            "--json",
+            "--targets",
+            "plot.csv",
+        ]
+    )
+    cmd = cli_args.func(cli_args)
+
+    data = mocker.MagicMock()
+    mocker.patch("dvc.repo.plots.diff.diff", return_value=data)
+
+    renderers = mocker.MagicMock()
+    match_renderers = mocker.patch(
+        "dvc.render.match.match_renderers", return_value=renderers
+    )
+
+    assert cmd.run() == 0
+
+    match_renderers.assert_called_once_with(
+        plots_data=data,
+        out="dvc_plots",
+        templates_dir=str(tmp_dir / ".dvc/plots"),
+    )
+
+
 @pytest.mark.parametrize(
     "output", ("some_out", os.path.join("to", "subdir"), None)
 )

--- a/tests/unit/render/test_match.py
+++ b/tests/unit/render/test_match.py
@@ -178,3 +178,18 @@ def test_match_renderers_with_out(tmp_dir, mocker):
     assert (
         tmp_dir / "foo" / "workspace_other_file.jpg"
     ).read_bytes() == b"content2"
+
+
+def test_match_renderers_template_dir(mocker):
+    from dvc_render import vega
+
+    vega_render = mocker.spy(vega.VegaRenderer, "__init__")
+    data = {
+        "v1": {
+            "data": {"file.json": {"data": [{"y": 4}, {"y": 5}], "props": {}}}
+        },
+    }
+
+    match_renderers(data, templates_dir="foo")
+
+    assert vega_render.call_args[1]["template_dir"] == "foo"


### PR DESCRIPTION
We were forgetting to pass the default template dir.

Fixes #7817.

* [X] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [X] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

