### PR TITLE
exp: support standalone (non-queued) `--temp` runs

### DIFF
--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -179,6 +179,10 @@ class Experiments:
         self.celery_queue.spawn_worker()
         failed = []
         try:
+            ui.write(
+                "Following logs for all queued experiments. Use Ctrl+C to "
+                "stop following logs (experiment execution will continue).\n"
+            )
             for entry in entries:
                 # wait for task execution to start
                 while not self.celery_queue.proc.get(entry.stash_rev):

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -19,6 +19,7 @@ from .exceptions import (
 from .executor.base import BaseExecutor, ExecutorInfo
 from .queue.base import BaseStashQueue, QueueEntry
 from .queue.celery import LocalCeleryQueue
+from .queue.tempdir import TempDirQueue
 from .queue.workspace import WorkspaceQueue
 from .refs import (
     CELERY_FAILED_STASH,
@@ -78,6 +79,12 @@ class Experiments:
     @cached_property
     def workspace_queue(self) -> WorkspaceQueue:
         return WorkspaceQueue(self.repo, WORKSPACE_STASH)
+
+    @cached_property
+    def tempdir_queue(self) -> TempDirQueue:
+        # NOTE: tempdir and workspace stash is shared since both
+        # implementations immediately push -> pop (queue length is only 0 or 1)
+        return TempDirQueue(self.repo, WORKSPACE_STASH)
 
     @cached_property
     def celery_queue(self) -> LocalCeleryQueue:

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -18,7 +18,8 @@ from .exceptions import (
 )
 from .executor.base import BaseExecutor, ExecutorInfo
 from .queue.base import BaseStashQueue, QueueEntry
-from .queue.local import LocalCeleryQueue, WorkspaceQueue
+from .queue.celery import LocalCeleryQueue
+from .queue.workspace import WorkspaceQueue
 from .refs import (
     CELERY_FAILED_STASH,
     CELERY_STASH,

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -432,15 +432,20 @@ class Experiments:
         """Return info for running experiments."""
         result = {}
         infofile = self.workspace_queue.get_infofile_path("workspace")
-        result.update(self._get_running_exp("workspace", infofile, fetch_refs))
-        for entry in self.celery_queue.iter_active():
-            infofile = self.celery_queue.get_infofile_path(entry.stash_rev)
-            result.update(
-                self._get_running_exp(entry.stash_rev, infofile, fetch_refs)
-            )
+        result.update(
+            self._fetch_running_exp("workspace", infofile, fetch_refs)
+        )
+        for queue in (self.tempdir_queue, self.celery_queue):
+            for entry in queue.iter_active():
+                infofile = queue.get_infofile_path(entry.stash_rev)
+                result.update(
+                    self._fetch_running_exp(
+                        entry.stash_rev, infofile, fetch_refs
+                    )
+                )
         return result
 
-    def _get_running_exp(
+    def _fetch_running_exp(
         self, rev: str, infofile: str, fetch_refs: bool
     ) -> Dict[str, Any]:
         from dvc.scm import InvalidRemoteSCMRepo

--- a/dvc/repo/experiments/executor/local.py
+++ b/dvc/repo/experiments/executor/local.py
@@ -65,7 +65,7 @@ class TempDirExecutor(BaseLocalExecutor):
     # suggestions) that are not applicable outside of workspace runs
     WARN_UNTRACKED = True
     QUIET = True
-    DEFAULT_LOCATION = "temp"
+    DEFAULT_LOCATION = "tempdir"
 
     def init_git(self, scm: "Git", branch: Optional[str] = None):
         from dulwich.repo import Repo as DulwichRepo
@@ -127,7 +127,9 @@ class TempDirExecutor(BaseLocalExecutor):
         makedirs(parent_dir, exist_ok=True)
         tmp_dir = mkdtemp(dir=parent_dir)
         try:
-            executor = cls._from_stash_entry(repo, stash_rev, entry, tmp_dir)
+            executor = cls._from_stash_entry(
+                repo, stash_rev, entry, tmp_dir, **kwargs
+            )
             logger.debug("Init temp dir executor in '%s'", tmp_dir)
             return executor
         except Exception:
@@ -150,7 +152,9 @@ class WorkspaceExecutor(BaseLocalExecutor):
         **kwargs,
     ):
         root_dir = repo.scm.root_dir
-        executor = cls._from_stash_entry(repo, stash_rev, entry, root_dir)
+        executor = cls._from_stash_entry(
+            repo, stash_rev, entry, root_dir, **kwargs
+        )
         logger.debug("Init workspace executor in '%s'", root_dir)
         return executor
 

--- a/dvc/repo/experiments/executor/local.py
+++ b/dvc/repo/experiments/executor/local.py
@@ -8,7 +8,7 @@ from funcy import cached_property
 from scmrepo.exceptions import SCMError as _SCMError
 
 from dvc.scm import SCM, GitMergeError
-from dvc.utils.fs import remove
+from dvc.utils.fs import makedirs, remove
 
 from ..refs import (
     EXEC_APPLY,
@@ -123,7 +123,9 @@ class TempDirExecutor(BaseLocalExecutor):
         wdir: Optional[str] = None,
         **kwargs,
     ):
-        tmp_dir = mkdtemp(dir=wdir or os.path.join(repo.tmp_dir, EXEC_TMP_DIR))
+        parent_dir: str = wdir or os.path.join(repo.tmp_dir, EXEC_TMP_DIR)
+        makedirs(parent_dir, exist_ok=True)
+        tmp_dir = mkdtemp(dir=parent_dir)
         try:
             executor = cls._from_stash_entry(repo, stash_rev, entry, tmp_dir)
             logger.debug("Init temp dir executor in '%s'", tmp_dir)

--- a/dvc/repo/experiments/executor/local.py
+++ b/dvc/repo/experiments/executor/local.py
@@ -120,9 +120,10 @@ class TempDirExecutor(BaseLocalExecutor):
         repo: "Repo",
         stash_rev: str,
         entry: "ExpStashEntry",
+        wdir: Optional[str] = None,
         **kwargs,
     ):
-        tmp_dir = mkdtemp(dir=os.path.join(repo.tmp_dir, EXEC_TMP_DIR))
+        tmp_dir = mkdtemp(dir=wdir or os.path.join(repo.tmp_dir, EXEC_TMP_DIR))
         try:
             executor = cls._from_stash_entry(repo, stash_rev, entry, tmp_dir)
             logger.debug("Init temp dir executor in '%s'", tmp_dir)

--- a/dvc/repo/experiments/queue/base.py
+++ b/dvc/repo/experiments/queue/base.py
@@ -542,6 +542,7 @@ class BaseStashQueue(ABC):
         exp: "Experiments",
         queue_entry: QueueEntry,
         executor_cls: Type[BaseExecutor] = WorkspaceExecutor,
+        **kwargs,
     ) -> BaseExecutor:
         scm = exp.scm
         stash = ExpStash(scm, queue_entry.stash_ref)
@@ -563,7 +564,9 @@ class BaseStashQueue(ABC):
         #   EXEC_MERGE - the unmerged changes (from our stash)
         #       to be reproduced
         #   EXEC_BASELINE - the baseline commit for this experiment
-        return executor_cls.from_stash_entry(exp.repo, stash_rev, stash_entry)
+        return executor_cls.from_stash_entry(
+            exp.repo, stash_rev, stash_entry, **kwargs
+        )
 
     def get_infofile_path(self, name: str) -> str:
         return os.path.join(

--- a/dvc/repo/experiments/queue/celery.py
+++ b/dvc/repo/experiments/queue/celery.py
@@ -22,12 +22,7 @@ from dvc.exceptions import DvcException
 from dvc.ui import ui
 
 from ..exceptions import UnresolvedQueueExpNamesError
-from ..executor.base import (
-    EXEC_PID_DIR,
-    EXEC_TMP_DIR,
-    ExecutorInfo,
-    ExecutorResult,
-)
+from ..executor.base import EXEC_TMP_DIR, ExecutorInfo, ExecutorResult
 from ..stash import ExpStashEntry
 from .base import BaseStashQueue, QueueDoneResult, QueueEntry, QueueGetResult
 from .tasks import run_exp
@@ -89,8 +84,7 @@ class LocalCeleryQueue(BaseStashQueue):
     def proc(self) -> "ProcessManager":
         from dvc_task.proc.manager import ProcessManager
 
-        pid_dir = os.path.join(self.repo.tmp_dir, EXEC_TMP_DIR, EXEC_PID_DIR)
-        return ProcessManager(pid_dir)
+        return ProcessManager(self.pid_dir)
 
     @cached_property
     def worker(self) -> "TemporaryWorker":

--- a/dvc/repo/experiments/queue/celery.py
+++ b/dvc/repo/experiments/queue/celery.py
@@ -2,7 +2,6 @@ import hashlib
 import locale
 import logging
 import os
-from collections import defaultdict
 from typing import (
     TYPE_CHECKING,
     Collection,
@@ -15,29 +14,25 @@ from typing import (
     Set,
 )
 
-from funcy import cached_property, first
+from funcy import cached_property
 from kombu.message import Message
 
 from dvc.daemon import daemonize
 from dvc.exceptions import DvcException
 from dvc.ui import ui
 
-from ..exceptions import ExpQueueEmptyError, UnresolvedQueueExpNamesError
+from ..exceptions import UnresolvedQueueExpNamesError
 from ..executor.base import (
     EXEC_PID_DIR,
     EXEC_TMP_DIR,
-    BaseExecutor,
     ExecutorInfo,
     ExecutorResult,
 )
-from ..executor.local import WorkspaceExecutor
-from ..refs import EXEC_BRANCH
 from ..stash import ExpStashEntry
 from .base import BaseStashQueue, QueueDoneResult, QueueEntry, QueueGetResult
 from .tasks import run_exp
 
 if TYPE_CHECKING:
-    from dvc.repo.experiments import Experiments
     from dvc_task.app import FSApp
     from dvc_task.proc.manager import ProcessManager
     from dvc_task.worker import TemporaryWorker
@@ -352,128 +347,3 @@ class LocalCeleryQueue(BaseStashQueue):
         status = self.celery.control.inspect().active() or {}
         logger.debug(f"Worker status: {status}")
         return status
-
-
-class WorkspaceQueue(BaseStashQueue):
-    def put(self, *args, **kwargs) -> QueueEntry:
-        return self._stash_exp(*args, **kwargs)
-
-    def get(self) -> QueueGetResult:
-        revs = self.stash.stash_revs
-        if not revs:
-            raise ExpQueueEmptyError("No experiments in the queue.")
-        stash_rev, stash_entry = first(revs.items())
-        entry = QueueEntry(
-            self.repo.root_dir,
-            self.scm.root_dir,
-            self.ref,
-            stash_rev,
-            stash_entry.baseline_rev,
-            stash_entry.branch,
-            stash_entry.name,
-            stash_entry.head_rev,
-        )
-        executor = self.setup_executor(self.repo.experiments, entry)
-        return QueueGetResult(entry, executor)
-
-    def iter_queued(self) -> Generator[QueueEntry, None, None]:
-        for rev, entry in self.stash.stash_revs:
-            yield QueueEntry(
-                self.repo.root_dir,
-                self.scm.root_dir,
-                self.ref,
-                rev,
-                entry.baseline_rev,
-                entry.branch,
-                entry.name,
-                entry.head_rev,
-            )
-
-    def iter_active(self) -> Generator[QueueEntry, None, None]:
-        # Workspace run state is reflected in the workspace itself and does not
-        # need to be handled via the queue
-        raise NotImplementedError
-
-    def iter_done(self) -> Generator[QueueDoneResult, None, None]:
-        raise NotImplementedError
-
-    def reproduce(self) -> Dict[str, Dict[str, str]]:
-        results: Dict[str, Dict[str, str]] = defaultdict(dict)
-        try:
-            while True:
-                entry, executor = self.get()
-                results.update(self._reproduce_entry(entry, executor))
-        except ExpQueueEmptyError:
-            pass
-        return results
-
-    def _reproduce_entry(
-        self, entry: QueueEntry, executor: BaseExecutor
-    ) -> Dict[str, Dict[str, str]]:
-        from dvc.stage.monitor import CheckpointKilledError
-
-        results: Dict[str, Dict[str, str]] = defaultdict(dict)
-        exec_name = "workspace"
-        infofile = self.get_infofile_path(exec_name)
-        try:
-            rev = entry.stash_rev
-            exec_result = executor.reproduce(
-                info=executor.info,
-                rev=rev,
-                infofile=infofile,
-                log_level=logger.getEffectiveLevel(),
-                log_errors=not isinstance(executor, WorkspaceExecutor),
-            )
-            if not exec_result.exp_hash:
-                raise DvcException(
-                    f"Failed to reproduce experiment '{rev[:7]}'"
-                )
-            if exec_result.ref_info:
-                results[rev].update(
-                    self.collect_executor(
-                        self.repo.experiments, executor, exec_result
-                    )
-                )
-        except CheckpointKilledError:
-            # Checkpoint errors have already been logged
-            return {}
-        except DvcException:
-            raise
-        except Exception as exc:
-            raise DvcException(
-                f"Failed to reproduce experiment '{rev[:7]}'"
-            ) from exc
-        finally:
-            executor.cleanup()
-        return results
-
-    @staticmethod
-    def collect_executor(  # pylint: disable=unused-argument
-        exp: "Experiments",
-        executor: BaseExecutor,
-        exec_result: ExecutorResult,
-    ) -> Dict[str, str]:
-        results: Dict[str, str] = {}
-        exp_rev = exp.scm.get_ref(EXEC_BRANCH)
-        if exp_rev:
-            assert exec_result.exp_hash
-            logger.debug("Collected experiment '%s'.", exp_rev[:7])
-            results[exp_rev] = exec_result.exp_hash
-        return results
-
-    def get_result(self, entry: QueueEntry) -> Optional[ExecutorResult]:
-        raise NotImplementedError
-
-    def kill(self, revs: Collection[str]) -> None:
-        raise NotImplementedError
-
-    def shutdown(self, kill: bool = False):
-        raise NotImplementedError
-
-    def logs(
-        self,
-        rev: str,
-        encoding: Optional[str] = None,
-        follow: bool = False,
-    ):
-        raise NotImplementedError

--- a/dvc/repo/experiments/queue/tasks.py
+++ b/dvc/repo/experiments/queue/tasks.py
@@ -62,11 +62,9 @@ def collect_exp(
     exec_result = executor_info.result
     try:
         if exec_result is not None:
-            results = BaseStashQueue.collect_executor(
+            BaseStashQueue.collect_executor(
                 repo.experiments, executor, exec_result
             )
-            for rev in results:
-                logger.debug("Collected experiment '%s'", rev[:7])
         else:
             logger.debug("Experiment failed (Exec result was None)")
             celery_queue.stash_failed(entry)

--- a/dvc/repo/experiments/queue/tasks.py
+++ b/dvc/repo/experiments/queue/tasks.py
@@ -29,7 +29,10 @@ def setup_exp(entry_dict: Dict[str, Any]) -> str:
     # TODO: split executor.init_cache into separate subtask - we can release
     # exp.scm_lock before DVC push
     executor = BaseStashQueue.setup_executor(
-        repo.experiments, entry, TempDirExecutor
+        repo.experiments,
+        entry,
+        TempDirExecutor,
+        location="dvc-task",
     )
     infofile = repo.experiments.celery_queue.get_infofile_path(entry.stash_rev)
     executor.info.dump_json(infofile)

--- a/dvc/repo/experiments/queue/tempdir.py
+++ b/dvc/repo/experiments/queue/tempdir.py
@@ -1,0 +1,93 @@
+import logging
+import os
+from typing import TYPE_CHECKING, Dict, Generator
+
+from funcy import cached_property, first
+
+from ..exceptions import ExpQueueEmptyError
+from ..executor.base import (
+    EXEC_PID_DIR,
+    EXEC_TMP_DIR,
+    BaseExecutor,
+    ExecutorInfo,
+    ExecutorResult,
+)
+from ..executor.local import TempDirExecutor
+from .base import BaseStashQueue, QueueEntry, QueueGetResult
+from .workspace import WorkspaceQueue
+
+if TYPE_CHECKING:
+    from dvc.repo.experiments import Experiments
+    from dvc_task.proc.manager import ProcessManager
+
+logger = logging.getLogger(__name__)
+
+
+_STANDALONE_TMP_DIR = os.path.join(EXEC_TMP_DIR, "standalone")
+
+
+class TempDirQueue(WorkspaceQueue):
+    """Standalone/tempdir exp queue implementation."""
+
+    @cached_property
+    def _standalone_tmp_dir(self) -> str:
+        return os.path.join(self.repo.tmp_dir, _STANDALONE_TMP_DIR)
+
+    @cached_property
+    def pid_dir(self) -> str:
+        return os.path.join(self._standalone_tmp_dir, EXEC_PID_DIR)
+
+    @cached_property
+    def proc(self) -> "ProcessManager":
+        from dvc_task.proc.manager import ProcessManager
+
+        return ProcessManager(self.pid_dir)
+
+    def get(self) -> QueueGetResult:
+        revs = self.stash.stash_revs
+        if not revs:
+            raise ExpQueueEmptyError("No stashed standalone experiments.")
+        stash_rev, stash_entry = first(revs.items())
+        entry = QueueEntry(
+            self.repo.root_dir,
+            self.scm.root_dir,
+            self.ref,
+            stash_rev,
+            stash_entry.baseline_rev,
+            stash_entry.branch,
+            stash_entry.name,
+            stash_entry.head_rev,
+        )
+        executor = self.setup_executor(
+            self.repo.experiments,
+            entry,
+            TempDirExecutor,
+            wdir=self._standalone_tmp_dir,
+        )
+        return QueueGetResult(entry, executor)
+
+    def iter_active(self) -> Generator[QueueEntry, None, None]:
+        # NOTE: Yielded queue entries are not complete for performance reasons.
+        # Retrieving exec ref information is unavailable without doing a
+        # git-fetch, and is unneeded in the common use cases for iter_active.
+        for stash_rev in self.proc:
+            infofile = self.get_infofile_path(stash_rev)
+            executor_info = ExecutorInfo.load_json(infofile)
+            yield QueueEntry(
+                self.repo.root_dir,
+                self.scm.root_dir,
+                self.ref,
+                stash_rev,
+                executor_info.baseline_rev,
+                None,  # branch unavailable without doing a git-fetch
+                executor_info.name,
+                None,
+            )
+
+    @staticmethod
+    def collect_executor(
+        exp: "Experiments",
+        executor: BaseExecutor,
+        exec_result: ExecutorResult,
+    ) -> Dict[str, str]:
+        return BaseStashQueue.collect_executor(exp, executor, exec_result)

--- a/dvc/repo/experiments/queue/workspace.py
+++ b/dvc/repo/experiments/queue/workspace.py
@@ -19,6 +19,8 @@ logger = logging.getLogger(__name__)
 
 
 class WorkspaceQueue(BaseStashQueue):
+    _EXEC_NAME: Optional[str] = "workspace"
+
     def put(self, *args, **kwargs) -> QueueEntry:
         return self._stash_exp(*args, **kwargs)
 
@@ -77,7 +79,7 @@ class WorkspaceQueue(BaseStashQueue):
         from dvc.stage.monitor import CheckpointKilledError
 
         results: Dict[str, Dict[str, str]] = defaultdict(dict)
-        exec_name = "workspace"
+        exec_name = self._EXEC_NAME or entry.stash_rev
         infofile = self.get_infofile_path(exec_name)
         try:
             rev = entry.stash_rev

--- a/dvc/repo/experiments/queue/workspace.py
+++ b/dvc/repo/experiments/queue/workspace.py
@@ -1,0 +1,143 @@
+import logging
+from collections import defaultdict
+from typing import TYPE_CHECKING, Collection, Dict, Generator, Optional
+
+from funcy import first
+
+from dvc.exceptions import DvcException
+
+from ..exceptions import ExpQueueEmptyError
+from ..executor.base import BaseExecutor, ExecutorResult
+from ..executor.local import WorkspaceExecutor
+from ..refs import EXEC_BRANCH
+from .base import BaseStashQueue, QueueDoneResult, QueueEntry, QueueGetResult
+
+if TYPE_CHECKING:
+    from dvc.repo.experiments import Experiments
+
+logger = logging.getLogger(__name__)
+
+
+class WorkspaceQueue(BaseStashQueue):
+    def put(self, *args, **kwargs) -> QueueEntry:
+        return self._stash_exp(*args, **kwargs)
+
+    def get(self) -> QueueGetResult:
+        revs = self.stash.stash_revs
+        if not revs:
+            raise ExpQueueEmptyError("No experiments in the queue.")
+        stash_rev, stash_entry = first(revs.items())
+        entry = QueueEntry(
+            self.repo.root_dir,
+            self.scm.root_dir,
+            self.ref,
+            stash_rev,
+            stash_entry.baseline_rev,
+            stash_entry.branch,
+            stash_entry.name,
+            stash_entry.head_rev,
+        )
+        executor = self.setup_executor(self.repo.experiments, entry)
+        return QueueGetResult(entry, executor)
+
+    def iter_queued(self) -> Generator[QueueEntry, None, None]:
+        for rev, entry in self.stash.stash_revs:
+            yield QueueEntry(
+                self.repo.root_dir,
+                self.scm.root_dir,
+                self.ref,
+                rev,
+                entry.baseline_rev,
+                entry.branch,
+                entry.name,
+                entry.head_rev,
+            )
+
+    def iter_active(self) -> Generator[QueueEntry, None, None]:
+        # Workspace run state is reflected in the workspace itself and does not
+        # need to be handled via the queue
+        raise NotImplementedError
+
+    def iter_done(self) -> Generator[QueueDoneResult, None, None]:
+        raise NotImplementedError
+
+    def reproduce(self) -> Dict[str, Dict[str, str]]:
+        results: Dict[str, Dict[str, str]] = defaultdict(dict)
+        try:
+            while True:
+                entry, executor = self.get()
+                results.update(self._reproduce_entry(entry, executor))
+        except ExpQueueEmptyError:
+            pass
+        return results
+
+    def _reproduce_entry(
+        self, entry: QueueEntry, executor: BaseExecutor
+    ) -> Dict[str, Dict[str, str]]:
+        from dvc.stage.monitor import CheckpointKilledError
+
+        results: Dict[str, Dict[str, str]] = defaultdict(dict)
+        exec_name = "workspace"
+        infofile = self.get_infofile_path(exec_name)
+        try:
+            rev = entry.stash_rev
+            exec_result = executor.reproduce(
+                info=executor.info,
+                rev=rev,
+                infofile=infofile,
+                log_level=logger.getEffectiveLevel(),
+                log_errors=not isinstance(executor, WorkspaceExecutor),
+            )
+            if not exec_result.exp_hash:
+                raise DvcException(
+                    f"Failed to reproduce experiment '{rev[:7]}'"
+                )
+            if exec_result.ref_info:
+                results[rev].update(
+                    self.collect_executor(
+                        self.repo.experiments, executor, exec_result
+                    )
+                )
+        except CheckpointKilledError:
+            # Checkpoint errors have already been logged
+            return {}
+        except DvcException:
+            raise
+        except Exception as exc:
+            raise DvcException(
+                f"Failed to reproduce experiment '{rev[:7]}'"
+            ) from exc
+        finally:
+            executor.cleanup()
+        return results
+
+    @staticmethod
+    def collect_executor(  # pylint: disable=unused-argument
+        exp: "Experiments",
+        executor: BaseExecutor,
+        exec_result: ExecutorResult,
+    ) -> Dict[str, str]:
+        results: Dict[str, str] = {}
+        exp_rev = exp.scm.get_ref(EXEC_BRANCH)
+        if exp_rev:
+            assert exec_result.exp_hash
+            logger.debug("Collected experiment '%s'.", exp_rev[:7])
+            results[exp_rev] = exec_result.exp_hash
+        return results
+
+    def get_result(self, entry: QueueEntry) -> Optional[ExecutorResult]:
+        raise NotImplementedError
+
+    def kill(self, revs: Collection[str]) -> None:
+        raise NotImplementedError
+
+    def shutdown(self, kill: bool = False):
+        raise NotImplementedError
+
+    def logs(
+        self,
+        rev: str,
+        encoding: Optional[str] = None,
+        follow: bool = False,
+    ):
+        raise NotImplementedError

--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -193,8 +193,10 @@ def show(
                 running=running,
                 onerror=onerror,
             )
-        # collect celery experiments
+
+        # collect standalone & celery experiments
         for entry in chain(
+            repo.experiments.tempdir_queue.iter_active(),
             repo.experiments.celery_queue.iter_active(),
             repo.experiments.celery_queue.iter_queued(),
         ):

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,7 +68,7 @@ install_requires =
     aiohttp-retry>=2.4.5
     scmrepo==0.0.24
     dvc-render==0.0.6
-    dvc-task@git+https://github.com/iterative/dvc-task.git@0.0.11
+    dvc-task@git+https://github.com/iterative/dvc-task.git@0.0.12
     dvclive>=0.7.3
     dvc-data==0.0.5
 

--- a/tests/func/experiments/test_experiments.py
+++ b/tests/func/experiments/test_experiments.py
@@ -211,19 +211,17 @@ def test_add_params(tmp_dir, scm, dvc, changes):
         dvc.experiments.run(stage.addressing, params=changes)
 
 
-@pytest.mark.parametrize("queue", [True, False])
-def test_apply(tmp_dir, scm, dvc, exp_stage, queue, test_queue):
+def test_apply(tmp_dir, scm, dvc, exp_stage):
     from dvc.exceptions import InvalidArgumentError
     from dvc.repo.experiments.exceptions import ApplyConflictError
 
-    metrics_original = (tmp_dir / "metrics.yaml").read_text().strip()
     results = dvc.experiments.run(
-        exp_stage.addressing, params=["foo=2"], queue=queue, tmp_dir=True
+        exp_stage.addressing, params=["foo=2"], tmp_dir=True
     )
     exp_a = first(results)
 
     results = dvc.experiments.run(
-        exp_stage.addressing, params=["foo=3"], queue=queue, tmp_dir=True
+        exp_stage.addressing, params=["foo=3"], tmp_dir=True
     )
     exp_b = first(results)
 
@@ -232,29 +230,45 @@ def test_apply(tmp_dir, scm, dvc, exp_stage, queue, test_queue):
 
     dvc.experiments.apply(exp_a)
     assert (tmp_dir / "params.yaml").read_text().strip() == "foo: 2"
-    assert (
-        (tmp_dir / "metrics.yaml").read_text().strip() == metrics_original
-        if queue
-        else "foo: 2"
-    )
+    assert (tmp_dir / "metrics.yaml").read_text().strip() == "foo: 2"
 
     with pytest.raises(ApplyConflictError):
         dvc.experiments.apply(exp_b, force=False)
         # failed apply should revert everything to prior state
         assert (tmp_dir / "params.yaml").read_text().strip() == "foo: 2"
-        assert (
-            (tmp_dir / "metrics.yaml").read_text().strip() == metrics_original
-            if queue
-            else "foo: 2"
-        )
+        assert (tmp_dir / "metrics.yaml").read_text().strip() == "foo: 2"
 
     dvc.experiments.apply(exp_b)
     assert (tmp_dir / "params.yaml").read_text().strip() == "foo: 3"
-    assert (
-        (tmp_dir / "metrics.yaml").read_text().strip() == metrics_original
-        if queue
-        else "foo: 3"
+    assert (tmp_dir / "metrics.yaml").read_text().strip() == "foo: 3"
+
+
+def test_apply_queued(tmp_dir, scm, dvc, exp_stage, test_queue):
+    # from dvc.exceptions import InvalidArgumentError
+    from dvc.repo.experiments.exceptions import ApplyConflictError
+
+    metrics_original = (tmp_dir / "metrics.yaml").read_text().strip()
+    dvc.experiments.run(
+        exp_stage.addressing, params=["foo=2"], name="exp-a", queue=True
     )
+    dvc.experiments.run(
+        exp_stage.addressing, params=["foo=3"], name="exp-b", queue=True
+    )
+    queue_revs = {
+        entry.name: entry.stash_rev
+        for entry in dvc.experiments.celery_queue.iter_queued()
+    }
+
+    dvc.experiments.apply(queue_revs["exp-a"])
+    assert (tmp_dir / "params.yaml").read_text().strip() == "foo: 2"
+    assert (tmp_dir / "metrics.yaml").read_text().strip() == metrics_original
+
+    with pytest.raises(ApplyConflictError):
+        dvc.experiments.apply(queue_revs["exp-b"], force=False)
+
+    dvc.experiments.apply(queue_revs["exp-b"])
+    assert (tmp_dir / "params.yaml").read_text().strip() == "foo: 3"
+    assert (tmp_dir / "metrics.yaml").read_text().strip() == metrics_original
 
 
 def test_get_baseline(tmp_dir, scm, dvc, exp_stage):

--- a/tests/unit/command/test_queue.py
+++ b/tests/unit/command/test_queue.py
@@ -21,7 +21,7 @@ def test_experiments_remove(dvc, scm, mocker):
 
     cmd = cli_args.func(cli_args)
     m = mocker.patch(
-        "dvc.repo.experiments.queue.local.LocalCeleryQueue.clear",
+        "dvc.repo.experiments.queue.celery.LocalCeleryQueue.clear",
         return_value={},
     )
 
@@ -40,7 +40,7 @@ def test_experiments_remove(dvc, scm, mocker):
 
     cmd = cli_args.func(cli_args)
     m = mocker.patch(
-        "dvc.repo.experiments.queue.local.LocalCeleryQueue.remove",
+        "dvc.repo.experiments.queue.celery.LocalCeleryQueue.remove",
         return_value={},
     )
 
@@ -61,7 +61,7 @@ def test_experiments_kill(dvc, scm, mocker):
 
     cmd = cli_args.func(cli_args)
     m = mocker.patch(
-        "dvc.repo.experiments.queue.local.LocalCeleryQueue.kill",
+        "dvc.repo.experiments.queue.celery.LocalCeleryQueue.kill",
         return_value={},
     )
 
@@ -75,7 +75,7 @@ def test_experiments_start(dvc, scm, mocker):
 
     cmd = cli_args.func(cli_args)
     m = mocker.patch(
-        "dvc.repo.experiments.queue.local.LocalCeleryQueue.spawn_worker",
+        "dvc.repo.experiments.queue.celery.LocalCeleryQueue.spawn_worker",
     )
 
     assert cmd.run() == 0
@@ -94,7 +94,7 @@ def test_experiments_stop(dvc, scm, mocker):
 
     cmd = cli_args.func(cli_args)
     m = mocker.patch(
-        "dvc.repo.experiments.queue.local.LocalCeleryQueue.shutdown",
+        "dvc.repo.experiments.queue.celery.LocalCeleryQueue.shutdown",
     )
 
     assert cmd.run() == 0
@@ -134,11 +134,11 @@ def test_worker_status(dvc, scm, worker_status, output, mocker, capsys):
 
     cmd = cli_args.func(cli_args)
     mocker.patch(
-        "dvc.repo.experiments.queue.local.LocalCeleryQueue.status",
+        "dvc.repo.experiments.queue.celery.LocalCeleryQueue.status",
         return_value=[],
     )
     m = mocker.patch(
-        "dvc.repo.experiments.queue.local.LocalCeleryQueue.worker_status",
+        "dvc.repo.experiments.queue.celery.LocalCeleryQueue.worker_status",
         return_value=worker_status,
     )
 
@@ -176,7 +176,7 @@ def test_experiments_status(dvc, scm, mocker, capsys):
         },
     ]
     m = mocker.patch(
-        "dvc.repo.experiments.queue.local.LocalCeleryQueue.status",
+        "dvc.repo.experiments.queue.celery.LocalCeleryQueue.status",
         return_value=status_result,
     )
 
@@ -194,7 +194,7 @@ def test_queue_logs(dvc, scm, mocker):
 
     cmd = cli_args.func(cli_args)
     m = mocker.patch(
-        "dvc.repo.experiments.queue.local.LocalCeleryQueue.logs",
+        "dvc.repo.experiments.queue.celery.LocalCeleryQueue.logs",
         return_value={},
     )
 

--- a/tests/unit/repo/experiments/conftest.py
+++ b/tests/unit/repo/experiments/conftest.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 
 import pytest
 
-from dvc.repo.experiments.queue.local import LocalCeleryQueue
+from dvc.repo.experiments.queue.celery import LocalCeleryQueue
 
 
 @contextmanager


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

- Separates `--temp` from the celery queue (preserves existing support for one-off standalone exp runs outside of the workspace)
- `exp show`: Running standalone temp directory runs are now labeled as `tempdir` in the `Executor` column (previously was `temp`)
- `exp show`: Running dvc-task/celery queued runs are now labeled as `dvc-task` in the `Executor` column (previously was `temp`)

related: https://github.com/iterative/dvc/issues/7592#issuecomment-1153869162