### PR TITLE
exp apply: preserve untracked files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ install_requires =
     typing-extensions>=3.7.4
     fsspec[http]>=2021.10.1
     aiohttp-retry>=2.4.5
-    scmrepo==0.0.24
+    scmrepo==0.0.25
     dvc-render==0.0.6
     dvclive>=0.7.3
     dvc-data==0.0.6

--- a/tests/func/experiments/test_experiments.py
+++ b/tests/func/experiments/test_experiments.py
@@ -217,6 +217,25 @@ def test_apply(tmp_dir, scm, dvc, exp_stage, queue):
     )
 
 
+def test_apply_untracked(tmp_dir, scm, dvc, exp_stage):
+    from dvc.repo.experiments.base import ApplyConflictError
+
+    results = dvc.experiments.run(exp_stage.addressing, params=["foo=2"])
+    exp = first(results)
+    tmp_dir.gen("untracked", "untracked")
+    tmp_dir.gen("params.yaml", "conflict")
+
+    with pytest.raises(ApplyConflictError):
+        dvc.experiments.apply(exp, force=False)
+
+    assert (tmp_dir / "untracked").read_text() == "untracked"
+    assert (tmp_dir / "params.yaml").read_text() == "conflict"
+
+    dvc.experiments.apply(exp, force=True)
+    assert (tmp_dir / "untracked").read_text() == "untracked"
+    assert (tmp_dir / "params.yaml").read_text().strip() == "foo: 2"
+
+
 def test_get_baseline(tmp_dir, scm, dvc, exp_stage):
     from dvc.repo.experiments.base import EXPS_STASH
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Untracked files are now preserved on `exp apply`

- With `--force` (default), if a file currently untracked in the workspace exists in the experiment to apply, the experiment version will replace the workspace version. If the untracked file does not exist in the experiment, the workspace version is preserved after applying the experiment.
- With `--no-force`, workspace state for untracked files is preserved (`apply` will fail due to conflicts if the file exists in the experiment)
 
Fixes #6930 