### PR TITLE
tests: limit printed durations to 50

### DIFF
--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -14,7 +14,7 @@ os.putenv(
 )
 os.putenv("DVC_HOME", REPO_ROOT)
 
-opts = "-v -n=auto --dist loadscope --cov=dvc --durations=0"
+opts = "-v -n=auto --dist loadscope --cov=dvc --durations=50"
 params = " ".join(sys.argv[1:])
 cmd = f"{sys.executable} -m pytest {opts} {params}"
 check_call(cmd, shell=True)


### PR DESCRIPTION
Having 300+ lines reporting durations of `0.X` seconds doesn't feel helpful in the CI context and makes the navigation of the logs cumbersome. 
The flag can still be overridden locally.