### PR TITLE
import-url/update: add --no-download flag

### DIFF
--- a/dvc/commands/data_sync.py
+++ b/dvc/commands/data_sync.py
@@ -43,7 +43,8 @@ class CmdDataPull(CmdDataBase):
             )
             self.log_summary(stats)
         except (CheckoutError, DvcException) as exc:
-            self.log_summary(getattr(exc, "stats", {}))
+            if stats := getattr(exc, "stats", {}):
+                self.log_summary(stats)
             logger.exception("failed to pull data from the cloud")
             return 1
 

--- a/dvc/commands/imp.py
+++ b/dvc/commands/imp.py
@@ -19,6 +19,7 @@ class CmdImport(CmdBase):
                 fname=self.args.file,
                 rev=self.args.rev,
                 no_exec=self.args.no_exec,
+                no_download=self.args.no_download,
                 desc=self.args.desc,
                 jobs=self.args.jobs,
             )
@@ -69,11 +70,19 @@ def add_parser(subparsers, parent_parser):
         help="Specify name of the .dvc file this command will generate.",
         metavar="<filename>",
     )
-    import_parser.add_argument(
+    no_download_exec_group = import_parser.add_mutually_exclusive_group()
+    no_download_exec_group.add_argument(
         "--no-exec",
         action="store_true",
         default=False,
-        help="Only create .dvc file without actually downloading it.",
+        help="Only create .dvc file without actually importing target data.",
+    )
+    no_download_exec_group.add_argument(
+        "--no-download",
+        action="store_true",
+        default=False,
+        help="Create .dvc file including target data hash value(s)"
+        " but do not actually download the file(s).",
     )
     import_parser.add_argument(
         "--desc",

--- a/dvc/commands/imp_url.py
+++ b/dvc/commands/imp_url.py
@@ -17,6 +17,7 @@ class CmdImportUrl(CmdBase):
                 out=self.args.out,
                 fname=self.args.file,
                 no_exec=self.args.no_exec,
+                no_download=self.args.no_download,
                 remote=self.args.remote,
                 to_remote=self.args.to_remote,
                 desc=self.args.desc,
@@ -66,11 +67,19 @@ def add_parser(subparsers, parent_parser):
         help="Specify name of the .dvc file this command will generate.",
         metavar="<filename>",
     ).complete = completion.DIR
-    import_parser.add_argument(
+    no_download_exec_group = import_parser.add_mutually_exclusive_group()
+    no_download_exec_group.add_argument(
         "--no-exec",
         action="store_true",
         default=False,
-        help="Only create .dvc file without actually downloading it.",
+        help="Only create .dvc file without actually importing target data.",
+    )
+    no_download_exec_group.add_argument(
+        "--no-download",
+        action="store_true",
+        default=False,
+        help="Create .dvc file including target data hash value(s)"
+        " but do not actually download the file(s).",
     )
     import_parser.add_argument(
         "--to-remote",

--- a/dvc/commands/update.py
+++ b/dvc/commands/update.py
@@ -18,6 +18,7 @@ class CmdUpdate(CmdBase):
                 rev=self.args.rev,
                 recursive=self.args.recursive,
                 to_remote=self.args.to_remote,
+                no_download=self.args.no_download,
                 remote=self.args.remote,
                 jobs=self.args.jobs,
             )
@@ -54,6 +55,13 @@ def add_parser(subparsers, parent_parser):
         action="store_true",
         default=False,
         help="Update all stages in the specified directory.",
+    )
+    update_parser.add_argument(
+        "--no-download",
+        action="store_true",
+        default=False,
+        help="Update .dvc file hash value(s)"
+        " but do not download the file(s).",
     )
     update_parser.add_argument(
         "--to-remote",

--- a/dvc/output.py
+++ b/dvc/output.py
@@ -375,6 +375,11 @@ class Output:
 
         return self.fs.path.relpath(self.fs_path, self.repo.root_dir)
 
+    def clear(self):
+        self.hash_info = HashInfo.from_dict({})
+        self.meta = Meta.from_dict({})
+        self.obj = None
+
     @property
     def protocol(self):
         return self.fs.protocol

--- a/dvc/repo/imp_url.py
+++ b/dvc/repo/imp_url.py
@@ -17,6 +17,7 @@ def imp_url(
     fname=None,
     erepo=None,
     frozen=True,
+    no_download=False,
     no_exec=False,
     remote=None,
     to_remote=False,
@@ -31,9 +32,9 @@ def imp_url(
         self, out, always_local=to_remote and not out
     )
 
-    if to_remote and no_exec:
+    if to_remote and (no_exec or no_download):
         raise InvalidArgumentError(
-            "--no-exec can't be combined with --to-remote"
+            "--no-exec/--no-download cannot be combined with --to-remote"
         )
 
     if not to_remote and remote:
@@ -80,7 +81,7 @@ def imp_url(
         stage.save_deps()
         stage.md5 = stage.compute_md5()
     else:
-        stage.run(jobs=jobs)
+        stage.run(jobs=jobs, no_download=no_download)
 
     stage.frozen = frozen
 

--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -246,6 +246,28 @@ class Index:
                 used[odb].update(objs)
         return used
 
+    def partial_imports(
+        self,
+        targets: "TargetType" = None,
+        recursive: bool = False,
+    ) -> List["Stage"]:
+        from itertools import chain
+
+        from dvc.utils.collections import ensure_list
+
+        collect_targets: Sequence[Optional[str]] = (None,)
+        if targets:
+            collect_targets = ensure_list(targets)
+
+        pairs = chain.from_iterable(
+            self.stage_collector.collect_granular(
+                target, recursive=recursive, with_deps=True
+            )
+            for target in collect_targets
+        )
+
+        return [stage for stage, _ in pairs if stage.is_partial_import]
+
     # Following methods help us treat the collection as a set-like structure
     # and provides faux-immutability.
     # These methods do not preserve stages order.

--- a/dvc/repo/update.py
+++ b/dvc/repo/update.py
@@ -10,6 +10,7 @@ def update(
     rev=None,
     recursive=False,
     to_remote=False,
+    no_download=False,
     remote=None,
     jobs=None,
 ):
@@ -21,6 +22,11 @@ def update(
     if isinstance(targets, str):
         targets = [targets]
 
+    if to_remote and no_download:
+        raise InvalidArgumentError(
+            "--to-remote can't be used with --no-download"
+        )
+
     if not to_remote and remote:
         raise InvalidArgumentError(
             "--remote can't be used without --to-remote"
@@ -31,7 +37,13 @@ def update(
         stages.update(self.stage.collect(target, recursive=recursive))
 
     for stage in stages:
-        stage.update(rev, to_remote=to_remote, remote=remote, jobs=jobs)
+        stage.update(
+            rev,
+            to_remote=to_remote,
+            remote=remote,
+            no_download=no_download,
+            jobs=jobs,
+        )
         dvcfile = Dvcfile(self, stage.path)
         dvcfile.dump(stage)
 

--- a/dvc/stage/exceptions.py
+++ b/dvc/stage/exceptions.py
@@ -80,6 +80,11 @@ class MissingDataSource(DvcException):
         super().__init__(msg)
 
 
+class DataSourceChanged(DvcException):
+    def __init__(self, path: str):
+        super().__init__(f"data source changed: {path}")
+
+
 class StageNotFound(DvcException, KeyError):
     def __init__(self, file, name):
         self.file = file.relpath

--- a/dvc/stage/imports.py
+++ b/dvc/stage/imports.py
@@ -17,20 +17,37 @@ def _update_import_on_remote(stage, remote, jobs):
     stage.outs[0].transfer(url, odb=odb, jobs=jobs, update=True)
 
 
-def update_import(stage, rev=None, to_remote=False, remote=None, jobs=None):
+def update_import(
+    stage, rev=None, to_remote=False, remote=None, no_download=None, jobs=None
+):
     stage.deps[0].update(rev=rev)
+    outs = stage.outs
+    deps = stage.deps
+
     frozen = stage.frozen
     stage.frozen = False
+
+    if stage.outs:
+        stage.outs[0].clear()
     try:
         if to_remote:
             _update_import_on_remote(stage, remote, jobs)
         else:
-            stage.reproduce(jobs=jobs)
+            stage.reproduce(no_download=no_download, jobs=jobs)
     finally:
+        if deps == stage.deps:
+            stage.outs = outs
         stage.frozen = frozen
 
 
-def sync_import(stage, dry=False, force=False, jobs=None):
+def sync_import(
+    stage,
+    dry=False,
+    force=False,
+    jobs=None,
+    no_download=False,
+    check_changed=False,
+):
     """Synchronize import's outs to the workspace."""
     logger.info("Importing '%s' -> '%s'", stage.deps[0], stage.outs[0])
     if dry:
@@ -39,5 +56,13 @@ def sync_import(stage, dry=False, force=False, jobs=None):
     if not force and stage.already_cached():
         stage.outs[0].checkout()
     else:
+        if check_changed:
+            old_hash_info = stage.deps[0].hash_info
         stage.save_deps()
-        stage.deps[0].download(stage.outs[0], jobs=jobs)
+        if check_changed and not old_hash_info == stage.deps[0].hash_info:
+            from dvc.stage.exceptions import DataSourceChanged
+
+            raise DataSourceChanged(f"{stage} ({stage.deps[0]})")
+
+        if not no_download:
+            stage.deps[0].download(stage.outs[0], jobs=jobs)

--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -273,6 +273,20 @@ def test_pull_external_dvc_imports(tmp_dir, dvc, scm, erepo_dir):
     assert (tmp_dir / "new_dir" / "bar").read_text() == "bar"
 
 
+def test_pull_partial_import(tmp_dir, dvc, local_workspace):
+    local_workspace.gen("file", "file content")
+    dst = tmp_dir / "file"
+    stage = dvc.imp_url(
+        "remote://workspace/file", os.fspath(dst), no_download=True
+    )
+
+    result = dvc.pull("file")
+    assert result["fetched"] == 1
+    assert dst.exists()
+
+    assert stage.outs[0].get_hash().value == "d10b4c3ff123b26dc068d43a8bef2d23"
+
+
 def test_pull_external_dvc_imports_mixed(
     tmp_dir, dvc, scm, erepo_dir, local_remote
 ):

--- a/tests/unit/command/test_imp.py
+++ b/tests/unit/command/test_imp.py
@@ -34,6 +34,7 @@ def test_import(mocker):
         fname="file",
         rev="version",
         no_exec=False,
+        no_download=False,
         desc="description",
         jobs=3,
     )
@@ -69,6 +70,43 @@ def test_import_no_exec(mocker):
         fname="file",
         rev="version",
         no_exec=True,
+        no_download=False,
+        desc="description",
+        jobs=None,
+    )
+
+
+def test_import_no_download(mocker):
+    cli_args = parse_args(
+        [
+            "import",
+            "repo_url",
+            "src",
+            "--out",
+            "out",
+            "--file",
+            "file",
+            "--rev",
+            "version",
+            "--no-download",
+            "--desc",
+            "description",
+        ]
+    )
+
+    cmd = cli_args.func(cli_args)
+    m = mocker.patch.object(cmd.repo, "imp", autospec=True)
+
+    assert cmd.run() == 0
+
+    m.assert_called_once_with(
+        "repo_url",
+        path="src",
+        out="out",
+        fname="file",
+        rev="version",
+        no_exec=False,
+        no_download=True,
         desc="description",
         jobs=None,
     )

--- a/tests/unit/command/test_update.py
+++ b/tests/unit/command/test_update.py
@@ -26,6 +26,7 @@ def test_update(dvc, mocker):
         rev="REV",
         recursive=True,
         to_remote=False,
+        no_download=False,
         remote=None,
         jobs=8,
     )
@@ -56,6 +57,7 @@ def test_update_to_remote(dvc, mocker):
         rev=None,
         recursive=True,
         to_remote=True,
+        no_download=False,
         remote="remote",
         jobs=5,
     )

--- a/tests/unit/output/test_output.py
+++ b/tests/unit/output/test_output.py
@@ -104,7 +104,7 @@ def test_get_used_objs(exists, expected_message, mocker, caplog):
     assert first(caplog.messages) == expected_message
 
 
-def test_remote_missing_depenency_on_dir_pull(tmp_dir, scm, dvc, mocker):
+def test_remote_missing_dependency_on_dir_pull(tmp_dir, scm, dvc, mocker):
     tmp_dir.dvc_gen({"dir": {"subfile": "file2 content"}}, commit="add dir")
     with dvc.config.edit() as conf:
         conf["remote"]["s3"] = {"url": "s3://bucket/name"}


### PR DESCRIPTION
add `--no-download` flag to `dvc import-url`/`dvc import`/`dvc update` to only create/update `.dvc` files without downloading the associated data

Closes #7918 