### PR TITLE
queue status: will show the current worker status

### DIFF
--- a/dvc/commands/queue/start.py
+++ b/dvc/commands/queue/start.py
@@ -12,13 +12,12 @@ class CmdQueueStart(CmdBase):
     """Start exp queue workers."""
 
     def run(self):
-        for _ in range(self.args.jobs):
-            self.repo.experiments.celery_queue.spawn_worker()
-
-        suffix = "s" if self.args.jobs > 1 else ""
-        ui.write(
-            f"Start {self.args.jobs} worker{suffix} to process the queue."
+        started = self.repo.experiments.celery_queue.start_workers(
+            self.args.jobs
         )
+
+        suffix = "s" if started > 1 else ""
+        ui.write(f"Start {started} new worker{suffix} to process the queue.")
 
         return 0
 

--- a/dvc/commands/queue/status.py
+++ b/dvc/commands/queue/status.py
@@ -5,6 +5,7 @@ from typing import List, Mapping, Optional
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
 from dvc.compare import TabularData
+from dvc.ui import ui
 
 from ..experiments.show import format_time
 
@@ -26,6 +27,13 @@ class CmdQueueStatus(CmdBase):
                 [exp["rev"][:7], exp.get("name", ""), created, exp["status"]]
             )
         td.render()
+        worker_count = len(self.repo.experiments.celery_queue.active_worker())
+        if worker_count == 1:
+            ui.write("There is 1 worker active at present.")
+        elif worker_count == 0:
+            ui.write("No worker active at present.")
+        else:
+            ui.write(f"There are {worker_count} worker active at present.")
 
         return 0
 

--- a/dvc/commands/queue/status.py
+++ b/dvc/commands/queue/status.py
@@ -27,13 +27,29 @@ class CmdQueueStatus(CmdBase):
                 [exp["rev"][:7], exp.get("name", ""), created, exp["status"]]
             )
         td.render()
-        worker_count = len(self.repo.experiments.celery_queue.active_worker())
-        if worker_count == 1:
-            ui.write("There is 1 worker active at present.")
-        elif worker_count == 0:
-            ui.write("No worker active at present.")
+
+        if not result:
+            ui.write("No experiments in task queue for now.")
+
+        worker_status = self.repo.experiments.celery_queue.worker_status()
+        active_count = len(
+            [name for name, task in worker_status.items() if task]
+        )
+        idle_count = len(worker_status) - active_count
+
+        if active_count == 1:
+            ui.write("There is 1 worker active", end=", ")
+        elif active_count == 0:
+            ui.write("No worker active", end=", ")
         else:
-            ui.write(f"There are {worker_count} worker active at present.")
+            ui.write(f"There are {active_count} workers active", end=", ")
+
+        if idle_count == 1:
+            ui.write("1 worker idle at present.")
+        elif idle_count == 0:
+            ui.write("no worker idle at present.")
+        else:
+            ui.write(f"{idle_count} workers idle at present.")
 
         return 0
 


### PR DESCRIPTION
fix: #7950
Currently queue worker status are not show in `queue status` makes it
hard to tell if the worker is still living.

1. add a new method `active_worker` to return the currently running
   worker node name.
2. give every worker a unique name.
3. `queue status` will show how much worker running at present.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Some tests are still required for this change.