### PR TITLE
metrics: show: Fix show from subdir.

### DIFF
--- a/dvc/repo/metrics/show.py
+++ b/dvc/repo/metrics/show.py
@@ -85,12 +85,14 @@ def _read_metrics(repo, metrics, rev, onerror=None):
 
     res = {}
     for metric in metrics:
+        rel_metric_path = os.path.join(relpath, *fs.path.parts(metric))
         if not fs.isfile(metric):
-            continue
+            if fs.isfile(rel_metric_path):
+                metric = rel_metric_path
+            else:
+                continue
 
-        res[os.path.join(relpath, *fs.path.parts(metric))] = _read_metric(
-            metric, fs, rev, onerror=onerror
-        )
+        res[rel_metric_path] = _read_metric(metric, fs, rev, onerror=onerror)
 
     return res
 

--- a/tests/func/metrics/test_show.py
+++ b/tests/func/metrics/test_show.py
@@ -21,6 +21,32 @@ def test_show_simple(tmp_dir, dvc, run_copy_metrics):
     }
 
 
+def test_show_simple_from_subdir(tmp_dir, dvc, run_copy_metrics):
+    subdir = tmp_dir / "subdir"
+    subdir.mkdir()
+    tmp_dir.gen("metrics_t.yaml", "1.1")
+    run_copy_metrics(
+        "metrics_t.yaml",
+        "subdir/metrics.yaml",
+        metrics=["subdir/metrics.yaml"],
+    )
+
+    expected_path = os.path.join("subdir", "metrics.yaml")
+    assert dvc.metrics.show() == {"": {"data": {expected_path: {"data": 1.1}}}}
+
+    expected_path = os.path.join("..", "subdir", "metrics.yaml")
+    with subdir.chdir():
+        assert dvc.metrics.show() == {
+            "": {"data": {expected_path: {"data": 1.1}}}
+        }
+    subdir2 = tmp_dir / "subdir2"
+    subdir2.mkdir()
+    with subdir2.chdir():
+        assert dvc.metrics.show() == {
+            "": {"data": {expected_path: {"data": 1.1}}}
+        }
+
+
 def test_show(tmp_dir, dvc, run_copy_metrics):
     tmp_dir.gen("metrics_t.yaml", "foo: 1.1")
     run_copy_metrics(


### PR DESCRIPTION
Closes #8020 

This was a regression introduced in #7712.
Calling `repo.metrics.show` from a subdir stopped returning metrics because `fs.isfile(metric)` check returned false.

