### PR TITLE
exp run: Support composing and dumping Hydra config. 

### DIFF
--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -289,4 +289,9 @@ SCHEMA = {
         "bool": All(Lower, Choices("store_true", "boolean_optional")),
         "list": All(Lower, Choices("nargs", "append")),
     },
+    "hydra": {
+        Optional("enabled", default=False): Bool,
+        "config_dir": str,
+        "config_name": str,
+    },
 }

--- a/dvc/repo/experiments/run.py
+++ b/dvc/repo/experiments/run.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Dict, Iterable, Optional
 
+from dvc.dependency.param import ParamsDependency
 from dvc.repo import locked
 from dvc.ui import ui
 from dvc.utils.cli_parse import to_path_overrides
@@ -31,7 +32,15 @@ def run(
         return repo.experiments.reproduce_celery(entries, jobs=jobs)
 
     if params:
-        params = to_path_overrides(params)
+        path_overrides = to_path_overrides(params)
+    else:
+        path_overrides = {}
+
+    hydra_enabled = repo.config.get("hydra", {}).get("enabled", False)
+    hydra_output_file = ParamsDependency.DEFAULT_PARAMS_FILE
+    if hydra_enabled and hydra_output_file not in path_overrides:
+        # Force `_update_params` even if `--set-param` was not used
+        path_overrides[hydra_output_file] = []
 
     if queue:
         if not kwargs.get("checkpoint_resume", None):
@@ -39,7 +48,7 @@ def run(
         queue_entry = repo.experiments.queue_one(
             repo.experiments.celery_queue,
             targets=targets,
-            params=params,
+            params=path_overrides,
             **kwargs,
         )
         name = queue_entry.name or queue_entry.stash_rev[:7]
@@ -47,5 +56,5 @@ def run(
         return {}
 
     return repo.experiments.reproduce_one(
-        targets=targets, params=params, tmp_dir=tmp_dir, **kwargs
+        targets=targets, params=path_overrides, tmp_dir=tmp_dir, **kwargs
     )

--- a/dvc/utils/hydra.py
+++ b/dvc/utils/hydra.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import TYPE_CHECKING, List
 
+from hydra import compose, initialize_config_dir
 from hydra._internal.config_loader_impl import ConfigLoaderImpl
 from hydra.core.override_parser.overrides_parser import OverridesParser
 from hydra.errors import ConfigCompositionException, OverrideParseException
@@ -10,10 +11,36 @@ from omegaconf import OmegaConf
 from dvc.exceptions import InvalidArgumentError
 
 from .collections import merge_dicts, remove_missing_keys, to_omegaconf
-from .serialize import MODIFIERS
+from .serialize import DUMPERS, MODIFIERS
 
 if TYPE_CHECKING:
     from dvc.types import StrPath
+
+
+def compose_and_dump(
+    output_file: "StrPath",
+    config_dir: str,
+    config_name: str,
+    overrides: List[str],
+) -> None:
+    """Compose Hydra config and dumpt it to `output_file`.
+
+    Args:
+        output_file: File where the composed config will be dumped.
+        config_dir: Folder containing the Hydra config files.
+            Must be absolute file system path.
+        config_name: Name of the config file containing defaults,
+            without the .yaml extension.
+        overrides: List of `Hydra Override`_ patterns.
+
+    .. _Hydra Override:
+        https://hydra.cc/docs/advanced/override_grammar/basic/
+    """
+    with initialize_config_dir(config_dir, version_base=None):
+        cfg = compose(config_name=config_name, overrides=overrides)
+
+    dumper = DUMPERS[Path(output_file).suffix.lower()]
+    dumper(output_file, OmegaConf.to_object(cfg))
 
 
 def apply_overrides(path: "StrPath", overrides: List[str]) -> None:

--- a/tests/func/experiments/test_experiments.py
+++ b/tests/func/experiments/test_experiments.py
@@ -104,20 +104,6 @@ def test_failed_exp_workspace(
     )
 
 
-@pytest.mark.parametrize(
-    "changes, expected",
-    [
-        [["foo=baz"], "foo: baz\ngoo:\n  bag: 3.0\nlorem: false"],
-        [["params.yaml:foo=baz"], "foo: baz\ngoo:\n  bag: 3.0\nlorem: false"],
-    ],
-)
-def test_modify_params(params_repo, dvc, changes, expected):
-    dvc.experiments.run(params=changes)
-    # pylint: disable=unspecified-encoding
-    with open("params.yaml", mode="r") as fobj:
-        assert fobj.read().strip() == expected
-
-
 def test_apply(tmp_dir, scm, dvc, exp_stage):
     from dvc.exceptions import InvalidArgumentError
     from dvc.repo.experiments.exceptions import ApplyConflictError

--- a/tests/func/experiments/test_set_params.py
+++ b/tests/func/experiments/test_set_params.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from ..utils.test_hydra import hydra_setup
@@ -17,7 +19,18 @@ def test_modify_params(params_repo, dvc, changes, expected):
         assert fobj.read().strip() == expected
 
 
-@pytest.mark.parametrize("hydra_enabled", [True, False])
+@pytest.mark.parametrize(
+    "hydra_enabled",
+    [
+        pytest.param(
+            True,
+            marks=pytest.mark.skipif(
+                sys.version_info >= (3, 11), reason="unsupported on 3.11"
+            ),
+        ),
+        False,
+    ],
+)
 @pytest.mark.parametrize(
     "config_dir,config_name",
     [

--- a/tests/func/experiments/test_set_params.py
+++ b/tests/func/experiments/test_set_params.py
@@ -1,0 +1,74 @@
+import pytest
+
+from ..utils.test_hydra import hydra_setup
+
+
+@pytest.mark.parametrize(
+    "changes, expected",
+    [
+        [["foo=baz"], "foo: baz\ngoo:\n  bag: 3.0\nlorem: false"],
+        [["params.yaml:foo=baz"], "foo: baz\ngoo:\n  bag: 3.0\nlorem: false"],
+    ],
+)
+def test_modify_params(params_repo, dvc, changes, expected):
+    dvc.experiments.run(params=changes)
+    # pylint: disable=unspecified-encoding
+    with open("params.yaml", mode="r") as fobj:
+        assert fobj.read().strip() == expected
+
+
+@pytest.mark.parametrize("hydra_enabled", [True, False])
+@pytest.mark.parametrize(
+    "config_dir,config_name",
+    [
+        (None, None),
+        (None, "bar"),
+        ("conf", "bar"),
+    ],
+)
+def test_hydra_compose_and_dump(
+    tmp_dir, params_repo, dvc, hydra_enabled, config_dir, config_name
+):
+    hydra_setup(
+        tmp_dir,
+        config_dir=config_dir or "conf",
+        config_name=config_name or "config",
+    )
+
+    dvc.experiments.run()
+    assert (tmp_dir / "params.yaml").parse() == {
+        "foo": [{"bar": 1}, {"baz": 2}],
+        "goo": {"bag": 3.0},
+        "lorem": False,
+    }
+
+    with dvc.config.edit() as conf:
+        if hydra_enabled:
+            conf["hydra"]["enabled"] = True
+        if config_dir is not None:
+            conf["hydra"]["config_dir"] = config_dir
+        if config_name is not None:
+            conf["hydra"]["config_name"] = config_name
+
+    dvc.experiments.run()
+
+    if hydra_enabled:
+        assert (tmp_dir / "params.yaml").parse() == {
+            "db": {"driver": "mysql", "user": "omry", "pass": "secret"},
+        }
+
+        dvc.experiments.run(params=["db=postgresql"])
+        assert (tmp_dir / "params.yaml").parse() == {
+            "db": {
+                "driver": "postgresql",
+                "user": "foo",
+                "pass": "bar",
+                "timeout": 10,
+            }
+        }
+    else:
+        assert (tmp_dir / "params.yaml").parse() == {
+            "foo": [{"bar": 1}, {"baz": 2}],
+            "goo": {"bag": 3.0},
+            "lorem": False,
+        }

--- a/tests/func/utils/test_hydra.py
+++ b/tests/func/utils/test_hydra.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from dvc.exceptions import InvalidArgumentError
@@ -138,6 +140,7 @@ def hydra_setup(tmp_dir, config_dir, config_name):
     return str(config_dir)
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 11), reason="unsupported on 3.11")
 @pytest.mark.parametrize("suffix", ["yaml", "toml", "json"])
 @pytest.mark.parametrize(
     "overrides,expected",


### PR DESCRIPTION
The feature will be used depending on whether `config.hydra.enabled` is True or False.

Uses https://hydra.cc/docs/advanced/compose_api/ to build the config and dump it to `params.yaml`. The content of the output file will be overwritten.

`config.hydra.config_dir` and `config.hydra.config_name` can be used to customize the values passed to the APIs used from hydra (`hydra.initialize_config_dir` and `hydra.compose`).

Can be combined with `--set-param` overrides.

Closes https://github.com/iterative/dvc/issues/8082

---

* [X] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.
