### PR TITLE
config: remove core.jobs dead code

### DIFF
--- a/dvc/fs/__init__.py
+++ b/dvc/fs/__init__.py
@@ -104,11 +104,6 @@ def get_cloud_fs(repo, **kwargs):
     except Invalid as exc:
         raise RepoConfigError(str(exc)) from None
 
-    if "jobs" not in remote_conf:
-        jobs = core_config.get("jobs")
-        if jobs:
-            remote_conf["jobs"] = jobs
-
     if "checksum_jobs" not in remote_conf:
         checksum_jobs = core_config.get("checksum_jobs")
         if checksum_jobs:

--- a/tests/unit/remote/test_remote.py
+++ b/tests/unit/remote/test_remote.py
@@ -23,7 +23,6 @@ def test_remote_with_jobs(dvc):
         "url": "s3://bucket/name",
         "jobs": 100,
     }
-    dvc.config["core"]["jobs"] = 200
 
     cls, config, _ = get_cloud_fs(dvc, name="with_jobs")
     fs = cls(**config)


### PR DESCRIPTION
Fixes #1626. There was a `core.jobs` option that's not supported by the schema nor documented. I guess it was intended to apply across multiple remotes, but nobody has asked about it, so I'm proposing to remove it and close the issue.