### PR TITLE
deps: remove setuptools_scm_git_archive

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,1 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true)$
 ref-names: $Format:%D$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=48", "setuptools_scm[toml]>=6.3.1", "setuptools_scm_git_archive==1.1"]
+requires = ["setuptools>=48", "setuptools_scm[toml]>=7"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,8 +26,7 @@ classifiers =
 [options]
 setup_requires =
     setuptools>=48
-    setuptools_scm[toml]>=6.3.1
-    setuptools_scm_git_archive==1.1
+    setuptools_scm[toml]>=7
 
 python_requires = >=3.8
 zip_safe = False


### PR DESCRIPTION
setuptools_scm can now work with git archives, so we don't need this plugin.
See https://github.com/pypa/setuptools_scm#git-archives.
