### PR TITLE
bump scmrepo to 0.0.23

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ install_requires =
     typing-extensions>=3.7.4
     fsspec[http]>=2021.10.1
     aiohttp-retry>=2.4.5
-    scmrepo==0.0.22
+    scmrepo==0.0.23
     dvc-render==0.0.5
     dvclive>=0.7.3
     dvc-data==0.0.2

--- a/tests/func/test_api.py
+++ b/tests/func/test_api.py
@@ -20,7 +20,7 @@ def test_get_url_external(tmp_dir, erepo_dir, cloud):
         erepo_dir.dvc_gen("foo", "foo", commit="add foo")
 
     # Using file url to force clone to tmp repo
-    repo_url = f"file://{erepo_dir}"
+    repo_url = f"file://{erepo_dir.as_posix()}"
     expected_url = (cloud / "ac/bd18db4cc2f85cedef654fccc4a4d8").url
     assert api.get_url("foo", repo=repo_url) == expected_url
 
@@ -32,7 +32,7 @@ def test_get_url_requires_dvc(tmp_dir, scm):
         api.get_url("foo", repo=os.fspath(tmp_dir))
 
     with pytest.raises(OutputNotFoundError, match="output 'foo'"):
-        api.get_url("foo", repo=f"file://{tmp_dir}")
+        api.get_url("foo", repo=f"file://{tmp_dir.as_posix()}")
 
 
 def test_open_external(tmp_dir, erepo_dir, cloud):
@@ -51,7 +51,7 @@ def test_open_external(tmp_dir, erepo_dir, cloud):
     remove(erepo_dir.dvc.odb.local.cache_dir)
 
     # Using file url to force clone to tmp repo
-    repo_url = f"file://{erepo_dir}"
+    repo_url = f"file://{erepo_dir.as_posix()}"
     with api.open("version", repo=repo_url) as fd:
         assert fd.read() == "master"
 
@@ -138,7 +138,7 @@ def test_api_missing_local_cache_exists_on_remote(
     remove(dvc.odb.local.cache_dir)
     remove(first(files))
 
-    repo_url = f"file://{tmp_dir}" if as_external else None
+    repo_url = f"file://{tmp_dir.as_posix()}" if as_external else None
     file_content = get_in(files, to_read.split(os.sep))
     assert api.read(to_read, repo=repo_url) == file_content
 
@@ -154,7 +154,7 @@ def test_read_with_subrepos(tmp_dir, scm, local_cloud, local_repo):
         subrepo.dvc_gen("dvc-file", "dvc-file", commit="add dir")
         subrepo.dvc.push()
 
-    repo_path = None if local_repo else f"file://{tmp_dir}"
+    repo_path = None if local_repo else f"file://{tmp_dir.as_posix()}"
     subrepo_path = os.path.join("dir", "subrepo")
 
     assert api.read("foo.txt", repo=repo_path) == "foo.txt"
@@ -223,6 +223,8 @@ def test_open_from_remote(tmp_dir, erepo_dir, cloud, local_cloud):
     remove(erepo_dir.dvc.odb.local.cache_dir)
 
     with api.open(
-        os.path.join("dir", "foo"), repo=f"file://{erepo_dir}", remote="other"
+        os.path.join("dir", "foo"),
+        repo=f"file://{erepo_dir.as_posix()}",
+        remote="other",
     ) as fd:
         assert fd.read() == "foo content"

--- a/tests/func/test_external_repo.py
+++ b/tests/func/test_external_repo.py
@@ -57,7 +57,7 @@ def test_cache_reused(erepo_dir, mocker, local_cloud):
     download_spy = mocker.spy(generic, "transfer")
 
     # Use URL to prevent any fishy optimizations
-    url = f"file://{erepo_dir}"
+    url = f"file://{erepo_dir.as_posix()}"
     with external_repo(url) as repo:
         repo.fetch()
         assert download_spy.mock.call_count == 1
@@ -72,7 +72,7 @@ def test_cache_reused(erepo_dir, mocker, local_cloud):
 def test_known_sha(erepo_dir):
     erepo_dir.scm.commit("init")
 
-    url = f"file://{erepo_dir}"
+    url = f"file://{erepo_dir.as_posix()}"
     with external_repo(url) as repo:
         rev = repo.scm.get_rev()
         prev_rev = repo.scm.resolve_rev("HEAD^")

--- a/tests/func/test_get.py
+++ b/tests/func/test_get.py
@@ -266,7 +266,7 @@ def test_get_pipeline_tracked_outs(
     dvc.scm.commit("add pipeline stage")
 
     with git_dir.chdir():
-        Repo.get(f"file://{os.fspath(tmp_dir)}", "bar", out="baz")
+        Repo.get(f"file://{tmp_dir.as_posix()}", "bar", out="baz")
         assert (git_dir / "baz").read_text() == "foo"
 
 

--- a/tests/func/test_import.py
+++ b/tests/func/test_import.py
@@ -408,7 +408,7 @@ def test_import_pipeline_tracked_outs(
     dvc.scm.commit("add pipeline stage")
 
     with erepo_dir.chdir():
-        erepo_dir.dvc.imp(f"file://{os.fspath(tmp_dir)}", "bar", out="baz")
+        erepo_dir.dvc.imp(f"file://{tmp_dir.as_posix()}", "bar", out="baz")
         assert (erepo_dir / "baz").read_text() == "foo"
 
 

--- a/tests/func/test_ls.py
+++ b/tests/func/test_ls.py
@@ -319,7 +319,7 @@ def test_ls_remote_repo(erepo_dir):
         erepo_dir.scm_gen(FS_STRUCTURE, commit="init")
         erepo_dir.dvc_gen(DVC_STRUCTURE, commit="dvc")
 
-    url = f"file://{erepo_dir}"
+    url = f"file://{erepo_dir.as_posix()}"
     files = Repo.ls(url)
     match_files(
         files,
@@ -340,7 +340,7 @@ def test_ls_remote_repo_recursive(erepo_dir):
         erepo_dir.scm_gen(FS_STRUCTURE, commit="init")
         erepo_dir.dvc_gen(DVC_STRUCTURE, commit="dvc")
 
-    url = f"file://{erepo_dir}"
+    url = f"file://{erepo_dir.as_posix()}"
     files = Repo.ls(url, recursive=True)
     match_files(
         files,
@@ -369,7 +369,7 @@ def test_ls_remote_git_only_repo_recursive(git_dir):
     with git_dir.chdir():
         git_dir.scm_gen(FS_STRUCTURE, commit="init")
 
-    url = f"file://{git_dir}"
+    url = f"file://{git_dir.as_posix()}"
     files = Repo.ls(url, recursive=True)
     match_files(
         files,
@@ -387,7 +387,7 @@ def test_ls_remote_repo_with_path_dir(erepo_dir):
         erepo_dir.scm_gen(FS_STRUCTURE, commit="init")
         erepo_dir.dvc_gen(DVC_STRUCTURE, commit="dvc")
 
-    url = f"file://{erepo_dir}"
+    url = f"file://{erepo_dir.as_posix()}"
     path = "model"
     files = Repo.ls(url, path)
     match_files(
@@ -408,7 +408,7 @@ def test_ls_remote_repo_with_rev(erepo_dir):
         erepo_dir.dvc_gen(DVC_STRUCTURE, commit="dvc")
 
     rev = erepo_dir.scm.list_all_commits()[1]
-    url = f"file://{erepo_dir}"
+    url = f"file://{erepo_dir.as_posix()}"
     files = Repo.ls(url, rev=rev)
     match_files(
         files,
@@ -427,7 +427,7 @@ def test_ls_remote_repo_with_rev_recursive(erepo_dir):
         erepo_dir.scm_gen(FS_STRUCTURE, commit="init")
 
     rev = erepo_dir.scm.list_all_commits()[1]
-    url = f"file://{erepo_dir}"
+    url = f"file://{erepo_dir.as_posix()}"
     files = Repo.ls(url, rev=rev, recursive=True)
     match_files(
         files,

--- a/tests/func/utils/test_strict_yaml.py
+++ b/tests/func/utils/test_strict_yaml.py
@@ -394,7 +394,7 @@ def test_on_revision(
     tmp_dir.scm_gen("dvc.yaml", text, commit="add dvc.yaml")
     capsys.readouterr()  # clear outputs
 
-    assert main(["ls", f"file://{tmp_dir}", "--rev", "HEAD"]) != 0
+    assert main(["ls", f"file://{tmp_dir.as_posix()}", "--rev", "HEAD"]) != 0
 
     out, err = capsys.readouterr()
     assert not out


### PR DESCRIPTION
`scmrepo==0.0.23` includes proper support for windows file:// URLs (https://github.com/iterative/scmrepo/pull/68), so Windows tests relying on file URLs had to be fixed in order to be valid [RFC 8089](https://datatracker.ietf.org/doc/html/rfc8089) file URLs.

Closes #7833.
