### PR TITLE
queue remove: add remove support for short revs(#7840)

### DIFF
--- a/dvc/commands/queue/remove.py
+++ b/dvc/commands/queue/remove.py
@@ -19,8 +19,13 @@ class CmdQueueRemove(CmdBase):
                 revs=self.args.experiment
             )
 
-        removed = ", ".join(removed_list)
-        ui.write(f"Removed experiments in queue: {removed}")
+        if removed_list:
+            removed = ", ".join(removed_list)
+            ui.write(f"Removed experiments in queue: {removed}")
+        else:
+            ui.write(
+                f"No experiments found in queue named {self.args.experiment}"
+            )
 
         return 0
 

--- a/dvc/repo/experiments/queue/local.py
+++ b/dvc/repo/experiments/queue/local.py
@@ -144,17 +144,12 @@ class LocalCeleryQueue(BaseStashQueue):
         raise NotImplementedError
 
     def _remove_revs(self, stash_revs: Mapping[str, ExpStashEntry]):
-        to_drop: List[int] = []
         try:
             for msg, queue_entry in self._iter_queued():
                 if queue_entry.stash_rev in stash_revs:
                     self.celery.reject(msg.delivery_tag)
-                    stash_entry = stash_revs[queue_entry.stash_rev]
-                    assert stash_entry.stash_index is not None
-                    to_drop.append(stash_entry.stash_index)
         finally:
-            for index in sorted(to_drop, reverse=True):
-                self.stash.drop(index)
+            super()._remove_revs(stash_revs)
 
     def iter_queued(self) -> Generator[QueueEntry, None, None]:
         for _, entry in self._iter_queued():
@@ -335,17 +330,6 @@ class WorkspaceQueue(BaseStashQueue):
         )
         executor = self.setup_executor(self.repo.experiments, entry)
         return QueueGetResult(entry, executor)
-
-    def _remove_revs(self, stash_revs: Mapping[str, ExpStashEntry]):
-        for index in sorted(
-            (
-                entry.stash_index
-                for entry in stash_revs.values()
-                if entry.stash_index is not None
-            ),
-            reverse=True,
-        ):
-            self.stash.drop(index)
 
     def iter_queued(self) -> Generator[QueueEntry, None, None]:
         for rev, entry in self.stash.stash_revs:

--- a/dvc/repo/experiments/remove.py
+++ b/dvc/repo/experiments/remove.py
@@ -155,6 +155,6 @@ def _remove_commited_exps(
 def _remove_queued_exps(
     repo: "Repo", named_entries: Mapping[str, QueueEntry]
 ) -> List[str]:
-    for entry in named_entries.values():
-        repo.experiments.celery_queue.remove(entry.stash_rev)
+    stash_rev_list = [entry.stash_rev for entry in named_entries.values()]
+    repo.experiments.celery_queue.remove(stash_rev_list)
     return list(named_entries.keys())


### PR DESCRIPTION
fix: #7840

Now queue remove can not accept short rev as name.

1. Refactor the queue entry match in `queue remove`
2. Better output if no queue task found for name.
3. short rev on kill can only be work for rev with lens longer than 4

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

coming from a wrongly closed PR #7841
