### PR TITLE
exp run: workspace status wrong

### DIFF
--- a/dvc/repo/experiments/queue/workspace.py
+++ b/dvc/repo/experiments/queue/workspace.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING, Collection, Dict, Generator, Optional
 from funcy import first
 
 from dvc.exceptions import DvcException
-
 from dvc.utils.fs import remove
+
 from ..exceptions import ExpQueueEmptyError
 from ..executor.base import BaseExecutor, ExecutorResult
 from ..executor.local import WorkspaceExecutor

--- a/dvc/repo/experiments/queue/workspace.py
+++ b/dvc/repo/experiments/queue/workspace.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from collections import defaultdict
 from typing import TYPE_CHECKING, Collection, Dict, Generator, Optional
 
@@ -6,6 +7,7 @@ from funcy import first
 
 from dvc.exceptions import DvcException
 
+from ....utils.fs import remove
 from ..exceptions import ExpQueueEmptyError
 from ..executor.base import BaseExecutor, ExecutorResult
 from ..executor.local import WorkspaceExecutor
@@ -116,6 +118,8 @@ class WorkspaceQueue(BaseStashQueue):
                 f"Failed to reproduce experiment '{rev[:7]}'"
             ) from exc
         finally:
+            if self._EXEC_NAME == exec_name:
+                remove(os.path.join(self.pid_dir, exec_name))
             executor.cleanup()
         return results
 

--- a/dvc/repo/experiments/queue/workspace.py
+++ b/dvc/repo/experiments/queue/workspace.py
@@ -7,7 +7,7 @@ from funcy import first
 
 from dvc.exceptions import DvcException
 
-from ....utils.fs import remove
+from dvc.utils.fs import remove
 from ..exceptions import ExpQueueEmptyError
 from ..executor.base import BaseExecutor, ExecutorResult
 from ..executor.local import WorkspaceExecutor

--- a/tests/func/experiments/test_experiments.py
+++ b/tests/func/experiments/test_experiments.py
@@ -99,6 +99,9 @@ def test_failed_exp_workspace(
     tmp_dir.gen("params.yaml", "foo: 2")
     with pytest.raises(ReproductionError):
         dvc.experiments.run(failed_exp_stage.addressing)
+    assert not dvc.fs.exists(
+        os.path.join(dvc.experiments.workspace_queue.pid_dir, "workspace")
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
fix: #8045

Not sure, whether workspace can be `fail`?

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
