### PR TITLE
queue start: give every worker a unique name

### DIFF
--- a/dvc/repo/experiments/queue/local.py
+++ b/dvc/repo/experiments/queue/local.py
@@ -117,18 +117,21 @@ class LocalCeleryQueue(BaseStashQueue):
         )
 
     def spawn_worker(self):
+        from shortuuid import uuid
+
         from dvc_task.proc.process import ManagedProcess
 
         logger.debug("Spawning exp queue worker")
         wdir_hash = hashlib.sha256(self.wdir.encode("utf-8")).hexdigest()[:6]
         node_name = f"dvc-exp-{wdir_hash}-1@localhost"
         cmd = ["exp", "queue-worker", node_name]
+        name = "dvc-exp-worker"
+        if logger.getEffectiveLevel() < logging.INFO:
+            name = name + str(uuid())
         if os.name == "nt":
             daemonize(cmd)
         else:
-            ManagedProcess.spawn(
-                ["dvc"] + cmd, wdir=self.wdir, name="dvc-exp-worker"
-            )
+            ManagedProcess.spawn(["dvc"] + cmd, wdir=self.wdir, name=name)
 
     def put(self, *args, **kwargs) -> QueueEntry:
         """Stash an experiment and add it to the queue."""


### PR DESCRIPTION
    Currently, all of our celery workers are called `dvc-exp-worker` and
    they will write to the same log path.

    We give every single worker a unique name and seperate they logs.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
