### PR TITLE
exp remove: support removing failed tasks and associated successful tasks

### DIFF
--- a/dvc/commands/experiments/remove.py
+++ b/dvc/commands/experiments/remove.py
@@ -10,23 +10,22 @@ logger = logging.getLogger(__name__)
 
 
 class CmdExperimentsRemove(CmdBase):
-    def raise_error_if_all_disabled(self):
+    def argument_checking(self):
         if not any(
             [
-                self.args.experiment,
                 self.args.all_commits,
                 self.args.rev,
                 self.args.queue,
             ]
-        ):
+        ) ^ bool(self.args.experiment):
             raise InvalidArgumentError(
                 "Either provide an `experiment` argument, or use the "
-                "`--rev` or `--all-commits` flag."
+                "`--rev` or `--all-commits` or `--queue` flag."
             )
 
     def run(self):
 
-        self.raise_error_if_all_disabled()
+        self.argument_checking()
 
         removed_list = self.repo.experiments.remove(
             exp_names=self.args.experiment,

--- a/dvc/commands/experiments/remove.py
+++ b/dvc/commands/experiments/remove.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 class CmdExperimentsRemove(CmdBase):
-    def argument_checking(self):
+    def check_arguments(self):
         if not any(
             [
                 self.args.all_commits,
@@ -25,7 +25,7 @@ class CmdExperimentsRemove(CmdBase):
 
     def run(self):
 
-        self.argument_checking()
+        self.check_arguments()
 
         removed_list = self.repo.experiments.remove(
             exp_names=self.args.experiment,

--- a/dvc/commands/queue/remove.py
+++ b/dvc/commands/queue/remove.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 class CmdQueueRemove(CmdBase):
     """Remove exp in queue."""
 
-    def argument_checking(self):
+    def check_arguments(self):
         clear_flag = any(
             [
                 self.args.all,
@@ -29,7 +29,7 @@ class CmdQueueRemove(CmdBase):
 
     def run(self):
 
-        self.argument_checking()
+        self.check_arguments()
 
         if self.args.all:
             self.args.queued = True

--- a/dvc/repo/experiments/queue/remove.py
+++ b/dvc/repo/experiments/queue/remove.py
@@ -14,7 +14,7 @@ from dvc.repo.experiments.queue.base import QueueDoneResult
 
 if TYPE_CHECKING:
     from dvc.repo.experiments.queue.base import QueueEntry
-    from dvc.repo.experiments.queue.local import LocalCeleryQueue
+    from dvc.repo.experiments.queue.celery import LocalCeleryQueue
     from dvc.repo.experiments.stash import ExpStashEntry
 
 
@@ -134,27 +134,15 @@ def celery_clear(self: "LocalCeleryQueue", **kwargs) -> List[str]:
 def celery_remove(
     self: "LocalCeleryQueue",
     revs: Collection[str],
-    queued: bool = False,
-    failed: bool = False,
-    success: bool = False,
-    all_: bool = False,
 ) -> List[str]:
     """Remove the specified entries from the queue.
 
     Arguments:
         revs: Stash revisions or queued exp names to be removed.
-        queued: Remove all queued tasks.
-        failed: Remove all failed tasks.
-        success: Remove all success tasks.
-        all_: Remove all tasks.
 
     Returns:
         Revisions (or names) which were removed.
     """
-    if all_:
-        queued = failed = success = True
-    if queued or failed or success:
-        return self.clear(failed=failed, success=success, queued=queued)
 
     # match_queued
     queue_match_results = self.match_queue_entry_by_name(

--- a/dvc/repo/experiments/queue/remove.py
+++ b/dvc/repo/experiments/queue/remove.py
@@ -23,17 +23,15 @@ def remove_tasks(
     stash_revs: Dict[str, "ExpStashEntry"] = {}
     failed_stash_revs: List["ExpStashEntry"] = []
     done_entry_set: Set["QueueEntry"] = set()
+    stash_rev_all = celery_queue.stash.stash_revs
+    failed_rev_all = celery_queue.failed_stash.stash_revs
     for entry in queue_entries:
-        if entry.stash_rev in celery_queue.stash.stash_revs:
-            stash_revs[entry.stash_rev] = celery_queue.stash.stash_revs[
-                entry.stash_rev
-            ]
+        if entry.stash_rev in stash_rev_all:
+            stash_revs[entry.stash_rev] = stash_rev_all[entry.stash_rev]
         else:
             done_entry_set.add(entry)
-            if entry.stash_rev in celery_queue.failed_stash.stash_revs:
-                failed_stash_revs.append(
-                    celery_queue.failed_stash.stash_revs[entry.stash_rev]
-                )
+            if entry.stash_rev in failed_rev_all:
+                failed_stash_revs.append(failed_rev_all[entry.stash_rev])
 
     try:
         for (

--- a/dvc/repo/experiments/queue/remove.py
+++ b/dvc/repo/experiments/queue/remove.py
@@ -1,13 +1,4 @@
-from typing import (
-    TYPE_CHECKING,
-    Collection,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Set,
-    Union,
-)
+from typing import TYPE_CHECKING, Collection, Dict, Iterable, List, Set, Union
 
 from dvc.repo.experiments.exceptions import UnresolvedExpNamesError
 from dvc.repo.experiments.queue.base import QueueDoneResult
@@ -18,21 +9,31 @@ if TYPE_CHECKING:
     from dvc.repo.experiments.stash import ExpStashEntry
 
 
-def _remove_queued_tasks(
+def remove_tasks(
     celery_queue: "LocalCeleryQueue",
-    queue_entries: Iterable[Optional["QueueEntry"]],
+    queue_entries: Iterable["QueueEntry"],
 ):
     """Remove tasks from task queue.
 
     Arguments:
-        queue_entries: An iterable list of queued task to remove
+        queue_entries: An iterable list of task to remove
     """
+    from celery.result import AsyncResult
+
     stash_revs: Dict[str, "ExpStashEntry"] = {}
+    failed_stash_revs: List["ExpStashEntry"] = []
+    done_entry_set: Set["QueueEntry"] = set()
     for entry in queue_entries:
-        if entry:
+        if entry.stash_rev in celery_queue.stash.stash_revs:
             stash_revs[entry.stash_rev] = celery_queue.stash.stash_revs[
                 entry.stash_rev
             ]
+        else:
+            done_entry_set.add(entry)
+            if entry.stash_rev in celery_queue.failed_stash.stash_revs:
+                failed_stash_revs.append(
+                    celery_queue.failed_stash.stash_revs[entry.stash_rev]
+                )
 
     try:
         for (
@@ -44,28 +45,6 @@ def _remove_queued_tasks(
     finally:
         celery_queue.stash.remove_revs(list(stash_revs.values()))
 
-
-def _remove_done_tasks(
-    celery_queue: "LocalCeleryQueue",
-    queue_entries: Iterable[Optional["QueueEntry"]],
-):
-    """Remove done tasks.
-
-    Arguments:
-        queue_entries: An iterable list of done task to remove
-    """
-    from celery.result import AsyncResult
-
-    failed_stash_revs: List["ExpStashEntry"] = []
-    queue_entry_set: Set["QueueEntry"] = set()
-    for entry in queue_entries:
-        if entry:
-            queue_entry_set.add(entry)
-            if entry.stash_rev in celery_queue.failed_stash.stash_revs:
-                failed_stash_revs.append(
-                    celery_queue.failed_stash.stash_revs[entry.stash_rev]
-                )
-
     try:
         for (
             msg,
@@ -73,7 +52,7 @@ def _remove_done_tasks(
         ) in (
             celery_queue._iter_processed()  # pylint: disable=protected-access
         ):
-            if queue_entry not in queue_entry_set:
+            if queue_entry not in done_entry_set:
                 continue
             task_id = msg.headers["id"]
             result: AsyncResult = AsyncResult(task_id)
@@ -98,7 +77,12 @@ def _get_names(entries: Iterable[Union["QueueEntry", "QueueDoneResult"]]):
     return names
 
 
-def celery_clear(self: "LocalCeleryQueue", **kwargs) -> List[str]:
+def celery_clear(
+    self: "LocalCeleryQueue",
+    queued: bool = False,
+    failed: bool = False,
+    success: bool = False,
+) -> List[str]:
     """Remove entries from the queue.
 
     Arguments:
@@ -109,24 +93,23 @@ def celery_clear(self: "LocalCeleryQueue", **kwargs) -> List[str]:
     Returns:
         Revisions which were removed.
     """
-    queued = kwargs.pop("queued", False)
-    failed = kwargs.get("failed", False)
-    success = kwargs.get("success", False)
 
-    removed = []
+    removed: List[str] = []
+    entry_list: List["QueueEntry"] = []
     if queued:
-        queue_entries = list(self.iter_queued())
-        _remove_queued_tasks(self, queue_entries)
+        queue_entries: List["QueueEntry"] = list(self.iter_queued())
+        entry_list.extend(queue_entries)
         removed.extend(_get_names(queue_entries))
-    if failed or success:
-        done_tasks: List["QueueDoneResult"] = []
-        if failed:
-            done_tasks.extend(self.iter_failed())
-        if success:
-            done_tasks.extend(self.iter_success())
-        done_entries = [result.entry for result in done_tasks]
-        _remove_done_tasks(self, done_entries)
-        removed.extend(_get_names(done_tasks))
+    if failed:
+        failed_tasks: List["QueueDoneResult"] = list(self.iter_failed())
+        entry_list.extend([result.entry for result in failed_tasks])
+        removed.extend(_get_names(failed_tasks))
+    if success:
+        success_tasks: List["QueueDoneResult"] = list(self.iter_success())
+        entry_list.extend([result.entry for result in success_tasks])
+        removed.extend(_get_names(success_tasks))
+
+    remove_tasks(self, entry_list)
 
     return removed
 
@@ -144,36 +127,24 @@ def celery_remove(
         Revisions (or names) which were removed.
     """
 
-    # match_queued
-    queue_match_results = self.match_queue_entry_by_name(
-        revs, self.iter_queued()
+    match_results = self.match_queue_entry_by_name(
+        revs, self.iter_queued(), self.iter_done()
     )
-
-    done_match_results = self.match_queue_entry_by_name(revs, self.iter_done())
 
     remained: List[str] = []
     removed: List[str] = []
-    queued_to_remove: List["QueueEntry"] = []
-    done_to_remove: List["QueueEntry"] = []
-    for name in revs:
-        done_match = done_match_results[name]
-        if done_match:
-            done_to_remove.append(done_match)
+    entry_to_remove: List["QueueEntry"] = []
+    for name, entry in match_results.items():
+        if entry:
+            entry_to_remove.append(entry)
             removed.append(name)
-            continue
-        queue_match = queue_match_results[name]
-        if queue_match:
-            queued_to_remove.append(queue_match)
-            removed.append(name)
-            continue
-        remained.append(name)
+        else:
+            remained.append(name)
 
     if remained:
         raise UnresolvedExpNamesError(remained)
 
-    if done_to_remove:
-        _remove_done_tasks(self, done_to_remove)
-    if queued_to_remove:
-        _remove_queued_tasks(self, queued_to_remove)
+    if entry_to_remove:
+        remove_tasks(self, entry_to_remove)
 
     return removed

--- a/dvc/repo/experiments/remove.py
+++ b/dvc/repo/experiments/remove.py
@@ -1,12 +1,20 @@
 import logging
-from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Union,
+)
 
 from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
 from dvc.scm import iter_revs
 
 from .exceptions import UnresolvedExpNamesError
-from .queue.base import QueueEntry
+from .queue.remove import remove_tasks
 from .refs import ExpRefInfo
 from .utils import (
     exp_refs,
@@ -21,8 +29,54 @@ if TYPE_CHECKING:
     from dvc.repo.experiments.queue.celery import LocalCeleryQueue
     from dvc.scm import Git
 
+    from .queue.base import QueueEntry
+
 
 logger = logging.getLogger(__name__)
+
+
+class ExpRefAndQueueEntry(NamedTuple):
+    exp_ref_list: List["ExpRefInfo"]
+    queue_entry_list: List["QueueEntry"]
+    removed: List["str"]
+
+
+def _get_ref_and_entry_by_names(
+    exp_names: Union[str, List[str]],
+    scm: "Git",
+    celery_queue: "LocalCeleryQueue",
+    git_remote: Optional[str],
+) -> ExpRefAndQueueEntry:
+    exp_ref_list: List["ExpRefInfo"] = []
+    queue_entry_list: List["QueueEntry"] = []
+    removed: List[str] = []
+    if isinstance(exp_names, str):
+        exp_names = [exp_names]
+    exp_ref_match: Dict[str, Optional["ExpRefInfo"]] = resolve_name(
+        scm, exp_names, git_remote
+    )
+    if not git_remote:
+        queue_entry_match: Dict[
+            str, Optional["QueueEntry"]
+        ] = celery_queue.match_queue_entry_by_name(
+            exp_names, celery_queue.iter_queued()
+        )
+
+    remained = []
+    for exp_name in exp_names:
+        exp_ref = exp_ref_match[exp_name]
+        queue_entry = None if git_remote else queue_entry_match[exp_name]
+        if exp_ref or queue_entry:
+            if exp_ref:
+                exp_ref_list.append(exp_ref)
+            if queue_entry:
+                queue_entry_list.append(queue_entry)
+            removed.append(exp_name)
+        else:
+            remained.append(exp_name)
+    if remained:
+        raise UnresolvedExpNamesError(remained)
+    return ExpRefAndQueueEntry(exp_ref_list, queue_entry_list, removed)
 
 
 @locked
@@ -39,98 +93,64 @@ def remove(
     removed: List[str] = []
     if not any([exp_names, queue, all_commits, rev]):
         return removed
+    celery_queue: "LocalCeleryQueue" = repo.experiments.celery_queue
 
     if queue:
-        removed.extend(repo.experiments.celery_queue.clear(queued=True))
+        removed.extend(celery_queue.clear(queued=True))
     if all_commits:
-        removed.extend(_clear_all_commits(repo, git_remote))
+        removed.extend(
+            _remove_commited_exps(
+                repo.scm, list(exp_refs(repo.scm, git_remote)), git_remote
+            )
+        )
         return removed
 
-    commit_ref_dict: Dict[ExpRefInfo, str] = {}
-    queue_entry_dict: Dict[str, QueueEntry] = {}
+    exp_ref_list: List["ExpRefInfo"] = []
+    queue_entry_list: List["QueueEntry"] = []
     if exp_names:
-        _resolve_exp_by_name(
-            repo, exp_names, commit_ref_dict, queue_entry_dict, git_remote
+        result = _get_ref_and_entry_by_names(
+            exp_names, repo.scm, celery_queue, git_remote
         )
+        removed.extend(exp_names)
+        exp_ref_list.extend(result.exp_ref_list)
+        queue_entry_list.extend(result.queue_entry_list)
+    elif rev:
+        exp_ref_dict = _resolve_exp_by_baseline(repo, rev, num, git_remote)
+        removed.extend(exp_ref_dict.keys())
+        exp_ref_list.extend(exp_ref_dict.values())
 
-    if rev:
-        _resolve_exp_by_baseline(repo, rev, num, commit_ref_dict, git_remote)
+    if exp_ref_list:
+        _remove_commited_exps(repo.scm, exp_ref_list, git_remote)
 
-    if commit_ref_dict:
-        removed.extend(
-            _remove_commited_exps(repo.scm, commit_ref_dict, git_remote)
-        )
-
-    if queue_entry_dict:
-        removed.extend(_remove_queued_exps(repo, queue_entry_dict))
+    if queue_entry_list:
+        remove_tasks(celery_queue, queue_entry_list)
 
     return removed
-
-
-def _resolve_exp_by_name(
-    repo: "Repo",
-    exp_names: Union[str, List[str]],
-    commit_ref_dict: Dict["ExpRefInfo", str],
-    queue_entry_dict: Dict[str, QueueEntry],
-    git_remote: Optional[str],
-):
-    remained = set()
-    if isinstance(exp_names, str):
-        exp_names = [exp_names]
-
-    exp_ref_dict = resolve_name(repo.scm, exp_names, git_remote)
-    for exp_name, exp_ref in exp_ref_dict.items():
-        if exp_ref is None:
-            remained.add(exp_name)
-        else:
-            commit_ref_dict[exp_ref] = exp_name
-
-    if not git_remote:
-        celery_queue: "LocalCeleryQueue" = repo.experiments.celery_queue
-
-        _named_entries = celery_queue.match_queue_entry_by_name(
-            remained, celery_queue.iter_queued(), celery_queue.iter_active()
-        )
-        for exp_name, entry in _named_entries.items():
-            if entry is not None:
-                queue_entry_dict[exp_name] = entry
-                remained.remove(exp_name)
-
-    if remained:
-        raise UnresolvedExpNamesError(remained)
 
 
 def _resolve_exp_by_baseline(
     repo,
     rev: str,
     num: int,
-    commit_ref_dict: Dict[ExpRefInfo, str],
     git_remote: Optional[str] = None,
-):
+) -> Dict[str, "ExpRefInfo"]:
+    commit_ref_dict: Dict[str, "ExpRefInfo"] = {}
     rev_dict = iter_revs(repo.scm, [rev], num)
     rev_set = set(rev_dict.keys())
     ref_info_dict = exp_refs_by_baseline(repo.scm, rev_set, git_remote)
-
     for _, ref_info_list in ref_info_dict.items():
         for ref_info in ref_info_list:
-            if ref_info not in commit_ref_dict:
-                commit_ref_dict[ref_info] = ref_info.name
-
-
-def _clear_all_commits(repo, git_remote) -> List:
-    ref_infos = {
-        ref_info: ref_info.name for ref_info in exp_refs(repo.scm, git_remote)
-    }
-    return _remove_commited_exps(repo.scm, ref_infos, git_remote)
+            commit_ref_dict[ref_info.name] = ref_info
+    return commit_ref_dict
 
 
 def _remove_commited_exps(
-    scm: "Git", exp_ref_dict: Mapping[ExpRefInfo, str], remote: Optional[str]
+    scm: "Git", exp_refs_list: Iterable[ExpRefInfo], remote: Optional[str]
 ) -> List[str]:
     if remote:
         from dvc.scm import TqdmGit
 
-        for ref_info in exp_ref_dict:
+        for ref_info in exp_refs_list:
             with TqdmGit(desc="Pushing git refs") as pbar:
                 push_refspec(
                     scm,
@@ -140,13 +160,5 @@ def _remove_commited_exps(
                     progress=pbar.update_git,
                 )
     else:
-        remove_exp_refs(scm, exp_ref_dict)
-    return list(exp_ref_dict.values())
-
-
-def _remove_queued_exps(
-    repo: "Repo", named_entries: Mapping[str, QueueEntry]
-) -> List[str]:
-    stash_rev_list = [entry.stash_rev for entry in named_entries.values()]
-    repo.experiments.celery_queue.remove(stash_rev_list)
-    return list(named_entries.keys())
+        remove_exp_refs(scm, exp_refs_list)
+    return [exp_ref.name for exp_ref in exp_refs_list]

--- a/tests/func/experiments/test_queue.py
+++ b/tests/func/experiments/test_queue.py
@@ -86,10 +86,7 @@ def test_queue_remove_done(dvc, failed_tasks, success_tasks):
     status = to_dict(dvc.experiments.celery_queue.status())
     assert set(status) == set(failed_tasks[1:] + success_tasks[:2])
 
-    assert (
-        dvc.experiments.celery_queue.remove([], failed=True)
-        == failed_tasks[1:]
-    )
+    assert dvc.experiments.celery_queue.clear(failed=True) == failed_tasks[1:]
 
     assert len(dvc.experiments.celery_queue.failed_stash) == 0
     assert set(to_dict(dvc.experiments.celery_queue.status())) == set(
@@ -97,8 +94,7 @@ def test_queue_remove_done(dvc, failed_tasks, success_tasks):
     )
 
     assert (
-        dvc.experiments.celery_queue.remove([], success=True)
-        == success_tasks[:2]
+        dvc.experiments.celery_queue.clear(success=True) == success_tasks[:2]
     )
 
     assert dvc.experiments.celery_queue.status() == []

--- a/tests/unit/repo/experiments/queue/test_remove.py
+++ b/tests/unit/repo/experiments/queue/test_remove.py
@@ -37,7 +37,7 @@ def test_remove_queued(test_queue, mocker):
     remove_revs_mocker.reset_mock()
     reject_mocker.reset_mock()
 
-    assert test_queue.remove([], queued=True) == queued_test
+    assert test_queue.clear(queued=True) == queued_test
     remove_revs_mocker.assert_called_once_with(list(stash_dict.values()))
     reject_mocker.assert_has_calls(
         [call("msg_queue1"), call("msg_queue2"), call("msg_queue3")]
@@ -103,7 +103,7 @@ def test_remove_done(test_queue, mocker):
     remove_revs_mocker.reset_mock()
     purge_mocker.reset_mock()
 
-    assert set(test_queue.remove([], success=True, failed=True)) == set(
+    assert set(test_queue.clear(success=True, failed=True)) == set(
         failed_test
     ) | set(success_test)
     purge_mocker.assert_has_calls(
@@ -118,11 +118,3 @@ def test_remove_done(test_queue, mocker):
         any_order=True,
     )
     remove_revs_mocker.assert_called_once_with(list(stash_dict.values()))
-
-
-def test_remove_all(test_queue, mocker):
-    clear_mocker = mocker.patch.object(
-        test_queue, "clear", return_value=mocker.Mock()
-    )
-    test_queue.remove([], all_=True)
-    assert clear_mocker.called_once_with(queud=True, failed=True, success=True)

--- a/tests/unit/repo/experiments/test_remove.py
+++ b/tests/unit/repo/experiments/test_remove.py
@@ -1,0 +1,55 @@
+from dvc.repo.experiments.queue.base import QueueDoneResult
+
+
+def test_remove_done_tasks(dvc, test_queue, scm, mocker):
+    from funcy import concat
+
+    failed_test = ["failed1", "failed2"]
+    success_test = ["success1", "success2"]
+
+    # create mock ref info
+    ref_info_dict = {}
+    for name in success_test:
+        ref_info_dict[name] = mocker.Mock()
+    for name in failed_test:
+        ref_info_dict[name] = None
+
+    # create mock queue entry
+    entry_dict = {}
+    for name in concat(failed_test, success_test):
+        entry_dict[name] = mocker.Mock(stash_rev=name)
+        entry_dict[name].name = name
+
+    done_iter = [
+        QueueDoneResult(entry_dict[name], None)
+        for name in concat(failed_test, success_test)
+    ]
+
+    mocker.patch.object(test_queue, "iter_done", return_value=done_iter)
+
+    mocker.patch(
+        "dvc.repo.experiments.utils.resolve_name",
+        autospec=True,
+        return_value=ref_info_dict,
+    )
+
+    remove_exp_refs = mocker.patch(
+        "dvc.repo.experiments.utils.remove_exp_refs",
+    )
+    remove_tasks_mocker = mocker.patch(
+        "dvc.repo.experiments.queue.remove.remove_tasks",
+    )
+
+    assert (
+        dvc.experiments.remove(failed_test + success_test)
+        == failed_test + success_test
+    )
+
+    remove_tasks_mocker.assert_called_once_with(
+        test_queue,
+        [entry_dict[name] for name in failed_test + success_test],
+    )
+
+    remove_exp_refs.assert_called_once_with(
+        dvc.scm, [ref_info_dict[name] for name in success_test]
+    )


### PR DESCRIPTION
will 
fix: #8018
fix: #8071

1. Replace the `_clear_queue` function with `celery_queue.clear`
2. Decouple queue clear and remove commands
3. Make a better API for `dvc.repo.experiments.queue.remove.py` ( Unify remove queued and remove done)
4. Make `exp remove` flags and arguments mutually exclusive.
5. Refactor dvc.repo.experiment.remove to make matching exp by name also return queue entry info.
6. Add one line to make `exp remove` can remove failed tasks, and will also delete associated successful tasks
7. Add a new unit test for this behavior.


* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

[![asciicast](https://asciinema.org/a/B4euzD75a9fXOdf0gedqC1S2u.svg)](https://asciinema.org/a/B4euzD75a9fXOdf0gedqC1S2u)

The document also needs some updates later.