### PR TITLE
dvc plots: allow for setting output directory via config

### DIFF
--- a/dvc/commands/plots.py
+++ b/dvc/commands/plots.py
@@ -69,7 +69,9 @@ class CmdPlots(CmdBase):
                     "visualization file will not be created."
                 )
 
-            out: str = self.args.out or "dvc_plots"
+            out: str = self.args.out or self.repo.config.get("plots", {}).get(
+                "out_dir", "dvc_plots"
+            )
 
             renderers_out = (
                 out if self.args.json else os.path.join(out, "static")

--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -269,6 +269,7 @@ SCHEMA = {
     "plots": {
         "html_template": str,
         Optional("auto_open", default=False): Bool,
+        "out_dir": str,
     },
     "exp": {
         "code": str,

--- a/tests/integration/plots/test_json.py
+++ b/tests/integration/plots/test_json.py
@@ -252,3 +252,30 @@ def test_repo_with_removed_plots(tmp_dir, capsys, repo_with_plots):
         for p in {"linear.json", "confusion.json", "image.png"}:
             assert json_result[p] == []
             assert split_json_result[p] == []
+
+
+def test_config_output_dir(tmp_dir, dvc, capsys):
+    subdir = tmp_dir / "subdir"
+    ret = main(["config", "plots.out_dir", os.fspath(subdir)])
+    assert ret == 0
+
+    metric = [{"first_val": 100, "val": 2}, {"first_val": 200, "val": 3}]
+    (tmp_dir / "metric.json").dump_json(metric, sort_keys=True)
+
+    assert main(["plots", "show", "metric.json"]) == 0
+
+    out, _ = capsys.readouterr()
+    assert subdir.as_uri() in out
+    assert subdir.is_dir()
+    assert (subdir / "index.html").is_file()
+
+    cli_arg_subdir = tmp_dir / "cli_option"
+    assert (
+        main(["plots", "show", "-o", os.fspath(cli_arg_subdir), "metric.json"])
+        == 0
+    )
+
+    out, _ = capsys.readouterr()
+    assert cli_arg_subdir.as_uri() in out
+    assert cli_arg_subdir.is_dir()
+    assert (cli_arg_subdir / "index.html").is_file()


### PR DESCRIPTION
* [x ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

This PR allows users to set output directory for `dvc plots show` via `dvc config`. I added a test covering this scenario. 
To test run the following script:
```
#!/bin/bash

set -ex
rm -rf repo
mkdir repo
pushd repo

echo '[{"first_val": 100, "val": 2}, {"first_val": 200, "val": 3}]' >> metric.json

dvc config plots.out_dir config_dir

dvc plots show metric.json

dvc plots show -o arg_dir metric.json
```
