### PR TITLE
data status: add spinners during diff

### DIFF
--- a/dvc/repo/data.py
+++ b/dvc/repo/data.py
@@ -2,6 +2,8 @@ import os
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict, cast
 
+from dvc.ui import ui
+
 if TYPE_CHECKING:
     from scmrepo.base import Base
 
@@ -169,7 +171,8 @@ def _diff_index_to_wtree(repo: "Repo", **kwargs: Any) -> Dict[str, List[str]]:
         cache = repo.odb.local
         root = str(out)
         old = out.get_obj()
-        d = _diff(root, old, new, cache, **kwargs)
+        with ui.status(f"Calculating diff for {root} between index/workspace"):
+            d = _diff(root, old, new, cache, **kwargs)
         for state, items in d.items():
             if not items:
                 continue
@@ -197,7 +200,8 @@ def _diff_head_to_index(
     for root, obj_d in objs.items():
         old = obj_d.get(head, None)
         new = obj_d.get("index", None)
-        d = _diff(root, old, new, cache, **kwargs)
+        with ui.status(f"Calculating diff for {root} between head/index"):
+            d = _diff(root, old, new, cache, **kwargs)
         for state, items in d.items():
             if not items:
                 continue


### PR DESCRIPTION
`dvc-bench` shows that `diff` is slow (even for noop). The non-granular status takes 5.7634s, so the rest of 19s is from `diff`.

```console
Name (time in s)                                                   Min                Max               Mean            StdDev             Median               IQR            Outliers     OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

test_data_status-data-noop[2.15.0-all_flags] (0001_test_da)     24.9396 (4.33)     24.9396 (4.33)     24.9396 (4.33)     0.0000 (1.0)      24.9396 (4.33)     0.0000 (1.0)           0;0  0.0401 (0.23)          1           1
```

This will add a spinner during diff. This also helps us to notice where exactly the performance issues are.