### PR TITLE
[RFC] Use `--no-config` option in fish > 3.3

### DIFF
--- a/dvc/stage/run.py
+++ b/dvc/stage/run.py
@@ -1,9 +1,9 @@
 import logging
 import os
+import re
 import signal
 import subprocess
 import threading
-import re
 
 from packaging.version import Version
 
@@ -14,6 +14,7 @@ from .decorators import unlocked_repo
 from .exceptions import StageCmdFailedError
 
 logger = logging.getLogger(__name__)
+
 
 def _get_shell_version(executable):
     name = os.path.basename(executable).lower()
@@ -46,6 +47,7 @@ def _make_cmd(executable, cmd):
 
     name = os.path.basename(executable).lower()
     return [executable] + get_opts(name) + ["-c", cmd]
+
 
 def warn_if_fish(executable):
     if (


### PR DESCRIPTION
This is a first draft of fixing #1307. However, I am quite unhappy about it.

Because only fish version > 3.3 supports the `--no-config` option, it cannot be applied without checking first. Thus, I am running the shell and parse the `$shellname_VERSION` variable.

I went that way, because the `$FISH_VERSION` does not seem to be available in the dvc process context. Also, it is not guaranteed that dvc itself is run with `$SHELL` itself, is it?

I do not think, this is a great solution and would like some input. Does somebody have a better idea?

---

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
