### PR TITLE
exp: Replace status Running with Pending if no worker runs.

### DIFF
--- a/dvc/repo/experiments/queue/base.py
+++ b/dvc/repo/experiments/queue/base.py
@@ -160,7 +160,6 @@ class BaseStashQueue(ABC):
             return datetime.fromtimestamp(commit.commit_time)
 
         for queue_entry in self.iter_active():
-            print(queue_entry, queue_entry.name)
             result.append(
                 {
                     "rev": queue_entry.stash_rev,

--- a/dvc/repo/experiments/queue/base.py
+++ b/dvc/repo/experiments/queue/base.py
@@ -149,17 +149,18 @@ class BaseStashQueue(ABC):
         self._remove_revs(stash_revs)
         return removed
 
-    def status(self) -> List[Mapping[str, Optional[str]]]:
+    def status(self) -> List[Dict[str, Optional[str]]]:
         """Show the status of exp tasks in queue"""
         from datetime import datetime
 
-        result: List[Mapping[str, Optional[str]]] = []
+        result: List[Dict[str, Optional[str]]] = []
 
         def _get_timestamp(rev):
             commit = self.scm.resolve_commit(rev)
             return datetime.fromtimestamp(commit.commit_time)
 
         for queue_entry in self.iter_active():
+            print(queue_entry, queue_entry.name)
             result.append(
                 {
                     "rev": queue_entry.stash_rev,

--- a/dvc/repo/experiments/queue/local.py
+++ b/dvc/repo/experiments/queue/local.py
@@ -322,6 +322,15 @@ class LocalCeleryQueue(BaseStashQueue):
         for line in self.proc.follow(queue_entry.stash_rev, encoding):
             ui.write(line)
 
+    def status(self) -> List[Dict[str, Optional[str]]]:
+        results = super().status()
+        if not self.celery.control.inspect().active():
+            for result in results:
+                if result["status"] == "Running":
+                    result["status"] = "Pending"
+
+        return results
+
 
 class WorkspaceQueue(BaseStashQueue):
     def put(self, *args, **kwargs) -> QueueEntry:


### PR DESCRIPTION
    Currently our `queue status` shows Running even if no worker running at
    present, replace it with "Pending"

    1. Replace "running" with "Pending" if no active worker
    2. Add unit test for `queue status`

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
