### PR TITLE
pyinstaller: Restrict to 5.0

### DIFF
--- a/scripts/build-requirements.txt
+++ b/scripts/build-requirements.txt
@@ -1,3 +1,3 @@
 # NOTE: using strict version due to
 # https://github.com/iterative/dvc/issues/7949
-PyInstaller==5.2
+PyInstaller==5.0


### PR DESCRIPTION
5.2 didn't fix https://github.com/iterative/dvc/issues/7949
Need to research proper fix for the hook