### PR TITLE
build: bump ruby to 2.6

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -17,10 +17,10 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.9
-    - name: Set up Ruby 2.4
-      uses: actions/setup-ruby@v1.1.3
+    - name: Set up Ruby 2.6
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.4
+        ruby-version: '2.6'
     - name: Install deps
       run: |
         pip install .[all]


### PR DESCRIPTION
Package building is failing, see https://github.com/iterative/dvc/runs/7933069474?check_suite_focus=true#step:5:481:
```console
ERROR:  Error installing fpm:
	public_suffix requires Ruby version >= 2.6.
```