### PR TITLE
data status: fix not-in-cache bugs

### DIFF
--- a/dvc/commands/data.py
+++ b/dvc/commands/data.py
@@ -52,6 +52,7 @@ class CmdDataStatus(CmdBase):
                     file: state
                     for state, files in stage_status.items()
                     for file in files
+                    if state != "unknown"
                 }
             if not items:
                 continue

--- a/dvc/repo/data.py
+++ b/dvc/repo/data.py
@@ -99,8 +99,20 @@ def _granular_diff(
     return dict(output)
 
 
+def _get_obj_items(root: str, obj: Optional["HashFile"]) -> List[str]:
+    if not obj:
+        return []
+
+    from dvc_data.objects.tree import Tree
+
+    sep = os.path.sep
+    if isinstance(obj, Tree):
+        return [sep.join([root, *key]) for key, _, _ in obj]
+    return [root]
+
+
 def _diff(
-    root,
+    root: str,
     old_oid: Optional["HashInfo"],
     old_obj: Optional["HashFile"],
     new_oid: Optional["HashInfo"],
@@ -108,12 +120,14 @@ def _diff(
     odb: "HashFileDB",
     with_dirs: bool = False,
     granular: bool = False,
-):
+) -> Dict[str, List[str]]:
     if not granular:
         return _shallow_diff(root, old_oid, new_oid, odb)
     if (old_oid and not old_obj) or (new_oid and not new_obj):
         # we don't have enough information to give full details
-        return _shallow_diff(root, old_oid, new_oid, odb)
+        unknown = _get_obj_items(root, new_obj or old_obj)
+        shallow_diff = _shallow_diff(root, old_oid, new_oid, odb)
+        return {**shallow_diff, "unknown": unknown}
     return _granular_diff(root, old_obj, new_obj, odb, with_dirs=with_dirs)
 
 

--- a/dvc/repo/data.py
+++ b/dvc/repo/data.py
@@ -109,7 +109,9 @@ def _diff(
     with_dirs: bool = False,
     granular: bool = False,
 ):
-    if not granular or not (old_obj or new_obj):
+    if not granular:
+        return _shallow_diff(root, old_oid, new_oid, odb)
+    if (old_oid and not old_obj) or (new_oid and not new_obj):
         # we don't have enough information to give full details
         return _shallow_diff(root, old_oid, new_oid, odb)
     return _granular_diff(root, old_obj, new_obj, odb, with_dirs=with_dirs)
@@ -174,8 +176,6 @@ def _diff_index_to_wtree(repo: "Repo", **kwargs: Any) -> Dict[str, List[str]]:
         cache = repo.odb.repo
         root = str(out)
         old = out.get_obj()
-        if not old and new and out.hash_info == new.hash_info:
-            old = new
 
         with ui.status(f"Calculating diff for {root} between index/workspace"):
             d = _diff(

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,7 +68,7 @@ install_requires =
     dvc-render==0.0.9
     dvc-task==0.1.2
     dvclive>=0.10.0
-    dvc-data==0.1.22
+    dvc-data==0.1.23
     dvc-http==0.0.2
     hydra-core>=1.1.0
 

--- a/tests/func/test_data_status.py
+++ b/tests/func/test_data_status.py
@@ -171,7 +171,6 @@ def test_missing_cache_workspace_exists(M, tmp_dir, dvc, scm):
         **EMPTY_STATUS,
         "untracked": M.unordered("foobar.dvc", "dir.dvc", ".gitignore"),
         "committed": {"added": M.unordered("foobar", join("dir", ""))},
-        "uncommitted": {},
         "not_in_cache": M.unordered("foobar", join("dir", "")),
         "git": M.dict(),
     }
@@ -184,7 +183,9 @@ def test_missing_cache_workspace_exists(M, tmp_dir, dvc, scm):
         #       "foobar", join("dir", "foo"), join("dir", "bar")
         # )},
         "committed": {"added": M.unordered("foobar", join("dir", ""))},
-        "uncommitted": {},
+        "uncommitted": {
+            "unknown": M.unordered(join("dir", "foo"), join("dir", "bar"))
+        },
         # even though we don't have cache obj, we can repurpose
         # what we have in the workspace
         "not_in_cache": M.unordered(
@@ -238,6 +239,9 @@ def test_git_committed_missing_cache_workspace_exists(M, tmp_dir, dvc, scm):
             "foobar",
             join("dir", ""),
         ),
+        "uncommitted": {
+            "unknown": M.unordered(join("dir", "foo"), join("dir", "bar"))
+        },
         "git": M.dict(),
         # TODO: clarify what is unchanged
         "unchanged": M.unordered("foobar", join("dir", "")),
@@ -303,7 +307,10 @@ def test_missing_dir_object_from_head(M, tmp_dir, dvc, scm):
     }
     assert dvc.data_status(granular=True) == {
         **EMPTY_STATUS,
-        "committed": {"modified": [join("dir", "")]},
+        "committed": {
+            "modified": [join("dir", "")],
+            "unknown": [join("dir", "foobar")],
+        },
         "git": M.dict(),
     }
 

--- a/tests/func/test_data_status.py
+++ b/tests/func/test_data_status.py
@@ -153,7 +153,9 @@ def test_untracked_newly_added_files(M, tmp_dir, dvc, scm):
 
     expected = {
         **EMPTY_STATUS,
-        "untracked": M.unordered("dir/foo", "dir/bar", "foobar"),
+        "untracked": M.unordered(
+            join("dir", "foo"), join("dir", "bar"), "foobar"
+        ),
         "git": M.dict(),
     }
     assert dvc.data_status(untracked_files="all") == expected
@@ -186,7 +188,8 @@ def test_missing_cache_workspace_exists(M, tmp_dir, dvc, scm):
         # even though we don't have cache obj, we can repurpose
         # what we have in the workspace
         "not_in_cache": M.unordered(
-            "foobar", join("dir", "bar"), join("dir", "foo")
+            "foobar",
+            join("dir", ""),
         ),
         "git": M.dict(),
     }
@@ -200,19 +203,19 @@ def test_missing_cache_missing_workspace(M, tmp_dir, dvc, scm):
 
     assert dvc.data_status(untracked_files="all") == {
         **EMPTY_STATUS,
-        "untracked": ["foobar.dvc", "dir.dvc", ".gitignore"],
-        "uncommitted": {"deleted": ["foobar", join("dir", "")]},
-        "committed": {"added": ["foobar", join("dir", "")]},
-        "not_in_cache": ["foobar", join("dir", "")],
+        "untracked": M.unordered("foobar.dvc", "dir.dvc", ".gitignore"),
+        "uncommitted": {"deleted": M.unordered("foobar", join("dir", ""))},
+        "committed": {"added": M.unordered("foobar", join("dir", ""))},
+        "not_in_cache": M.unordered("foobar", join("dir", "")),
         "git": M.dict(),
     }
 
     assert dvc.data_status(granular=True, untracked_files="all") == {
         **EMPTY_STATUS,
-        "untracked": ["foobar.dvc", "dir.dvc", ".gitignore"],
-        "uncommitted": {"deleted": ["foobar", join("dir", "")]},
-        "committed": {"added": ["foobar", join("dir", "")]},
-        "not_in_cache": ["foobar", join("dir", "")],
+        "untracked": M.unordered("foobar.dvc", "dir.dvc", ".gitignore"),
+        "uncommitted": {"deleted": M.unordered("foobar", join("dir", ""))},
+        "committed": {"added": M.unordered("foobar", join("dir", ""))},
+        "not_in_cache": M.unordered("foobar", join("dir", "")),
         "git": M.dict(),
     }
 
@@ -224,7 +227,7 @@ def test_git_committed_missing_cache_workspace_exists(M, tmp_dir, dvc, scm):
 
     assert dvc.data_status(untracked_files="all") == {
         **EMPTY_STATUS,
-        "not_in_cache": ["foobar", join("dir", "")],
+        "not_in_cache": M.unordered("foobar", join("dir", "")),
         "git": M.dict(),
         # TODO: clarify what is unchanged
         "unchanged": M.unordered("foobar", join("dir", "")),
@@ -232,11 +235,12 @@ def test_git_committed_missing_cache_workspace_exists(M, tmp_dir, dvc, scm):
     assert dvc.data_status(granular=True) == {
         **EMPTY_STATUS,
         "not_in_cache": M.unordered(
-            "foobar", join("dir", "foo"), join("dir", "bar")
+            "foobar",
+            join("dir", ""),
         ),
         "git": M.dict(),
         # TODO: clarify what is unchanged
-        "unchanged": M.unordered("foobar"),
+        "unchanged": M.unordered("foobar", join("dir", "")),
     }
 
 
@@ -299,7 +303,7 @@ def test_missing_dir_object_from_head(M, tmp_dir, dvc, scm):
     }
     assert dvc.data_status(granular=True) == {
         **EMPTY_STATUS,
-        "committed": {"added": [join("dir", "foobar")]},
+        "committed": {"modified": [join("dir", "")]},
         "git": M.dict(),
     }
 


### PR DESCRIPTION
~~Depends on https://github.com/iterative/dvc-data/pull/141 and https://github.com/iterative/dvc-data/pull/142. And requires a new version of `dvc-data` to be released.~~

Fixes https://github.com/iterative/dvc/issues/8062 when both of the objects are not in cache.
Eg: let's take a directory, `data` that is dvc-committed and it's dvcfile git-committed. In that case, when we compare `HEAD` to  `index` (i.e. what's in dvcfile), we'll be comparing between the same object, i.e. `old` and `new` are going to be the same.

In case the `.dir` file does not exist, both values are going to be `None` as the cache does not exist. This fixes that, we'll show a shallow diff (as if `--granular` was not used). Providing more granular information is not possible in this case, as we don't have any information and we don't fetch `.dir` file from the remote.