### PR TITLE
api: Fix params_show when stage has no params

### DIFF
--- a/dvc/repo/params/show.py
+++ b/dvc/repo/params/show.py
@@ -36,7 +36,7 @@ def _is_params(dep: "Output"):
 
 
 def _collect_configs(
-    repo: "Repo", rev, targets=None, duplicates=False
+    repo: "Repo", rev, targets=None, deps=False, stages=None
 ) -> Tuple[List["Output"], List[str]]:
 
     params, fs_paths = collect(
@@ -45,10 +45,10 @@ def _collect_configs(
         deps=True,
         output_filter=_is_params,
         rev=rev,
-        duplicates=duplicates,
+        duplicates=deps or stages is not None,
     )
     all_fs_paths = fs_paths + [p.fs_path for p in params]
-    if not targets:
+    if not any([deps, targets, stages]):
         default_params = repo.fs.path.join(
             repo.root_dir, ParamsDependency.DEFAULT_PARAMS_FILE
         )
@@ -56,6 +56,7 @@ def _collect_configs(
             default_params
         ):
             fs_paths.append(default_params)
+
     return params, fs_paths
 
 
@@ -173,7 +174,7 @@ def _gather_params(
     repo, rev, targets=None, deps=False, onerror=None, stages=None
 ):
     param_outs, params_fs_paths = _collect_configs(
-        repo, rev, targets=targets, duplicates=deps or stages
+        repo, rev, targets=targets, deps=deps, stages=stages
     )
     params = _read_params(
         repo,

--- a/tests/func/api/test_params.py
+++ b/tests/func/api/test_params.py
@@ -13,6 +13,11 @@ def params_repo(tmp_dir, scm, dvc):
     tmp_dir.gen("other_params.json", '{"foo": {"bar": 4}}')
 
     dvc.run(
+        name="stage-0",
+        cmd="echo stage-0",
+    )
+
+    dvc.run(
         name="stage-1",
         cmd="echo stage-1",
         params=["foo", "params.json:bar"],
@@ -83,6 +88,9 @@ def test_params_show_stages(params_repo):
 
     assert api.params_show("params.json", stages="stage-3") == {"foobar": 3}
 
+    with pytest.raises(DvcException, match="No params found"):
+        api.params_show(stages="stage-0")
+
 
 def test_params_show_revs(params_repo):
     assert api.params_show(rev="HEAD~1") == {
@@ -145,3 +153,18 @@ def test_params_show_no_params_found(tmp_dir, dvc):
     dvc.stage.add(name="echo", cmd="echo foo")
     with pytest.raises(DvcException, match="No params found"):
         api.params_show()
+
+
+def test_params_show_stage_without_params(tmp_dir, dvc):
+    tmp_dir.gen("params.yaml", "foo: 1")
+
+    dvc.run(
+        name="stage-0",
+        cmd="echo stage-0",
+    )
+
+    with pytest.raises(DvcException, match="No params found"):
+        api.params_show(stages="stage-0")
+
+    with pytest.raises(DvcException, match="No params found"):
+        api.params_show(deps=True)


### PR DESCRIPTION
Also, fix when `deps=True` and no params in the entire pipeline.

Closes #8064

* [X] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [X] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

