### PR TITLE
data status: handle path joining properly for tree leaves/items

### DIFF
--- a/dvc/repo/data.py
+++ b/dvc/repo/data.py
@@ -68,13 +68,17 @@ def _granular_diff(
     from dvc_data.diff import diff as odiff
     from dvc_data.objects.tree import Tree
 
+    drop_root = False
+    trees = isinstance(old_obj, Tree) or isinstance(new_obj, Tree)
+    if trees:
+        drop_root = not with_dirs
+
     def path_join(root: str, *paths: str) -> str:
-        if not isinstance(new_obj, Tree):
+        if not trees and paths == ROOT:
             return root
         return os.path.sep.join([root, *paths])
 
     diff_data = odiff(old_obj, new_obj, cache)
-    drop_root = not with_dirs and isinstance(new_obj, Tree)
 
     output: Dict[str, List[str]] = defaultdict(list)
     for state in ("added", "deleted", "modified", "unchanged"):


### PR DESCRIPTION
We were only joining paths when `new_obj` was a tree. But technically they could be absent from the workspace or cache which prevented from path joining, hence all of the items inside a tree would show up with the root's name. Now, we check for either-or.

Fixes #8053.

Another tricky thing here that I have ignored for now is, what happens if the old obj was a tree and the new obj is a hashfile? Currently `diff` does not work with non-tree objects (i.e. hashfile), so we'd have to handle that here if we decided to support this (which we should but not here).
