### PR TITLE
queue status: show final experiment name

### DIFF
--- a/dvc/repo/experiments/queue/base.py
+++ b/dvc/repo/experiments/queue/base.py
@@ -184,9 +184,12 @@ class BaseStashQueue(ABC):
 
         def _format_entry(
             entry: QueueEntry,
+            exp_result: Optional[ExecutorResult] = None,
             status: str = "Unknown",
         ) -> Dict[str, Any]:
             name = entry.name
+            if not name and exp_result and exp_result.ref_info:
+                name = exp_result.ref_info.name
             # NOTE: We fallback to Unknown status for experiments
             # generated in prior (incompatible) DVC versions
             return {
@@ -209,8 +212,8 @@ class BaseStashQueue(ABC):
             for queue_entry, _ in self.iter_failed()
         )
         result.extend(
-            _format_entry(queue_entry, status="Success")
-            for queue_entry, _ in self.iter_success()
+            _format_entry(queue_entry, exp_result=exp_result, status="Success")
+            for queue_entry, exp_result in self.iter_success()
         )
         return result
 


### PR DESCRIPTION
fix: #8059

1. showing final experiment name in `queue status` for successful tasks.
2. Add a unit test for `celery_queue.status`

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
