### PR TITLE
dvc: drop python 3.7

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -16,7 +16,7 @@ jobs:
           access_token: ${{ github.token }}
       - uses: actions/setup-python@v3
         with:
-            python-version: 3.7
+            python-version: 3.8
       - uses: iterative/dvc-bench@main
         with:
             pytest_options: "-k 'test_init or test_help'"

--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -139,10 +139,10 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v3
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install
       run: pip install ".[all,tests]"
     - name: Build packages

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-latest]
-        pyv: ["3.7", "3.8", "3.9", "3.10"]
+        pyv: ["3.8", "3.9", "3.10"]
     steps:
     - uses: actions/checkout@v3
       with:

--- a/dvc/commands/experiments/init.py
+++ b/dvc/commands/experiments/init.py
@@ -80,7 +80,7 @@ class CmdExperimentsInit(CmdBase):
     ) -> None:
         from dvc.utils import humanize
 
-        path_fmt = "[green]{0}[/green]".format
+        path_fmt = "[green]{}[/green]".format
         if new_deps:
             deps_paths = humanize.join(map(path_fmt, new_deps))
             ui.write(f"Creating dependencies: {deps_paths}", styled=True)

--- a/dvc/info.py
+++ b/dvc/info.py
@@ -1,3 +1,4 @@
+import importlib.metadata as importlib_metadata
 import itertools
 import os
 import pathlib
@@ -12,12 +13,6 @@ from dvc.repo import Repo
 from dvc.scm import SCMError
 from dvc.utils import error_link
 from dvc.utils.pkg import PKG
-
-try:
-    import importlib.metadata as importlib_metadata
-except ImportError:  # < 3.8
-    import importlib_metadata  # type: ignore[no-redef]
-
 
 package = "" if PKG is None else f"({PKG})"
 

--- a/dvc/proc/manager.py
+++ b/dvc/proc/manager.py
@@ -30,8 +30,7 @@ class ProcessManager:
     def __iter__(self) -> Generator[str, None, None]:
         if not os.path.exists(self.wdir):
             return
-        for name in os.listdir(self.wdir):
-            yield name
+        yield from os.listdir(self.wdir)
 
     def __getitem__(self, key: str) -> "ProcessInfo":
         info_path = os.path.join(self.wdir, key, f"{key}.json")

--- a/dvc/testing/fixtures.py
+++ b/dvc/testing/fixtures.py
@@ -60,7 +60,6 @@ def make_tmp_dir(tmp_path_factory, request, worker_id):
         # connection resulting in PermissionErrors in Windows.
         ignore = ignore_patterns("cache.db*")
         for entry in os.listdir(cache):
-            # shutil.copytree's dirs_exist_ok is only available in >=3.8
             _fs_copy(
                 os.path.join(cache, entry),
                 os.path.join(path, entry),

--- a/dvc/utils/strictyaml.py
+++ b/dvc/utils/strictyaml.py
@@ -207,7 +207,7 @@ class YAMLValidationError(PrettyDvcException):
         self.path = path or ""
 
         message = f"'{rel}' validation failed"
-        message += " in revision '{}'".format(rev[:7]) if rev else ""
+        message += f" in revision '{rev[:7]}'" if rev else ""
         if len(self.exc.errors) > 1:
             message += f": {len(self.exc.errors)} errors"
         super().__init__(f"{message}")

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ keywords = data-science, data-version-control, machine-learning, git
 classifiers =
     Development Status :: 4 - Beta
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -30,7 +29,7 @@ setup_requires =
     setuptools_scm[toml]>=6.3.1
     setuptools_scm_git_archive==1.1
 
-python_requires = >=3.7
+python_requires = >=3.8
 zip_safe = False
 packages = find:
 include_package_data = True
@@ -55,7 +54,6 @@ install_requires =
     networkx>=2.5
     psutil>=5.8.0
     pydot>=1.2.4
-    importlib-metadata>=1.4; python_version < '3.8'
     importlib-resources>=5.2.2; python_version < '3.9'
     flatten_dict>=0.4.1,<1
     tabulate>=0.8.7

--- a/tests/dir_helpers.py
+++ b/tests/dir_helpers.py
@@ -148,7 +148,7 @@ class GitRemote:
 @pytest.fixture
 def git_upstream(tmp_dir, erepo_dir, git_dir, request):
     remote = erepo_dir if "dvc" in request.fixturenames else git_dir
-    url = "file://{}".format(remote.resolve().as_posix())
+    url = f"file://{remote.resolve().as_posix()}"
     tmp_dir.scm.gitpython.repo.create_remote("upstream", url)
     return GitRemote(remote, "upstream", url)
 
@@ -156,6 +156,6 @@ def git_upstream(tmp_dir, erepo_dir, git_dir, request):
 @pytest.fixture
 def git_downstream(tmp_dir, erepo_dir, git_dir, request):
     remote = erepo_dir if "dvc" in request.fixturenames else git_dir
-    url = "file://{}".format(tmp_dir.resolve().as_posix())
+    url = f"file://{tmp_dir.resolve().as_posix()}"
     remote.scm.gitpython.repo.create_remote("upstream", url)
     return GitRemote(remote, "upstream", url)

--- a/tests/func/machine/test_machine_config.py
+++ b/tests/func/machine/test_machine_config.py
@@ -122,7 +122,7 @@ def test_machine_rename_success(
         return_value=True,
     )
 
-    os.makedirs((tmp_dir / ".dvc" / "tmp" / "machine" / "terraform" / "foo"))
+    os.makedirs(tmp_dir / ".dvc" / "tmp" / "machine" / "terraform" / "foo")
 
     assert main(["machine", "rename", "foo", "bar"]) == 0
     cap = capsys.readouterr()
@@ -158,7 +158,7 @@ def test_machine_rename_error(
     tmp_dir, scm, dvc, machine_config, caplog, mocker
 ):
     config_file = tmp_dir / ".dvc" / "config"
-    os.makedirs((tmp_dir / ".dvc" / "tmp" / "machine" / "terraform" / "foo"))
+    os.makedirs(tmp_dir / ".dvc" / "tmp" / "machine" / "terraform" / "foo")
 
     def cmd_error(self, source, destination, **kwargs):
         raise tpi.TPIError("test error")

--- a/tests/func/test_ignore.py
+++ b/tests/func/test_ignore.py
@@ -19,8 +19,7 @@ def _to_pattern_info_list(str_list: List):
 
 
 def walk_files(dvc, *args):
-    for fs_path in dvc.dvcignore.find(*args):
-        yield fs_path
+    yield from dvc.dvcignore.find(*args)
 
 
 @pytest.mark.parametrize("filename", ["ignored", "тест"])

--- a/tests/integration/plots/test_json.py
+++ b/tests/integration/plots/test_json.py
@@ -50,7 +50,7 @@ def filter_fields(datapoints: List[Dict], fields: List[str]):
 
 def verify_image(tmp_dir, version, filename, content, html_path, json_result):
     assert os.path.exists(html_path)
-    with open(html_path, "r", encoding="utf-8") as fd:
+    with open(html_path, encoding="utf-8") as fd:
         html_content = fd.read()
 
     image_data = {}
@@ -92,7 +92,7 @@ def verify_vega(
 ):
 
     assert os.path.exists(html_path)
-    with open(html_path, "r", encoding="utf-8") as fd:
+    with open(html_path, encoding="utf-8") as fd:
         html_content = fd.read()
     assert _remove_blanks(
         json.dumps(dpath.util.get(json_result, [filename, 0, "content"]))

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -659,7 +659,7 @@ def test_show_experiments_sort_by(capsys, sort_order):
     rows = list(csv.reader(cap.out.strip().split("\n")))
     # [3:] To skip header, workspace and baseline(master)
     # which are not affected by order
-    params = tuple([int(row[-1]) for row in rows[3:]])
+    params = tuple(int(row[-1]) for row in rows[3:])
 
     if sort_order == "asc":
         assert params == (0, 1, 2)

--- a/tests/unit/command/test_machine.py
+++ b/tests/unit/command/test_machine.py
@@ -1,8 +1,8 @@
 import os
+from unittest.mock import call
 
 import configobj
 import pytest
-from mock import call
 
 from dvc.cli import parse_args
 from dvc.commands.machine import (

--- a/tests/unit/fs/test_ssh.py
+++ b/tests/unit/fs/test_ssh.py
@@ -2,9 +2,9 @@
 
 import getpass
 import os
+from unittest.mock import mock_open, patch
 
 import pytest
-from mock import mock_open, patch
 
 from dvc.fs import DEFAULT_SSH_PORT, SSHFileSystem
 

--- a/tests/unit/remote/test_http.py
+++ b/tests/unit/remote/test_http.py
@@ -1,6 +1,5 @@
 import ssl
-
-from mock import patch
+from unittest.mock import patch
 
 from dvc.fs import HTTPFileSystem
 

--- a/tests/unit/test_analytics.py
+++ b/tests/unit/test_analytics.py
@@ -1,7 +1,7 @@
 import json
 import platform
+from unittest import mock
 
-import mock
 import pytest
 from voluptuous import Any, Schema
 

--- a/tests/unit/utils/test_collections.py
+++ b/tests/unit/utils/test_collections.py
@@ -1,9 +1,9 @@
 # pylint: disable=unidiomatic-typecheck
 import json
 from json import encoder
+from unittest.mock import create_autospec
 
 import pytest
-from mock import create_autospec
 
 from dvc.utils.collections import (
     apply_diff,


### PR DESCRIPTION
Particularly, we already had to drop it in `dvc-objects` and `dvc-data` because of the overhead of trying to support 3.7 in conda packages.

Also upgraded with `pyupgrade --py38-plus`

Fixes #7708
