### PR TITLE
Revert to lazy formatting introduced in #8073

### DIFF
--- a/dvc/output.py
+++ b/dvc/output.py
@@ -715,7 +715,8 @@ class Output:
             return
 
         if os.path.isdir(self.fs_path):
-            logger.debug(f"directory '{self}' cannot be used as metrics.")
+            msg = "directory '%s' cannot be used as %s."
+            logger.debug(msg, str(self), "metrics")
             return
 
         if not istextfile(self.fs_path, self.fs):


### PR DESCRIPTION
* [ ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

This PR reverts f-strings to  lazy string formatting in the logger call
Related: https://github.com/iterative/dvc/pull/8073