### PR TITLE
stage add: fix hint message consistency

### DIFF
--- a/dvc/repo/scm_context.py
+++ b/dvc/repo/scm_context.py
@@ -46,7 +46,7 @@ class SCMContext:
     @staticmethod
     def _make_git_add_cmd(paths: Union[str, Iterable[str]]) -> str:
         files = " ".join(map(shlex.quote, ensure_list(paths)))
-        return f"\tgit add {files}".expandtabs(4)
+        return f"\tgit add {files}"
 
     def add(self, paths: Union[str, Iterable[str]]) -> None:
         from scmrepo.exceptions import UnsupportedIndexFormat


### PR DESCRIPTION
Make from this:

<img width="540" alt="Screen Shot 2022-08-08 at 10 11 00 PM" src="https://user-images.githubusercontent.com/3659196/183569425-d4e0d98c-26c8-4170-bcd4-560ddf75ba39.png">

this:

<img width="540" alt="Screen Shot 2022-08-08 at 10 11 14 PM" src="https://user-images.githubusercontent.com/3659196/183569455-aa68e615-0257-49aa-9de6-6596bfe92255.png">

we don't really use `expandtabs` much, and especially not for these messages