### PR TITLE
data status: optimize printing status list

### DIFF
--- a/tests/unit/command/test_data_status.py
+++ b/tests/unit/command/test_data_status.py
@@ -7,6 +7,7 @@ from dvc.cli import main, parse_args
 from dvc.commands.data import CmdDataStatus
 from dvc.repo import Repo
 from dvc.repo.data import Status
+from tests.func.parsing.test_errors import escape_ansi
 
 
 @pytest.fixture
@@ -135,5 +136,5 @@ DVC unchanged files:
         expected_out += """\
 (there are other changes not tracked by dvc, use "git status" to see)
 """
-    assert out == expected_out
+    assert escape_ansi(out) == expected_out
     assert not err


### PR DESCRIPTION
`--untracked-files` and `--unchanged` coupled with `--granular`
puts a lot of stress on `_show_status`. Currently, with those options,
dvc spends ~26s on `_show_status` function.

Unhappy with the above result, I looked into improving the situation by using
`console.out(highlight=False)`. It did reduce that to 9s but it still felt like a lot.

Then I dropped to good old colorama, which dropped to 3s(term)/1.24(redirected).
I tested with buffering output which dropped this further to ~600ms(term)/~100ms(redirected).

Note that this result was in VSCode which is slower than other terminals.
In gnome-terminal, I get about 175ms, and in kitty, it is around 125ms (undirected).

This may seem like premature optimization, but this was preventing me
from figuring out perf issues in granular outputs, and I believe the
users should not be penalized for using features that we already offer.

