### PR TITLE
queue status: use a short rev to represent tasks

### DIFF
--- a/dvc/commands/queue/status.py
+++ b/dvc/commands/queue/status.py
@@ -23,7 +23,7 @@ class CmdQueueStatus(CmdBase):
         for exp in result:
             created = format_time(exp.get("timestamp"))
             td.append(
-                [exp["rev"], exp.get("name", ""), created, exp["status"]]
+                [exp["rev"][:7], exp.get("name", ""), created, exp["status"]]
             )
         td.render()
 


### PR DESCRIPTION
1. use a short rev to represent tasks
2. Add a unit test for the result shown

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
