### PR TITLE
Update setup.cfg: typo in `webhdfs_kerberos` extras

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -114,7 +114,7 @@ webdav = webdav4>=0.9.3
 # not to break `dvc[webhdfs]`
 webhdfs =
 # requests-kerberos requires krb5 & gssapi, which does not provide wheels Linux
-webdhfs_kerberos = requests-kerberos==0.14.0
+webhdfs_kerberos = requests-kerberos==0.14.0
 terraform = tpi[ssh]>=2.1.0
 tests =
     %(terraform)s


### PR DESCRIPTION
It seems there is a typo in `webhdfs_kerberos` extras.