### PR TITLE
refactor: use relative imports

### DIFF
--- a/dvc/__init__.py
+++ b/dvc/__init__.py
@@ -4,6 +4,7 @@ DVC
 Make your data science projects reproducible and shareable.
 """
 import dvc.logger
+
 from .version import __version__  # noqa: F401
 
 dvc.logger.setup()

--- a/dvc/__init__.py
+++ b/dvc/__init__.py
@@ -4,6 +4,6 @@ DVC
 Make your data science projects reproducible and shareable.
 """
 import dvc.logger
-from dvc.version import __version__  # noqa: F401
+from .version import __version__  # noqa: F401
 
 dvc.logger.setup()

--- a/dvc/__main__.py
+++ b/dvc/__main__.py
@@ -1,7 +1,7 @@
 """Main entry point for DVC command line tool."""
 import sys
 
-from dvc.cli import main
+from .cli import main
 
 if __name__ == "__main__":
     sys.exit(main(sys.argv[1:]))

--- a/dvc/analytics.py
+++ b/dvc/analytics.py
@@ -86,7 +86,6 @@ def _scm_in_use():
 
     from .exceptions import NotDvcRepoError
     from .repo import Repo
-
     from .scm import SCM, SCMError
 
     try:

--- a/dvc/analytics.py
+++ b/dvc/analytics.py
@@ -21,7 +21,7 @@ def collect_and_send_report(args=None, return_code=None):
     """
     import tempfile
 
-    from dvc.daemon import daemon
+    from .daemon import daemon
 
     report = {}
 
@@ -38,8 +38,8 @@ def collect_and_send_report(args=None, return_code=None):
 
 
 def is_enabled():
-    from dvc.config import Config, to_bool
-    from dvc.utils import env2bool
+    from .config import Config, to_bool
+    from .utils import env2bool
 
     if env2bool("DVC_TEST"):
         return False
@@ -84,8 +84,8 @@ def send(path):
 def _scm_in_use():
     from scmrepo.noscm import NoSCM
 
-    from dvc.exceptions import NotDvcRepoError
-    from dvc.repo import Repo
+    from .exceptions import NotDvcRepoError
+    from .repo import Repo
 
     from .scm import SCM, SCMError
 
@@ -102,8 +102,8 @@ def _runtime_info():
     """
     Gather information from the environment where DVC runs to fill a report.
     """
-    from dvc import __version__
-    from dvc.utils import is_binary
+    from . import __version__
+    from .utils import is_binary
 
     return {
         "dvc_version": __version__,
@@ -160,9 +160,9 @@ def _find_or_create_user_id():
     """
     import uuid
 
-    from dvc.config import Config
-    from dvc.lock import Lock, LockError
-    from dvc.utils.fs import makedirs
+    from .config import Config
+    from .lock import Lock, LockError
+    from .utils.fs import makedirs
 
     config_dir = Config.get_dir("global")
     fname = os.path.join(config_dir, "user_id")

--- a/dvc/api/data.py
+++ b/dvc/api/data.py
@@ -3,8 +3,8 @@ from typing import Optional
 
 from funcy import reraise
 
-from dvc.exceptions import OutputNotFoundError, PathMissingError
-from dvc.repo import Repo
+from ..exceptions import OutputNotFoundError, PathMissingError
+from ..repo import Repo
 
 
 def get_url(path, repo=None, rev=None, remote=None):

--- a/dvc/api/experiments.py
+++ b/dvc/api/experiments.py
@@ -2,9 +2,9 @@ import builtins
 import os
 from time import sleep
 
-from dvc.env import DVC_CHECKPOINT, DVC_ROOT
-from dvc.repo import Repo
-from dvc.stage.monitor import CheckpointTask
+from ..env import DVC_CHECKPOINT, DVC_ROOT
+from ..repo import Repo
+from ..stage.monitor import CheckpointTask
 
 
 def make_checkpoint():

--- a/dvc/api/params.py
+++ b/dvc/api/params.py
@@ -3,7 +3,7 @@ from typing import Dict, Iterable, Optional, Union
 
 from funcy import first
 
-from dvc.repo import Repo
+from ..repo import Repo
 
 
 def params_show(

--- a/dvc/cli/__init__.py
+++ b/dvc/cli/__init__.py
@@ -38,8 +38,8 @@ def parse_args(argv=None):
 
 
 def _log_unknown_exceptions() -> None:
-    from dvc.info import get_dvc_info
-    from dvc.logger import FOOTER
+    from ..info import get_dvc_info
+    from ..logger import FOOTER
 
     logger.exception("unexpected error")
     if logger.isEnabledFor(logging.DEBUG):
@@ -50,7 +50,7 @@ def _log_unknown_exceptions() -> None:
 
 def _log_exceptions(exc: Exception) -> Optional[int]:
     """Try to log some known exceptions, that are not DVCExceptions."""
-    from dvc.utils import error_link, format_link
+    from ..utils import error_link, format_link
 
     if isinstance(exc, OSError):
         import errno
@@ -66,10 +66,10 @@ def _log_exceptions(exc: Exception) -> Optional[int]:
             _log_unknown_exceptions()
         return None
 
-    from dvc.fs import AuthError, ConfigError, RemoteMissingDepsError
+    from ..fs import AuthError, ConfigError, RemoteMissingDepsError
 
     if isinstance(exc, RemoteMissingDepsError):
-        from dvc.utils.pkg import PKG
+        from ..utils.pkg import PKG
 
         proto = exc.protocol
         by_pkg = {
@@ -110,7 +110,7 @@ def _log_exceptions(exc: Exception) -> Optional[int]:
     from dvc_data.hashfile.cache import DiskError
 
     if isinstance(exc, DiskError):
-        from dvc.utils import relpath
+        from ..utils import relpath
 
         directory = relpath(exc.directory)
         logger.exception(
@@ -140,10 +140,10 @@ def main(argv=None):  # noqa: C901
     Returns:
         int: command's return code.
     """
-    from dvc._debug import debugtools
-    from dvc.config import ConfigError
-    from dvc.exceptions import DvcException, NotDvcRepoError
-    from dvc.logger import disable_other_loggers, set_loggers_level
+    from .._debug import debugtools
+    from ..config import ConfigError
+    from ..exceptions import DvcException, NotDvcRepoError
+    from ..logger import disable_other_loggers, set_loggers_level
 
     # NOTE: stderr/stdout may be closed if we are running from dvc.daemon.
     # On Linux we directly call cli.main after double forking and closing
@@ -176,7 +176,7 @@ def main(argv=None):  # noqa: C901
         logger.trace(args)
 
         if not sys.stdout.closed and not args.quiet:
-            from dvc.ui import ui
+            from ..ui import ui
 
             ui.enable()
 
@@ -202,7 +202,7 @@ def main(argv=None):  # noqa: C901
         ret = _log_exceptions(exc) or 255
 
     try:
-        from dvc import analytics
+        from .. import analytics
 
         if analytics.is_enabled():
             analytics.collect_and_send_report(args, ret)
@@ -211,7 +211,7 @@ def main(argv=None):  # noqa: C901
     finally:
         logger.setLevel(outerLogLevel)
 
-        from dvc.external_repo import clean_repos
+        from ..external_repo import clean_repos
 
         # Remove cached repos in the end of the call, these are anonymous
         # so won't be reused by any other subsequent run anyway.

--- a/dvc/cli/command.py
+++ b/dvc/cli/command.py
@@ -9,7 +9,7 @@ class CmdBase(ABC):
     UNINITIALIZED = False
 
     def __init__(self, args):
-        from dvc.repo import Repo
+        from ..repo import Repo
 
         os.chdir(args.cd)
 

--- a/dvc/cli/parser.py
+++ b/dvc/cli/parser.py
@@ -4,7 +4,7 @@ import logging
 import os
 import sys
 
-from dvc.commands import (
+from ..commands import (
     add,
     cache,
     check_ignore,
@@ -127,7 +127,7 @@ class VersionAction(argparse.Action):  # pragma: no cover
     """Shows DVC version and exits."""
 
     def __call__(self, parser, namespace, values, option_string=None):
-        from dvc import __version__
+        from .. import __version__
 
         print(__version__)
         sys.exit(0)
@@ -140,7 +140,7 @@ def get_parent_parser():
     When overwriting `-q` or `-v`, you need to instantiate a new object
     in order to prevent some weird behavior.
     """
-    from dvc._debug import add_debugging_flags
+    from .._debug import add_debugging_flags
 
     parent_parser = argparse.ArgumentParser(add_help=False)
     add_debugging_flags(parent_parser)

--- a/dvc/cli/parser.py
+++ b/dvc/cli/parser.py
@@ -43,7 +43,6 @@ from ..commands import (
     update,
     version,
 )
-
 from . import DvcParserError
 
 logger = logging.getLogger(__name__)

--- a/dvc/cli/utils.py
+++ b/dvc/cli/utils.py
@@ -11,7 +11,7 @@ def fix_subparsers(subparsers):
 
 
 def append_doc_link(help_message, path):
-    from dvc.utils import format_link
+    from ..utils import format_link
 
     if not path:
         return help_message

--- a/dvc/commands/add.py
+++ b/dvc/commands/add.py
@@ -1,16 +1,16 @@
 import argparse
 import logging
 
-from dvc.cli import completion
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
+from ..cli import completion
+from ..cli.command import CmdBase
+from ..cli.utils import append_doc_link
 
 logger = logging.getLogger(__name__)
 
 
 class CmdAdd(CmdBase):
     def run(self):
-        from dvc.exceptions import (
+        from ..exceptions import (
             DvcException,
             RecursiveAddingWhileUsingFilename,
         )

--- a/dvc/commands/cache.py
+++ b/dvc/commands/cache.py
@@ -1,9 +1,9 @@
 import argparse
 
-from dvc.cli import completion
-from dvc.cli.utils import append_doc_link, fix_subparsers
-from dvc.commands.config import CmdConfig
-from dvc.ui import ui
+from ..cli import completion
+from ..cli.utils import append_doc_link, fix_subparsers
+from .config import CmdConfig
+from ..ui import ui
 
 
 class CmdCacheDir(CmdConfig):
@@ -28,7 +28,7 @@ class CmdCacheDir(CmdConfig):
 
 
 def add_parser(subparsers, parent_parser):
-    from dvc.commands.config import parent_config_parser
+    from .config import parent_config_parser
 
     CACHE_HELP = "Manage cache settings."
 

--- a/dvc/commands/cache.py
+++ b/dvc/commands/cache.py
@@ -2,8 +2,8 @@ import argparse
 
 from ..cli import completion
 from ..cli.utils import append_doc_link, fix_subparsers
-from .config import CmdConfig
 from ..ui import ui
+from .config import CmdConfig
 
 
 class CmdCacheDir(CmdConfig):

--- a/dvc/commands/check_ignore.py
+++ b/dvc/commands/check_ignore.py
@@ -1,9 +1,9 @@
 import argparse
 
-from dvc.cli import completion
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
-from dvc.ui import ui
+from ..cli import completion
+from ..cli.command import CmdBase
+from ..cli.utils import append_doc_link
+from ..ui import ui
 
 
 class CmdCheckIgnore(CmdBase):
@@ -53,7 +53,7 @@ class CmdCheckIgnore(CmdBase):
         return ret
 
     def _check_args(self):
-        from dvc.exceptions import DvcException
+        from ..exceptions import DvcException
 
         if not self.args.stdin and not self.args.targets:
             raise DvcException("`targets` or `--stdin` needed")

--- a/dvc/commands/checkout.py
+++ b/dvc/commands/checkout.py
@@ -1,11 +1,11 @@
 import argparse
 import operator
 
-from dvc.cli import completion
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
-from dvc.exceptions import CheckoutError
-from dvc.ui import ui
+from ..cli import completion
+from ..cli.command import CmdBase
+from ..cli.utils import append_doc_link
+from ..exceptions import CheckoutError
+from ..ui import ui
 
 
 def log_changes(stats):
@@ -29,7 +29,7 @@ def log_changes(stats):
 
 class CmdCheckout(CmdBase):
     def run(self):
-        from dvc.utils.humanize import get_summary
+        from ..utils.humanize import get_summary
 
         stats, exc = None, None
         try:

--- a/dvc/commands/commit.py
+++ b/dvc/commands/commit.py
@@ -1,16 +1,16 @@
 import argparse
 import logging
 
-from dvc.cli import completion
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
+from ..cli import completion
+from ..cli.command import CmdBase
+from ..cli.utils import append_doc_link
 
 logger = logging.getLogger(__name__)
 
 
 class CmdCommit(CmdBase):
     def run(self):
-        from dvc.exceptions import DvcException
+        from ..exceptions import DvcException
 
         if not self.args.targets:
             self.args.targets = [None]

--- a/dvc/commands/completion.py
+++ b/dvc/commands/completion.py
@@ -1,10 +1,10 @@
 import argparse
 import logging
 
-from dvc.cli.command import CmdBaseNoRepo
-from dvc.cli.completion import PREAMBLE
-from dvc.cli.utils import append_doc_link
-from dvc.ui import ui
+from ..cli.command import CmdBaseNoRepo
+from ..cli.completion import PREAMBLE
+from ..cli.utils import append_doc_link
+from ..ui import ui
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/commands/config.py
+++ b/dvc/commands/config.py
@@ -2,9 +2,9 @@ import argparse
 import logging
 import os
 
-from dvc.cli.command import CmdBaseNoRepo
-from dvc.cli.utils import append_doc_link
-from dvc.ui import ui
+from ..cli.command import CmdBaseNoRepo
+from ..cli.utils import append_doc_link
+from ..ui import ui
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +30,7 @@ def _name_type(value):
 
 class CmdConfig(CmdBaseNoRepo):
     def __init__(self, args):
-        from dvc.config import Config
+        from ..config import Config
 
         super().__init__(args)
 
@@ -81,7 +81,7 @@ class CmdConfig(CmdBaseNoRepo):
         return 0
 
     def _get(self, remote, section, opt):
-        from dvc.config import ConfigError
+        from ..config import ConfigError
 
         levels = self._get_appropriate_levels(self.args.level)[::-1]
 
@@ -125,7 +125,7 @@ class CmdConfig(CmdBaseNoRepo):
         return 0
 
     def _check(self, conf, remote, section, opt=None):
-        from dvc.config import ConfigError
+        from ..config import ConfigError
 
         name = "remote" if remote else "section"
         if section not in conf:
@@ -145,21 +145,21 @@ class CmdConfig(CmdBaseNoRepo):
         return self.config.LEVELS
 
     def _validate_level_for_non_repo_operation(self, level):
-        from dvc.config import ConfigError
+        from ..config import ConfigError
 
         if self.config.dvc_dir is None and level in self.config.REPO_LEVELS:
             raise ConfigError("Not inside a DVC repo")
 
     @staticmethod
     def _format_config(config, prefix=""):
-        from dvc.utils.flatten import flatten
+        from ..utils.flatten import flatten
 
         for key, value in flatten(config).items():
             yield f"{prefix}{key}={value}"
 
     @staticmethod
     def _config_file_prefix(show_origin, config, level):
-        from dvc.repo import Repo
+        from ..repo import Repo
 
         if not show_origin:
             return ""

--- a/dvc/commands/daemon.py
+++ b/dvc/commands/daemon.py
@@ -1,6 +1,6 @@
-from dvc.cli import completion
-from dvc.cli.command import CmdBaseNoRepo
-from dvc.cli.utils import fix_subparsers
+from ..cli import completion
+from ..cli.command import CmdBaseNoRepo
+from ..cli.utils import fix_subparsers
 
 
 class CmdDaemonBase(CmdBaseNoRepo):
@@ -11,9 +11,9 @@ class CmdDaemonUpdater(CmdDaemonBase):
     def run(self):
         import os
 
-        from dvc.config import Config
-        from dvc.repo import Repo
-        from dvc.updater import Updater
+        from ..config import Config
+        from ..repo import Repo
+        from ..updater import Updater
 
         root_dir = Repo.find_root()
         dvc_dir = os.path.join(root_dir, Repo.DVC_DIR)
@@ -28,7 +28,7 @@ class CmdDaemonUpdater(CmdDaemonBase):
 
 class CmdDaemonAnalytics(CmdDaemonBase):
     def run(self):
-        from dvc import analytics
+        from .. import analytics
 
         analytics.send(self.args.target)
 

--- a/dvc/commands/dag.py
+++ b/dvc/commands/dag.py
@@ -1,17 +1,17 @@
 import argparse
 from typing import TYPE_CHECKING
 
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
-from dvc.ui import ui
+from ..cli.command import CmdBase
+from ..cli.utils import append_doc_link
+from ..ui import ui
 
 if TYPE_CHECKING:
     from networkx import DiGraph
 
 
 def _show_ascii(G: "DiGraph"):
-    from dvc.dagascii import draw
-    from dvc.repo.graph import get_pipelines
+    from ..dagascii import draw
+    from ..repo.graph import get_pipelines
 
     pipelines = get_pipelines(G)
 
@@ -45,7 +45,7 @@ def _show_dot(G: "DiGraph"):
 
 
 def _show_mermaid(G, markdown: bool = False):
-    from dvc.repo.graph import get_pipelines
+    from ..repo.graph import get_pipelines
 
     pipelines = get_pipelines(G)
 
@@ -97,7 +97,7 @@ def _collect_targets(repo, target, outs):
 def _transform(index, outs):
     import networkx as nx
 
-    from dvc.stage import Stage
+    from ..stage import Stage
 
     def _relabel(node) -> str:
         return node.addressing if isinstance(node, Stage) else str(node)

--- a/dvc/commands/data_sync.py
+++ b/dvc/commands/data_sync.py
@@ -1,17 +1,17 @@
 import argparse
 import logging
 
-from dvc.cli import completion
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
+from ..cli import completion
+from ..cli.command import CmdBase
+from ..cli.utils import append_doc_link
 
 logger = logging.getLogger(__name__)
 
 
 class CmdDataBase(CmdBase):
     def log_summary(self, stats):
-        from dvc.ui import ui
-        from dvc.utils.humanize import get_summary
+        from ..ui import ui
+        from ..utils.humanize import get_summary
 
         default_msg = "Everything is up to date."
         ui.write(get_summary(stats.items()) or default_msg)
@@ -19,13 +19,13 @@ class CmdDataBase(CmdBase):
 
 class CmdDataPull(CmdDataBase):
     def log_summary(self, stats):
-        from dvc.commands.checkout import log_changes
+        from .checkout import log_changes
 
         log_changes(stats)
         super().log_summary(stats)
 
     def run(self):
-        from dvc.exceptions import CheckoutError, DvcException
+        from ..exceptions import CheckoutError, DvcException
 
         try:
             stats = self.repo.pull(
@@ -52,7 +52,7 @@ class CmdDataPull(CmdDataBase):
 
 class CmdDataPush(CmdDataBase):
     def run(self):
-        from dvc.exceptions import DvcException
+        from ..exceptions import DvcException
 
         try:
             processed_files_count = self.repo.push(
@@ -76,7 +76,7 @@ class CmdDataPush(CmdDataBase):
 
 class CmdDataFetch(CmdDataBase):
     def run(self):
-        from dvc.exceptions import DvcException
+        from ..exceptions import DvcException
 
         try:
             processed_files_count = self.repo.fetch(
@@ -98,7 +98,7 @@ class CmdDataFetch(CmdDataBase):
 
 
 def shared_parent_parser():
-    from dvc.cli.parser import get_parent_parser
+    from ..cli.parser import get_parent_parser
 
     # Parent parser used in pull/push/status
     parent_parser = argparse.ArgumentParser(
@@ -127,7 +127,7 @@ def shared_parent_parser():
 
 
 def add_parser(subparsers, _parent_parser):
-    from dvc.commands.status import CmdDataStatus
+    from .status import CmdDataStatus
 
     # Pull
     PULL_HELP = "Download tracked files or directories from remote storage."

--- a/dvc/commands/destroy.py
+++ b/dvc/commands/destroy.py
@@ -1,16 +1,16 @@
 import argparse
 import logging
 
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
+from ..cli.command import CmdBase
+from ..cli.utils import append_doc_link
 
 logger = logging.getLogger(__name__)
 
 
 class CmdDestroy(CmdBase):
     def run(self):
-        from dvc.exceptions import DvcException
-        from dvc.ui import ui
+        from ..exceptions import DvcException
+        from ..ui import ui
 
         try:
             statement = (

--- a/dvc/commands/diff.py
+++ b/dvc/commands/diff.py
@@ -2,10 +2,10 @@ import argparse
 import logging
 import os
 
-from dvc.cli import completion
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
-from dvc.ui import ui
+from ..cli import completion
+from ..cli.command import CmdBase
+from ..cli.utils import append_doc_link
+from ..ui import ui
 
 logger = logging.getLogger(__name__)
 
@@ -119,7 +119,7 @@ class CmdDiff(CmdBase):
         ui.write("files summary:", states_summary)
 
     def run(self):
-        from dvc.exceptions import DvcException
+        from ..exceptions import DvcException
 
         try:
             diff = self.repo.diff(

--- a/dvc/commands/experiments/__init__.py
+++ b/dvc/commands/experiments/__init__.py
@@ -1,11 +1,11 @@
 import argparse
 
-from dvc.cli.utils import (
+from ...cli.utils import (
     append_doc_link,
     fix_plumbing_subparsers,
     fix_subparsers,
 )
-from dvc.commands.experiments import (
+from . import (
     apply,
     branch,
     diff,

--- a/dvc/commands/experiments/apply.py
+++ b/dvc/commands/experiments/apply.py
@@ -1,9 +1,9 @@
 import argparse
 import logging
 
-from dvc.cli import completion
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
+from ...cli import completion
+from ...cli.command import CmdBase
+from ...cli.utils import append_doc_link
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/commands/experiments/branch.py
+++ b/dvc/commands/experiments/branch.py
@@ -1,8 +1,8 @@
 import argparse
 import logging
 
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
+from ...cli.command import CmdBase
+from ...cli.utils import append_doc_link
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/commands/experiments/diff.py
+++ b/dvc/commands/experiments/diff.py
@@ -4,9 +4,9 @@ import logging
 from ...cli import completion
 from ...cli.command import CmdBase
 from ...cli.utils import append_doc_link
-from ..metrics import DEFAULT_PRECISION
 from ...exceptions import DvcException
 from ...ui import ui
+from ..metrics import DEFAULT_PRECISION
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/commands/experiments/diff.py
+++ b/dvc/commands/experiments/diff.py
@@ -1,12 +1,12 @@
 import argparse
 import logging
 
-from dvc.cli import completion
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
-from dvc.commands.metrics import DEFAULT_PRECISION
-from dvc.exceptions import DvcException
-from dvc.ui import ui
+from ...cli import completion
+from ...cli.command import CmdBase
+from ...cli.utils import append_doc_link
+from ..metrics import DEFAULT_PRECISION
+from ...exceptions import DvcException
+from ...ui import ui
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +28,7 @@ class CmdExperimentsDiff(CmdBase):
         if self.args.json:
             ui.write_json(diff)
         else:
-            from dvc.compare import show_diff
+            from ...compare import show_diff
 
             precision = self.args.precision or DEFAULT_PRECISION
             diffs = [("metrics", "Metric"), ("params", "Param")]

--- a/dvc/commands/experiments/exec_run.py
+++ b/dvc/commands/experiments/exec_run.py
@@ -1,6 +1,6 @@
 import logging
 
-from dvc.cli.command import CmdBaseNoRepo
+from ...cli.command import CmdBaseNoRepo
 
 logger = logging.getLogger(__name__)
 
@@ -9,11 +9,11 @@ class CmdExecutorRun(CmdBaseNoRepo):
     """Run an experiment executor."""
 
     def run(self):
-        from dvc.repo.experiments.executor.base import (
+        from ...repo.experiments.executor.base import (
             BaseExecutor,
             ExecutorInfo,
         )
-        from dvc.utils.serialize import load_json
+        from ...utils.serialize import load_json
 
         info = ExecutorInfo.from_dict(load_json(self.args.infofile))
         BaseExecutor.reproduce(

--- a/dvc/commands/experiments/gc.py
+++ b/dvc/commands/experiments/gc.py
@@ -1,10 +1,10 @@
 import argparse
 import logging
 
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
-from dvc.exceptions import InvalidArgumentError
-from dvc.ui import ui
+from ...cli.command import CmdBase
+from ...cli.utils import append_doc_link
+from ...exceptions import InvalidArgumentError
+from ...ui import ui
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/commands/experiments/init.py
+++ b/dvc/commands/experiments/init.py
@@ -4,14 +4,14 @@ from typing import TYPE_CHECKING, List
 
 from funcy import compact
 
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
-from dvc.exceptions import InvalidArgumentError
-from dvc.ui import ui
+from ...cli.command import CmdBase
+from ...cli.utils import append_doc_link
+from ...exceptions import InvalidArgumentError
+from ...ui import ui
 
 if TYPE_CHECKING:
-    from dvc.dependency import Dependency
-    from dvc.stage import PipelineStage
+    from ...dependency import Dependency
+    from ...stage import PipelineStage
 
 
 logger = logging.getLogger(__name__)
@@ -35,13 +35,13 @@ class CmdExperimentsInit(CmdBase):
     }
 
     def run(self):
-        from dvc.commands.stage import parse_cmd
+        from ..stage import parse_cmd
 
         cmd = parse_cmd(self.args.command)
         if not self.args.interactive and not cmd:
             raise InvalidArgumentError("command is not specified")
 
-        from dvc.repo.experiments.init import init
+        from ...repo.experiments.init import init
 
         defaults = {}
         if not self.args.explicit:
@@ -83,7 +83,7 @@ class CmdExperimentsInit(CmdBase):
         new_deps: List["Dependency"],
         new_out_dirs: List[str],
     ) -> None:
-        from dvc.utils import humanize
+        from ...utils import humanize
 
         path_fmt = "[green]{}[/green]".format
         if new_deps:

--- a/dvc/commands/experiments/ls.py
+++ b/dvc/commands/experiments/ls.py
@@ -1,8 +1,8 @@
 import argparse
 import logging
 
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
+from ...cli.command import CmdBase
+from ...cli.utils import append_doc_link
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/commands/experiments/pull.py
+++ b/dvc/commands/experiments/pull.py
@@ -1,10 +1,10 @@
 import argparse
 import logging
 
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
-from dvc.exceptions import InvalidArgumentError
-from dvc.ui import ui
+from ...cli.command import CmdBase
+from ...cli.utils import append_doc_link
+from ...exceptions import InvalidArgumentError
+from ...ui import ui
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/commands/experiments/push.py
+++ b/dvc/commands/experiments/push.py
@@ -1,11 +1,11 @@
 import argparse
 import logging
 
-from dvc.cli import completion
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
-from dvc.exceptions import InvalidArgumentError
-from dvc.ui import ui
+from ...cli import completion
+from ...cli.command import CmdBase
+from ...cli.utils import append_doc_link
+from ...exceptions import InvalidArgumentError
+from ...ui import ui
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/commands/experiments/remove.py
+++ b/dvc/commands/experiments/remove.py
@@ -1,10 +1,10 @@
 import argparse
 import logging
 
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
-from dvc.exceptions import InvalidArgumentError
-from dvc.ui import ui
+from ...cli.command import CmdBase
+from ...cli.utils import append_doc_link
+from ...exceptions import InvalidArgumentError
+from ...ui import ui
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/commands/experiments/run.py
+++ b/dvc/commands/experiments/run.py
@@ -1,19 +1,19 @@
 import argparse
 import logging
 
-from dvc.cli import completion
-from dvc.cli.utils import append_doc_link
-from dvc.commands.repro import CmdRepro
-from dvc.commands.repro import add_arguments as add_repro_arguments
-from dvc.exceptions import InvalidArgumentError
-from dvc.ui import ui
+from ...cli import completion
+from ...cli.utils import append_doc_link
+from ..repro import CmdRepro
+from ..repro import add_arguments as add_repro_arguments
+from ...exceptions import InvalidArgumentError
+from ...ui import ui
 
 logger = logging.getLogger(__name__)
 
 
 class CmdExperimentsRun(CmdRepro):
     def run(self):
-        from dvc.compare import show_metrics
+        from ...compare import show_metrics
 
         if self.args.checkpoint_resume:
             if self.args.reset:

--- a/dvc/commands/experiments/run.py
+++ b/dvc/commands/experiments/run.py
@@ -3,10 +3,10 @@ import logging
 
 from ...cli import completion
 from ...cli.utils import append_doc_link
-from ..repro import CmdRepro
-from ..repro import add_arguments as add_repro_arguments
 from ...exceptions import InvalidArgumentError
 from ...ui import ui
+from ..repro import CmdRepro
+from ..repro import add_arguments as add_repro_arguments
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/commands/experiments/show.py
+++ b/dvc/commands/experiments/show.py
@@ -8,18 +8,18 @@ from typing import TYPE_CHECKING
 
 from funcy import lmap
 
-from dvc.cli import completion
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
-from dvc.commands.metrics import DEFAULT_PRECISION
-from dvc.exceptions import DvcException, InvalidArgumentError
-from dvc.ui import ui
-from dvc.utils.flatten import flatten
-from dvc.utils.serialize import encode_exception
+from ...cli import completion
+from ...cli.command import CmdBase
+from ...cli.utils import append_doc_link
+from ..metrics import DEFAULT_PRECISION
+from ...exceptions import DvcException, InvalidArgumentError
+from ...ui import ui
+from ...utils.flatten import flatten
+from ...utils.serialize import encode_exception
 
 if TYPE_CHECKING:
-    from dvc.compare import TabularData
-    from dvc.ui import RichText
+    from ...compare import TabularData
+    from ...ui import RichText
 
 FILL_VALUE = "-"
 FILL_VALUE_ERRORED = "!"
@@ -233,7 +233,7 @@ def _format_time(datetime_obj, fill_value=FILL_VALUE, iso=False):
 
 
 def _extend_row(row, names, headers, items, precision, fill_value=FILL_VALUE):
-    from dvc.compare import _format_field, with_value
+    from ...compare import _format_field, with_value
 
     for fname, data in items:
         item = data.get("data", {})
@@ -269,7 +269,7 @@ def experiments_table(
 ) -> "TabularData":
     from funcy import lconcat
 
-    from dvc.compare import TabularData
+    from ...compare import TabularData
 
     all_headers = lconcat(headers, metric_headers, param_headers, deps_names)
     td = TabularData(all_headers, fill_value=fill_value)

--- a/dvc/commands/experiments/show.py
+++ b/dvc/commands/experiments/show.py
@@ -11,11 +11,11 @@ from funcy import lmap
 from ...cli import completion
 from ...cli.command import CmdBase
 from ...cli.utils import append_doc_link
-from ..metrics import DEFAULT_PRECISION
 from ...exceptions import DvcException, InvalidArgumentError
 from ...ui import ui
 from ...utils.flatten import flatten
 from ...utils.serialize import encode_exception
+from ..metrics import DEFAULT_PRECISION
 
 if TYPE_CHECKING:
     from ...compare import TabularData

--- a/dvc/commands/freeze.py
+++ b/dvc/commands/freeze.py
@@ -1,10 +1,10 @@
 import argparse
 import logging
 
-from dvc.cli import completion
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
-from dvc.exceptions import DvcException
+from ..cli import completion
+from ..cli.command import CmdBase
+from ..cli.utils import append_doc_link
+from ..exceptions import DvcException
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/commands/gc.py
+++ b/dvc/commands/gc.py
@@ -2,16 +2,16 @@ import argparse
 import logging
 import os
 
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
-from dvc.ui import ui
+from ..cli.command import CmdBase
+from ..cli.utils import append_doc_link
+from ..ui import ui
 
 logger = logging.getLogger(__name__)
 
 
 class CmdGC(CmdBase):
     def run(self):
-        from dvc.repo.gc import _raise_error_if_all_disabled
+        from ..repo.gc import _raise_error_if_all_disabled
 
         _raise_error_if_all_disabled(
             all_branches=self.args.all_branches,

--- a/dvc/commands/get.py
+++ b/dvc/commands/get.py
@@ -1,9 +1,9 @@
 import argparse
 import logging
 
-from dvc.cli import completion
-from dvc.cli.command import CmdBaseNoRepo
-from dvc.exceptions import DvcException
+from ..cli import completion
+from ..cli.command import CmdBaseNoRepo
+from ..exceptions import DvcException
 
 from ..cli.utils import append_doc_link
 
@@ -12,8 +12,8 @@ logger = logging.getLogger(__name__)
 
 class CmdGet(CmdBaseNoRepo):
     def _show_url(self):
-        from dvc.api import get_url
-        from dvc.ui import ui
+        from ..api import get_url
+        from ..ui import ui
 
         try:
             url = get_url(
@@ -33,7 +33,7 @@ class CmdGet(CmdBaseNoRepo):
         return self._get_file_from_repo()
 
     def _get_file_from_repo(self):
-        from dvc.repo import Repo
+        from ..repo import Repo
 
         try:
             Repo.get(

--- a/dvc/commands/get.py
+++ b/dvc/commands/get.py
@@ -3,9 +3,8 @@ import logging
 
 from ..cli import completion
 from ..cli.command import CmdBaseNoRepo
-from ..exceptions import DvcException
-
 from ..cli.utils import append_doc_link
+from ..exceptions import DvcException
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/commands/get_url.py
+++ b/dvc/commands/get_url.py
@@ -1,9 +1,9 @@
 import argparse
 import logging
 
-from dvc.cli import completion
-from dvc.cli.command import CmdBaseNoRepo
-from dvc.exceptions import DvcException
+from ..cli import completion
+from ..cli.command import CmdBaseNoRepo
+from ..exceptions import DvcException
 
 from ..cli.utils import append_doc_link
 
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 class CmdGetUrl(CmdBaseNoRepo):
     def run(self):
-        from dvc.repo import Repo
+        from ..repo import Repo
 
         try:
             Repo.get_url(self.args.url, out=self.args.out, jobs=self.args.jobs)

--- a/dvc/commands/get_url.py
+++ b/dvc/commands/get_url.py
@@ -3,9 +3,8 @@ import logging
 
 from ..cli import completion
 from ..cli.command import CmdBaseNoRepo
-from ..exceptions import DvcException
-
 from ..cli.utils import append_doc_link
+from ..exceptions import DvcException
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/commands/git_hook.py
+++ b/dvc/commands/git_hook.py
@@ -1,16 +1,16 @@
 import logging
 import os
 
-from dvc.cli.command import CmdBaseNoRepo
-from dvc.cli.utils import fix_subparsers
-from dvc.exceptions import NotDvcRepoError
+from ..cli.command import CmdBaseNoRepo
+from ..cli.utils import fix_subparsers
+from ..exceptions import NotDvcRepoError
 
 logger = logging.getLogger(__name__)
 
 
 class CmdHookBase(CmdBaseNoRepo):
     def run(self):
-        from dvc.repo import Repo
+        from ..repo import Repo
 
         try:
             repo = Repo()
@@ -26,7 +26,7 @@ class CmdHookBase(CmdBaseNoRepo):
 
 class CmdPreCommit(CmdHookBase):
     def _run(self):
-        from dvc.cli import main
+        from ..cli import main
 
         return main(["status"])
 
@@ -50,22 +50,22 @@ class CmdPostCheckout(CmdHookBase):
         if os.path.isdir(os.path.join(".git", "rebase-merge")):
             return 0
 
-        from dvc.cli import main
+        from ..cli import main
 
         return main(["checkout"])
 
 
 class CmdPrePush(CmdHookBase):
     def _run(self):
-        from dvc.cli import main
+        from ..cli import main
 
         return main(["push"])
 
 
 class CmdMergeDriver(CmdHookBase):
     def _run(self):
-        from dvc.dvcfile import Dvcfile
-        from dvc.repo import Repo
+        from ..dvcfile import Dvcfile
+        from ..repo import Repo
 
         dvc = Repo()
 

--- a/dvc/commands/imp.py
+++ b/dvc/commands/imp.py
@@ -1,10 +1,10 @@
 import argparse
 import logging
 
-from dvc.cli import completion
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
-from dvc.exceptions import DvcException
+from ..cli import completion
+from ..cli.command import CmdBase
+from ..cli.utils import append_doc_link
+from ..exceptions import DvcException
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/commands/imp_url.py
+++ b/dvc/commands/imp_url.py
@@ -1,10 +1,10 @@
 import argparse
 import logging
 
-from dvc.cli import completion
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
-from dvc.exceptions import DvcException
+from ..cli import completion
+from ..cli.command import CmdBase
+from ..cli.utils import append_doc_link
+from ..exceptions import DvcException
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/commands/init.py
+++ b/dvc/commands/init.py
@@ -3,17 +3,17 @@ import logging
 
 import colorama
 
-from dvc import analytics
-from dvc.cli.command import CmdBaseNoRepo
-from dvc.cli.utils import append_doc_link
-from dvc.utils import boxify
-from dvc.utils import format_link as fmt_link
+from .. import analytics
+from ..cli.command import CmdBaseNoRepo
+from ..cli.utils import append_doc_link
+from ..utils import boxify
+from ..utils import format_link as fmt_link
 
 logger = logging.getLogger(__name__)
 
 
 def _welcome_message():
-    from dvc.ui import ui
+    from ..ui import ui
 
     if analytics.is_enabled():
         ui.write(
@@ -38,8 +38,8 @@ def _welcome_message():
 
 class CmdInit(CmdBaseNoRepo):
     def run(self):
-        from dvc.exceptions import InitError
-        from dvc.repo import Repo
+        from ..exceptions import InitError
+        from ..repo import Repo
 
         try:
             with Repo.init(

--- a/dvc/commands/install.py
+++ b/dvc/commands/install.py
@@ -1,9 +1,9 @@
 import argparse
 import logging
 
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
-from dvc.exceptions import DvcException
+from ..cli.command import CmdBase
+from ..cli.utils import append_doc_link
+from ..exceptions import DvcException
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/commands/ls/__init__.py
+++ b/dvc/commands/ls/__init__.py
@@ -4,9 +4,9 @@ import logging
 from ...cli import completion
 from ...cli.command import CmdBaseNoRepo
 from ...cli.utils import append_doc_link
-from .ls_colors import LsColors
 from ...exceptions import DvcException
 from ...ui import ui
+from .ls_colors import LsColors
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/commands/ls/__init__.py
+++ b/dvc/commands/ls/__init__.py
@@ -1,12 +1,12 @@
 import argparse
 import logging
 
-from dvc.cli import completion
-from dvc.cli.command import CmdBaseNoRepo
-from dvc.cli.utils import append_doc_link
-from dvc.commands.ls.ls_colors import LsColors
-from dvc.exceptions import DvcException
-from dvc.ui import ui
+from ...cli import completion
+from ...cli.command import CmdBaseNoRepo
+from ...cli.utils import append_doc_link
+from .ls_colors import LsColors
+from ...exceptions import DvcException
+from ...ui import ui
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ def _prettify(entries, with_color=False):
 
 class CmdList(CmdBaseNoRepo):
     def run(self):
-        from dvc.repo import Repo
+        from ...repo import Repo
 
         try:
             entries = Repo.ls(

--- a/dvc/commands/machine.py
+++ b/dvc/commands/machine.py
@@ -2,13 +2,13 @@ import argparse
 
 from ..cli.command import CmdBase
 from ..cli.utils import append_doc_link, fix_subparsers
-from .config import CmdConfig
 from ..compare import TabularData
 from ..config import ConfigError
 from ..exceptions import DvcException
 from ..types import Dict, List
 from ..ui import ui
 from ..utils import format_link
+from .config import CmdConfig
 
 
 class MachineDisabledError(ConfigError):

--- a/dvc/commands/machine.py
+++ b/dvc/commands/machine.py
@@ -1,14 +1,14 @@
 import argparse
 
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link, fix_subparsers
-from dvc.commands.config import CmdConfig
-from dvc.compare import TabularData
-from dvc.config import ConfigError
-from dvc.exceptions import DvcException
-from dvc.types import Dict, List
-from dvc.ui import ui
-from dvc.utils import format_link
+from ..cli.command import CmdBase
+from ..cli.utils import append_doc_link, fix_subparsers
+from .config import CmdConfig
+from ..compare import TabularData
+from ..config import ConfigError
+from ..exceptions import DvcException
+from ..types import Dict, List
+from ..ui import ui
+from ..utils import format_link
 
 
 class MachineDisabledError(ConfigError):
@@ -33,7 +33,7 @@ class CmdMachineConfig(CmdConfig):
 
 class CmdMachineAdd(CmdMachineConfig):
     def run(self):
-        from dvc.machine import validate_name
+        from ..machine import validate_name
 
         validate_name(self.args.name)
 
@@ -129,7 +129,7 @@ class CmdMachineList(CmdMachineConfig):
 
 class CmdMachineModify(CmdMachineConfig):
     def run(self):
-        from dvc.config import merge
+        from ..config import merge
 
         with self.config.edit(self.args.level) as conf:
             merged = self.config.load_config_to_level(self.args.level)
@@ -156,7 +156,7 @@ class CmdMachineRename(CmdBase):
             conf["core"]["machine"] = self.args.new
 
     def _check_before_rename(self):
-        from dvc.machine import validate_name
+        from ..machine import validate_name
 
         validate_name(self.args.new)
 
@@ -310,7 +310,7 @@ class CmdMachineSsh(CmdBase):
 
 
 def add_parser(subparsers, parent_parser):
-    from dvc.commands.config import parent_config_parser
+    from .config import parent_config_parser
 
     machine_HELP = "Set up and manage cloud machines."
     machine_parser = subparsers.add_parser(

--- a/dvc/commands/metrics.py
+++ b/dvc/commands/metrics.py
@@ -1,12 +1,12 @@
 import argparse
 import logging
 
-from dvc.cli import completion
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link, fix_subparsers
-from dvc.exceptions import DvcException
-from dvc.ui import ui
-from dvc.utils.serialize import encode_exception
+from ..cli import completion
+from ..cli.command import CmdBase
+from ..cli.utils import append_doc_link, fix_subparsers
+from ..exceptions import DvcException
+from ..ui import ui
+from ..utils.serialize import encode_exception
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ class CmdMetricsShow(CmdMetricsBase):
         if self.args.json:
             ui.write_json(metrics, default=encode_exception)
         else:
-            from dvc.compare import show_metrics
+            from ..compare import show_metrics
 
             show_metrics(
                 metrics,
@@ -67,7 +67,7 @@ class CmdMetricsDiff(CmdMetricsBase):
         if self.args.json:
             ui.write_json(diff)
         else:
-            from dvc.compare import show_diff
+            from ..compare import show_diff
 
             show_diff(
                 diff,

--- a/dvc/commands/move.py
+++ b/dvc/commands/move.py
@@ -1,10 +1,10 @@
 import argparse
 import logging
 
-from dvc.cli import completion
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
-from dvc.exceptions import DvcException
+from ..cli import completion
+from ..cli.command import CmdBase
+from ..cli.utils import append_doc_link
+from ..exceptions import DvcException
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/commands/params.py
+++ b/dvc/commands/params.py
@@ -1,11 +1,11 @@
 import argparse
 import logging
 
-from dvc.cli import completion
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link, fix_subparsers
-from dvc.exceptions import DvcException
-from dvc.ui import ui
+from ..cli import completion
+from ..cli.command import CmdBase
+from ..cli.utils import append_doc_link, fix_subparsers
+from ..exceptions import DvcException
+from ..ui import ui
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ class CmdParamsDiff(CmdBase):
         if self.args.json:
             ui.write_json(diff)
         else:
-            from dvc.compare import show_diff
+            from ..compare import show_diff
 
             show_diff(
                 diff,

--- a/dvc/commands/plots.py
+++ b/dvc/commands/plots.py
@@ -5,18 +5,18 @@ import os
 
 from funcy import first
 
-from dvc.cli import completion
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link, fix_subparsers
-from dvc.exceptions import DvcException
-from dvc.ui import ui
-from dvc.utils import format_link
+from ..cli import completion
+from ..cli.command import CmdBase
+from ..cli.utils import append_doc_link, fix_subparsers
+from ..exceptions import DvcException
+from ..ui import ui
+from ..utils import format_link
 
 logger = logging.getLogger(__name__)
 
 
 def _show_json(renderers, split=False):
-    from dvc.render.convert import to_json
+    from ..render.convert import to_json
 
     result = {
         renderer.name: to_json(renderer, split) for renderer in renderers
@@ -25,7 +25,7 @@ def _show_json(renderers, split=False):
 
 
 def _adjust_vega_renderers(renderers):
-    from dvc.render import VERSION_FIELD
+    from ..render import VERSION_FIELD
     from dvc_render import VegaRenderer
 
     for r in renderers:
@@ -48,7 +48,7 @@ def _adjust_vega_renderers(renderers):
 def _summarize_version_infos(renderer):
     from collections import defaultdict
 
-    from dvc.render import VERSION_FIELD
+    from ..render import VERSION_FIELD
 
     result = defaultdict(set)
 
@@ -83,7 +83,7 @@ class CmdPlots(CmdBase):
         raise NotImplementedError
 
     def _props(self):
-        from dvc.schema import PLOT_PROPS
+        from ..schema import PLOT_PROPS
 
         # Pass only props specified by user, to not shadow ones from plot def
         props = {p: getattr(self.args, p) for p in PLOT_PROPS}
@@ -110,7 +110,7 @@ class CmdPlots(CmdBase):
     def run(self):
         from pathlib import Path
 
-        from dvc.render.match import match_defs_renderers
+        from ..render.match import match_defs_renderers
         from dvc_render import render_html
 
         if self.args.show_vega:

--- a/dvc/commands/plots.py
+++ b/dvc/commands/plots.py
@@ -25,8 +25,9 @@ def _show_json(renderers, split=False):
 
 
 def _adjust_vega_renderers(renderers):
-    from ..render import VERSION_FIELD
     from dvc_render import VegaRenderer
+
+    from ..render import VERSION_FIELD
 
     for r in renderers:
         if isinstance(r, VegaRenderer):
@@ -110,8 +111,9 @@ class CmdPlots(CmdBase):
     def run(self):
         from pathlib import Path
 
-        from ..render.match import match_defs_renderers
         from dvc_render import render_html
+
+        from ..render.match import match_defs_renderers
 
         if self.args.show_vega:
             if not self.args.targets:

--- a/dvc/commands/remote.py
+++ b/dvc/commands/remote.py
@@ -1,9 +1,9 @@
 import argparse
 
-from dvc.cli.utils import append_doc_link, fix_subparsers
-from dvc.commands.config import CmdConfig
-from dvc.ui import ui
-from dvc.utils import format_link
+from ..cli.utils import append_doc_link, fix_subparsers
+from .config import CmdConfig
+from ..ui import ui
+from ..utils import format_link
 
 
 class CmdRemote(CmdConfig):
@@ -14,7 +14,7 @@ class CmdRemote(CmdConfig):
             self.args.name = self.args.name.lower()
 
     def _check_exists(self, conf):
-        from dvc.config import ConfigError
+        from ..config import ConfigError
 
         if self.args.name not in conf["remote"]:
             raise ConfigError(f"remote '{self.args.name}' doesn't exist.")
@@ -22,7 +22,7 @@ class CmdRemote(CmdConfig):
 
 class CmdRemoteAdd(CmdRemote):
     def run(self):
-        from dvc.config import ConfigError
+        from ..config import ConfigError
 
         if self.args.default:
             ui.write(f"Setting '{self.args.name}' as a default remote.")
@@ -62,7 +62,7 @@ class CmdRemoteRemove(CmdRemote):
 
 class CmdRemoteModify(CmdRemote):
     def run(self):
-        from dvc.config import merge
+        from ..config import merge
 
         with self.config.edit(self.args.level) as conf:
             merged = self.config.load_config_to_level(self.args.level)
@@ -81,7 +81,7 @@ class CmdRemoteModify(CmdRemote):
 
 class CmdRemoteDefault(CmdRemote):
     def run(self):
-        from dvc.config import ConfigError
+        from ..config import ConfigError
 
         if self.args.name is None and not self.args.unset:
             conf = self.config.read(self.args.level)
@@ -124,7 +124,7 @@ class CmdRemoteRename(CmdRemote):
             conf["core"]["remote"] = self.args.new
 
     def run(self):
-        from dvc.config import ConfigError
+        from ..config import ConfigError
 
         all_config = self.config.load_config_to_level(None)
         if self.args.new in all_config.get("remote", {}):
@@ -151,7 +151,7 @@ class CmdRemoteRename(CmdRemote):
 
 
 def add_parser(subparsers, parent_parser):
-    from dvc.commands.config import parent_config_parser
+    from .config import parent_config_parser
 
     REMOTE_HELP = "Set up and manage data remotes."
     remote_parser = subparsers.add_parser(

--- a/dvc/commands/remote.py
+++ b/dvc/commands/remote.py
@@ -1,9 +1,9 @@
 import argparse
 
 from ..cli.utils import append_doc_link, fix_subparsers
-from .config import CmdConfig
 from ..ui import ui
 from ..utils import format_link
+from .config import CmdConfig
 
 
 class CmdRemote(CmdConfig):

--- a/dvc/commands/remove.py
+++ b/dvc/commands/remove.py
@@ -1,10 +1,10 @@
 import argparse
 import logging
 
-from dvc.cli import completion
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
-from dvc.exceptions import DvcException
+from ..cli import completion
+from ..cli.command import CmdBase
+from ..cli.utils import append_doc_link
+from ..exceptions import DvcException
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/commands/repro.py
+++ b/dvc/commands/repro.py
@@ -1,14 +1,14 @@
 import argparse
 
-from dvc.cli import completion
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
-from dvc.commands.status import CmdDataStatus
+from ..cli import completion
+from ..cli.command import CmdBase
+from ..cli.utils import append_doc_link
+from .status import CmdDataStatus
 
 
 class CmdRepro(CmdBase):
     def run(self):
-        from dvc.ui import ui
+        from ..ui import ui
 
         stages = self.repo.reproduce(
             **self._common_kwargs, **self._repro_kwargs
@@ -19,7 +19,7 @@ class CmdRepro(CmdBase):
             ui.write("Use `dvc push` to send your updates to remote storage.")
 
         if self.args.metrics:
-            from dvc.compare import show_metrics
+            from ..compare import show_metrics
 
             metrics = self.repo.metrics.show()
             show_metrics(metrics)

--- a/dvc/commands/root.py
+++ b/dvc/commands/root.py
@@ -1,17 +1,17 @@
 import argparse
 import logging
 
-from dvc.cli.command import CmdBaseNoRepo
-from dvc.cli.utils import append_doc_link
-from dvc.utils import relpath
+from ..cli.command import CmdBaseNoRepo
+from ..cli.utils import append_doc_link
+from ..utils import relpath
 
 logger = logging.getLogger(__name__)
 
 
 class CmdRoot(CmdBaseNoRepo):
     def run(self):
-        from dvc.repo import Repo
-        from dvc.ui import ui
+        from ..repo import Repo
+        from ..ui import ui
 
         ui.write(relpath(Repo.find_root()))
         return 0

--- a/dvc/commands/run.py
+++ b/dvc/commands/run.py
@@ -3,8 +3,8 @@ import logging
 
 from ..cli.command import CmdBase
 from ..cli.utils import append_doc_link
-from .stage import parse_cmd
 from ..exceptions import DvcException
+from .stage import parse_cmd
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/commands/run.py
+++ b/dvc/commands/run.py
@@ -1,10 +1,10 @@
 import argparse
 import logging
 
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
-from dvc.commands.stage import parse_cmd
-from dvc.exceptions import DvcException
+from ..cli.command import CmdBase
+from ..cli.utils import append_doc_link
+from .stage import parse_cmd
+from ..exceptions import DvcException
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +53,7 @@ class CmdRun(CmdBase):
 
 
 def add_parser(subparsers, parent_parser):
-    from dvc.commands.stage import _add_common_args
+    from .stage import _add_common_args
 
     RUN_HELP = (
         "Generate a dvc.yaml file from a command and execute the command."

--- a/dvc/commands/stage.py
+++ b/dvc/commands/stage.py
@@ -3,15 +3,15 @@ import logging
 from itertools import chain, filterfalse
 from typing import TYPE_CHECKING, Dict, Iterable, List
 
-from dvc.cli import completion
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link, fix_subparsers
-from dvc.utils.cli_parse import parse_params
-from dvc.utils.humanize import truncate_text
+from ..cli import completion
+from ..cli.command import CmdBase
+from ..cli.utils import append_doc_link, fix_subparsers
+from ..utils.cli_parse import parse_params
+from ..utils.humanize import truncate_text
 
 if TYPE_CHECKING:
-    from dvc.output import Output
-    from dvc.stage import Stage
+    from ..output import Output
+    from ..stage import Stage
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +83,7 @@ class CmdStageList(CmdBase):
         return dict.fromkeys(collected).keys()
 
     def run(self):
-        from dvc.ui import ui
+        from ..ui import ui
 
         def log_error(relpath: str, exc: Exception):
             if self.args.fail:

--- a/dvc/commands/status.py
+++ b/dvc/commands/status.py
@@ -1,9 +1,9 @@
 import logging
 
-from dvc.commands.data_sync import CmdDataBase
-from dvc.exceptions import DvcException
-from dvc.ui import ui
-from dvc.utils import format_link
+from .data_sync import CmdDataBase
+from ..exceptions import DvcException
+from ..ui import ui
+from ..utils import format_link
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +45,7 @@ class CmdDataStatus(CmdDataBase):
                 self._show(value, indent + 1)
 
     def run(self):
-        from dvc.repo import lock_repo
+        from ..repo import lock_repo
 
         indent = 1 if self.args.cloud else 0
 

--- a/dvc/commands/status.py
+++ b/dvc/commands/status.py
@@ -1,9 +1,9 @@
 import logging
 
-from .data_sync import CmdDataBase
 from ..exceptions import DvcException
 from ..ui import ui
 from ..utils import format_link
+from .data_sync import CmdDataBase
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/commands/unprotect.py
+++ b/dvc/commands/unprotect.py
@@ -1,10 +1,10 @@
 import argparse
 import logging
 
-from dvc.cli import completion
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
-from dvc.exceptions import DvcException
+from ..cli import completion
+from ..cli.command import CmdBase
+from ..cli.utils import append_doc_link
+from ..exceptions import DvcException
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/commands/update.py
+++ b/dvc/commands/update.py
@@ -1,10 +1,10 @@
 import argparse
 import logging
 
-from dvc.cli import completion
-from dvc.cli.command import CmdBase
-from dvc.cli.utils import append_doc_link
-from dvc.exceptions import DvcException
+from ..cli import completion
+from ..cli.command import CmdBase
+from ..cli.utils import append_doc_link
+from ..exceptions import DvcException
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/commands/version.py
+++ b/dvc/commands/version.py
@@ -1,17 +1,17 @@
 import argparse
 import logging
 
-from dvc.cli.command import CmdBaseNoRepo
-from dvc.cli.utils import append_doc_link
-from dvc.ui import ui
+from ..cli.command import CmdBaseNoRepo
+from ..cli.utils import append_doc_link
+from ..ui import ui
 
 logger = logging.getLogger(__name__)
 
 
 class CmdVersion(CmdBaseNoRepo):
     def run(self):
-        from dvc.info import get_dvc_info
-        from dvc.updater import notify_updates
+        from ..info import get_dvc_info
+        from ..updater import notify_updates
 
         dvc_info = get_dvc_info()
         ui.write(dvc_info, force=True)

--- a/dvc/compare.py
+++ b/dvc/compare.py
@@ -22,8 +22,8 @@ from typing import (
 from funcy import reraise
 
 if TYPE_CHECKING:
-    from dvc.types import StrPath
-    from dvc.ui.table import CellT
+    from .types import StrPath
+    from .ui.table import CellT
 
 
 class Column(List["CellT"]):
@@ -200,7 +200,7 @@ class TabularData(MutableSequence[Sequence["CellT"]]):
         self.append(row)
 
     def render(self, **kwargs: Any):
-        from dvc.ui import ui
+        from .ui import ui
 
         if kwargs.pop("csv", False):
             ui.write(self.to_csv(), end="")
@@ -423,8 +423,8 @@ def metrics_table(
     precision: int = None,
     round_digits: bool = False,
 ):
-    from dvc.utils.diff import format_dict
-    from dvc.utils.flatten import flatten
+    from .utils.diff import format_dict
+    from .utils.flatten import flatten
 
     td = TabularData(["Revision", "Path"], fill_value="-")
 

--- a/dvc/config.py
+++ b/dvc/config.py
@@ -227,10 +227,9 @@ class Config(dict):
 
     @staticmethod
     def _to_relpath(conf_dir, path):
+        from .config_schema import RelPath
         from .fs import localfs
         from .utils import relpath
-
-        from .config_schema import RelPath
 
         if re.match(r"\w+://", path):
             return path

--- a/dvc/config.py
+++ b/dvc/config.py
@@ -7,7 +7,7 @@ from functools import partial
 
 from funcy import cached_property, compact, memoize, re_find
 
-from dvc.exceptions import DvcException, NotDvcRepoError
+from .exceptions import DvcException, NotDvcRepoError
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +86,7 @@ class Config(dict):
     def __init__(
         self, dvc_dir=None, validate=True, fs=None, config=None
     ):  # pylint: disable=super-init-not-called
-        from dvc.fs import LocalFileSystem
+        from .fs import LocalFileSystem
 
         self.dvc_dir = dvc_dir
         self.wfs = LocalFileSystem()
@@ -94,7 +94,7 @@ class Config(dict):
 
         if not dvc_dir:
             try:
-                from dvc.repo import Repo
+                from .repo import Repo
 
                 self.dvc_dir = Repo.find_dvc_dir()
             except NotDvcRepoError:
@@ -227,8 +227,8 @@ class Config(dict):
 
     @staticmethod
     def _to_relpath(conf_dir, path):
-        from dvc.fs import localfs
-        from dvc.utils import relpath
+        from .fs import localfs
+        from .utils import relpath
 
         from .config_schema import RelPath
 

--- a/dvc/daemon.py
+++ b/dvc/daemon.py
@@ -7,8 +7,8 @@ import platform
 import sys
 from subprocess import Popen
 
-from dvc.env import DVC_DAEMON
-from dvc.utils import fix_env, is_binary
+from .env import DVC_DAEMON
+from .utils import fix_env, is_binary
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ def _spawn_windows(cmd, env):
 
 
 def _spawn_posix(cmd, env):
-    from dvc.cli import main
+    from .cli import main
 
     # NOTE: using os._exit instead of sys.exit, because dvc built
     # with PyInstaller has trouble with SystemExit exception and throws

--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -32,7 +32,7 @@ class DataCloud:
         name: Optional[str] = None,
         command: str = "<command>",
     ) -> "HashFileDB":
-        from dvc.config import NoRemoteError
+        from .config import NoRemoteError
 
         if not name:
             name = self.repo.config["core"].get("remote")
@@ -56,7 +56,7 @@ class DataCloud:
         raise NoRemoteError(error_msg)
 
     def _init_odb(self, name):
-        from dvc.fs import get_cloud_fs
+        from .fs import get_cloud_fs
         from dvc_data.db import get_odb
 
         cls, config, fs_path = get_cloud_fs(self.repo, name=name)
@@ -81,7 +81,7 @@ class DataCloud:
         objs: Iterable["HashInfo"],
         **kwargs,
     ):
-        from dvc.exceptions import FileTransferError
+        from .exceptions import FileTransferError
         from dvc_data.transfer import TransferError, transfer
 
         try:

--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -56,8 +56,9 @@ class DataCloud:
         raise NoRemoteError(error_msg)
 
     def _init_odb(self, name):
-        from .fs import get_cloud_fs
         from dvc_data.db import get_odb
+
+        from .fs import get_cloud_fs
 
         cls, config, fs_path = get_cloud_fs(self.repo, name=name)
         config["tmp_dir"] = self.repo.index_db_dir
@@ -81,8 +82,9 @@ class DataCloud:
         objs: Iterable["HashInfo"],
         **kwargs,
     ):
-        from .exceptions import FileTransferError
         from dvc_data.transfer import TransferError, transfer
+
+        from .exceptions import FileTransferError
 
         try:
             return transfer(src_odb, dest_odb, objs, **kwargs)

--- a/dvc/dependency/__init__.py
+++ b/dvc/dependency/__init__.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 from typing import Any, Mapping
 
 from ..output import ARTIFACT_SCHEMA, Output
-
 from .base import Dependency
 from .param import ParamsDependency
 from .repo import RepoDependency

--- a/dvc/dependency/__init__.py
+++ b/dvc/dependency/__init__.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from typing import Any, Mapping
 
-from dvc.output import ARTIFACT_SCHEMA, Output
+from ..output import ARTIFACT_SCHEMA, Output
 
 from .base import Dependency
 from .param import ParamsDependency

--- a/dvc/dependency/base.py
+++ b/dvc/dependency/base.py
@@ -1,7 +1,7 @@
 from typing import Type
 
-from dvc.exceptions import DvcException
-from dvc.output import Output
+from ..exceptions import DvcException
+from ..output import Output
 
 
 class DependencyDoesNotExistError(DvcException):

--- a/dvc/dependency/param.py
+++ b/dvc/dependency/param.py
@@ -7,8 +7,8 @@ from typing import Dict
 import dpath.util
 from voluptuous import Any
 
-from dvc.exceptions import DvcException
-from dvc.utils.serialize import LOADERS, ParseError
+from ..exceptions import DvcException
+from ..utils.serialize import LOADERS, ParseError
 from dvc_data.hashfile.hash_info import HashInfo
 
 from .base import Dependency

--- a/dvc/dependency/param.py
+++ b/dvc/dependency/param.py
@@ -7,10 +7,10 @@ from typing import Dict
 import dpath.util
 from voluptuous import Any
 
-from ..exceptions import DvcException
-from ..utils.serialize import LOADERS, ParseError
 from dvc_data.hashfile.hash_info import HashInfo
 
+from ..exceptions import DvcException
+from ..utils.serialize import LOADERS, ParseError
 from .base import Dependency
 
 logger = logging.getLogger(__name__)

--- a/dvc/dependency/repo.py
+++ b/dvc/dependency/repo.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Dict, Optional, Set, Tuple
 
 from voluptuous import Required
 
-from dvc.prompt import confirm
+from ..prompt import confirm
 
 from .base import Dependency
 
@@ -100,9 +100,9 @@ class RepoDependency(Dependency):
     def _get_used_and_obj(
         self, obj_only=False, **kwargs
     ) -> Tuple[Dict[Optional["ObjectDB"], Set["HashInfo"]], "HashFile"]:
-        from dvc.config import NoRemoteError
-        from dvc.exceptions import NoOutputOrStageError, PathMissingError
-        from dvc.utils import as_posix
+        from ..config import NoRemoteError
+        from ..exceptions import NoOutputOrStageError, PathMissingError
+        from ..utils import as_posix
         from dvc_data.objects.tree import Tree, TreeError
         from dvc_data.stage import stage
 
@@ -153,8 +153,8 @@ class RepoDependency(Dependency):
             return used_obj_ids, staged_obj
 
     def _check_circular_import(self, odb, obj_ids):
-        from dvc.exceptions import CircularImportError
-        from dvc.fs.dvc import DvcFileSystem
+        from ..exceptions import CircularImportError
+        from ..fs.dvc import DvcFileSystem
         from dvc_data.db.reference import ReferenceHashFileDB
         from dvc_data.objects.tree import Tree
 
@@ -198,7 +198,7 @@ class RepoDependency(Dependency):
         return obj
 
     def _make_repo(self, locked=True, **kwargs):
-        from dvc.external_repo import external_repo
+        from ..external_repo import external_repo
 
         d = self.def_repo
         rev = self._get_rev(locked=locked)

--- a/dvc/dependency/repo.py
+++ b/dvc/dependency/repo.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Dict, Optional, Set, Tuple
 from voluptuous import Required
 
 from ..prompt import confirm
-
 from .base import Dependency
 
 if TYPE_CHECKING:
@@ -100,11 +99,12 @@ class RepoDependency(Dependency):
     def _get_used_and_obj(
         self, obj_only=False, **kwargs
     ) -> Tuple[Dict[Optional["ObjectDB"], Set["HashInfo"]], "HashFile"]:
+        from dvc_data.objects.tree import Tree, TreeError
+        from dvc_data.stage import stage
+
         from ..config import NoRemoteError
         from ..exceptions import NoOutputOrStageError, PathMissingError
         from ..utils import as_posix
-        from dvc_data.objects.tree import Tree, TreeError
-        from dvc_data.stage import stage
 
         local_odb = self.repo.odb.local
         locked = kwargs.pop("locked", True)
@@ -153,10 +153,11 @@ class RepoDependency(Dependency):
             return used_obj_ids, staged_obj
 
     def _check_circular_import(self, odb, obj_ids):
-        from ..exceptions import CircularImportError
-        from ..fs.dvc import DvcFileSystem
         from dvc_data.db.reference import ReferenceHashFileDB
         from dvc_data.objects.tree import Tree
+
+        from ..exceptions import CircularImportError
+        from ..fs.dvc import DvcFileSystem
 
         if not isinstance(odb, ReferenceHashFileDB):
             return

--- a/dvc/dvcfile.py
+++ b/dvc/dvcfile.py
@@ -3,21 +3,21 @@ import logging
 import os
 from typing import TYPE_CHECKING, Any, Callable, Tuple, TypeVar, Union
 
-from dvc.exceptions import DvcException
-from dvc.parsing.versions import LOCKFILE_VERSION, SCHEMA_KWD
-from dvc.stage import serialize
-from dvc.stage.exceptions import (
+from .exceptions import DvcException
+from .parsing.versions import LOCKFILE_VERSION, SCHEMA_KWD
+from .stage import serialize
+from .stage.exceptions import (
     StageFileBadNameError,
     StageFileDoesNotExistError,
     StageFileIsNotDvcFileError,
 )
-from dvc.types import AnyPath
-from dvc.utils import relpath
-from dvc.utils.collections import apply_diff
-from dvc.utils.serialize import dump_yaml, modify_yaml
+from .types import AnyPath
+from .utils import relpath
+from .utils.collections import apply_diff
+from .utils.serialize import dump_yaml, modify_yaml
 
 if TYPE_CHECKING:
-    from dvc.repo import Repo
+    from .repo import Repo
 
 logger = logging.getLogger(__name__)
 _T = TypeVar("_T")
@@ -59,8 +59,8 @@ def is_lock_file(path):
 
 
 def is_git_ignored(repo, path):
-    from dvc.fs import LocalFileSystem
-    from dvc.scm import NoSCMError
+    from .fs import LocalFileSystem
+    from .scm import NoSCMError
 
     try:
         return isinstance(repo.fs, LocalFileSystem) and repo.scm.is_ignored(
@@ -151,12 +151,12 @@ class FileMixin:
 
     @classmethod
     def validate(cls, d: _T, fname: str = None) -> _T:
-        from dvc.utils.strictyaml import validate
+        from .utils.strictyaml import validate
 
         return validate(d, cls.SCHEMA, path=fname)  # type: ignore[arg-type]
 
     def _load_yaml(self, **kwargs: Any) -> Tuple[Any, str]:
-        from dvc.utils import strictyaml
+        from .utils import strictyaml
 
         return strictyaml.load(
             self.path,
@@ -177,8 +177,8 @@ class FileMixin:
 
 
 class SingleStageFile(FileMixin):
-    from dvc.schema import COMPILED_SINGLE_STAGE_SCHEMA as SCHEMA
-    from dvc.stage.loader import SingleStageLoader as LOADER
+    from .schema import COMPILED_SINGLE_STAGE_SCHEMA as SCHEMA
+    from .stage.loader import SingleStageLoader as LOADER
 
     @property
     def stage(self):
@@ -192,7 +192,7 @@ class SingleStageFile(FileMixin):
 
     def dump(self, stage, **kwargs):
         """Dumps given stage appropriately in the dvcfile."""
-        from dvc.stage import PipelineStage
+        from .stage import PipelineStage
 
         assert not isinstance(stage, PipelineStage)
         if self.verify:
@@ -216,8 +216,8 @@ class SingleStageFile(FileMixin):
 class PipelineFile(FileMixin):
     """Abstraction for pipelines file, .yaml + .lock combined."""
 
-    from dvc.schema import COMPILED_MULTI_STAGE_SCHEMA as SCHEMA
-    from dvc.stage.loader import StageLoader as LOADER
+    from .schema import COMPILED_MULTI_STAGE_SCHEMA as SCHEMA
+    from .stage.loader import StageLoader as LOADER
 
     @property
     def _lockfile(self):
@@ -227,7 +227,7 @@ class PipelineFile(FileMixin):
         self, stage, update_pipeline=True, update_lock=True, **kwargs
     ):  # pylint: disable=arguments-differ
         """Dumps given stage appropriately in the dvcfile."""
-        from dvc.stage import PipelineStage
+        from .stage import PipelineStage
 
         assert isinstance(stage, PipelineStage)
         if self.verify:
@@ -312,7 +312,7 @@ class PipelineFile(FileMixin):
 
 
 def get_lockfile_schema(d):
-    from dvc.schema import (
+    from .schema import (
         COMPILED_LOCKFILE_V1_SCHEMA,
         COMPILED_LOCKFILE_V2_SCHEMA,
     )

--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -1,5 +1,5 @@
 """Exceptions raised by the dvc."""
-from dvc.utils import format_link
+from .utils import format_link
 
 
 class DvcException(Exception):
@@ -50,7 +50,7 @@ class OutputNotFoundError(DvcException):
     """
 
     def __init__(self, output, repo=None):
-        from dvc.utils import relpath
+        from .utils import relpath
 
         self.output = output
         self.repo = repo
@@ -221,7 +221,7 @@ class UploadError(FileTransferError):
 
 class CheckoutError(DvcException):
     def __init__(self, target_infos, stats=None):
-        from dvc.utils import error_link
+        from .utils import error_link
 
         self.target_infos = target_infos
         self.stats = stats
@@ -248,7 +248,7 @@ class NoRemoteInExternalRepoError(DvcException):
 
 class NoOutputInExternalRepoError(DvcException):
     def __init__(self, path, external_repo_path, external_repo_url):
-        from dvc.utils import relpath
+        from .utils import relpath
 
         super().__init__(
             "Output '{}' not found in target repository '{}'".format(

--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Dict
 
 from funcy import retry, wrap_with
 
-from dvc.exceptions import (
+from .exceptions import (
     FileMissingError,
     NoOutputInExternalRepoError,
     NoRemoteInExternalRepoError,
@@ -15,9 +15,9 @@ from dvc.exceptions import (
     OutputNotFoundError,
     PathMissingError,
 )
-from dvc.repo import Repo
-from dvc.scm import CloneError, map_scm_exception
-from dvc.utils import relpath
+from .repo import Repo
+from .scm import CloneError, map_scm_exception
+from .utils import relpath
 
 if TYPE_CHECKING:
     from scmrepo import Git
@@ -32,8 +32,8 @@ def external_repo(
 ):
     from scmrepo.git import Git
 
-    from dvc.config import NoRemoteError
-    from dvc.fs import GitFileSystem
+    from .config import NoRemoteError
+    from .fs import GitFileSystem
 
     logger.debug("Creating external repo %s@%s", url, rev)
     path = _cached_clone(url, rev, for_write=for_write)
@@ -95,7 +95,7 @@ def external_repo(
 
 
 def erepo_factory(url, root_dir, cache_config):
-    from dvc.fs import localfs
+    from .fs import localfs
 
     def make_repo(path, fs=None, **_kwargs):
         _config = cache_config.copy()
@@ -215,7 +215,7 @@ def _clone_default_branch(url, rev, for_write=False):
                     logger.debug("erepo: git pull '%s'", url)
                     _pull(git)
         else:
-            from dvc.scm import clone
+            from .scm import clone
 
             logger.debug("erepo: git clone '%s' to a temporary dir", url)
             clone_path = tempfile.mkdtemp("dvc-clone")
@@ -247,7 +247,7 @@ def _clone_default_branch(url, rev, for_write=False):
 
 
 def _pull(git: "Git", unshallow: bool = False):
-    from dvc.repo.experiments.utils import fetch_all_exps
+    from .repo.experiments.utils import fetch_all_exps
 
     git.fetch(unshallow=unshallow)
     _merge_upstream(git)
@@ -278,7 +278,7 @@ def _git_checkout(repo_path, rev):
 
 
 def _remove(path):
-    from dvc.utils.fs import remove
+    from .utils.fs import remove
 
     if os.name == "nt":
         # git.exe may hang for a while not permitting to remove temp dir

--- a/dvc/fs/__init__.py
+++ b/dvc/fs/__init__.py
@@ -50,7 +50,7 @@ def get_fs_config(repo, config, **kwargs):
         try:
             remote_conf = config["remote"][name.lower()]
         except KeyError:
-            from dvc.config import RemoteNotFoundError
+            from ..config import RemoteNotFoundError
 
             raise RemoteNotFoundError(f"remote '{name}' doesn't exist")
     else:
@@ -92,8 +92,8 @@ def _resolve_remote_refs(repo, config, remote_conf):
 
 
 def get_cloud_fs(repo, **kwargs):
-    from dvc.config import ConfigError as RepoConfigError
-    from dvc.config_schema import SCHEMA, Invalid
+    from ..config import ConfigError as RepoConfigError
+    from ..config_schema import SCHEMA, Invalid
 
     repo_config = repo.config if repo else {}
     core_config = repo_config.get("core", {})

--- a/dvc/fs/callbacks.py
+++ b/dvc/fs/callbacks.py
@@ -11,7 +11,7 @@ from dvc_objects.fs.callbacks import (  # noqa: F401
 )
 
 if TYPE_CHECKING:
-    from dvc.ui._rich_progress import RichTransferProgress
+    from ..ui._rich_progress import RichTransferProgress
 
 
 class RichCallback(Callback):
@@ -40,8 +40,8 @@ class RichCallback(Callback):
 
     @cached_property
     def progress(self):
-        from dvc.ui import ui
-        from dvc.ui._rich_progress import RichTransferProgress
+        from ..ui import ui
+        from ..ui._rich_progress import RichTransferProgress
 
         if self._progress is not None:
             return self._progress

--- a/dvc/fs/data.py
+++ b/dvc/fs/data.py
@@ -9,7 +9,7 @@ from dvc_objects.fs.base import FileSystem
 from dvc_objects.fs.callbacks import DEFAULT_CALLBACK
 
 if typing.TYPE_CHECKING:
-    from dvc.types import AnyPath
+    from ..types import AnyPath
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +60,7 @@ class _DataFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
         return (self.workspace, *key)
 
     def _get_fs_path(self, path: "AnyPath", remote=None):
-        from dvc.config import NoRemoteError
+        from ..config import NoRemoteError
 
         info = self.info(path)
         if info["type"] == "directory":

--- a/dvc/fs/dvc.py
+++ b/dvc/fs/dvc.py
@@ -17,7 +17,7 @@ from dvc_objects.fs.path import Path
 from .data import DataFileSystem
 
 if TYPE_CHECKING:
-    from dvc.repo import Repo
+    from ..repo import Repo
 
 logger = logging.getLogger(__name__)
 
@@ -106,7 +106,7 @@ class _DvcFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
             )
 
         if not repo_factory:
-            from dvc.repo import Repo
+            from ..repo import Repo
 
             self.repo_factory: RepoFactory = Repo
         else:
@@ -166,8 +166,8 @@ class _DvcFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
     def _repo_from_fs_config(
         cls, **config
     ) -> Tuple["Repo", Optional["RepoFactory"]]:
-        from dvc.external_repo import erepo_factory, external_repo
-        from dvc.repo import Repo
+        from ..external_repo import erepo_factory, external_repo
+        from ..repo import Repo
 
         url = config.get(cls.PARAM_REPO_URL)
         root = config.get(cls.PARAM_REPO_ROOT)
@@ -260,7 +260,7 @@ class _DvcFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
         if not self._traverse_subrepos:
             return False
 
-        from dvc.repo import Repo
+        from ..repo import Repo
 
         repo_path = self.repo.fs.path.join(dir_path, Repo.DVC_DIR)
         return self.repo.fs.isdir(repo_path)
@@ -347,8 +347,8 @@ class _DvcFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
         dvcfiles = kwargs.get("dvcfiles", False)
 
         def _func(fname):
-            from dvc.dvcfile import is_valid_filename
-            from dvc.ignore import DvcIgnore
+            from ..dvcfile import is_valid_filename
+            from ..ignore import DvcIgnore
 
             if dvcfiles:
                 return True

--- a/dvc/fs/git.py
+++ b/dvc/fs/git.py
@@ -24,7 +24,7 @@ class GitFileSystem(FileSystem):  # pylint:disable=abstract-method
         trie: "GitTrie" = None,
         **kwargs: Any,
     ) -> None:
-        from dvc.scm import resolve_rev
+        from ..scm import resolve_rev
 
         super().__init__()
         self.fs_args.update(

--- a/dvc/ignore.py
+++ b/dvc/ignore.py
@@ -8,9 +8,9 @@ from pathspec.patterns import GitWildMatchPattern
 from pathspec.util import normalize_file
 from pygtrie import Trie
 
-from dvc.fs import AnyFSPath, FileSystem, Schemes, localfs
-from dvc.pathspec_math import PatternInfo, merge_patterns
-from dvc.types import List, Optional
+from .fs import AnyFSPath, FileSystem, Schemes, localfs
+from .pathspec_math import PatternInfo, merge_patterns
+from .types import List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -159,7 +159,7 @@ def _no_match(path):
 
 class DvcIgnoreFilter:
     def __init__(self, fs, root_dir):
-        from dvc.repo import Repo
+        from .repo import Repo
 
         default_ignore_patterns = [
             ".hg/",
@@ -244,7 +244,7 @@ class DvcIgnoreFilter:
                 )
 
     def _update_sub_repo(self, path, ignore_trie: Trie):
-        from dvc.repo import Repo
+        from .repo import Repo
 
         if path == self.root_dir:
             return
@@ -431,7 +431,7 @@ def init(path):
 
 
 def destroy(path):
-    from dvc.utils.fs import remove
+    from .utils.fs import remove
 
     dvcignore = os.path.join(path, DvcIgnore.DVCIGNORE_FILE)
     remove(dvcignore)

--- a/dvc/info.py
+++ b/dvc/info.py
@@ -6,13 +6,13 @@ import platform
 
 import psutil
 
-from dvc import __version__
-from dvc.exceptions import NotDvcRepoError
-from dvc.fs import FS_MAP, generic, get_fs_cls, get_fs_config
-from dvc.repo import Repo
-from dvc.scm import SCMError
-from dvc.utils import error_link
-from dvc.utils.pkg import PKG
+from . import __version__
+from .exceptions import NotDvcRepoError
+from .fs import FS_MAP, generic, get_fs_cls, get_fs_config
+from .repo import Repo
+from .scm import SCMError
+from .utils import error_link
+from .utils.pkg import PKG
 
 package = "" if PKG is None else f"({PKG})"
 

--- a/dvc/lock.py
+++ b/dvc/lock.py
@@ -9,9 +9,9 @@ import flufl.lock
 import zc.lockfile
 from funcy import retry
 
-from dvc.exceptions import DvcException
-from dvc.progress import Tqdm
-from dvc.utils import format_link
+from .exceptions import DvcException
+from .progress import Tqdm
+from .utils import format_link
 
 DEFAULT_TIMEOUT = 3
 

--- a/dvc/logger.py
+++ b/dvc/logger.py
@@ -5,7 +5,7 @@ import logging.handlers
 
 import colorama
 
-from dvc.progress import Tqdm
+from .progress import Tqdm
 
 FOOTER = (
     "\n{yellow}Having any troubles?{nc}"

--- a/dvc/machine/__init__.py
+++ b/dvc/machine/__init__.py
@@ -12,11 +12,11 @@ from typing import (
     Type,
 )
 
-from dvc.exceptions import DvcException
-from dvc.types import StrPath
+from ..exceptions import DvcException
+from ..types import StrPath
 
 if TYPE_CHECKING:
-    from dvc.repo import Repo
+    from ..repo import Repo
 
     from .backend.base import BaseMachineBackend
 
@@ -43,7 +43,7 @@ sudo echo "OK" > /var/log/dvc-machine-init.log
 
 
 def validate_name(name: str):
-    from dvc.exceptions import InvalidArgumentError
+    from ..exceptions import InvalidArgumentError
 
     name = name.lower()
     if name in RESERVED_NAMES:
@@ -134,7 +134,7 @@ class MachineManager:
         self,
         name: Optional[str] = None,
     ) -> Tuple[dict, "BaseMachineBackend"]:
-        from dvc.config import NoMachineError
+        from ..config import NoMachineError
 
         if not name:
             name = self.repo.config["core"].get("machine")
@@ -165,7 +165,7 @@ class MachineManager:
                 conf = config["machine"][name.lower()]
                 conf["name"] = name
             except KeyError:
-                from dvc.config import MachineNotFoundError
+                from ..config import MachineNotFoundError
 
                 raise MachineNotFoundError(f"machine '{name}' doesn't exist")
         else:
@@ -173,7 +173,7 @@ class MachineManager:
         return conf
 
     def _get_backend(self, cloud: str) -> "BaseMachineBackend":
-        from dvc.config import NoMachineError
+        from ..config import NoMachineError
 
         try:
             backend = self.CLOUD_BACKENDS[cloud]

--- a/dvc/machine/__init__.py
+++ b/dvc/machine/__init__.py
@@ -17,7 +17,6 @@ from ..types import StrPath
 
 if TYPE_CHECKING:
     from ..repo import Repo
-
     from .backend.base import BaseMachineBackend
 
     BackendCls = Type[BaseMachineBackend]

--- a/dvc/machine/backend/base.py
+++ b/dvc/machine/backend/base.py
@@ -3,8 +3,8 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, Iterator, Optional
 
 if TYPE_CHECKING:
-    from dvc.fs import SSHFileSystem
-    from dvc.types import StrPath
+    from ...fs import SSHFileSystem
+    from ...types import StrPath
 
 
 class BaseMachineBackend(ABC):

--- a/dvc/machine/backend/terraform.py
+++ b/dvc/machine/backend/terraform.py
@@ -3,14 +3,14 @@ from contextlib import contextmanager
 from functools import partial, partialmethod
 from typing import TYPE_CHECKING, Iterator, Optional
 
-from dvc.exceptions import DvcException
-from dvc.fs import DEFAULT_SSH_PORT, SSHFileSystem
-from dvc.utils.fs import makedirs
+from ...exceptions import DvcException
+from ...fs import DEFAULT_SSH_PORT, SSHFileSystem
+from ...utils.fs import makedirs
 
 from .base import BaseMachineBackend
 
 if TYPE_CHECKING:
-    from dvc.types import StrPath
+    from ...types import StrPath
 
 
 @contextmanager

--- a/dvc/machine/backend/terraform.py
+++ b/dvc/machine/backend/terraform.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Iterator, Optional
 from ...exceptions import DvcException
 from ...fs import DEFAULT_SSH_PORT, SSHFileSystem
 from ...utils.fs import makedirs
-
 from .base import BaseMachineBackend
 
 if TYPE_CHECKING:

--- a/dvc/odbmgr.py
+++ b/dvc/odbmgr.py
@@ -1,5 +1,6 @@
-from .fs import Schemes
 from dvc_data.db import get_odb
+
+from .fs import Schemes
 
 
 def _get_odb(repo, settings):

--- a/dvc/odbmgr.py
+++ b/dvc/odbmgr.py
@@ -1,9 +1,9 @@
-from dvc.fs import Schemes
+from .fs import Schemes
 from dvc_data.db import get_odb
 
 
 def _get_odb(repo, settings):
-    from dvc.fs import get_cloud_fs
+    from .fs import get_cloud_fs
 
     if not settings:
         return None
@@ -35,7 +35,7 @@ class ODBManager:
         elif "dir" not in config:
             settings = None
         else:
-            from dvc.config_schema import LOCAL_COMMON
+            from .config_schema import LOCAL_COMMON
 
             settings = {"url": config["dir"]}
             for opt in LOCAL_COMMON.keys():

--- a/dvc/output.py
+++ b/dvc/output.py
@@ -7,16 +7,6 @@ from urllib.parse import urlparse
 from funcy import collecting, project
 from voluptuous import And, Any, Coerce, Length, Lower, Required, SetTo
 
-from . import prompt
-from .exceptions import (
-    CacheLinkError,
-    CheckoutError,
-    CollectCacheError,
-    ConfirmRemoveError,
-    DvcException,
-    MergeError,
-    RemoteCacheRequiredError,
-)
 from dvc_data import Tree
 from dvc_data import check as ocheck
 from dvc_data import load as oload
@@ -28,6 +18,16 @@ from dvc_data.stage import stage as ostage
 from dvc_data.transfer import transfer as otransfer
 from dvc_objects.errors import ObjectFormatError
 
+from . import prompt
+from .exceptions import (
+    CacheLinkError,
+    CheckoutError,
+    CollectCacheError,
+    ConfirmRemoveError,
+    DvcException,
+    MergeError,
+    RemoteCacheRequiredError,
+)
 from .fs import (
     HDFSFileSystem,
     LocalFileSystem,

--- a/dvc/output.py
+++ b/dvc/output.py
@@ -7,8 +7,8 @@ from urllib.parse import urlparse
 from funcy import collecting, project
 from voluptuous import And, Any, Coerce, Length, Lower, Required, SetTo
 
-from dvc import prompt
-from dvc.exceptions import (
+from . import prompt
+from .exceptions import (
     CacheLinkError,
     CheckoutError,
     CollectCacheError,
@@ -178,11 +178,11 @@ def load_from_pipeline(stage, data, typ="outs"):
     for path, flags in d.items():
         plt_d, live_d = {}, {}
         if plot:
-            from dvc.schema import PLOT_PROPS
+            from .schema import PLOT_PROPS
 
             plt_d, flags = _split_dict(flags, keys=PLOT_PROPS.keys())
         if live:
-            from dvc.schema import LIVE_PROPS
+            from .schema import LIVE_PROPS
 
             live_d, flags = _split_dict(flags, keys=LIVE_PROPS.keys())
         extra = project(
@@ -726,7 +726,7 @@ class Output:
             raise DvcException(msg.format(self.fs_path, name))
 
     def download(self, to, jobs=None):
-        from dvc.fs.callbacks import Callback
+        from .fs.callbacks import Callback
 
         with Callback.as_tqdm_callback(
             desc=f"Downloading {self.fs.path.name(self.fs_path)}",
@@ -1004,7 +1004,7 @@ class Output:
         return dep.get_used_objs(**kwargs)
 
     def _validate_output_path(self, path, stage=None):
-        from dvc.dvcfile import is_valid_filename
+        from .dvcfile import is_valid_filename
 
         if is_valid_filename(path):
             raise self.IsStageFileError(path)

--- a/dvc/parsing/__init__.py
+++ b/dvc/parsing/__init__.py
@@ -17,8 +17,6 @@ from typing import (
 from funcy import cached_property, collecting, first, isa, join, reraise
 
 from ..exceptions import DvcException
-from .interpolate import ParseError
-
 from .context import (
     Context,
     ContextError,
@@ -29,6 +27,7 @@ from .context import (
     VarsAlreadyLoaded,
 )
 from .interpolate import (
+    ParseError,
     check_recursive_parse_errors,
     is_interpolated_string,
     recurse,

--- a/dvc/parsing/__init__.py
+++ b/dvc/parsing/__init__.py
@@ -16,8 +16,8 @@ from typing import (
 
 from funcy import cached_property, collecting, first, isa, join, reraise
 
-from dvc.exceptions import DvcException
-from dvc.parsing.interpolate import ParseError
+from ..exceptions import DvcException
+from .interpolate import ParseError
 
 from .context import (
     Context,
@@ -38,7 +38,7 @@ from .interpolate import (
 if TYPE_CHECKING:
     from typing_extensions import NoReturn
 
-    from dvc.repo import Repo
+    from ..repo import Repo
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/parsing/context.py
+++ b/dvc/parsing/context.py
@@ -10,8 +10,8 @@ from typing import Any, Dict, List, Optional, Union
 
 from funcy import identity, lfilter, nullcontext, select
 
-from dvc.exceptions import DvcException
-from dvc.parsing.interpolate import (
+from ..exceptions import DvcException
+from .interpolate import (
     get_expression,
     get_matches,
     is_exact_string,
@@ -31,7 +31,7 @@ class ContextError(DvcException):
 
 class ReservedKeyError(ContextError):
     def __init__(self, keys, path=None):
-        from dvc.utils.humanize import join
+        from ..utils.humanize import join
 
         self.keys = keys
         self.path = path
@@ -356,7 +356,7 @@ class Context(CtxDict):
     def load_from(
         cls, fs, path: str, select_keys: List[str] = None
     ) -> "Context":
-        from dvc.utils.serialize import LOADERS
+        from ..utils.serialize import LOADERS
 
         if not fs.exists(path):
             raise ParamsLoadError(f"'{path}' does not exist")

--- a/dvc/parsing/interpolate.py
+++ b/dvc/parsing/interpolate.py
@@ -5,7 +5,7 @@ from functools import singledispatch
 
 from funcy import memoize, rpartial
 
-from dvc.exceptions import DvcException
+from ..exceptions import DvcException
 
 if typing.TYPE_CHECKING:
     from typing import List, Match
@@ -83,7 +83,7 @@ def _(obj: bool):
 def _format_exc_msg(exc: "ParseException"):
     from pyparsing import ParseException
 
-    from dvc.utils import colorize
+    from ..utils import colorize
 
     exc.loc += 2  # 2 because we append `${` at the start of expr below
 

--- a/dvc/pathspec_math.py
+++ b/dvc/pathspec_math.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 
 from pathspec.util import normalize_file
 
-from dvc.utils import relpath
+from .utils import relpath
 
 PatternInfo = namedtuple("PatternInfo", ["patterns", "file_info"])
 

--- a/dvc/proc/exceptions.py
+++ b/dvc/proc/exceptions.py
@@ -1,4 +1,4 @@
-from dvc.exceptions import DvcException
+from ..exceptions import DvcException
 
 
 class ProcessNotTerminatedError(DvcException):

--- a/dvc/proc/manager.py
+++ b/dvc/proc/manager.py
@@ -47,7 +47,7 @@ class ProcessManager:
             return json.dump(value.asdict(), fobj)
 
     def __delitem__(self, key: str) -> None:
-        from dvc.utils.fs import remove
+        from ..utils.fs import remove
 
         path = os.path.join(self.wdir, key)
         if os.path.exists(path):

--- a/dvc/proc/process.py
+++ b/dvc/proc/process.py
@@ -11,7 +11,6 @@ from funcy import cached_property
 from shortuuid import uuid
 
 from ..utils.fs import makedirs
-
 from .exceptions import TimeoutExpired
 
 logger = logging.getLogger(__name__)

--- a/dvc/proc/process.py
+++ b/dvc/proc/process.py
@@ -10,7 +10,7 @@ from typing import List, Optional, TextIO, Union
 from funcy import cached_property
 from shortuuid import uuid
 
-from dvc.utils.fs import makedirs
+from ..utils.fs import makedirs
 
 from .exceptions import TimeoutExpired
 

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -5,8 +5,8 @@ from threading import RLock
 
 from tqdm import tqdm
 
-from dvc.env import DVC_IGNORE_ISATTY
-from dvc.utils import env2bool
+from .env import DVC_IGNORE_ISATTY
+from .utils import env2bool
 
 logger = logging.getLogger(__name__)
 tqdm.set_lock(RLock())

--- a/dvc/render/convert.py
+++ b/dvc/render/convert.py
@@ -2,9 +2,9 @@ import json
 from collections import defaultdict
 from typing import Dict, List, Union
 
-from dvc.render import REVISION_FIELD, REVISIONS_KEY, SRC_FIELD, TYPE_KEY
-from dvc.render.converter.image import ImageConverter
-from dvc.render.converter.vega import VegaConverter
+from . import REVISION_FIELD, REVISIONS_KEY, SRC_FIELD, TYPE_KEY
+from .converter.image import ImageConverter
+from .converter.vega import VegaConverter
 
 
 def _get_converter(

--- a/dvc/render/converter/image.py
+++ b/dvc/render/converter/image.py
@@ -3,7 +3,6 @@ import os
 from typing import TYPE_CHECKING, Dict, List, Tuple
 
 from .. import FILENAME_FIELD, REVISION_FIELD, SRC_FIELD
-
 from . import Converter
 
 if TYPE_CHECKING:

--- a/dvc/render/converter/image.py
+++ b/dvc/render/converter/image.py
@@ -2,12 +2,12 @@ import base64
 import os
 from typing import TYPE_CHECKING, Dict, List, Tuple
 
-from dvc.render import FILENAME_FIELD, REVISION_FIELD, SRC_FIELD
+from .. import FILENAME_FIELD, REVISION_FIELD, SRC_FIELD
 
 from . import Converter
 
 if TYPE_CHECKING:
-    from dvc.types import StrPath
+    from ...types import StrPath
 
 
 class ImageConverter(Converter):

--- a/dvc/render/converter/vega.py
+++ b/dvc/render/converter/vega.py
@@ -5,13 +5,7 @@ from typing import Dict, Iterable, List, Optional, Set, Union
 from funcy import first, project
 
 from ...exceptions import DvcException
-from .. import (
-    FILENAME_FIELD,
-    INDEX_FIELD,
-    REVISION_FIELD,
-    VERSION_FIELD,
-)
-
+from .. import FILENAME_FIELD, INDEX_FIELD, REVISION_FIELD, VERSION_FIELD
 from . import Converter
 
 

--- a/dvc/render/converter/vega.py
+++ b/dvc/render/converter/vega.py
@@ -4,8 +4,8 @@ from typing import Dict, Iterable, List, Optional, Set, Union
 
 from funcy import first, project
 
-from dvc.exceptions import DvcException
-from dvc.render import (
+from ...exceptions import DvcException
+from .. import (
     FILENAME_FIELD,
     INDEX_FIELD,
     REVISION_FIELD,

--- a/dvc/render/match.py
+++ b/dvc/render/match.py
@@ -5,13 +5,13 @@ import dpath.options
 import dpath.util
 from funcy import last
 
-from dvc.repo.plots import infer_data_sources
-from dvc.utils.plots import get_plot_id
+from ..repo.plots import infer_data_sources
+from ..utils.plots import get_plot_id
 
 from .convert import _get_converter
 
 if TYPE_CHECKING:
-    from dvc.types import StrPath
+    from ..types import StrPath
 
 dpath.options.ALLOW_EMPTY_STRING_KEYS = True
 

--- a/dvc/render/match.py
+++ b/dvc/render/match.py
@@ -7,7 +7,6 @@ from funcy import last
 
 from ..repo.plots import infer_data_sources
 from ..utils.plots import get_plot_id
-
 from .convert import _get_converter
 
 if TYPE_CHECKING:

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -16,8 +16,8 @@ from ..utils.fs import path_isin
 
 if TYPE_CHECKING:
     from ..fs import FileSystem
-    from .scm_context import SCMContext
     from ..scm import Base
+    from .scm_context import SCMContext
 
 logger = logging.getLogger(__name__)
 
@@ -153,18 +153,19 @@ class Repo:
         repo_factory=None,
         scm=None,
     ):
+        from dvc_data.hashfile.state import State, StateNoop
+
         from ..config import Config
         from ..data_cloud import DataCloud
         from ..fs import GitFileSystem, localfs
         from ..lock import LockNoop, make_lock
         from ..odbmgr import ODBManager
+        from ..scm import SCM
+        from ..stage.cache import StageCache
         from .metrics import Metrics
         from .params import Params
         from .plots import Plots
         from .stage import StageLoad
-        from ..scm import SCM
-        from ..stage.cache import StageCache
-        from dvc_data.hashfile.state import State, StateNoop
 
         self.url = url
         self._fs_conf = {"repo_factory": repo_factory}

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -7,17 +7,17 @@ from typing import TYPE_CHECKING, Callable, Optional
 
 from funcy import cached_property
 
-from dvc.exceptions import FileMissingError
-from dvc.exceptions import IsADirectoryError as DvcIsADirectoryError
-from dvc.exceptions import NotDvcRepoError, OutputNotFoundError
-from dvc.ignore import DvcIgnoreFilter
-from dvc.utils import env2bool
-from dvc.utils.fs import path_isin
+from ..exceptions import FileMissingError
+from ..exceptions import IsADirectoryError as DvcIsADirectoryError
+from ..exceptions import NotDvcRepoError, OutputNotFoundError
+from ..ignore import DvcIgnoreFilter
+from ..utils import env2bool
+from ..utils.fs import path_isin
 
 if TYPE_CHECKING:
-    from dvc.fs import FileSystem
-    from dvc.repo.scm_context import SCMContext
-    from dvc.scm import Base
+    from ..fs import FileSystem
+    from .scm_context import SCMContext
+    from ..scm import Base
 
 logger = logging.getLogger(__name__)
 
@@ -53,28 +53,28 @@ def locked(f):
 class Repo:
     DVC_DIR = ".dvc"
 
-    from dvc.repo.add import add  # type: ignore[misc]
-    from dvc.repo.checkout import checkout  # type: ignore[misc]
-    from dvc.repo.commit import commit  # type: ignore[misc]
-    from dvc.repo.destroy import destroy  # type: ignore[misc]
-    from dvc.repo.diff import diff  # type: ignore[misc]
-    from dvc.repo.fetch import fetch  # type: ignore[misc]
-    from dvc.repo.freeze import freeze, unfreeze  # type: ignore[misc]
-    from dvc.repo.gc import gc  # type: ignore[misc]
-    from dvc.repo.get import get as _get  # type: ignore[misc]
-    from dvc.repo.get_url import get_url as _get_url  # type: ignore[misc]
-    from dvc.repo.imp import imp  # type: ignore[misc]
-    from dvc.repo.imp_url import imp_url  # type: ignore[misc]
-    from dvc.repo.install import install  # type: ignore[misc]
-    from dvc.repo.ls import ls as _ls  # type: ignore[misc]
-    from dvc.repo.move import move  # type: ignore[misc]
-    from dvc.repo.pull import pull  # type: ignore[misc]
-    from dvc.repo.push import push  # type: ignore[misc]
-    from dvc.repo.remove import remove  # type: ignore[misc]
-    from dvc.repo.reproduce import reproduce  # type: ignore[misc]
-    from dvc.repo.run import run  # type: ignore[misc]
-    from dvc.repo.status import status  # type: ignore[misc]
-    from dvc.repo.update import update  # type: ignore[misc]
+    from .add import add  # type: ignore[misc]
+    from .checkout import checkout  # type: ignore[misc]
+    from .commit import commit  # type: ignore[misc]
+    from .destroy import destroy  # type: ignore[misc]
+    from .diff import diff  # type: ignore[misc]
+    from .fetch import fetch  # type: ignore[misc]
+    from .freeze import freeze, unfreeze  # type: ignore[misc]
+    from .gc import gc  # type: ignore[misc]
+    from .get import get as _get  # type: ignore[misc]
+    from .get_url import get_url as _get_url  # type: ignore[misc]
+    from .imp import imp  # type: ignore[misc]
+    from .imp_url import imp_url  # type: ignore[misc]
+    from .install import install  # type: ignore[misc]
+    from .ls import ls as _ls  # type: ignore[misc]
+    from .move import move  # type: ignore[misc]
+    from .pull import pull  # type: ignore[misc]
+    from .push import push  # type: ignore[misc]
+    from .remove import remove  # type: ignore[misc]
+    from .reproduce import reproduce  # type: ignore[misc]
+    from .run import run  # type: ignore[misc]
+    from .status import status  # type: ignore[misc]
+    from .update import update  # type: ignore[misc]
 
     ls = staticmethod(_ls)
     get = staticmethod(_get)
@@ -87,8 +87,8 @@ class Repo:
         uninitialized: bool = False,
         scm: "Base" = None,
     ):
-        from dvc.fs import localfs
-        from dvc.scm import SCM, SCMError
+        from ..fs import localfs
+        from ..scm import SCM, SCMError
 
         dvc_dir = None
         tmp_dir = None
@@ -126,7 +126,7 @@ class Repo:
 
         import hashlib
 
-        from dvc.utils.fs import makedirs
+        from ..utils.fs import makedirs
 
         root_dir_hash = hashlib.sha224(
             self.root_dir.encode("utf-8")
@@ -153,17 +153,17 @@ class Repo:
         repo_factory=None,
         scm=None,
     ):
-        from dvc.config import Config
-        from dvc.data_cloud import DataCloud
-        from dvc.fs import GitFileSystem, localfs
-        from dvc.lock import LockNoop, make_lock
-        from dvc.odbmgr import ODBManager
-        from dvc.repo.metrics import Metrics
-        from dvc.repo.params import Params
-        from dvc.repo.plots import Plots
-        from dvc.repo.stage import StageLoad
-        from dvc.scm import SCM
-        from dvc.stage.cache import StageCache
+        from ..config import Config
+        from ..data_cloud import DataCloud
+        from ..fs import GitFileSystem, localfs
+        from ..lock import LockNoop, make_lock
+        from ..odbmgr import ODBManager
+        from .metrics import Metrics
+        from .params import Params
+        from .plots import Plots
+        from .stage import StageLoad
+        from ..scm import SCM
+        from ..stage.cache import StageCache
         from dvc_data.hashfile.state import State, StateNoop
 
         self.url = url
@@ -198,7 +198,7 @@ class Repo:
             self.odb = ODBManager(self)
             self.tmp_dir = None
         else:
-            from dvc.utils.fs import makedirs
+            from ..utils.fs import makedirs
 
             makedirs(self.tmp_dir, exist_ok=True)
             self.lock = make_lock(
@@ -230,7 +230,7 @@ class Repo:
 
     @cached_property
     def index(self):
-        from dvc.repo.index import Index
+        from .index import Index
 
         return Index(self)
 
@@ -245,13 +245,13 @@ class Repo:
             except NotDvcRepoError:
                 pass  # fallthrough to external_repo
 
-        from dvc.external_repo import external_repo
+        from ..external_repo import external_repo
 
         return external_repo(url, *args, **kwargs)
 
     @cached_property
     def scm(self):
-        from dvc.scm import SCM, SCMError
+        from ..scm import SCM, SCMError
 
         if self._scm:
             return self._scm
@@ -268,7 +268,7 @@ class Repo:
 
     @cached_property
     def scm_context(self) -> "SCMContext":
-        from dvc.repo.scm_context import SCMContext
+        from .scm_context import SCMContext
 
         return SCMContext(self.scm, self.config)
 
@@ -278,11 +278,11 @@ class Repo:
         return DvcIgnoreFilter(self.fs, self.root_dir)
 
     def get_rev(self):
-        from dvc.fs import LocalFileSystem
+        from ..fs import LocalFileSystem
 
         assert self.scm
         if isinstance(self.fs, LocalFileSystem):
-            from dvc.scm import map_scm_exception
+            from ..scm import map_scm_exception
 
             with map_scm_exception():
                 return self.scm.get_rev()
@@ -290,13 +290,13 @@ class Repo:
 
     @cached_property
     def experiments(self):
-        from dvc.repo.experiments import Experiments
+        from .experiments import Experiments
 
         return Experiments(self)
 
     @cached_property
     def machine(self):
-        from dvc.machine import MachineManager
+        from ..machine import MachineManager
 
         if self.tmp_dir and (
             self.config["feature"].get("machine", False)
@@ -321,7 +321,7 @@ class Repo:
 
     @classmethod
     def find_root(cls, root=None, fs=None) -> str:
-        from dvc.fs import LocalFileSystem, localfs
+        from ..fs import LocalFileSystem, localfs
 
         fs = fs or localfs
         root = root or os.curdir
@@ -355,7 +355,7 @@ class Repo:
 
     @staticmethod
     def init(root_dir=os.curdir, no_scm=False, force=False, subdir=False):
-        from dvc.repo.init import init
+        from .init import init
 
         return init(
             root_dir=root_dir, no_scm=no_scm, force=force, subdir=subdir
@@ -374,7 +374,7 @@ class Repo:
             self.scm_context.ignore(file)
 
     def brancher(self, *args, **kwargs):
-        from dvc.repo.brancher import brancher
+        from .brancher import brancher
 
         return brancher(self, *args, **kwargs)
 
@@ -472,13 +472,13 @@ class Repo:
 
     @cached_property
     def datafs(self):
-        from dvc.fs.data import DataFileSystem
+        from ..fs.data import DataFileSystem
 
         return DataFileSystem(repo=self)
 
     @cached_property
     def dvcfs(self):
-        from dvc.fs.dvc import DvcFileSystem
+        from ..fs.dvc import DvcFileSystem
 
         return DvcFileSystem(
             repo=self, subrepos=self.subrepos, **self._fs_conf
@@ -491,8 +491,8 @@ class Repo:
     @contextmanager
     def open_by_relpath(self, path, remote=None, mode="r", encoding=None):
         """Opens a specified resource as a file descriptor"""
-        from dvc.fs.data import DataFileSystem
-        from dvc.fs.dvc import DvcFileSystem
+        from ..fs.data import DataFileSystem
+        from ..fs.dvc import DvcFileSystem
 
         if os.path.isabs(path):
             fs = DataFileSystem(repo=self, workspace="local")

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Iterator, List
 
 import colorama
 
-from dvc.ui import ui
+from ..ui import ui
 
 from ..exceptions import (
     CacheLinkError,
@@ -15,15 +15,15 @@ from ..exceptions import (
     OverlappingOutputPathsError,
     RecursiveAddingWhileUsingFilename,
 )
-from ..repo.scm_context import scm_context
+from .scm_context import scm_context
 from ..utils import LARGE_DIR_SIZE, glob_targets, resolve_output, resolve_paths
 from ..utils.collections import ensure_list, validate
 from . import locked
 
 if TYPE_CHECKING:
-    from dvc.repo import Repo
-    from dvc.stage import Stage
-    from dvc.types import TargetType
+    from . import Repo
+    from ..stage import Stage
+    from ..types import TargetType
 
 Stages = List["Stage"]
 logger = logging.getLogger(__name__)
@@ -225,7 +225,7 @@ def collect_targets(
 def _find_all_targets(
     repo: "Repo", target: str, recursive: bool = False
 ) -> Iterator[str]:
-    from dvc.dvcfile import is_dvc_file
+    from ..dvcfile import is_dvc_file
 
     if os.path.isdir(target) and recursive:
         files = repo.dvcignore.find(repo.fs, target)

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -6,8 +6,6 @@ from typing import TYPE_CHECKING, Any, Iterator, List
 
 import colorama
 
-from ..ui import ui
-
 from ..exceptions import (
     CacheLinkError,
     InvalidArgumentError,
@@ -15,15 +13,16 @@ from ..exceptions import (
     OverlappingOutputPathsError,
     RecursiveAddingWhileUsingFilename,
 )
-from .scm_context import scm_context
+from ..ui import ui
 from ..utils import LARGE_DIR_SIZE, glob_targets, resolve_output, resolve_paths
 from ..utils.collections import ensure_list, validate
 from . import locked
+from .scm_context import scm_context
 
 if TYPE_CHECKING:
-    from . import Repo
     from ..stage import Stage
     from ..types import TargetType
+    from . import Repo
 
 Stages = List["Stage"]
 logger = logging.getLogger(__name__)

--- a/dvc/repo/brancher.py
+++ b/dvc/repo/brancher.py
@@ -1,4 +1,4 @@
-from dvc.scm import iter_revs
+from ..scm import iter_revs
 
 
 def brancher(  # noqa: E302
@@ -29,7 +29,7 @@ def brancher(  # noqa: E302
         yield ""
         return
 
-    from dvc.fs import LocalFileSystem
+    from ..fs import LocalFileSystem
 
     repo_root_parts = ()
     if self.fs.path.isin(self.root_dir, self.scm.root_dir):
@@ -65,7 +65,7 @@ def brancher(  # noqa: E302
     )
 
     try:
-        from dvc.fs import GitFileSystem
+        from ..fs import GitFileSystem
 
         for sha, names in found_revs.items():
             self.fs = GitFileSystem(scm=scm, rev=sha)

--- a/dvc/repo/checkout.py
+++ b/dvc/repo/checkout.py
@@ -2,13 +2,13 @@ import logging
 import os
 from typing import TYPE_CHECKING, Set
 
-from dvc.exceptions import (
+from ..exceptions import (
     CheckoutError,
     CheckoutErrorSuggestGit,
     NoOutputOrStageError,
 )
-from dvc.progress import Tqdm
-from dvc.utils import relpath
+from ..progress import Tqdm
+from ..utils import relpath
 
 from . import locked
 
@@ -44,7 +44,7 @@ def get_all_files_numbers(pairs):
 def _collect_pairs(
     self: "Repo", targets, with_deps: bool, recursive: bool
 ) -> Set["StageInfo"]:
-    from dvc.stage.exceptions import (
+    from ..stage.exceptions import (
         StageFileBadNameError,
         StageFileDoesNotExistError,
     )

--- a/dvc/repo/checkout.py
+++ b/dvc/repo/checkout.py
@@ -9,7 +9,6 @@ from ..exceptions import (
 )
 from ..progress import Tqdm
 from ..utils import relpath
-
 from . import locked
 
 if TYPE_CHECKING:

--- a/dvc/repo/collect.py
+++ b/dvc/repo/collect.py
@@ -1,11 +1,11 @@
 import logging
 from typing import TYPE_CHECKING, Callable, Iterable, List, Tuple
 
-from dvc.types import AnyPath
+from ..types import AnyPath
 
 if TYPE_CHECKING:
-    from dvc.output import Output
-    from dvc.repo import Repo
+    from ..output import Output
+    from . import Repo
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +30,7 @@ def _collect_paths(
     recursive: bool = False,
     rev: str = None,
 ) -> StrPaths:
-    from dvc.fs.dvc import DvcFileSystem
+    from ..fs.dvc import DvcFileSystem
 
     fs = DvcFileSystem(repo=repo)
     fs_paths = [fs.from_os_path(target) for target in targets]

--- a/dvc/repo/commit.py
+++ b/dvc/repo/commit.py
@@ -1,5 +1,4 @@
 from .. import prompt
-
 from . import locked
 
 

--- a/dvc/repo/commit.py
+++ b/dvc/repo/commit.py
@@ -1,4 +1,4 @@
-from dvc import prompt
+from .. import prompt
 
 from . import locked
 
@@ -26,7 +26,7 @@ def _prepare_message(stage, changes):
 
 
 def prompt_to_commit(stage, changes, force=False):
-    from dvc.stage.exceptions import StageCommitError
+    from ..stage.exceptions import StageCommitError
 
     if not (force or prompt.confirm(_prepare_message(stage, changes))):
         raise StageCommitError(
@@ -45,7 +45,7 @@ def commit(
     allow_missing=False,
     data_only=False,
 ):
-    from dvc.dvcfile import Dvcfile
+    from ..dvcfile import Dvcfile
 
     stages_info = [
         info

--- a/dvc/repo/destroy.py
+++ b/dvc/repo/destroy.py
@@ -1,5 +1,5 @@
-from dvc.ignore import destroy as destroy_dvcignore
-from dvc.utils.fs import remove
+from ..ignore import destroy as destroy_dvcignore
+from ..utils.fs import remove
 
 from . import locked
 

--- a/dvc/repo/destroy.py
+++ b/dvc/repo/destroy.py
@@ -1,6 +1,5 @@
 from ..ignore import destroy as destroy_dvcignore
 from ..utils.fs import remove
-
 from . import locked
 
 

--- a/dvc/repo/diff.py
+++ b/dvc/repo/diff.py
@@ -3,8 +3,8 @@ import os
 from collections import defaultdict
 from typing import Dict, List
 
-from dvc.exceptions import PathMissingError
-from dvc.repo import locked
+from ..exceptions import PathMissingError
+from . import locked
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ def diff(self, a_rev="HEAD", b_rev=None, targets=None):
     if self.scm.no_commits:
         return {}
 
-    from dvc.fs.dvc import DvcFileSystem
+    from ..fs.dvc import DvcFileSystem
 
     dvcfs = DvcFileSystem(repo=self)
 
@@ -111,7 +111,7 @@ def _paths_checksums(repo, targets):
 
 
 def _output_paths(repo, targets):
-    from dvc.fs import LocalFileSystem
+    from ..fs import LocalFileSystem
     from dvc_data.stage import stage as ostage
 
     on_working_fs = isinstance(repo.fs, LocalFileSystem)

--- a/dvc/repo/diff.py
+++ b/dvc/repo/diff.py
@@ -111,8 +111,9 @@ def _paths_checksums(repo, targets):
 
 
 def _output_paths(repo, targets):
-    from ..fs import LocalFileSystem
     from dvc_data.stage import stage as ostage
+
+    from ..fs import LocalFileSystem
 
     on_working_fs = isinstance(repo.fs, LocalFileSystem)
 

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -10,7 +10,6 @@ from ...dependency.param import MissingParamsError
 from ...env import DVCLIVE_RESUME
 from ...exceptions import DvcException
 from ...utils import relpath
-
 from .base import (
     EXEC_APPLY,
     EXEC_BRANCH,
@@ -746,7 +745,6 @@ class Experiments:
         """Return info for running experiments."""
         from ...scm import InvalidRemoteSCMRepo
         from ...utils.serialize import load_json
-
         from .executor.local import TempDirExecutor
 
         result = {}

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -6,10 +6,10 @@ from typing import Dict, Iterable, List, Mapping, Optional, Type
 
 from funcy import cached_property, first
 
-from dvc.dependency.param import MissingParamsError
-from dvc.env import DVCLIVE_RESUME
-from dvc.exceptions import DvcException
-from dvc.utils import relpath
+from ...dependency.param import MissingParamsError
+from ...env import DVCLIVE_RESUME
+from ...exceptions import DvcException
+from ...utils import relpath
 
 from .base import (
     EXEC_APPLY,
@@ -47,7 +47,7 @@ def scm_locked(f):
     # different sequences of git operations at once
     @wraps(f)
     def wrapper(exp, *args, **kwargs):
-        from dvc.scm import map_scm_exception
+        from ...scm import map_scm_exception
 
         with map_scm_exception(), exp.scm_lock:
             return f(exp, *args, **kwargs)
@@ -89,8 +89,8 @@ class Experiments:
     )
 
     def __init__(self, repo):
-        from dvc.lock import make_lock
-        from dvc.scm import NoSCMError
+        from ...lock import make_lock
+        from ...scm import NoSCMError
 
         if repo.config["core"].get("no_scm", False):
             raise NoSCMError
@@ -360,8 +360,8 @@ class Experiments:
 
     def _update_params(self, params: dict):
         """Update experiment params files with the specified values."""
-        from dvc.utils.collections import NewParamsFound, merge_params
-        from dvc.utils.serialize import MODIFIERS
+        from ...utils.collections import NewParamsFound, merge_params
+        from ...utils.serialize import MODIFIERS
 
         logger.debug("Using experiment params '%s'", params)
 
@@ -407,7 +407,7 @@ class Experiments:
                 self.scm.reset()
 
         if checkpoint_resume:
-            from dvc.scm import resolve_rev
+            from ...scm import resolve_rev
 
             resume_rev = resolve_rev(self.scm, checkpoint_resume)
             try:
@@ -695,7 +695,7 @@ class Experiments:
         return self._get_baseline(rev)
 
     def _get_baseline(self, rev):
-        from dvc.scm import resolve_rev
+        from ...scm import resolve_rev
 
         rev = resolve_rev(self.scm, rev)
 
@@ -744,8 +744,8 @@ class Experiments:
 
     def get_running_exps(self, fetch_refs: bool = True) -> Dict[str, int]:
         """Return info for running experiments."""
-        from dvc.scm import InvalidRemoteSCMRepo
-        from dvc.utils.serialize import load_json
+        from ...scm import InvalidRemoteSCMRepo
+        from ...utils.serialize import load_json
 
         from .executor.local import TempDirExecutor
 
@@ -800,51 +800,51 @@ class Experiments:
         return result
 
     def apply(self, *args, **kwargs):
-        from dvc.repo.experiments.apply import apply
+        from .apply import apply
 
         return apply(self.repo, *args, **kwargs)
 
     def branch(self, *args, **kwargs):
-        from dvc.repo.experiments.branch import branch
+        from .branch import branch
 
         return branch(self.repo, *args, **kwargs)
 
     def diff(self, *args, **kwargs):
-        from dvc.repo.experiments.diff import diff
+        from .diff import diff
 
         return diff(self.repo, *args, **kwargs)
 
     def show(self, *args, **kwargs):
-        from dvc.repo.experiments.show import show
+        from .show import show
 
         return show(self.repo, *args, **kwargs)
 
     def run(self, *args, **kwargs):
-        from dvc.repo.experiments.run import run
+        from .run import run
 
         return run(self.repo, *args, **kwargs)
 
     def gc(self, *args, **kwargs):
-        from dvc.repo.experiments.gc import gc
+        from .gc import gc
 
         return gc(self.repo, *args, **kwargs)
 
     def push(self, *args, **kwargs):
-        from dvc.repo.experiments.push import push
+        from .push import push
 
         return push(self.repo, *args, **kwargs)
 
     def pull(self, *args, **kwargs):
-        from dvc.repo.experiments.pull import pull
+        from .pull import pull
 
         return pull(self.repo, *args, **kwargs)
 
     def ls(self, *args, **kwargs):
-        from dvc.repo.experiments.ls import ls
+        from .ls import ls
 
         return ls(self.repo, *args, **kwargs)
 
     def remove(self, *args, **kwargs):
-        from dvc.repo.experiments.remove import remove
+        from .remove import remove
 
         return remove(self.repo, *args, **kwargs)

--- a/dvc/repo/experiments/apply.py
+++ b/dvc/repo/experiments/apply.py
@@ -3,9 +3,9 @@ import os
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Optional
 
-from dvc.repo import locked
-from dvc.repo.scm_context import scm_context
-from dvc.utils.fs import remove
+from .. import locked
+from ..scm_context import scm_context
+from ...utils.fs import remove
 
 from .base import (
     EXEC_APPLY,
@@ -18,7 +18,7 @@ from .executor.base import BaseExecutor
 if TYPE_CHECKING:
     from scmrepo import Git
 
-    from dvc.repo import Repo
+    from .. import Repo
 
 logger = logging.getLogger(__name__)
 
@@ -28,8 +28,8 @@ logger = logging.getLogger(__name__)
 def apply(repo: "Repo", rev: str, force: bool = True, **kwargs):
     from scmrepo.exceptions import SCMError as _SCMError
 
-    from dvc.repo.checkout import checkout as dvc_checkout
-    from dvc.scm import GitMergeError, RevError, resolve_rev
+    from ..checkout import checkout as dvc_checkout
+    from ...scm import GitMergeError, RevError, resolve_rev
 
     exps = repo.experiments
 

--- a/dvc/repo/experiments/apply.py
+++ b/dvc/repo/experiments/apply.py
@@ -3,10 +3,9 @@ import os
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Optional
 
+from ...utils.fs import remove
 from .. import locked
 from ..scm_context import scm_context
-from ...utils.fs import remove
-
 from .base import (
     EXEC_APPLY,
     ApplyConflictError,
@@ -28,8 +27,8 @@ logger = logging.getLogger(__name__)
 def apply(repo: "Repo", rev: str, force: bool = True, **kwargs):
     from scmrepo.exceptions import SCMError as _SCMError
 
-    from ..checkout import checkout as dvc_checkout
     from ...scm import GitMergeError, RevError, resolve_rev
+    from ..checkout import checkout as dvc_checkout
 
     exps = repo.experiments
 

--- a/dvc/repo/experiments/base.py
+++ b/dvc/repo/experiments/base.py
@@ -1,6 +1,6 @@
 from typing import NamedTuple, Optional
 
-from dvc.exceptions import DvcException, InvalidArgumentError
+from ...exceptions import DvcException, InvalidArgumentError
 
 # Experiment refs are stored according baseline git SHA:
 #   refs/exps/01/234abcd.../<exp_name>

--- a/dvc/repo/experiments/branch.py
+++ b/dvc/repo/experiments/branch.py
@@ -1,10 +1,9 @@
 import logging
 
 from ...exceptions import InvalidArgumentError
+from ...scm import RevError
 from .. import locked
 from ..scm_context import scm_context
-from ...scm import RevError
-
 from .base import InvalidExpRevError
 from .utils import exp_refs_by_rev
 

--- a/dvc/repo/experiments/branch.py
+++ b/dvc/repo/experiments/branch.py
@@ -1,9 +1,9 @@
 import logging
 
-from dvc.exceptions import InvalidArgumentError
-from dvc.repo import locked
-from dvc.repo.scm_context import scm_context
-from dvc.scm import RevError
+from ...exceptions import InvalidArgumentError
+from .. import locked
+from ..scm_context import scm_context
+from ...scm import RevError
 
 from .base import InvalidExpRevError
 from .utils import exp_refs_by_rev
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 @locked
 @scm_context
 def branch(repo, exp_rev, branch_name, *args, **kwargs):
-    from dvc.scm import resolve_rev
+    from ...scm import resolve_rev
 
     try:
         rev = resolve_rev(repo.scm, exp_rev)

--- a/dvc/repo/experiments/diff.py
+++ b/dvc/repo/experiments/diff.py
@@ -7,8 +7,8 @@ logger = logging.getLogger(__name__)
 
 
 def diff(repo, *args, a_rev=None, b_rev=None, param_deps=False, **kwargs):
-    from .show import _collect_experiment_commit
     from ...scm import resolve_rev
+    from .show import _collect_experiment_commit
 
     if repo.scm.no_commits:
         return {}

--- a/dvc/repo/experiments/diff.py
+++ b/dvc/repo/experiments/diff.py
@@ -1,14 +1,14 @@
 import logging
 
-from dvc.utils.diff import diff as _diff
-from dvc.utils.diff import format_dict
+from ...utils.diff import diff as _diff
+from ...utils.diff import format_dict
 
 logger = logging.getLogger(__name__)
 
 
 def diff(repo, *args, a_rev=None, b_rev=None, param_deps=False, **kwargs):
-    from dvc.repo.experiments.show import _collect_experiment_commit
-    from dvc.scm import resolve_rev
+    from .show import _collect_experiment_commit
+    from ...scm import resolve_rev
 
     if repo.scm.no_commits:
         return {}

--- a/dvc/repo/experiments/exceptions.py
+++ b/dvc/repo/experiments/exceptions.py
@@ -1,7 +1,6 @@
 from typing import Collection, Iterable
 
 from ...exceptions import InvalidArgumentError
-
 from .base import ExpRefInfo
 
 

--- a/dvc/repo/experiments/exceptions.py
+++ b/dvc/repo/experiments/exceptions.py
@@ -1,6 +1,6 @@
 from typing import Collection, Iterable
 
-from dvc.exceptions import InvalidArgumentError
+from ...exceptions import InvalidArgumentError
 
 from .base import ExpRefInfo
 

--- a/dvc/repo/experiments/executor/base.py
+++ b/dvc/repo/experiments/executor/base.py
@@ -19,11 +19,11 @@ from typing import (
     Union,
 )
 
-from dvc.env import DVC_EXP_AUTO_PUSH, DVC_EXP_GIT_REMOTE
-from dvc.exceptions import DvcException
-from dvc.stage.serialize import to_lockfile
-from dvc.utils import dict_sha256, env2bool, relpath
-from dvc.utils.fs import remove
+from ....env import DVC_EXP_AUTO_PUSH, DVC_EXP_GIT_REMOTE
+from ....exceptions import DvcException
+from ....stage.serialize import to_lockfile
+from ....utils import dict_sha256, env2bool, relpath
+from ....utils.fs import remove
 
 from ..base import (
     EXEC_BASELINE,
@@ -43,8 +43,8 @@ if TYPE_CHECKING:
 
     from scmrepo.git import Git
 
-    from dvc.repo import Repo
-    from dvc.stage import PipelineStage
+    from ... import Repo
+    from ....stage import PipelineStage
 
     from ..base import ExpStashEntry
 
@@ -92,8 +92,8 @@ class ExecutorInfo:
         )
 
     def dump_json(self, filename: str):
-        from dvc.utils.fs import makedirs
-        from dvc.utils.serialize import modify_json
+        from ....utils.fs import makedirs
+        from ....utils.serialize import modify_json
 
         makedirs(os.path.dirname(filename), exist_ok=True)
         with modify_json(filename) as d:
@@ -241,7 +241,7 @@ class BaseExecutor(ABC):
 
     @staticmethod
     def hash_exp(stages: Iterable["PipelineStage"]) -> str:
-        from dvc.stage import PipelineStage
+        from ....stage import PipelineStage
 
         exp_data = {}
         for stage in stages:
@@ -260,7 +260,7 @@ class BaseExecutor(ABC):
             open_func = fs.open
             fs.makedirs(dpath)
         else:
-            from dvc.utils.fs import makedirs
+            from ....utils.fs import makedirs
 
             open_func = open
             makedirs(dpath, exist_ok=True)
@@ -344,7 +344,7 @@ class BaseExecutor(ABC):
     def _validate_remotes(cls, dvc: "Repo", git_remote: Optional[str]):
         from scmrepo.exceptions import InvalidRemote
 
-        from dvc.scm import InvalidRemoteSCMRepo
+        from ....scm import InvalidRemoteSCMRepo
 
         if git_remote == dvc.root_dir:
             logger.warning(
@@ -377,9 +377,9 @@ class BaseExecutor(ABC):
             and force is a bool specifying whether or not this experiment
             should force overwrite any existing duplicates.
         """
-        from dvc.repo.checkout import checkout as dvc_checkout
-        from dvc.repo.reproduce import reproduce as dvc_reproduce
-        from dvc.stage import PipelineStage
+        from ...checkout import checkout as dvc_checkout
+        from ...reproduce import reproduce as dvc_reproduce
+        from ....stage import PipelineStage
 
         auto_push = env2bool(DVC_EXP_AUTO_PUSH)
         git_remote = os.getenv(DVC_EXP_GIT_REMOTE, None)
@@ -542,8 +542,8 @@ class BaseExecutor(ABC):
         log_errors: bool = True,
         **kwargs,
     ):
-        from dvc.repo import Repo
-        from dvc.stage.monitor import CheckpointKilledError
+        from ... import Repo
+        from ....stage.monitor import CheckpointKilledError
 
         dvc = Repo(os.path.join(info.root_dir, info.dvc_dir))
         if cls.QUIET:
@@ -692,7 +692,7 @@ class BaseExecutor(ABC):
 
     @staticmethod
     def _set_log_level(level):
-        from dvc.logger import disable_other_loggers
+        from ....logger import disable_other_loggers
 
         # When executor.reproduce is run in a multiprocessing child process,
         # dvc.cli.main will not be called for that child process so we need to

--- a/dvc/repo/experiments/executor/base.py
+++ b/dvc/repo/experiments/executor/base.py
@@ -24,7 +24,6 @@ from ....exceptions import DvcException
 from ....stage.serialize import to_lockfile
 from ....utils import dict_sha256, env2bool, relpath
 from ....utils.fs import remove
-
 from ..base import (
     EXEC_BASELINE,
     EXEC_BRANCH,
@@ -43,9 +42,8 @@ if TYPE_CHECKING:
 
     from scmrepo.git import Git
 
-    from ... import Repo
     from ....stage import PipelineStage
-
+    from ... import Repo
     from ..base import ExpStashEntry
 
 logger = logging.getLogger(__name__)
@@ -377,9 +375,9 @@ class BaseExecutor(ABC):
             and force is a bool specifying whether or not this experiment
             should force overwrite any existing duplicates.
         """
+        from ....stage import PipelineStage
         from ...checkout import checkout as dvc_checkout
         from ...reproduce import reproduce as dvc_reproduce
-        from ....stage import PipelineStage
 
         auto_push = env2bool(DVC_EXP_AUTO_PUSH)
         git_remote = os.getenv(DVC_EXP_GIT_REMOTE, None)
@@ -542,8 +540,8 @@ class BaseExecutor(ABC):
         log_errors: bool = True,
         **kwargs,
     ):
-        from ... import Repo
         from ....stage.monitor import CheckpointKilledError
+        from ... import Repo
 
         dvc = Repo(os.path.join(info.root_dir, info.dvc_dir))
         if cls.QUIET:

--- a/dvc/repo/experiments/executor/local.py
+++ b/dvc/repo/experiments/executor/local.py
@@ -9,7 +9,6 @@ from scmrepo.exceptions import SCMError as _SCMError
 
 from ....scm import SCM, GitMergeError
 from ....utils.fs import remove
-
 from ..base import (
     EXEC_APPLY,
     EXEC_BASELINE,
@@ -25,7 +24,6 @@ if TYPE_CHECKING:
     from scmrepo.git import Git
 
     from ... import Repo
-
     from ..base import ExpRefInfo, ExpStashEntry
 
 logger = logging.getLogger(__name__)

--- a/dvc/repo/experiments/executor/local.py
+++ b/dvc/repo/experiments/executor/local.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING, Optional
 from funcy import cached_property
 from scmrepo.exceptions import SCMError as _SCMError
 
-from dvc.scm import SCM, GitMergeError
-from dvc.utils.fs import remove
+from ....scm import SCM, GitMergeError
+from ....utils.fs import remove
 
 from ..base import (
     EXEC_APPLY,
@@ -24,7 +24,7 @@ from .base import EXEC_TMP_DIR, BaseExecutor
 if TYPE_CHECKING:
     from scmrepo.git import Git
 
-    from dvc.repo import Repo
+    from ... import Repo
 
     from ..base import ExpRefInfo, ExpStashEntry
 

--- a/dvc/repo/experiments/executor/manager/base.py
+++ b/dvc/repo/experiments/executor/manager/base.py
@@ -6,7 +6,6 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Deque, Dict, Generator, Optional, Tuple, Type
 
 from .....proc.manager import ProcessManager
-
 from ...base import (
     EXEC_BASELINE,
     EXEC_HEAD,

--- a/dvc/repo/experiments/executor/manager/base.py
+++ b/dvc/repo/experiments/executor/manager/base.py
@@ -5,7 +5,7 @@ from collections import defaultdict, deque
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Deque, Dict, Generator, Optional, Tuple, Type
 
-from dvc.proc.manager import ProcessManager
+from .....proc.manager import ProcessManager
 
 from ...base import (
     EXEC_BASELINE,
@@ -22,7 +22,7 @@ from ..local import TempDirExecutor, WorkspaceExecutor
 if TYPE_CHECKING:
     from scmrepo.git import Git
 
-    from dvc.repo import Repo
+    from .... import Repo
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +38,7 @@ class BaseExecutorManager(ABC, Mapping):
         wdir: str,
         **kwargs,
     ):
-        from dvc.utils.fs import makedirs
+        from .....utils.fs import makedirs
 
         self.scm = scm
         makedirs(wdir, exist_ok=True)
@@ -167,7 +167,7 @@ class BaseExecutorManager(ABC, Mapping):
         )
         from multiprocessing import Manager
 
-        from dvc.stage.monitor import CheckpointKilledError
+        from .....stage.monitor import CheckpointKilledError
 
         result: Dict[str, Dict[str, str]] = defaultdict(dict)
 
@@ -265,7 +265,7 @@ class BaseExecutorManager(ABC, Mapping):
         return results
 
     def cleanup_executor(self, rev: str, executor: "BaseExecutor"):
-        from dvc.utils.fs import remove
+        from .....utils.fs import remove
 
         executor.cleanup()
         try:

--- a/dvc/repo/experiments/executor/manager/local.py
+++ b/dvc/repo/experiments/executor/manager/local.py
@@ -15,7 +15,7 @@ from .base import BaseExecutorManager
 if TYPE_CHECKING:
     from scmrepo.git import Git
 
-    from dvc.repo import Repo
+    from .... import Repo
 
 logger = logging.getLogger(__name__)
 
@@ -72,8 +72,8 @@ class WorkspaceExecutorManager(BaseExecutorManager):
         Workspace execution is done within the main DVC process
         (rather than in multiprocessing context)
         """
-        from dvc.exceptions import DvcException
-        from dvc.stage.monitor import CheckpointKilledError
+        from .....exceptions import DvcException
+        from .....stage.monitor import CheckpointKilledError
 
         assert len(self._queue) == 1
         assert not detach

--- a/dvc/repo/experiments/executor/manager/ssh.py
+++ b/dvc/repo/experiments/executor/manager/ssh.py
@@ -11,7 +11,7 @@ from .base import BaseExecutorManager
 if TYPE_CHECKING:
     from scmrepo.git import Git
 
-    from dvc.repo import Repo
+    from .... import Repo
 
 logger = logging.getLogger(__name__)
 
@@ -63,8 +63,8 @@ class SSHExecutorManager(BaseExecutorManager):
         return f"{name}{BaseExecutor.INFOFILE_EXT}"
 
     def _exec_attached(self, repo: "Repo", jobs: Optional[int] = 1):
-        from dvc.exceptions import DvcException
-        from dvc.stage.monitor import CheckpointKilledError
+        from .....exceptions import DvcException
+        from .....stage.monitor import CheckpointKilledError
 
         assert len(self._queue) == 1
         result: Dict[str, Dict[str, str]] = defaultdict(dict)

--- a/dvc/repo/experiments/executor/ssh.py
+++ b/dvc/repo/experiments/executor/ssh.py
@@ -15,7 +15,6 @@ from ..base import (
     EXEC_MERGE,
     EXEC_NAMESPACE,
 )
-
 from .base import BaseExecutor, ExecutorInfo, ExecutorResult
 
 if TYPE_CHECKING:
@@ -24,7 +23,6 @@ if TYPE_CHECKING:
     from scmrepo.git import Git
 
     from ... import Repo
-
     from ..base import ExpRefInfo, ExpStashEntry
 
 logger = logging.getLogger(__name__)

--- a/dvc/repo/experiments/executor/ssh.py
+++ b/dvc/repo/experiments/executor/ssh.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING, Callable, Iterable, Optional
 
 from funcy import first
 
-from dvc.fs import SSHFileSystem
-from dvc.repo.experiments.base import (
+from ....fs import SSHFileSystem
+from ..base import (
     EXEC_BRANCH,
     EXEC_CHECKPOINT,
     EXEC_HEAD,
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
     from scmrepo.git import Git
 
-    from dvc.repo import Repo
+    from ... import Repo
 
     from ..base import ExpRefInfo, ExpStashEntry
 
@@ -182,7 +182,7 @@ class SSHExecutor(BaseExecutor):
         return sshfs.fs.execute(f"cd {working_dir};{cmd}", **kwargs)
 
     def init_cache(self, repo: "Repo", rev: str, run_cache: bool = True):
-        from dvc.repo.push import push
+        from ...push import push
 
         with self.get_odb() as odb:
             push(
@@ -197,14 +197,14 @@ class SSHExecutor(BaseExecutor):
         self, repo: "Repo", exp_ref: "ExpRefInfo", run_cache: bool = True
     ):
         """Collect DVC cache."""
-        from dvc.repo.experiments.pull import _pull_cache
+        from ..pull import _pull_cache
 
         with self.get_odb() as odb:
             _pull_cache(repo, exp_ref, run_cache=run_cache, odb=odb)
 
     @contextmanager
     def get_odb(self):
-        from dvc.odbmgr import ODBManager, get_odb
+        from ....odbmgr import ODBManager, get_odb
 
         cache_path = posixpath.join(
             self._repo_abspath,

--- a/dvc/repo/experiments/gc.py
+++ b/dvc/repo/experiments/gc.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional
 
-from dvc.repo import locked
+from .. import locked
 
 from .utils import exp_refs, remove_exp_refs
 

--- a/dvc/repo/experiments/gc.py
+++ b/dvc/repo/experiments/gc.py
@@ -2,7 +2,6 @@ import logging
 from typing import Optional
 
 from .. import locked
-
 from .utils import exp_refs, remove_exp_refs
 
 logger = logging.getLogger(__name__)

--- a/dvc/repo/experiments/init.py
+++ b/dvc/repo/experiments/init.py
@@ -17,16 +17,16 @@ from typing import (
 
 from funcy import compact, lremove, lsplit
 
-from dvc.exceptions import DvcException
-from dvc.stage import PipelineStage
-from dvc.types import OptStr
+from ...exceptions import DvcException
+from ...stage import PipelineStage
+from ...types import OptStr
 
 if TYPE_CHECKING:
-    from dvc.repo import Repo
-    from dvc.dvcfile import DVCFile
-    from dvc.dependency import Dependency
+    from .. import Repo
+    from ...dvcfile import DVCFile
+    from ...dependency import Dependency
 
-from dvc.ui import ui
+from ...ui import ui
 
 PROMPTS = {
     "cmd": "[b]Command[/b] to execute",
@@ -46,7 +46,7 @@ def _prompts(
     allow_omission: bool = True,
     stream: Optional[TextIO] = None,
 ) -> Dict[str, OptStr]:
-    from dvc.ui.prompt import Prompt
+    from ...ui.prompt import Prompt
 
     defaults = defaults or {}
     return {
@@ -115,7 +115,7 @@ def _check_stage_exists(
     dvcfile: "DVCFile", name: str, force: bool = False
 ) -> None:
     if not force and dvcfile.exists() and name in dvcfile.stages:
-        from dvc.stage.exceptions import DuplicateStageName
+        from ...stage.exceptions import DuplicateStageName
 
         hint = "Use '--force' to overwrite."
         raise DuplicateStageName(
@@ -126,11 +126,11 @@ def _check_stage_exists(
 def validate_prompts(
     repo: "Repo", key: str, value: str
 ) -> Union[Any, Tuple[Any, str]]:
-    from dvc.ui.prompt import InvalidResponse
+    from ...ui.prompt import InvalidResponse
 
     msg_format = "[yellow]'{0}' does not exist, the {1} will be created.[/]"
     if key == "params":
-        from dvc.dependency.param import (
+        from ...dependency.param import (
             MissingParamsFile,
             ParamsDependency,
             ParamsIsADirectoryError,
@@ -161,8 +161,8 @@ def is_file(path: str) -> bool:
 def init_deps(stage: PipelineStage) -> List["Dependency"]:
     from funcy import rpartial
 
-    from dvc.dependency import ParamsDependency
-    from dvc.fs import localfs
+    from ...dependency import ParamsDependency
+    from ...fs import localfs
 
     new_deps = [dep for dep in stage.deps if not dep.exists]
     params, deps = lsplit(rpartial(isinstance, ParamsDependency), new_deps)
@@ -181,7 +181,7 @@ def init_deps(stage: PipelineStage) -> List["Dependency"]:
 
 
 def init_out_dirs(stage: PipelineStage) -> List[str]:
-    from dvc.fs import localfs
+    from ...fs import localfs
 
     new_dirs = []
 
@@ -207,7 +207,7 @@ def init(
     force: bool = False,
     stream: Optional[TextIO] = None,
 ) -> Tuple[PipelineStage, List["Dependency"], List[str]]:
-    from dvc.dvcfile import make_dvcfile
+    from ...dvcfile import make_dvcfile
 
     dvcfile = make_dvcfile(repo, "dvc.yaml")
     _check_stage_exists(dvcfile, name, force=force)
@@ -235,7 +235,7 @@ def init(
 
     params = context.get("params")
     if params:
-        from dvc.dependency.param import (
+        from ...dependency.param import (
             MissingParamsFile,
             ParamsDependency,
             ParamsIsADirectoryError,

--- a/dvc/repo/experiments/ls.py
+++ b/dvc/repo/experiments/ls.py
@@ -1,11 +1,10 @@
 import logging
 from collections import defaultdict
 
-from .. import locked
-from ..scm_context import scm_context
 from ...scm import iter_revs
 from ...types import Optional
-
+from .. import locked
+from ..scm_context import scm_context
 from .utils import exp_refs, exp_refs_by_baseline
 
 logger = logging.getLogger(__name__)

--- a/dvc/repo/experiments/ls.py
+++ b/dvc/repo/experiments/ls.py
@@ -1,10 +1,10 @@
 import logging
 from collections import defaultdict
 
-from dvc.repo import locked
-from dvc.repo.scm_context import scm_context
-from dvc.scm import iter_revs
-from dvc.types import Optional
+from .. import locked
+from ..scm_context import scm_context
+from ...scm import iter_revs
+from ...types import Optional
 
 from .utils import exp_refs, exp_refs_by_baseline
 

--- a/dvc/repo/experiments/pull.py
+++ b/dvc/repo/experiments/pull.py
@@ -4,11 +4,10 @@ from typing import Iterable, List, Mapping, Optional, Set, Union
 from funcy import group_by
 from scmrepo.git.backend.base import SyncStatus
 
-from .. import locked
-from ..scm_context import scm_context
 from ...scm import TqdmGit, iter_revs
 from ...ui import ui
-
+from .. import locked
+from ..scm_context import scm_context
 from .base import ExpRefInfo
 from .exceptions import UnresolvedExpNamesError
 from .utils import exp_commits, exp_refs, exp_refs_by_baseline, resolve_name

--- a/dvc/repo/experiments/pull.py
+++ b/dvc/repo/experiments/pull.py
@@ -4,10 +4,10 @@ from typing import Iterable, List, Mapping, Optional, Set, Union
 from funcy import group_by
 from scmrepo.git.backend.base import SyncStatus
 
-from dvc.repo import locked
-from dvc.repo.scm_context import scm_context
-from dvc.scm import TqdmGit, iter_revs
-from dvc.ui import ui
+from .. import locked
+from ..scm_context import scm_context
+from ...scm import TqdmGit, iter_revs
+from ...ui import ui
 
 from .base import ExpRefInfo
 from .exceptions import UnresolvedExpNamesError

--- a/dvc/repo/experiments/push.py
+++ b/dvc/repo/experiments/push.py
@@ -4,11 +4,10 @@ from typing import Iterable, List, Mapping, Optional, Set, Union
 from funcy import group_by
 from scmrepo.git.backend.base import SyncStatus
 
-from .. import locked
-from ..scm_context import scm_context
 from ...scm import TqdmGit, iter_revs
 from ...ui import ui
-
+from .. import locked
+from ..scm_context import scm_context
 from .base import ExpRefInfo
 from .exceptions import UnresolvedExpNamesError
 from .utils import exp_commits, exp_refs, exp_refs_by_baseline, resolve_name

--- a/dvc/repo/experiments/push.py
+++ b/dvc/repo/experiments/push.py
@@ -4,10 +4,10 @@ from typing import Iterable, List, Mapping, Optional, Set, Union
 from funcy import group_by
 from scmrepo.git.backend.base import SyncStatus
 
-from dvc.repo import locked
-from dvc.repo.scm_context import scm_context
-from dvc.scm import TqdmGit, iter_revs
-from dvc.ui import ui
+from .. import locked
+from ..scm_context import scm_context
+from ...scm import TqdmGit, iter_revs
+from ...ui import ui
 
 from .base import ExpRefInfo
 from .exceptions import UnresolvedExpNamesError

--- a/dvc/repo/experiments/remove.py
+++ b/dvc/repo/experiments/remove.py
@@ -1,9 +1,9 @@
 import logging
 from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Set, Union
 
-from dvc.repo import locked
-from dvc.repo.scm_context import scm_context
-from dvc.scm import iter_revs
+from .. import locked
+from ..scm_context import scm_context
+from ...scm import iter_revs
 
 from .exceptions import UnresolvedExpNamesError
 from .utils import (
@@ -15,8 +15,8 @@ from .utils import (
 )
 
 if TYPE_CHECKING:
-    from dvc.repo import Repo
-    from dvc.scm import Git
+    from .. import Repo
+    from ...scm import Git
 
     from .base import ExpRefInfo
 
@@ -159,7 +159,7 @@ def _remove_commited_exps(
     scm: "Git", exp_ref_dict: Mapping["ExpRefInfo", str], remote: Optional[str]
 ) -> List[str]:
     if remote:
-        from dvc.scm import TqdmGit
+        from ...scm import TqdmGit
 
         for ref_info in exp_ref_dict:
             with TqdmGit(desc="Pushing git refs") as pbar:

--- a/dvc/repo/experiments/remove.py
+++ b/dvc/repo/experiments/remove.py
@@ -1,10 +1,9 @@
 import logging
 from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Set, Union
 
+from ...scm import iter_revs
 from .. import locked
 from ..scm_context import scm_context
-from ...scm import iter_revs
-
 from .exceptions import UnresolvedExpNamesError
 from .utils import (
     exp_refs,
@@ -15,9 +14,8 @@ from .utils import (
 )
 
 if TYPE_CHECKING:
-    from .. import Repo
     from ...scm import Git
-
+    from .. import Repo
     from .base import ExpRefInfo
 
 

--- a/dvc/repo/experiments/run.py
+++ b/dvc/repo/experiments/run.py
@@ -1,8 +1,8 @@
 import logging
 from typing import Iterable, Optional
 
-from dvc.repo import locked
-from dvc.utils.cli_parse import loads_param_overrides
+from .. import locked
+from ...utils.cli_parse import loads_param_overrides
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/repo/experiments/run.py
+++ b/dvc/repo/experiments/run.py
@@ -1,8 +1,8 @@
 import logging
 from typing import Iterable, Optional
 
-from .. import locked
 from ...utils.cli_parse import loads_param_overrides
+from .. import locked
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -3,11 +3,11 @@ from collections import OrderedDict, defaultdict
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
-from .base import ExpRefInfo
-from ..metrics.show import _gather_metrics
-from ..params.show import _gather_params
 from ...scm import iter_revs
 from ...utils import error_handler, onerror_collect, relpath
+from ..metrics.show import _gather_metrics
+from ..params.show import _gather_params
+from .base import ExpRefInfo
 
 if TYPE_CHECKING:
     from .. import Repo

--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -3,14 +3,14 @@ from collections import OrderedDict, defaultdict
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
-from dvc.repo.experiments.base import ExpRefInfo
-from dvc.repo.metrics.show import _gather_metrics
-from dvc.repo.params.show import _gather_params
-from dvc.scm import iter_revs
-from dvc.utils import error_handler, onerror_collect, relpath
+from .base import ExpRefInfo
+from ..metrics.show import _gather_metrics
+from ..params.show import _gather_params
+from ...scm import iter_revs
+from ...utils import error_handler, onerror_collect, relpath
 
 if TYPE_CHECKING:
-    from dvc.repo import Repo
+    from .. import Repo
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +26,7 @@ def _collect_experiment_commit(
     onerror: Optional[Callable] = None,
     is_baseline: bool = False,
 ):
-    from dvc.dependency import ParamsDependency, RepoDependency
+    from ...dependency import ParamsDependency, RepoDependency
 
     res: Dict[str, Optional[Any]] = defaultdict(dict)
     for rev in repo.brancher(revs=[exp_rev]):
@@ -97,7 +97,7 @@ def _collect_experiment_commit(
 def _collect_experiment_branch(
     res, repo, branch, baseline, onerror: Optional[Callable] = None, **kwargs
 ):
-    from dvc.scm import resolve_rev
+    from ...scm import resolve_rev
 
     exp_rev = resolve_rev(repo.scm, branch)
     prev = None

--- a/dvc/repo/experiments/utils.py
+++ b/dvc/repo/experiments/utils.py
@@ -13,8 +13,8 @@ from typing import (
 
 from scmrepo.git import Git
 
-from dvc.exceptions import InvalidArgumentError
-from dvc.repo.experiments.exceptions import AmbiguousExpRefInfo
+from ...exceptions import InvalidArgumentError
+from .exceptions import AmbiguousExpRefInfo
 
 from .base import (
     EXEC_BASELINE,
@@ -66,7 +66,7 @@ def iter_remote_refs(
 ):
     from scmrepo.exceptions import AuthError, InvalidRemote
 
-    from dvc.scm import GitAuthError, InvalidRemoteSCMRepo
+    from ...scm import GitAuthError, InvalidRemoteSCMRepo
 
     try:
         yield from scm.iter_remote_refs(url, base=base, **kwargs)

--- a/dvc/repo/experiments/utils.py
+++ b/dvc/repo/experiments/utils.py
@@ -14,8 +14,6 @@ from typing import (
 from scmrepo.git import Git
 
 from ...exceptions import InvalidArgumentError
-from .exceptions import AmbiguousExpRefInfo
-
 from .base import (
     EXEC_BASELINE,
     EXEC_NAMESPACE,
@@ -23,6 +21,7 @@ from .base import (
     EXPS_STASH,
     ExpRefInfo,
 )
+from .exceptions import AmbiguousExpRefInfo
 
 
 def exp_refs(

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, Optional
 
 from ..exceptions import DownloadError, FileTransferError
 from ..fs import Schemes
-
 from . import locked
 
 if TYPE_CHECKING:

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -1,8 +1,8 @@
 import logging
 from typing import TYPE_CHECKING, Optional
 
-from dvc.exceptions import DownloadError, FileTransferError
-from dvc.fs import Schemes
+from ..exceptions import DownloadError, FileTransferError
+from ..fs import Schemes
 
 from . import locked
 

--- a/dvc/repo/gc.py
+++ b/dvc/repo/gc.py
@@ -1,7 +1,6 @@
 import logging
 
 from ..exceptions import InvalidArgumentError
-
 from . import locked
 
 logger = logging.getLogger(__name__)
@@ -44,9 +43,10 @@ def gc(
 
     from contextlib import ExitStack
 
-    from . import Repo
     from dvc_data.db import get_index
     from dvc_data.gc import gc as ogc
+
+    from . import Repo
 
     if not repos:
         repos = []

--- a/dvc/repo/gc.py
+++ b/dvc/repo/gc.py
@@ -1,6 +1,6 @@
 import logging
 
-from dvc.exceptions import InvalidArgumentError
+from ..exceptions import InvalidArgumentError
 
 from . import locked
 
@@ -44,7 +44,7 @@ def gc(
 
     from contextlib import ExitStack
 
-    from dvc.repo import Repo
+    from . import Repo
     from dvc_data.db import get_index
     from dvc_data.gc import gc as ogc
 

--- a/dvc/repo/get.py
+++ b/dvc/repo/get.py
@@ -1,9 +1,9 @@
 import logging
 import os
 
-from dvc.exceptions import DvcException
-from dvc.utils import resolve_output
-from dvc.utils.fs import remove
+from ..exceptions import DvcException
+from ..utils import resolve_output
+from ..utils.fs import remove
 
 logger = logging.getLogger(__name__)
 
@@ -19,9 +19,9 @@ class GetDVCFileError(DvcException):
 def get(url, path, out=None, rev=None, jobs=None):
     import shortuuid
 
-    from dvc.dvcfile import is_valid_filename
-    from dvc.external_repo import external_repo
-    from dvc.fs.callbacks import Callback
+    from ..dvcfile import is_valid_filename
+    from ..external_repo import external_repo
+    from ..fs.callbacks import Callback
 
     out = resolve_output(path, out)
 
@@ -52,7 +52,7 @@ def get(url, path, out=None, rev=None, jobs=None):
         ) as repo:
 
             if os.path.isabs(path):
-                from dvc.fs.data import DataFileSystem
+                from ..fs.data import DataFileSystem
 
                 fs = DataFileSystem(repo=repo, workspace="local")
                 fs_path = path

--- a/dvc/repo/get_url.py
+++ b/dvc/repo/get_url.py
@@ -2,8 +2,8 @@ import os
 
 
 def get_url(url, out=None, jobs=None):
-    from dvc import dependency, output
-    from dvc.utils import resolve_output
+    from .. import dependency, output
+    from ..utils import resolve_output
 
     out = resolve_output(url, out)
 

--- a/dvc/repo/graph.py
+++ b/dvc/repo/graph.py
@@ -1,18 +1,18 @@
 from typing import TYPE_CHECKING, Iterator, List, Set
 
-from dvc.fs import localfs
-from dvc.utils.fs import path_isin
+from ..fs import localfs
+from ..utils.fs import path_isin
 
 if TYPE_CHECKING:
     from networkx import DiGraph
 
-    from dvc.stage import Stage
+    from ..stage import Stage
 
 
 def check_acyclic(graph: "DiGraph") -> None:
     import networkx as nx
 
-    from dvc.exceptions import CyclicGraphError
+    from ..exceptions import CyclicGraphError
 
     try:
         edges = nx.find_cycle(graph, orientation="original")
@@ -93,7 +93,7 @@ def build_graph(stages, outs_trie=None):
     """
     import networkx as nx
 
-    from dvc.exceptions import StagePathAsOutputError
+    from ..exceptions import StagePathAsOutputError
 
     from .trie import build_outs_trie
 

--- a/dvc/repo/graph.py
+++ b/dvc/repo/graph.py
@@ -94,7 +94,6 @@ def build_graph(stages, outs_trie=None):
     import networkx as nx
 
     from ..exceptions import StagePathAsOutputError
-
     from .trie import build_outs_trie
 
     G = nx.DiGraph()

--- a/dvc/repo/imp_url.py
+++ b/dvc/repo/imp_url.py
@@ -1,8 +1,8 @@
 import os
 
-from dvc.repo.scm_context import scm_context
-from dvc.utils import relpath, resolve_output, resolve_paths
-from dvc.utils.fs import path_isin
+from .scm_context import scm_context
+from ..utils import relpath, resolve_output, resolve_paths
+from ..utils.fs import path_isin
 
 from ..exceptions import InvalidArgumentError, OutputDuplicationError
 from . import locked
@@ -23,8 +23,8 @@ def imp_url(
     desc=None,
     jobs=None,
 ):
-    from dvc.dvcfile import Dvcfile
-    from dvc.stage import Stage, create_stage, restore_fields
+    from ..dvcfile import Dvcfile
+    from ..stage import Stage, create_stage, restore_fields
 
     out = resolve_output(url, out)
     path, wdir, out = resolve_paths(

--- a/dvc/repo/imp_url.py
+++ b/dvc/repo/imp_url.py
@@ -1,11 +1,10 @@
 import os
 
-from .scm_context import scm_context
+from ..exceptions import InvalidArgumentError, OutputDuplicationError
 from ..utils import relpath, resolve_output, resolve_paths
 from ..utils.fs import path_isin
-
-from ..exceptions import InvalidArgumentError, OutputDuplicationError
 from . import locked
+from .scm_context import scm_context
 
 
 @locked

--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -19,15 +19,16 @@ if TYPE_CHECKING:
     from networkx import DiGraph
     from pygtrie import Trie
 
-    from ..dependency import Dependency, ParamsDependency
-    from ..fs import FileSystem
-    from ..output import Output
-    from .stage import StageLoad
-    from ..stage import Stage
-    from ..types import StrPath, TargetType
     from dvc_data import Tree
     from dvc_data.hashfile.hash_info import HashInfo
     from dvc_objects.db import ObjectDB
+
+    from ..dependency import Dependency, ParamsDependency
+    from ..fs import FileSystem
+    from ..output import Output
+    from ..stage import Stage
+    from ..types import StrPath, TargetType
+    from .stage import StageLoad
 
 
 ObjectContainer = Dict[Optional["ObjectDB"], Set["HashInfo"]]
@@ -169,8 +170,9 @@ class Index:
 
     @cached_property
     def tree(self) -> "Tree":
-        from ..config import NoRemoteError
         from dvc_data import Tree
+
+        from ..config import NoRemoteError
 
         tree = Tree()
 

--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -13,18 +13,18 @@ from typing import (
 
 from funcy import cached_property, nullcontext
 
-from dvc.utils import dict_md5
+from ..utils import dict_md5
 
 if TYPE_CHECKING:
     from networkx import DiGraph
     from pygtrie import Trie
 
-    from dvc.dependency import Dependency, ParamsDependency
-    from dvc.fs import FileSystem
-    from dvc.output import Output
-    from dvc.repo.stage import StageLoad
-    from dvc.stage import Stage
-    from dvc.types import StrPath, TargetType
+    from ..dependency import Dependency, ParamsDependency
+    from ..fs import FileSystem
+    from ..output import Output
+    from .stage import StageLoad
+    from ..stage import Stage
+    from ..types import StrPath, TargetType
     from dvc_data import Tree
     from dvc_data.hashfile.hash_info import HashInfo
     from dvc_objects.db import ObjectDB
@@ -74,7 +74,7 @@ class Index:
         return self.stage_collector.collect_repo(onerror=onerror)
 
     def __repr__(self) -> str:
-        from dvc.fs import LocalFileSystem
+        from ..fs import LocalFileSystem
 
         rev = "workspace"
         if not isinstance(self.fs, LocalFileSystem):
@@ -103,8 +103,8 @@ class Index:
         return Index(self.repo, self.fs, stages=list(stages_it))
 
     def slice(self, path: "StrPath") -> "Index":
-        from dvc.utils import relpath
-        from dvc.utils.fs import path_isin
+        from ..utils import relpath
+        from ..utils.fs import path_isin
 
         target_path = relpath(path, self.repo.root_dir)
 
@@ -143,7 +143,7 @@ class Index:
 
     @property
     def params(self) -> Iterator["ParamsDependency"]:
-        from dvc.dependency import ParamsDependency
+        from ..dependency import ParamsDependency
 
         for dep in self.deps:
             if isinstance(dep, ParamsDependency):
@@ -151,25 +151,25 @@ class Index:
 
     @cached_property
     def outs_trie(self) -> "Trie":
-        from dvc.repo.trie import build_outs_trie
+        from .trie import build_outs_trie
 
         return build_outs_trie(self.stages)
 
     @cached_property
     def graph(self) -> "DiGraph":
-        from dvc.repo.graph import build_graph
+        from .graph import build_graph
 
         return build_graph(self.stages, self.outs_trie)
 
     @cached_property
     def outs_graph(self) -> "DiGraph":
-        from dvc.repo.graph import build_outs_graph
+        from .graph import build_outs_graph
 
         return build_outs_graph(self.graph, self.outs_trie)
 
     @cached_property
     def tree(self) -> "Tree":
-        from dvc.config import NoRemoteError
+        from ..config import NoRemoteError
         from dvc_data import Tree
 
         tree = Tree()
@@ -208,7 +208,7 @@ class Index:
         from collections import defaultdict
         from itertools import chain
 
-        from dvc.utils.collections import ensure_list
+        from ..utils.collections import ensure_list
 
         used: "ObjectContainer" = defaultdict(set)
         collect_targets: Sequence[Optional[str]] = (None,)
@@ -302,8 +302,8 @@ if __name__ == "__main__":
 
     from funcy import log_durations
 
-    from dvc.logger import setup
-    from dvc.repo import Repo
+    from ..logger import setup
+    from . import Repo
 
     setup(level=logging.TRACE)  # type: ignore[attr-defined]
 

--- a/dvc/repo/init.py
+++ b/dvc/repo/init.py
@@ -4,10 +4,10 @@ import os
 from ..config import Config
 from ..exceptions import InitError, InvalidArgumentError
 from ..ignore import init as init_dvcignore
-from . import Repo
 from ..scm import SCM, SCMError
 from ..utils import relpath
 from ..utils.fs import remove
+from . import Repo
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/repo/init.py
+++ b/dvc/repo/init.py
@@ -1,13 +1,13 @@
 import logging
 import os
 
-from dvc.config import Config
-from dvc.exceptions import InitError, InvalidArgumentError
-from dvc.ignore import init as init_dvcignore
-from dvc.repo import Repo
-from dvc.scm import SCM, SCMError
-from dvc.utils import relpath
-from dvc.utils.fs import remove
+from ..config import Config
+from ..exceptions import InitError, InvalidArgumentError
+from ..ignore import init as init_dvcignore
+from . import Repo
+from ..scm import SCM, SCMError
+from ..utils import relpath
+from ..utils.fs import remove
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/repo/install.py
+++ b/dvc/repo/install.py
@@ -1,17 +1,17 @@
 from typing import TYPE_CHECKING
 
-from dvc.exceptions import DvcException
+from ..exceptions import DvcException
 
 if TYPE_CHECKING:
     from scmrepo.git import Git
 
-    from dvc.repo import Repo
+    from . import Repo
 
 
 def pre_commit_install(scm: "Git") -> None:
     import os
 
-    from dvc.utils.serialize import modify_yaml
+    from ..utils.serialize import modify_yaml
 
     config_path = os.path.join(scm.root_dir, ".pre-commit-config.yaml")
     with modify_yaml(config_path) as config:
@@ -46,7 +46,7 @@ def pre_commit_install(scm: "Git") -> None:
 def install_hooks(scm: "Git") -> None:
     from scmrepo.exceptions import GitHookAlreadyExists
 
-    from dvc.utils import format_link
+    from ..utils import format_link
 
     hooks = ["post-checkout", "pre-commit", "pre-push"]
     for hook in hooks:

--- a/dvc/repo/live.py
+++ b/dvc/repo/live.py
@@ -4,11 +4,11 @@ from typing import TYPE_CHECKING, Optional
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from dvc.output import Output
+    from ..output import Output
 
 
 def summary_fs_path(out: "Output") -> Optional[str]:
-    from dvc.output import Output
+    from ..output import Output
 
     assert out.live
     has_summary = True

--- a/dvc/repo/ls.py
+++ b/dvc/repo/ls.py
@@ -2,10 +2,10 @@ import os
 from itertools import chain
 from typing import TYPE_CHECKING, Optional
 
-from dvc.exceptions import PathMissingError
+from ..exceptions import PathMissingError
 
 if TYPE_CHECKING:
-    from dvc.fs.dvc import DvcFileSystem
+    from ..fs.dvc import DvcFileSystem
 
     from . import Repo
 

--- a/dvc/repo/ls.py
+++ b/dvc/repo/ls.py
@@ -6,7 +6,6 @@ from ..exceptions import PathMissingError
 
 if TYPE_CHECKING:
     from ..fs.dvc import DvcFileSystem
-
     from . import Repo
 
 

--- a/dvc/repo/metrics/__init__.py
+++ b/dvc/repo/metrics/__init__.py
@@ -3,7 +3,7 @@ class Metrics:
         self.repo = repo
 
     def show(self, *args, **kwargs):
-        from dvc.repo.metrics.show import show
+        from .show import show
 
         return show(self.repo, *args, **kwargs)
 

--- a/dvc/repo/metrics/diff.py
+++ b/dvc/repo/metrics/diff.py
@@ -1,5 +1,5 @@
-from dvc.utils.diff import diff as _diff
-from dvc.utils.diff import format_dict
+from ...utils.diff import diff as _diff
+from ...utils.diff import format_dict
 
 
 def diff(repo, *args, a_rev=None, b_rev=None, **kwargs):

--- a/dvc/repo/metrics/show.py
+++ b/dvc/repo/metrics/show.py
@@ -4,14 +4,14 @@ from typing import List
 
 from scmrepo.exceptions import SCMError
 
-from dvc.fs.dvc import DvcFileSystem
-from dvc.output import Output
-from dvc.repo import locked
-from dvc.repo.collect import StrPaths, collect
-from dvc.repo.live import summary_fs_path
-from dvc.scm import NoSCMError
-from dvc.utils import error_handler, errored_revisions, onerror_collect
-from dvc.utils.serialize import load_yaml
+from ...fs.dvc import DvcFileSystem
+from ...output import Output
+from .. import locked
+from ..collect import StrPaths, collect
+from ..live import summary_fs_path
+from ...scm import NoSCMError
+from ...utils import error_handler, errored_revisions, onerror_collect
+from ...utils.serialize import load_yaml
 
 logger = logging.getLogger(__name__)
 
@@ -137,7 +137,7 @@ def show(
 
     errored = errored_revisions(res)
     if errored:
-        from dvc.ui import ui
+        from ...ui import ui
 
         ui.error_write(
             "DVC failed to load some metrics for following revisions:"

--- a/dvc/repo/metrics/show.py
+++ b/dvc/repo/metrics/show.py
@@ -6,12 +6,12 @@ from scmrepo.exceptions import SCMError
 
 from ...fs.dvc import DvcFileSystem
 from ...output import Output
-from .. import locked
-from ..collect import StrPaths, collect
-from ..live import summary_fs_path
 from ...scm import NoSCMError
 from ...utils import error_handler, errored_revisions, onerror_collect
 from ...utils.serialize import load_yaml
+from .. import locked
+from ..collect import StrPaths, collect
+from ..live import summary_fs_path
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/repo/move.py
+++ b/dvc/repo/move.py
@@ -1,7 +1,7 @@
 import os
 
-from dvc.exceptions import MoveNotDataSourceError
-from dvc.repo.scm_context import scm_context
+from ..exceptions import MoveNotDataSourceError
+from .scm_context import scm_context
 
 from . import locked
 
@@ -33,7 +33,7 @@ def move(self, from_path, to_path):
     also known as data sources.
     """
     import dvc.output as Output
-    from dvc.stage import Stage
+    from ..stage import Stage
 
     from ..dvcfile import DVC_FILE_SUFFIX, Dvcfile
 

--- a/dvc/repo/move.py
+++ b/dvc/repo/move.py
@@ -1,9 +1,8 @@
 import os
 
 from ..exceptions import MoveNotDataSourceError
-from .scm_context import scm_context
-
 from . import locked
+from .scm_context import scm_context
 
 
 def _expand_target_path(from_path, to_path):
@@ -33,9 +32,9 @@ def move(self, from_path, to_path):
     also known as data sources.
     """
     import dvc.output as Output
-    from ..stage import Stage
 
     from ..dvcfile import DVC_FILE_SUFFIX, Dvcfile
+    from ..stage import Stage
 
     from_out = Output.loads_from(Stage(self), [from_path])[0]
     assert from_out.protocol == "local"

--- a/dvc/repo/params/diff.py
+++ b/dvc/repo/params/diff.py
@@ -1,5 +1,5 @@
-from dvc.utils.diff import diff as _diff
-from dvc.utils.diff import format_dict
+from ...utils.diff import diff as _diff
+from ...utils.diff import format_dict
 
 
 def diff(repo, *args, a_rev=None, b_rev=None, **kwargs):

--- a/dvc/repo/params/show.py
+++ b/dvc/repo/params/show.py
@@ -14,18 +14,18 @@ from typing import (
 
 from scmrepo.exceptions import SCMError
 
-from dvc.dependency.param import ParamsDependency
-from dvc.repo import locked
-from dvc.repo.collect import collect
-from dvc.scm import NoSCMError
-from dvc.stage import PipelineStage
-from dvc.ui import ui
-from dvc.utils import error_handler, errored_revisions, onerror_collect
-from dvc.utils.serialize import LOADERS
+from ...dependency.param import ParamsDependency
+from .. import locked
+from ..collect import collect
+from ...scm import NoSCMError
+from ...stage import PipelineStage
+from ...ui import ui
+from ...utils import error_handler, errored_revisions, onerror_collect
+from ...utils.serialize import LOADERS
 
 if TYPE_CHECKING:
-    from dvc.output import Output
-    from dvc.repo import Repo
+    from ...output import Output
+    from .. import Repo
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/repo/params/show.py
+++ b/dvc/repo/params/show.py
@@ -15,13 +15,13 @@ from typing import (
 from scmrepo.exceptions import SCMError
 
 from ...dependency.param import ParamsDependency
-from .. import locked
-from ..collect import collect
 from ...scm import NoSCMError
 from ...stage import PipelineStage
 from ...ui import ui
 from ...utils import error_handler, errored_revisions, onerror_collect
 from ...utils.serialize import LOADERS
+from .. import locked
+from ..collect import collect
 
 if TYPE_CHECKING:
     from ...output import Output

--- a/dvc/repo/plots/__init__.py
+++ b/dvc/repo/plots/__init__.py
@@ -226,8 +226,9 @@ class Plots:
             out.plot.pop(prop)
 
     def modify(self, path, props=None, unset=None):
-        from ...dvcfile import Dvcfile
         from dvc_render.vega_templates import get_template
+
+        from ...dvcfile import Dvcfile
 
         props = props or {}
         template = props.get("template")

--- a/dvc/repo/plots/__init__.py
+++ b/dvc/repo/plots/__init__.py
@@ -20,13 +20,13 @@ import dpath.options
 import dpath.util
 from funcy import cached_property, first, project
 
-from dvc.exceptions import DvcException
-from dvc.utils import error_handler, errored_revisions, onerror_collect
-from dvc.utils.serialize import LOADERS
+from ...exceptions import DvcException
+from ...utils import error_handler, errored_revisions, onerror_collect
+from ...utils.serialize import LOADERS
 
 if TYPE_CHECKING:
-    from dvc.output import Output
-    from dvc.repo import Repo
+    from ...output import Output
+    from .. import Repo
 
 dpath.options.ALLOW_EMPTY_STRING_KEYS = True
 
@@ -109,7 +109,7 @@ class Plots:
 
             }
         """
-        from dvc.utils.collections import ensure_list
+        from ...utils.collections import ensure_list
 
         targets = ensure_list(targets)
         for rev in self.repo.brancher(revs=revs):
@@ -150,7 +150,7 @@ class Plots:
         props: Optional[Dict] = None,
         onerror: Optional[Callable] = None,
     ):
-        from dvc.fs.dvc import DvcFileSystem
+        from ...fs.dvc import DvcFileSystem
 
         fs = DvcFileSystem(repo=self.repo)
 
@@ -200,7 +200,7 @@ class Plots:
 
         errored = errored_revisions(result)
         if errored:
-            from dvc.ui import ui
+            from ...ui import ui
 
             ui.error_write(
                 "DVC failed to load some plots for following revisions: "
@@ -226,7 +226,7 @@ class Plots:
             out.plot.pop(prop)
 
     def modify(self, path, props=None, unset=None):
-        from dvc.dvcfile import Dvcfile
+        from ...dvcfile import Dvcfile
         from dvc_render.vega_templates import get_template
 
         props = props or {}
@@ -282,7 +282,7 @@ def _collect_plots(
     rev: str = None,
     recursive: bool = False,
 ) -> Dict[str, Dict]:
-    from dvc.repo.collect import collect
+    from ..collect import collect
 
     plots, fs_paths = collect(
         repo,
@@ -326,7 +326,7 @@ def infer_data_sources(plot_id, config=None):
 def _matches(targets, config_file, plot_id):
     import re
 
-    from dvc.utils.plots import get_plot_id
+    from ...utils.plots import get_plot_id
 
     if not targets:
         return True
@@ -411,7 +411,7 @@ def _adjust_definitions_to_cwd(fs, config_relpath, plots_definitions):
 
 
 def _collect_pipeline_files(repo, targets: List[str], props):
-    from dvc.dvcfile import PipelineFile
+    from ...dvcfile import PipelineFile
 
     result: Dict[str, Dict] = {}
     dvcfiles = {stage.dvcfile for stage in repo.index.stages}
@@ -449,7 +449,7 @@ def _collect_definitions(
     result: Dict = defaultdict(dict)
     props = props or {}
 
-    from dvc.fs.dvc import DvcFileSystem
+    from ...fs.dvc import DvcFileSystem
 
     fs = DvcFileSystem(repo=repo)
 
@@ -515,7 +515,7 @@ def parse(fs, path, props=None, **kwargs):
 
 
 def _plot_props(out: "Output") -> Dict:
-    from dvc.schema import PLOT_PROPS
+    from ...schema import PLOT_PROPS
 
     if not (out.plot or out.live):
         raise NotAPlotError(out)

--- a/dvc/repo/pull.py
+++ b/dvc/repo/pull.py
@@ -1,8 +1,8 @@
 import logging
 from typing import TYPE_CHECKING, Optional
 
-from dvc.repo import locked
-from dvc.utils import glob_targets
+from . import locked
+from ..utils import glob_targets
 
 if TYPE_CHECKING:
     from dvc_objects.db.base import ObjectDB

--- a/dvc/repo/pull.py
+++ b/dvc/repo/pull.py
@@ -1,8 +1,8 @@
 import logging
 from typing import TYPE_CHECKING, Optional
 
-from . import locked
 from ..utils import glob_targets
+from . import locked
 
 if TYPE_CHECKING:
     from dvc_objects.db.base import ObjectDB

--- a/dvc/repo/push.py
+++ b/dvc/repo/push.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Optional
 
-from dvc.exceptions import FileTransferError, UploadError
+from ..exceptions import FileTransferError, UploadError
 
 from ..utils import glob_targets
 from . import locked

--- a/dvc/repo/push.py
+++ b/dvc/repo/push.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING, Optional
 
 from ..exceptions import FileTransferError, UploadError
-
 from ..utils import glob_targets
 from . import locked
 

--- a/dvc/repo/remove.py
+++ b/dvc/repo/remove.py
@@ -4,7 +4,7 @@ import typing
 from . import locked
 
 if typing.TYPE_CHECKING:
-    from dvc.repo import Repo
+    from . import Repo
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -3,13 +3,11 @@ import typing
 from functools import partial
 
 from ..exceptions import DvcException, ReproductionError
-from .scm_context import scm_context
-
 from . import locked
+from .scm_context import scm_context
 
 if typing.TYPE_CHECKING:
     from ..stage import Stage
-
     from . import Repo
 
 logger = logging.getLogger(__name__)

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -2,13 +2,13 @@ import logging
 import typing
 from functools import partial
 
-from dvc.exceptions import DvcException, ReproductionError
-from dvc.repo.scm_context import scm_context
+from ..exceptions import DvcException, ReproductionError
+from .scm_context import scm_context
 
 from . import locked
 
 if typing.TYPE_CHECKING:
-    from dvc.stage import Stage
+    from ..stage import Stage
 
     from . import Repo
 
@@ -70,7 +70,7 @@ def _get_stage_files(stage: "Stage") -> typing.Iterator[str]:
         if not out.use_scm_ignore and out.is_in_repo:
             yield out.fs_path
         if out.live:
-            from dvc.repo.live import summary_fs_path
+            from .live import summary_fs_path
 
             summary = summary_fs_path(out)
             if summary:
@@ -78,7 +78,7 @@ def _get_stage_files(stage: "Stage") -> typing.Iterator[str]:
 
 
 def _track_stage(stage: "Stage") -> None:
-    from dvc.utils import relpath
+    from ..utils import relpath
 
     context = stage.repo.scm_context
     for path in _get_stage_files(stage):
@@ -105,7 +105,7 @@ def reproduce(
         targets = [targets]
 
     if not all_pipelines and not targets:
-        from dvc.dvcfile import PIPELINE_FILE
+        from ..dvcfile import PIPELINE_FILE
 
         targets = [PIPELINE_FILE]
 
@@ -197,7 +197,7 @@ def _reproduce_stages(
                 _repro_callback, checkpoint_func, unchanged
             )
 
-        from dvc.stage.monitor import CheckpointKilledError
+        from ..stage.monitor import CheckpointKilledError
 
         try:
             ret = _reproduce_stage(stage, **kwargs)

--- a/dvc/repo/run.py
+++ b/dvc/repo/run.py
@@ -1,13 +1,11 @@
 from typing import TYPE_CHECKING, Union
 
 from ..utils.cli_parse import parse_params
-
 from . import locked
 from .scm_context import scm_context
 
 if TYPE_CHECKING:
     from ..stage import PipelineStage, Stage
-
     from . import Repo
 
 

--- a/dvc/repo/run.py
+++ b/dvc/repo/run.py
@@ -1,12 +1,12 @@
 from typing import TYPE_CHECKING, Union
 
-from dvc.utils.cli_parse import parse_params
+from ..utils.cli_parse import parse_params
 
 from . import locked
 from .scm_context import scm_context
 
 if TYPE_CHECKING:
-    from dvc.stage import PipelineStage, Stage
+    from ..stage import PipelineStage, Stage
 
     from . import Repo
 

--- a/dvc/repo/scm_context.py
+++ b/dvc/repo/scm_context.py
@@ -13,13 +13,13 @@ from typing import (
     Union,
 )
 
-from dvc.utils import relpath
-from dvc.utils.collections import ensure_list
+from ..utils import relpath
+from ..utils.collections import ensure_list
 
 if TYPE_CHECKING:
     from scmrepo.base import Base
 
-    from dvc.repo import Repo
+    from . import Repo
 
 
 logger = logging.getLogger(__name__)
@@ -73,7 +73,7 @@ class SCMContext:
     def ignore(self, path: str) -> None:
         from scmrepo.exceptions import FileNotInRepoError
 
-        from dvc.scm import SCMError
+        from ..scm import SCMError
 
         try:
             gitignore_file = self.scm.ignore(path)
@@ -88,7 +88,7 @@ class SCMContext:
     def ignore_remove(self, path: str) -> None:
         from scmrepo.exceptions import FileNotInRepoError
 
-        from dvc.scm import SCMError
+        from ..scm import SCMError
 
         logger.debug("Removing '%s' from gitignore file.", path)
         try:
@@ -120,7 +120,7 @@ class SCMContext:
         if quiet is None:
             quiet = self.quiet
 
-        from dvc.scm import NoSCM
+        from ..scm import NoSCM
 
         if autostage:
             self.track_changed_files()

--- a/dvc/repo/stage.py
+++ b/dvc/repo/stage.py
@@ -22,18 +22,18 @@ from ..exceptions import (
     NoOutputOrStageError,
     OutputNotFoundError,
 )
-from . import lock_repo
 from ..utils import as_posix, parse_target, relpath
+from . import lock_repo
 
 logger = logging.getLogger(__name__)
 
 if typing.TYPE_CHECKING:
     from networkx import DiGraph
 
-    from . import Repo
     from ..stage import PipelineStage, Stage
     from ..stage.loader import StageLoader
     from ..types import OptStr
+    from . import Repo
 
 PIPELINE_FILE = "dvc.yaml"
 
@@ -167,12 +167,7 @@ class StageLoad:
             stage_data: Stage data to create from
                 (see create_stage and loads_from for more information)
         """
-        from ..stage import (
-            PipelineStage,
-            Stage,
-            create_stage,
-            restore_fields,
-        )
+        from ..stage import PipelineStage, Stage, create_stage, restore_fields
         from ..stage.exceptions import InvalidStageName
         from ..stage.utils import (
             is_valid_name,

--- a/dvc/repo/stage.py
+++ b/dvc/repo/stage.py
@@ -17,23 +17,23 @@ from typing import (
 
 from funcy.debug import format_time
 
-from dvc.exceptions import (
+from ..exceptions import (
     DvcException,
     NoOutputOrStageError,
     OutputNotFoundError,
 )
-from dvc.repo import lock_repo
-from dvc.utils import as_posix, parse_target, relpath
+from . import lock_repo
+from ..utils import as_posix, parse_target, relpath
 
 logger = logging.getLogger(__name__)
 
 if typing.TYPE_CHECKING:
     from networkx import DiGraph
 
-    from dvc.repo import Repo
-    from dvc.stage import PipelineStage, Stage
-    from dvc.stage.loader import StageLoader
-    from dvc.types import OptStr
+    from . import Repo
+    from ..stage import PipelineStage, Stage
+    from ..stage.loader import StageLoader
+    from ..types import OptStr
 
 PIPELINE_FILE = "dvc.yaml"
 
@@ -57,7 +57,7 @@ StageSet = Set["Stage"]
 
 
 def _collect_with_deps(stages: StageList, graph: "DiGraph") -> StageSet:
-    from dvc.repo.graph import collect_pipeline
+    from .graph import collect_pipeline
 
     res: StageSet = set()
     for stage in stages:
@@ -68,7 +68,7 @@ def _collect_with_deps(stages: StageList, graph: "DiGraph") -> StageSet:
 def _maybe_collect_from_dvc_yaml(
     loader: "StageLoad", target, with_deps: bool, **load_kwargs
 ) -> StageIter:
-    from dvc.stage.exceptions import StageNotFound
+    from ..stage.exceptions import StageNotFound
 
     stages: StageList = []
     if loader.fs.exists(PIPELINE_FILE):
@@ -84,7 +84,7 @@ def _collect_specific_target(
     recursive: bool,
     accept_group: bool,
 ) -> Tuple[StageIter, "OptStr", "OptStr"]:
-    from dvc.dvcfile import is_valid_filename
+    from ..dvcfile import is_valid_filename
 
     # Optimization: do not collect the graph for a specific target
     file, name = parse_target(target)
@@ -167,14 +167,14 @@ class StageLoad:
             stage_data: Stage data to create from
                 (see create_stage and loads_from for more information)
         """
-        from dvc.stage import (
+        from ..stage import (
             PipelineStage,
             Stage,
             create_stage,
             restore_fields,
         )
-        from dvc.stage.exceptions import InvalidStageName
-        from dvc.stage.utils import (
+        from ..stage.exceptions import InvalidStageName
+        from ..stage.utils import (
             is_valid_name,
             prepare_file_path,
             validate_kwargs,
@@ -198,7 +198,7 @@ class StageLoad:
         )
         if validate:
             if not force:
-                from dvc.stage.utils import check_stage_exists
+                from ..stage.utils import check_stage_exists
 
                 check_stage_exists(self.repo, stage, stage.path)
 
@@ -239,7 +239,7 @@ class StageLoad:
 
     @staticmethod
     def _get_group_keys(stages: "StageLoader", group: str) -> Iterable[str]:
-        from dvc.parsing import JOIN
+        from ..parsing import JOIN
 
         for key in stages:
             assert isinstance(key, str)
@@ -282,8 +282,8 @@ class StageLoad:
             glob: if true, `name` is considered as a glob, which is
                 used to filter list of stages from the given `path`.
         """
-        from dvc.dvcfile import Dvcfile
-        from dvc.stage.loader import SingleStageLoader, StageLoader
+        from ..dvcfile import Dvcfile
+        from ..stage.loader import SingleStageLoader, StageLoader
 
         path = self._get_filepath(path, name)
         dvcfile = Dvcfile(self.repo, path)
@@ -305,7 +305,7 @@ class StageLoad:
             path: if not provided, default `dvc.yaml` is assumed.
             name: required for `dvc.yaml` files, ignored for `.dvc` files.
         """
-        from dvc.dvcfile import Dvcfile
+        from ..dvcfile import Dvcfile
 
         path = self._get_filepath(path, name)
         dvcfile = Dvcfile(self.repo, path)
@@ -375,7 +375,7 @@ class StageLoad:
             return list(graph) if graph else list(self.repo.index)
 
         if recursive and self.fs.isdir(target):
-            from dvc.repo.graph import collect_inside_path
+            from .graph import collect_inside_path
 
             path = self.fs.path.abspath(target)
             return collect_inside_path(path, graph or self.graph)
@@ -428,8 +428,8 @@ class StageLoad:
                 except OutputNotFoundError:
                     pass
 
-            from dvc.dvcfile import is_valid_filename
-            from dvc.stage.exceptions import (
+            from ..dvcfile import is_valid_filename
+            from ..stage.exceptions import (
                 StageFileDoesNotExistError,
                 StageNotFound,
             )
@@ -464,8 +464,8 @@ class StageLoad:
                 (and, skip failed ones), or raise the exception to abort
                 the collection.
         """
-        from dvc.dvcfile import is_valid_filename
-        from dvc.fs import LocalFileSystem
+        from ..dvcfile import is_valid_filename
+        from ..fs import LocalFileSystem
 
         scm = self.repo.scm
         sep = self.fs.sep

--- a/dvc/repo/status.py
+++ b/dvc/repo/status.py
@@ -3,7 +3,7 @@ from itertools import compress
 
 from funcy.py3 import cat
 
-from dvc.exceptions import InvalidArgumentError
+from ..exceptions import InvalidArgumentError
 
 from . import locked
 

--- a/dvc/repo/status.py
+++ b/dvc/repo/status.py
@@ -4,7 +4,6 @@ from itertools import compress
 from funcy.py3 import cat
 
 from ..exceptions import InvalidArgumentError
-
 from . import locked
 
 logger = logging.getLogger(__name__)

--- a/dvc/repo/trie.py
+++ b/dvc/repo/trie.py
@@ -1,7 +1,7 @@
 from funcy import first
 from pygtrie import Trie
 
-from dvc.exceptions import OutputDuplicationError, OverlappingOutputPathsError
+from ..exceptions import OutputDuplicationError, OverlappingOutputPathsError
 
 
 def build_outs_trie(stages):

--- a/dvc/repo/update.py
+++ b/dvc/repo/update.py
@@ -1,5 +1,4 @@
 from ..exceptions import InvalidArgumentError
-
 from . import locked
 
 

--- a/dvc/repo/update.py
+++ b/dvc/repo/update.py
@@ -1,4 +1,4 @@
-from dvc.exceptions import InvalidArgumentError
+from ..exceptions import InvalidArgumentError
 
 from . import locked
 

--- a/dvc/schema.py
+++ b/dvc/schema.py
@@ -2,11 +2,11 @@ from collections.abc import Mapping
 
 from voluptuous import Any, Optional, Required, Schema
 
-from dvc import dependency, output
-from dvc.output import CHECKSUMS_SCHEMA, Output
-from dvc.parsing import DO_KWD, FOREACH_KWD, VARS_KWD
-from dvc.parsing.versions import SCHEMA_KWD, lockfile_version_schema
-from dvc.stage.params import StageParams
+from . import dependency, output
+from .output import CHECKSUMS_SCHEMA, Output
+from .parsing import DO_KWD, FOREACH_KWD, VARS_KWD
+from .parsing.versions import SCHEMA_KWD, lockfile_version_schema
+from .stage.params import StageParams
 from dvc_data.hashfile.meta import Meta
 
 STAGES = "stages"

--- a/dvc/schema.py
+++ b/dvc/schema.py
@@ -2,12 +2,13 @@ from collections.abc import Mapping
 
 from voluptuous import Any, Optional, Required, Schema
 
+from dvc_data.hashfile.meta import Meta
+
 from . import dependency, output
 from .output import CHECKSUMS_SCHEMA, Output
 from .parsing import DO_KWD, FOREACH_KWD, VARS_KWD
 from .parsing.versions import SCHEMA_KWD, lockfile_version_schema
 from .stage.params import StageParams
-from dvc_data.hashfile.meta import Meta
 
 STAGES = "stages"
 SINGLE_STAGE_SCHEMA = {

--- a/dvc/scm.py
+++ b/dvc/scm.py
@@ -9,9 +9,9 @@ from scmrepo.base import Base  # noqa: F401, pylint: disable=unused-import
 from scmrepo.git import Git
 from scmrepo.noscm import NoSCM
 
-from dvc.exceptions import DvcException
-from dvc.progress import Tqdm
-from dvc.utils import format_link
+from .exceptions import DvcException
+from .progress import Tqdm
+from .utils import format_link
 
 if TYPE_CHECKING:
     from scmrepo.progress import GitProgressEvent
@@ -138,7 +138,7 @@ class TqdmGit(Tqdm):
 def clone(url: str, to_path: str, **kwargs):
     from scmrepo.exceptions import CloneError as InternalCloneError
 
-    from dvc.repo.experiments.utils import fetch_all_exps
+    from .repo.experiments.utils import fetch_all_exps
 
     with TqdmGit(desc=f"Cloning {os.path.basename(url)}") as pbar:
         try:
@@ -153,7 +153,7 @@ def clone(url: str, to_path: str, **kwargs):
 def resolve_rev(scm: "Git", rev: str) -> str:
     from scmrepo.exceptions import RevError as InternalRevError
 
-    from dvc.repo.experiments.utils import fix_exp_head
+    from .repo.experiments.utils import fix_exp_head
 
     try:
         return scm.resolve_rev(fix_exp_head(scm, rev))
@@ -161,7 +161,7 @@ def resolve_rev(scm: "Git", rev: str) -> str:
         # `scm` will only resolve git branch and tag names,
         # if rev is not a sha it may be an abbreviated experiment name
         if not rev.startswith("refs/"):
-            from dvc.repo.experiments.utils import (
+            from .repo.experiments.utils import (
                 AmbiguousExpRefInfo,
                 resolve_name,
             )
@@ -216,7 +216,7 @@ def iter_revs(
             results.extend(scm.list_tags())
 
     if all_experiments:
-        from dvc.repo.experiments.utils import exp_commits
+        from .repo.experiments.utils import exp_commits
 
         results.extend(exp_commits(scm))
 

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -8,14 +8,14 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Set
 
 from funcy import cached_property, project
 
-from dvc import prompt
-from dvc.exceptions import (
+from .. import prompt
+from ..exceptions import (
     CacheLinkError,
     CheckoutError,
     DvcException,
     MergeError,
 )
-from dvc.utils import relpath
+from ..utils import relpath
 
 from . import params
 from .decorators import rwlocked
@@ -35,7 +35,7 @@ from .utils import (
 )
 
 if TYPE_CHECKING:
-    from dvc.dvcfile import DVCFile
+    from ..dvcfile import DVCFile
     from dvc_data.hashfile.hash_info import HashInfo
     from dvc_objects.db.base import ObjectDB
 
@@ -74,7 +74,7 @@ class RawData:
 
 
 def create_stage(cls, repo, path, external=False, **kwargs):
-    from dvc.dvcfile import check_dvcfile_path
+    from ..dvcfile import check_dvcfile_path
 
     wdir = os.path.abspath(kwargs.get("wdir", None) or os.curdir)
     path = os.path.abspath(path)
@@ -183,7 +183,7 @@ class Stage(params.StageParams):
                 "and is detached from dvcfile."
             )
 
-        from dvc.dvcfile import make_dvcfile
+        from ..dvcfile import make_dvcfile
 
         self._dvcfile = make_dvcfile(self.repo, self.path)
         return self._dvcfile
@@ -247,7 +247,7 @@ class Stage(params.StageParams):
         if not self.is_import:
             return False
 
-        from dvc.dependency import RepoDependency
+        from ..dependency import RepoDependency
 
         return isinstance(self.deps[0], RepoDependency)
 
@@ -271,9 +271,9 @@ class Stage(params.StageParams):
     def _read_env(self, out, checkpoint_func=None) -> Env:
         env: Env = {}
         if out.live:
-            from dvc.env import DVCLIVE_HTML, DVCLIVE_PATH, DVCLIVE_SUMMARY
-            from dvc.output import Output
-            from dvc.schema import LIVE_PROPS
+            from ..env import DVCLIVE_HTML, DVCLIVE_PATH, DVCLIVE_SUMMARY
+            from ..output import Output
+            from ..schema import LIVE_PROPS
 
             env[DVCLIVE_PATH] = relpath(out.fs_path, self.wdir)
             if isinstance(out.live, dict):
@@ -286,13 +286,13 @@ class Stage(params.StageParams):
                     int(config.get(Output.PARAM_LIVE_HTML, True))
                 )
         elif out.checkpoint and checkpoint_func:
-            from dvc.env import DVC_CHECKPOINT
+            from ..env import DVC_CHECKPOINT
 
             env.update({DVC_CHECKPOINT: "1"})
         return env
 
     def env(self, checkpoint_func=None) -> Env:
-        from dvc.env import DVC_ROOT
+        from ..env import DVC_ROOT
 
         env: Env = {}
         if self.repo:
@@ -463,7 +463,7 @@ class Stage(params.StageParams):
         self.repo.stage_cache.save(self)
 
     def save_deps(self, allow_missing=False):
-        from dvc.dependency.base import DependencyDoesNotExistError
+        from ..dependency.base import DependencyDoesNotExistError
 
         for dep in self.deps:
             try:
@@ -473,7 +473,7 @@ class Stage(params.StageParams):
                     raise
 
     def save_outs(self, allow_missing=False):
-        from dvc.output import OutputDoesNotExistError
+        from ..output import OutputDoesNotExistError
 
         for out in self.outs:
             try:
@@ -504,7 +504,7 @@ class Stage(params.StageParams):
 
     @rwlocked(write=["outs"])
     def commit(self, allow_missing=False, filter_info=None):
-        from dvc.output import OutputDoesNotExistError
+        from ..output import OutputDoesNotExistError
 
         link_failures = []
         for out in self.filter_outs(filter_info):
@@ -721,7 +721,7 @@ class PipelineStage(Stage):
 
     @property
     def addressing(self):
-        from dvc.dvcfile import PIPELINE_FILE
+        from ..dvcfile import PIPELINE_FILE
 
         if self.path and self.relpath == PIPELINE_FILE:
             return self.name

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -16,7 +16,6 @@ from ..exceptions import (
     MergeError,
 )
 from ..utils import relpath
-
 from . import params
 from .decorators import rwlocked
 from .exceptions import StageUpdateError
@@ -35,9 +34,10 @@ from .utils import (
 )
 
 if TYPE_CHECKING:
-    from ..dvcfile import DVCFile
     from dvc_data.hashfile.hash_info import HashInfo
     from dvc_objects.db.base import ObjectDB
+
+    from ..dvcfile import DVCFile
 
 logger = logging.getLogger(__name__)
 # Disallow all punctuation characters except hyphen and underscore

--- a/dvc/stage/cache.py
+++ b/dvc/stage/cache.py
@@ -6,10 +6,11 @@ from typing import TYPE_CHECKING, Optional
 
 from funcy import cached_property, first
 
+from dvc_data.transfer import _log_exceptions
+
 from .. import fs
 from ..exceptions import DvcException
 from ..utils import dict_sha256, relpath
-from dvc_data.transfer import _log_exceptions
 
 if TYPE_CHECKING:
     from dvc_objects.db import ObjectDB

--- a/dvc/stage/cache.py
+++ b/dvc/stage/cache.py
@@ -6,9 +6,9 @@ from typing import TYPE_CHECKING, Optional
 
 from funcy import cached_property, first
 
-from dvc import fs
-from dvc.exceptions import DvcException
-from dvc.utils import dict_sha256, relpath
+from .. import fs
+from ..exceptions import DvcException
+from ..utils import dict_sha256, relpath
 from dvc_data.transfer import _log_exceptions
 
 if TYPE_CHECKING:
@@ -76,8 +76,8 @@ class StageCache:
     def _load_cache(self, key, value):
         from voluptuous import Invalid
 
-        from dvc.schema import COMPILED_LOCK_FILE_STAGE_SCHEMA
-        from dvc.utils.serialize import YAMLFileCorruptedError, load_yaml
+        from ..schema import COMPILED_LOCK_FILE_STAGE_SCHEMA
+        from ..utils.serialize import YAMLFileCorruptedError, load_yaml
 
         path = self._get_cache_path(key, value)
 
@@ -166,8 +166,8 @@ class StageCache:
         if existing_cache:
             return
 
-        from dvc.schema import COMPILED_LOCK_FILE_STAGE_SCHEMA
-        from dvc.utils.serialize import dump_yaml
+        from ..schema import COMPILED_LOCK_FILE_STAGE_SCHEMA
+        from ..utils.serialize import dump_yaml
 
         # sanity check
         COMPILED_LOCK_FILE_STAGE_SCHEMA(cache)
@@ -217,8 +217,8 @@ class StageCache:
         cached_stage.checkout()
 
     def transfer(self, from_odb, to_odb):
-        from dvc.fs import HTTPFileSystem, LocalFileSystem
-        from dvc.fs.callbacks import Callback
+        from ..fs import HTTPFileSystem, LocalFileSystem
+        from ..fs.callbacks import Callback
 
         from_fs = from_odb.fs
         to_fs = to_odb.fs

--- a/dvc/stage/decorators.py
+++ b/dvc/stage/decorators.py
@@ -7,8 +7,8 @@ from funcy import decorator
 def rwlocked(call, read=None, write=None):
     import sys
 
-    from dvc.dependency.repo import RepoDependency
-    from dvc.rwlock import rwlock
+    from ..dependency.repo import RepoDependency
+    from ..rwlock import rwlock
 
     if read is None:
         read = []

--- a/dvc/stage/exceptions.py
+++ b/dvc/stage/exceptions.py
@@ -1,4 +1,4 @@
-from dvc.exceptions import DvcException
+from ..exceptions import DvcException
 
 
 class StageCmdFailedError(DvcException):
@@ -25,7 +25,7 @@ class StageFileAlreadyExistsError(DvcException):
 
 class StageFileIsNotDvcFileError(DvcException):
     def __init__(self, fname):
-        from dvc.dvcfile import DVC_FILE_SUFFIX, is_dvc_file
+        from ..dvcfile import DVC_FILE_SUFFIX, is_dvc_file
 
         msg = f"'{fname}' is not a .dvc file"
 

--- a/dvc/stage/imports.py
+++ b/dvc/stage/imports.py
@@ -1,6 +1,6 @@
 import logging
 
-from dvc.exceptions import InvalidArgumentError
+from ..exceptions import InvalidArgumentError
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/stage/loader.py
+++ b/dvc/stage/loader.py
@@ -5,12 +5,12 @@ from itertools import chain
 
 from funcy import cached_property, get_in, lcat, once, project
 
-from .. import dependency, output
-from ..parsing import FOREACH_KWD, JOIN, DataResolver, EntryNotFound
-from ..parsing.versions import LOCKFILE_VERSION
 from dvc_data.hashfile.hash_info import HashInfo
 from dvc_data.hashfile.meta import Meta
 
+from .. import dependency, output
+from ..parsing import FOREACH_KWD, JOIN, DataResolver, EntryNotFound
+from ..parsing.versions import LOCKFILE_VERSION
 from . import PipelineStage, Stage, loads_from
 from .exceptions import StageNameUnspecified, StageNotFound
 from .params import StageParams

--- a/dvc/stage/loader.py
+++ b/dvc/stage/loader.py
@@ -5,9 +5,9 @@ from itertools import chain
 
 from funcy import cached_property, get_in, lcat, once, project
 
-from dvc import dependency, output
-from dvc.parsing import FOREACH_KWD, JOIN, DataResolver, EntryNotFound
-from dvc.parsing.versions import LOCKFILE_VERSION
+from .. import dependency, output
+from ..parsing import FOREACH_KWD, JOIN, DataResolver, EntryNotFound
+from ..parsing.versions import LOCKFILE_VERSION
 from dvc_data.hashfile.hash_info import HashInfo
 from dvc_data.hashfile.meta import Meta
 

--- a/dvc/stage/monitor.py
+++ b/dvc/stage/monitor.py
@@ -6,11 +6,11 @@ import threading
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, List
 
-from dvc.stage.decorators import relock_repo
-from dvc.stage.exceptions import StageCmdFailedError
+from .decorators import relock_repo
+from .exceptions import StageCmdFailedError
 
 if TYPE_CHECKING:
-    from dvc.stage import Stage
+    from . import Stage
 
 
 logger = logging.getLogger(__name__)

--- a/dvc/stage/run.py
+++ b/dvc/stage/run.py
@@ -4,8 +4,8 @@ import signal
 import subprocess
 import threading
 
-from dvc.stage.monitor import Monitor
-from dvc.utils import fix_env
+from .monitor import Monitor
+from ..utils import fix_env
 
 from .decorators import unlocked_repo
 from .exceptions import StageCmdFailedError

--- a/dvc/stage/run.py
+++ b/dvc/stage/run.py
@@ -4,11 +4,10 @@ import signal
 import subprocess
 import threading
 
-from .monitor import Monitor
 from ..utils import fix_env
-
 from .decorators import unlocked_repo
 from .exceptions import StageCmdFailedError
+from .monitor import Monitor
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/stage/serialize.py
+++ b/dvc/stage/serialize.py
@@ -9,7 +9,6 @@ from ..dependency import ParamsDependency
 from ..output import Output
 from ..utils.collections import apply_diff
 from ..utils.serialize import parse_yaml_for_update
-
 from .params import StageParams
 from .utils import resolve_wdir, split_params_deps
 

--- a/dvc/stage/serialize.py
+++ b/dvc/stage/serialize.py
@@ -5,16 +5,16 @@ from typing import TYPE_CHECKING, List, no_type_check
 
 from funcy import post_processing
 
-from dvc.dependency import ParamsDependency
-from dvc.output import Output
-from dvc.utils.collections import apply_diff
-from dvc.utils.serialize import parse_yaml_for_update
+from ..dependency import ParamsDependency
+from ..output import Output
+from ..utils.collections import apply_diff
+from ..utils.serialize import parse_yaml_for_update
 
 from .params import StageParams
 from .utils import resolve_wdir, split_params_deps
 
 if TYPE_CHECKING:
-    from dvc.stage import PipelineStage, Stage
+    from . import PipelineStage, Stage
 
 PARAM_PARAMS = ParamsDependency.PARAM_PARAMS
 PARAM_PATH = ParamsDependency.PARAM_PATH

--- a/dvc/stage/utils.py
+++ b/dvc/stage/utils.py
@@ -4,9 +4,9 @@ from typing import TYPE_CHECKING, Union
 
 from funcy import concat, first, lsplit, rpartial, without
 
-from ..exceptions import InvalidArgumentError
 from dvc_data.hashfile.meta import Meta
 
+from ..exceptions import InvalidArgumentError
 from .exceptions import (
     MissingDataSource,
     StageExternalOutputsError,
@@ -17,7 +17,6 @@ from .exceptions import (
 
 if TYPE_CHECKING:
     from ..repo import Repo
-
     from . import PipelineStage, Stage
 
 
@@ -170,7 +169,6 @@ def check_missing_outputs(stage):
 
 def compute_md5(stage):
     from ..output import Output
-
     from ..utils import dict_md5
 
     d = stage.dumpd()
@@ -281,10 +279,7 @@ def check_stage_exists(
 ):
     from ..dvcfile import make_dvcfile
     from . import PipelineStage
-    from .exceptions import (
-        DuplicateStageName,
-        StageFileAlreadyExistsError,
-    )
+    from .exceptions import DuplicateStageName, StageFileAlreadyExistsError
 
     dvcfile = make_dvcfile(repo, path)
     if not dvcfile.exists():

--- a/dvc/stage/utils.py
+++ b/dvc/stage/utils.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Union
 
 from funcy import concat, first, lsplit, rpartial, without
 
-from dvc.exceptions import InvalidArgumentError
+from ..exceptions import InvalidArgumentError
 from dvc_data.hashfile.meta import Meta
 
 from .exceptions import (
@@ -16,13 +16,13 @@ from .exceptions import (
 )
 
 if TYPE_CHECKING:
-    from dvc.repo import Repo
+    from ..repo import Repo
 
     from . import PipelineStage, Stage
 
 
 def check_stage_path(repo, path, is_wdir=False):
-    from dvc.utils.fs import path_isin
+    from ..utils.fs import path_isin
 
     assert repo is not None
 
@@ -43,7 +43,7 @@ def check_stage_path(repo, path, is_wdir=False):
 
 
 def fill_stage_outputs(stage, **kwargs):
-    from dvc.output import loads_from
+    from ..output import loads_from
 
     assert not stage.outs
 
@@ -83,7 +83,7 @@ def _load_live_output(
     live_html=False,
     **kwargs,
 ):
-    from dvc.output import Output, loads_from
+    from ..output import Output, loads_from
 
     outs = []
     if live or live_no_cache:
@@ -104,7 +104,7 @@ def _load_live_output(
 
 
 def fill_stage_dependencies(stage, deps=None, erepo=None, params=None):
-    from dvc.dependency import loads_from, loads_params
+    from ..dependency import loads_from, loads_params
 
     assert not stage.deps
     stage.deps = []
@@ -115,7 +115,7 @@ def fill_stage_dependencies(stage, deps=None, erepo=None, params=None):
 def check_no_externals(stage):
     from urllib.parse import urlparse
 
-    from dvc.utils import format_link
+    from ..utils import format_link
 
     # NOTE: preventing users from accidentally using external outputs. See
     # https://github.com/iterative/dvc/issues/1545 for more details.
@@ -140,7 +140,7 @@ def check_no_externals(stage):
 
 
 def check_circular_dependency(stage):
-    from dvc.exceptions import CircularDependencyError
+    from ..exceptions import CircularDependencyError
 
     circular_dependencies = {d.fs_path for d in stage.deps} & {
         o.fs_path for o in stage.outs
@@ -153,7 +153,7 @@ def check_circular_dependency(stage):
 def check_duplicated_arguments(stage):
     from collections import Counter
 
-    from dvc.exceptions import ArgumentDuplicationError
+    from ..exceptions import ArgumentDuplicationError
 
     path_counts = Counter(edge.fs_path for edge in stage.deps + stage.outs)
 
@@ -169,7 +169,7 @@ def check_missing_outputs(stage):
 
 
 def compute_md5(stage):
-    from dvc.output import Output
+    from ..output import Output
 
     from ..utils import dict_md5
 
@@ -252,7 +252,7 @@ def prepare_file_path(kwargs):
 
     Used in creating .dvc files.
     """
-    from dvc.dvcfile import DVC_FILE, DVC_FILE_SUFFIX
+    from ..dvcfile import DVC_FILE, DVC_FILE_SUFFIX
 
     out = first(
         concat(
@@ -279,9 +279,9 @@ def prepare_file_path(kwargs):
 def check_stage_exists(
     repo: "Repo", stage: Union["Stage", "PipelineStage"], path: str
 ):
-    from dvc.dvcfile import make_dvcfile
-    from dvc.stage import PipelineStage
-    from dvc.stage.exceptions import (
+    from ..dvcfile import make_dvcfile
+    from . import PipelineStage
+    from .exceptions import (
         DuplicateStageName,
         StageFileAlreadyExistsError,
     )

--- a/dvc/testing/fixtures.py
+++ b/dvc/testing/fixtures.py
@@ -36,7 +36,7 @@ def make_tmp_dir(tmp_path_factory, request, worker_id):
 
         from scmrepo.git import Git
 
-        from dvc.repo import Repo
+        from ..repo import Repo
 
         from .tmp_dir import TmpDir
 
@@ -134,7 +134,7 @@ def local_remote(make_remote):
 @pytest.fixture
 def make_workspace(tmp_dir, dvc, make_cloud):
     def _make_workspace(name, typ="local"):
-        from dvc.odbmgr import ODBManager
+        from ..odbmgr import ODBManager
 
         cloud = make_cloud(typ)  # pylint: disable=W0621
 

--- a/dvc/testing/fixtures.py
+++ b/dvc/testing/fixtures.py
@@ -37,7 +37,6 @@ def make_tmp_dir(tmp_path_factory, request, worker_id):
         from scmrepo.git import Git
 
         from ..repo import Repo
-
         from .tmp_dir import TmpDir
 
         cache = CACHE.get((scm, dvc, subdir))

--- a/dvc/testing/path_info.py
+++ b/dvc/testing/path_info.py
@@ -7,7 +7,7 @@ from urllib.parse import urlparse
 
 from funcy import cached_property
 
-from dvc.utils import relpath
+from ..utils import relpath
 
 
 class _BasePath:

--- a/dvc/testing/test_api.py
+++ b/dvc/testing/test_api.py
@@ -1,5 +1,5 @@
-from dvc import api
-from dvc.utils.fs import remove
+from .. import api
+from ..utils.fs import remove
 
 
 class TestAPI:

--- a/dvc/testing/test_remote.py
+++ b/dvc/testing/test_remote.py
@@ -3,8 +3,8 @@ import shutil
 
 import pytest
 
-from dvc.stage.cache import RunCacheNotSupported
-from dvc.utils.fs import remove
+from ..stage.cache import RunCacheNotSupported
+from ..utils.fs import remove
 
 
 class TestRemote:

--- a/dvc/testing/test_workspace.py
+++ b/dvc/testing/test_workspace.py
@@ -20,7 +20,7 @@ class TestImport:
         pytest.skip()
 
     def test_import_dir(self, tmp_dir, dvc, workspace, stage_md5, dir_md5):
-        from dvc.odbmgr import ODBManager
+        from ..odbmgr import ODBManager
 
         workspace.gen(
             {"dir": {"file": "file", "subdir": {"subfile": "subfile"}}}
@@ -97,7 +97,7 @@ class TestAdd:
         pytest.skip()
 
     def test_add(self, tmp_dir, dvc, workspace, hash_name, hash_value):
-        from dvc.stage.exceptions import StageExternalOutputsError
+        from ..stage.exceptions import StageExternalOutputsError
 
         workspace.gen("file", "file")
 

--- a/dvc/testing/tmp_dir.py
+++ b/dvc/testing/tmp_dir.py
@@ -51,8 +51,8 @@ import sys
 from contextlib import contextmanager
 from functools import partialmethod
 
-from dvc.utils import serialize
-from dvc.utils.fs import makedirs
+from ..utils import serialize
+from ..utils.fs import makedirs
 
 
 class TmpDir(pathlib.Path):
@@ -91,7 +91,7 @@ class TmpDir(pathlib.Path):
     def init(self, *, scm=False, dvc=False, subdir=False):
         from scmrepo.git import Git
 
-        from dvc.repo import Repo
+        from ..repo import Repo
 
         assert not scm or not hasattr(self, "scm")
         assert not dvc or not hasattr(self, "dvc")

--- a/dvc/ui/__init__.py
+++ b/dvc/ui/__init__.py
@@ -19,9 +19,9 @@ if TYPE_CHECKING:
     from rich.status import Status
     from rich.text import Text as RichText
 
-    from dvc.progress import Tqdm
-    from dvc.types import StrPath
-    from dvc.ui.table import Headers, Styles, TableData
+    from ..progress import Tqdm
+    from ..types import StrPath
+    from .table import Headers, Styles, TableData
 
 
 class Formatter:
@@ -36,7 +36,7 @@ class Formatter:
         self.theme = defaultdict(lambda: defaults or {}, theme)
 
     def format(self, message: str, style: str = None, **kwargs) -> str:
-        from dvc.utils import colorize
+        from ..utils import colorize
 
         return colorize(message, **self.theme[style])
 
@@ -128,7 +128,7 @@ class Console:
     ) -> None:
         import sys
 
-        from dvc.progress import Tqdm
+        from ..progress import Tqdm
 
         sep = " " if sep is None else sep
         end = "\n" if end is None else end
@@ -155,7 +155,7 @@ class Console:
 
     @staticmethod
     def progress(*args, **kwargs) -> "Tqdm":
-        from dvc.progress import Tqdm
+        from ..progress import Tqdm
 
         return Tqdm(*args, **kwargs)
 
@@ -230,7 +230,7 @@ class Console:
         row_styles: Sequence["Styles"] = None,
         borders: Union[bool, str] = False,
     ) -> None:
-        from dvc.ui import table as t
+        from . import table as t
 
         if not data and not markdown:
             return
@@ -266,7 +266,7 @@ class Console:
         from pathlib import Path
         from platform import uname
 
-        from dvc.utils import relpath
+        from ..utils import relpath
 
         path = Path(file).resolve()
         url = (

--- a/dvc/ui/pager.py
+++ b/dvc/ui/pager.py
@@ -7,8 +7,8 @@ import sys
 
 from rich.pager import Pager
 
-from dvc.env import DVC_PAGER
-from dvc.utils import format_link
+from ..env import DVC_PAGER
+from ..utils import format_link
 
 logger = logging.getLogger(__name__)
 

--- a/dvc/ui/table.py
+++ b/dvc/ui/table.py
@@ -3,13 +3,13 @@ from contextlib import ExitStack, contextmanager
 from itertools import zip_longest
 from typing import TYPE_CHECKING, Dict, Iterator, Sequence, Union
 
-from dvc.types import DictStrAny
+from ..types import DictStrAny
 
 if TYPE_CHECKING:
     from rich.console import Console as RichConsole
     from rich.table import Table
 
-    from dvc.ui import Console, RichText
+    from . import Console, RichText
 
 SHOW_MAX_WIDTH = 1024
 
@@ -84,7 +84,7 @@ def rich_table(
 ) -> None:
     from rich import box
 
-    from dvc.utils.table import Table
+    from ..utils.table import Table
 
     border_style = {
         True: box.HEAVY_HEAD,  # is a default in rich,

--- a/dvc/updater.py
+++ b/dvc/updater.py
@@ -6,11 +6,11 @@ from typing import TYPE_CHECKING, Optional
 
 from packaging import version
 
-from dvc import __version__
-from dvc.utils.pkg import PKG
+from . import __version__
+from .utils.pkg import PKG
 
 if TYPE_CHECKING:
-    from dvc.ui import RichText
+    from .ui import RichText
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ class Updater:
     TIMEOUT_GET = 10
 
     def __init__(self, tmp_dir, friendly=False, hardlink_lock=False):
-        from dvc.lock import make_lock
+        from .lock import make_lock
 
         self.updater_file = os.path.join(tmp_dir, self.UPDATER_FILE)
         self.lock = make_lock(
@@ -41,7 +41,7 @@ class Updater:
         return outdated
 
     def _with_lock(self, func, action):
-        from dvc.lock import LockError
+        from .lock import LockError
 
         try:
             with self.lock:
@@ -51,7 +51,7 @@ class Updater:
             logger.debug(msg.format(self.lock.lockfile, action))
 
     def check(self):
-        from dvc.utils import env2bool
+        from .utils import env2bool
 
         if (
             os.getenv("CI")
@@ -84,7 +84,7 @@ class Updater:
             self._notify(latest)
 
     def fetch(self, detach=True):
-        from dvc.daemon import daemon
+        from .daemon import daemon
 
         if detach:
             daemon(["updater"])
@@ -109,7 +109,7 @@ class Updater:
             json.dump(info, fobj)
 
     def _notify(self, latest: str, pkg: Optional[str] = PKG) -> None:
-        from dvc.ui import ui
+        from .ui import ui
 
         if not sys.stdout.isatty():
             return
@@ -124,7 +124,7 @@ class Updater:
         color: str = "yellow",
         pkg: Optional[str] = None,
     ) -> "RichText":
-        from dvc.ui import ui
+        from .ui import ui
 
         current = current or self.current
         update_message = ui.rich_text.from_markup(
@@ -165,7 +165,7 @@ class Updater:
         return f"To upgrade, run '{instruction}'."
 
     def is_enabled(self):
-        from dvc.config import Config, to_bool
+        from .config import Config, to_bool
 
         enabled = to_bool(
             Config(validate=False).get("core", {}).get("check_update", "true")
@@ -179,7 +179,7 @@ class Updater:
 def notify_updates():
     from contextlib import suppress
 
-    from dvc.repo import NotDvcRepoError, Repo
+    from .repo import NotDvcRepoError, Repo
 
     with suppress(NotDvcRepoError), Repo() as repo:
         hardlink_lock = repo.config["core"].get("hardlink_lock", False)

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -293,10 +293,9 @@ def resolve_output(inp, out):
 def resolve_paths(repo, out, always_local=False):
     from urllib.parse import urlparse
 
-    from ..fs import localfs
-
     from ..dvcfile import DVC_FILE_SUFFIX
     from ..exceptions import DvcException
+    from ..fs import localfs
     from .fs import contains_symlink_up_to
 
     abspath = os.path.abspath(out)

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -293,7 +293,7 @@ def resolve_output(inp, out):
 def resolve_paths(repo, out, always_local=False):
     from urllib.parse import urlparse
 
-    from dvc.fs import localfs
+    from ..fs import localfs
 
     from ..dvcfile import DVC_FILE_SUFFIX
     from ..exceptions import DvcException
@@ -348,9 +348,9 @@ def error_link(name):
 def parse_target(
     target: str, default: str = None, isa_glob: bool = False
 ) -> Tuple[Optional[str], Optional[str]]:
-    from dvc.dvcfile import PIPELINE_FILE, PIPELINE_LOCK, is_valid_filename
-    from dvc.exceptions import DvcException
-    from dvc.parsing import JOIN
+    from ..dvcfile import PIPELINE_FILE, PIPELINE_LOCK, is_valid_filename
+    from ..exceptions import DvcException
+    from ..parsing import JOIN
 
     if not target:
         return None, None
@@ -437,7 +437,7 @@ def onerror_collect(result: Dict, exception: Exception, *args, **kwargs):
 
 
 def errored_revisions(rev_data: Dict) -> List:
-    from dvc.utils.collections import nested_contains
+    from .collections import nested_contains
 
     result = []
     for revision, data in rev_data.items():

--- a/dvc/utils/cli_parse.py
+++ b/dvc/utils/cli_parse.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Iterable, List
 
 def parse_params(path_params: Iterable[str]) -> List[Dict[str, List[str]]]:
     """Normalizes the shape of params from the CLI to dict."""
-    from dvc.dependency.param import ParamsDependency
+    from ..dependency.param import ParamsDependency
 
     ret: Dict[str, List[str]] = defaultdict(list)
     for path_param in path_params:
@@ -23,8 +23,8 @@ def loads_param_overrides(
     """Loads the content of params from the cli as Python object."""
     from ruamel.yaml import YAMLError
 
-    from dvc.dependency.param import ParamsDependency
-    from dvc.exceptions import InvalidArgumentError
+    from ..dependency.param import ParamsDependency
+    from ..exceptions import InvalidArgumentError
 
     from .serialize import loads_yaml
 

--- a/dvc/utils/cli_parse.py
+++ b/dvc/utils/cli_parse.py
@@ -25,7 +25,6 @@ def loads_param_overrides(
 
     from ..dependency.param import ParamsDependency
     from ..exceptions import InvalidArgumentError
-
     from .serialize import loads_yaml
 
     ret: Dict[str, Dict[str, Any]] = defaultdict(dict)

--- a/dvc/utils/collections.py
+++ b/dvc/utils/collections.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping
 from functools import wraps
 from typing import Callable, Dict, Iterable, List, TypeVar, Union
 
-from dvc.exceptions import DvcException
+from ..exceptions import DvcException
 
 
 class NewParamsFound(DvcException):

--- a/dvc/utils/fs.py
+++ b/dvc/utils/fs.py
@@ -6,10 +6,10 @@ import stat
 import sys
 from typing import TYPE_CHECKING
 
-from dvc.exceptions import DvcException
+from ..exceptions import DvcException
 
 if TYPE_CHECKING:
-    from dvc.types import StrPath
+    from ..types import StrPath
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ class BasePathNotInCheckedPathException(DvcException):
 
 
 def contains_symlink_up_to(path: "StrPath", base_path: "StrPath"):
-    from dvc.fs import system
+    from ..fs import system
 
     base_path = os.path.normcase(os.fspath(base_path))
     path = os.path.normcase(os.fspath(path))

--- a/dvc/utils/serialize/_common.py
+++ b/dvc/utils/serialize/_common.py
@@ -6,11 +6,11 @@ from typing import TYPE_CHECKING, Any, Callable, ContextManager, Dict, Union
 from funcy import reraise
 from typing_extensions import Protocol
 
-from dvc.exceptions import DvcException
+from ...exceptions import DvcException
 
 if TYPE_CHECKING:
-    from dvc.fs import FileSystem
-    from dvc.types import AnyPath
+    from ...fs import FileSystem
+    from ...types import AnyPath
 
 
 class DumperFn(Protocol):
@@ -40,7 +40,7 @@ class ParseError(DvcException):
     """Errors while parsing files"""
 
     def __init__(self, path: "AnyPath", message: str):
-        from dvc.utils import relpath
+        from .. import relpath
 
         path = relpath(path)
         self.path = path

--- a/dvc/utils/strictyaml.py
+++ b/dvc/utils/strictyaml.py
@@ -11,9 +11,9 @@ import typing
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, TypeVar
 
-from dvc.exceptions import PrettyDvcException
-from dvc.ui import ui
-from dvc.utils.serialize import (
+from ..exceptions import PrettyDvcException
+from ..ui import ui
+from .serialize import (
     EncodingError,
     YAMLFileCorruptedError,
     parse_yaml,
@@ -25,8 +25,8 @@ if TYPE_CHECKING:
     from ruamel.yaml import StreamMark
     from voluptuous import MultipleInvalid
 
-    from dvc.fs import FileSystem
-    from dvc.ui import RichText
+    from ..fs import FileSystem
+    from ..ui import RichText
 
 
 _T = TypeVar("_T")
@@ -36,7 +36,7 @@ merge_conflict_marker = re.compile("^([<=>]{7}) .*$", re.MULTILINE)
 def make_relpath(path: str) -> str:
     import os
 
-    from dvc.utils import relpath
+    from . import relpath
 
     rel = relpath(path)
     prefix = ""


### PR DESCRIPTION
Fixes #3109

This was done by installing https://github.com/MarcoGorelli/absolufy-imports and running `absolufy-imports --never dvc/**/*.py`. They also have a commit hook, should I add it to `.pre-commit-config.yaml`?

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.