### PR TITLE
queue: missing `f` format for the error message.

### DIFF
--- a/dvc/repo/experiments/queue/celery.py
+++ b/dvc/repo/experiments/queue/celery.py
@@ -281,7 +281,7 @@ class LocalCeleryQueue(BaseStashQueue):
             return _load_collected(entry.stash_rev)
         except FileNotFoundError:
             pass
-        raise DvcException("Invalid experiment '{entry.stash_rev[:7]}'.")
+        raise DvcException(f"Invalid experiment '{entry.stash_rev[:7]}'.")
 
     def kill(self, revs: Collection[str]) -> None:
         to_kill: Set[QueueEntry] = set()


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

related to #8014 