### PR TITLE
fix logic for unlock on unlocked lock calls

### DIFF
--- a/tests/func/test_lock.py
+++ b/tests/func/test_lock.py
@@ -1,6 +1,7 @@
 import pytest
 
 from dvc.cli import main
+from dvc.exceptions import DvcException
 from dvc.lock import Lock, LockError
 
 
@@ -12,6 +13,28 @@ def test_with(tmp_dir, dvc, mocker):
     with Lock(lockfile):
         with pytest.raises(LockError), Lock(lockfile):
             pass
+
+
+def test_(tmp_dir, dvc, mocker):
+    # patching to speedup tests
+    mocker.patch("dvc.lock.DEFAULT_TIMEOUT", 0.01)
+
+    lockfile = tmp_dir / dvc.tmp_dir / "lock"
+    lock = Lock(lockfile)
+    lock_ext = Lock(lockfile)
+
+    # It's a common scenario now to have lock unlocked and locked back (e.g. in
+    # repro of a stage) in with. We should see LockError exception here.
+    with pytest.raises(LockError), lock:
+        lock.unlock()
+        lock_ext.lock()  # imitate an exernal process has time to lock it
+        lock.lock()
+
+
+def test_unlock_unlocked_raises():
+    lock = Lock("lock")
+    with pytest.raises(DvcException):
+        lock.unlock()
 
 
 def test_cli(tmp_dir, dvc, mocker, caplog):


### PR DESCRIPTION
Fixes  `'NoneType' object has no attribute 'close'` on running multiple `repro` in parallel when they compete for resources and one of them fails to acquire the lock back.

- Double unlock is not allowed and now raises an explicit better `DvcException`. This is aligned with usual lock semantics and we want to keep as much of it as possible so that we detect missing `lock()` calls, or some misplaced unlocks, etc.
- Unlock on an unlocked is allowed _only_ if this lock failed last time we tried to acquire it. This is unfortunate, but should be more or less safe. This is the best we can do considering the way we lock, unlock stuff in stages now. 
