### PR TITLE
fs: optimize dvc list --recursive

### DIFF
--- a/dvc/fs/dvc.py
+++ b/dvc/fs/dvc.py
@@ -301,13 +301,7 @@ class _DvcFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
             dvc_fs = self._datafss.get(())
         else:
             repo_parts = fs.path.relparts(repo.root_dir, self.repo.root_dir)
-            if repo_parts[0] == os.curdir:
-                repo_parts = repo_parts[1:]
-
             dvc_parts = key[len(repo_parts) :]
-            if dvc_parts and dvc_parts[0] == os.curdir:
-                dvc_parts = dvc_parts[1:]
-
             key = self._get_key(repo.root_dir)
             dvc_fs = self._datafss.get(key)
 

--- a/dvc/fs/dvc.py
+++ b/dvc/fs/dvc.py
@@ -34,6 +34,14 @@ def _wrap_walk(dvc_fs, *args, **kwargs):
         yield dvc_fs.path.join(dvc_fs.repo.root_dir, root), dnames, fnames
 
 
+# NOT the same as dvc.dvcfile.is_dvc_file()!
+def _is_dvc_file(fname):
+    from dvc.dvcfile import is_valid_filename
+    from dvc.ignore import DvcIgnore
+
+    return is_valid_filename(fname) or fname == DvcIgnore.DVCIGNORE_FILE
+
+
 def _ls(fs, path):
     dnames = []
     fnames = []
@@ -353,19 +361,8 @@ class _DvcFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
                 pass
 
         dvcfiles = kwargs.get("dvcfiles", False)
-
-        def _func(fname):
-            from dvc.dvcfile import is_valid_filename
-            from dvc.ignore import DvcIgnore
-
-            if dvcfiles:
-                return True
-
-            return not (
-                is_valid_filename(fname) or fname == DvcIgnore.DVCIGNORE_FILE
-            )
-
-        names = filter(_func, names)
+        if not dvcfiles:
+            names = (name for name in names if not _is_dvc_file(name))
 
         infos = []
         paths = []

--- a/dvc/repo/ls.py
+++ b/dvc/repo/ls.py
@@ -85,11 +85,10 @@ def _ls(
     ret = {}
     for name, info in infos.items():
         dvc_info = info.get("dvc_info", {})
-        if fs.isdvc(info["name"], recursive=True) or not dvc_only:
-            ret[name] = {
-                "isout": dvc_info.get("isout", False),
-                "isdir": info["type"] == "directory",
-                "isexec": info.get("isexec", False),
-            }
+        ret[name] = {
+            "isout": dvc_info.get("isout", False),
+            "isdir": info["type"] == "directory",
+            "isexec": info.get("isexec", False),
+        }
 
     return ret

--- a/dvc/repo/ls.py
+++ b/dvc/repo/ls.py
@@ -1,5 +1,4 @@
 import os
-from itertools import chain
 from typing import TYPE_CHECKING, Optional
 
 from dvc.exceptions import PathMissingError
@@ -66,15 +65,16 @@ def _ls(
 
     infos = {}
     for root, dirs, files in fs.walk(
-        fs_path, dvcfiles=True, dvc_only=dvc_only
+        fs_path, dvcfiles=True, dvc_only=dvc_only, detail=True
     ):
-        entries = chain(files, dirs) if not recursive else files
+        if not recursive:
+            files.update(dirs)
 
-        for entry in entries:
-            entry_fs_path = fs.path.join(root, entry)
+        for name, entry in files.items():
+            entry_fs_path = fs.path.join(root, name)
             relparts = fs.path.relparts(entry_fs_path, fs_path)
             name = os.path.join(*relparts)
-            infos[name] = fs.info(entry_fs_path)
+            infos[name] = entry
 
         if not recursive:
             break


### PR DESCRIPTION
See #8135 for context.

`._get_key()` is quite expensive. The general idea is to avoid flip-flopping between path and "key" representations.