### PR TITLE
metrics: support TOML files

### DIFF
--- a/dvc/repo/metrics/show.py
+++ b/dvc/repo/metrics/show.py
@@ -12,7 +12,7 @@ from dvc.repo.live import summary_fs_path
 from dvc.scm import NoSCMError
 from dvc.utils import error_handler, errored_revisions, onerror_collect
 from dvc.utils.collections import ensure_list
-from dvc.utils.serialize import load_yaml
+from dvc.utils.serialize import LOADERS
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +71,9 @@ def _extract_metrics(metrics, path, rev):
 
 @error_handler
 def _read_metric(path, fs, rev, **kwargs):
-    val = load_yaml(path, fs=fs)
+    suffix = fs.path.suffix(path).lower()
+    loader = LOADERS[suffix]
+    val = loader(path, fs=fs)
     val = _extract_metrics(val, path, rev)
     return val or {}
 

--- a/tests/func/metrics/test_show.py
+++ b/tests/func/metrics/test_show.py
@@ -8,7 +8,7 @@ from dvc.dvcfile import PIPELINE_FILE
 from dvc.exceptions import OverlappingOutputPathsError
 from dvc.repo import Repo
 from dvc.utils.fs import remove
-from dvc.utils.serialize import YAMLFileCorruptedError
+from dvc.utils.serialize import JSONFileCorruptedError, YAMLFileCorruptedError
 
 
 def test_show_simple(tmp_dir, dvc, run_copy_metrics):
@@ -28,6 +28,16 @@ def test_show(tmp_dir, dvc, run_copy_metrics):
     )
     assert dvc.metrics.show() == {
         "": {"data": {"metrics.yaml": {"data": {"foo": 1.1}}}}
+    }
+
+
+def test_show_toml(tmp_dir, dvc, run_copy_metrics):
+    tmp_dir.gen("metrics_t.toml", "[foo]\nbar = 1.2")
+    run_copy_metrics(
+        "metrics_t.toml", "metrics.toml", metrics=["metrics.toml"]
+    )
+    assert dvc.metrics.show() == {
+        "": {"data": {"metrics.toml": {"data": {"foo": {"bar": 1.2}}}}}
     }
 
 
@@ -218,7 +228,7 @@ def test_show_malformed_metric(tmp_dir, scm, dvc, caplog):
         dvc.metrics.show(targets=["metric.json"])[""]["data"]["metric.json"][
             "error"
         ],
-        YAMLFileCorruptedError,
+        JSONFileCorruptedError,
     )
 
 


### PR DESCRIPTION
Fixes #6402

I haven't forbidden `.py` files as suggested there because it just seemed like it would clutter the code more than it would add any real value, but I can do so if requested.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.