### PR TITLE
run-cache: http: restrict uploads/downloads

### DIFF
--- a/dvc/testing/test_remote.py
+++ b/dvc/testing/test_remote.py
@@ -1,6 +1,9 @@
 import os
 import shutil
 
+import pytest
+
+from dvc.stage.cache import RunCacheNotSupported
 from dvc.utils.fs import remove
 
 
@@ -92,6 +95,7 @@ class TestRemote:
         status_dir = dvc.cloud.status(dir_hashes)
         _check_status(status_dir, ok=dir_hashes)
 
+    @pytest.mark.xfail(raises=RunCacheNotSupported, strict=False)
     def test_stage_cache_push_pull(self, tmp_dir, dvc, remote):
         tmp_dir.gen("foo", "foo")
         stage = dvc.stage.add(


### PR DESCRIPTION
Currently, there is no way to find run-cache in HTTP remotes.
In the future, we could use directory listings from supported
webservers to find files.
Temporarily, we are restricting the run-cache uploads. This is a bit
strict, we could have only restricted the downloads, but it might be
more confusing to the users, so I went to categorically restrict
stage cache uploads and downloads for http filesystems.

~~waiting for #7873 to get merged.~~
