### PR TITLE
checkout: use dvcignore

### DIFF
--- a/dvc/output.py
+++ b/dvc/output.py
@@ -583,6 +583,7 @@ class Output:
         from dvc_data.checkout import CheckoutError as _CheckoutError
         from dvc_data.checkout import LinkError, PromptError
 
+        kwargs.setdefault("ignore", self.dvcignore)
         try:
             return checkout(*args, **kwargs)
         except PromptError as exc:
@@ -627,7 +628,6 @@ class Output:
                 obj,
                 self.odb,
                 relink=True,
-                ignore=self.dvcignore,
                 state=self.repo.state,
                 prompt=prompt.confirm,
             )

--- a/tests/func/test_ignore.py
+++ b/tests/func/test_ignore.py
@@ -418,3 +418,27 @@ def test_run_dvcignored_dep(tmp_dir, dvc, run_copy):
     tmp_dir.gen({".dvcignore": "dir\n", "dir": {"foo": "foo"}})
     run_copy(os.path.join("dir", "foo"), "bar", name="copy-foo-to-bar")
     assert (tmp_dir / "bar").read_text() == "foo"
+
+
+def test_pull_ignore(tmp_dir, dvc, local_cloud):
+    from dvc.utils.fs import remove
+
+    tmp_dir.dvc_gen(
+        {
+            ".dvcignore": "data/processed/",
+            "data": {"foo": "foo", "processed": {"bar": "bar"}},
+        }
+    )
+    tmp_dir.add_remote(config=local_cloud.config)
+    dvc.add("data")
+    dvc.push()
+
+    foo_path = tmp_dir / "data" / "foo"
+    foo_path.unlink()
+    assert not foo_path.exists()
+
+    remove(tmp_dir / ".dvc/cache")
+    dvc.pull()
+
+    assert foo_path.exists()
+    assert foo_path.read_text() == "foo"


### PR DESCRIPTION
Fixes #7374

Note that there are many places the `ignore` argument could be added instead. This is the deepest call, right before delegating to `dvc_data`. Not sure if that's the right choice.

Will add tests soon.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.