### PR TITLE
repo: Handle no commits for `exp show` and `plots diff`.

### DIFF
--- a/dvc/commands/experiments/diff.py
+++ b/dvc/commands/experiments/diff.py
@@ -27,7 +27,7 @@ class CmdExperimentsDiff(CmdBase):
 
         if self.args.json:
             ui.write_json(diff)
-        else:
+        elif diff:
             from dvc.compare import show_diff
 
             precision = self.args.precision or DEFAULT_PRECISION

--- a/dvc/repo/data.py
+++ b/dvc/repo/data.py
@@ -263,9 +263,7 @@ def _transform_git_paths_to_dvc(repo: "Repo", files: List[str]):
 
 
 def status(repo: "Repo", untracked_files: str = "no", **kwargs: Any) -> Status:
-    from scmrepo.exceptions import SCMError
-
-    from dvc.scm import NoSCMError
+    from dvc.scm import NoSCMError, SCMError
 
     head = kwargs.pop("head", "HEAD")
     uncommitted_diff = _diff_index_to_wtree(repo, **kwargs)

--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -142,6 +142,9 @@ def show(
     fetch_running: bool = True,
 ):
 
+    if repo.scm.no_commits:
+        return {}
+
     if onerror is None:
         onerror = onerror_collect
 

--- a/dvc/repo/plots/diff.py
+++ b/dvc/repo/plots/diff.py
@@ -12,6 +12,8 @@ def _revisions(repo, revs, experiment):
 
 
 def diff(repo, *args, revs=None, experiment=False, **kwargs):
+    if repo.scm.no_commits:
+        return {}
     return repo.plots.show(
         *args, revs=_revisions(repo, revs, experiment), **kwargs
     )

--- a/dvc/scm.py
+++ b/dvc/scm.py
@@ -160,7 +160,7 @@ def resolve_rev(scm: "Git", rev: str) -> str:
     except InternalRevError as exc:
         # `scm` will only resolve git branch and tag names,
         # if rev is not a sha it may be an abbreviated experiment name
-        if not rev.startswith("refs/"):
+        if not (rev == "HEAD" or rev.startswith("refs/")):
             from dvc.repo.experiments.utils import (
                 AmbiguousExpRefInfo,
                 resolve_name,

--- a/tests/func/experiments/test_diff.py
+++ b/tests/func/experiments/test_diff.py
@@ -1,6 +1,17 @@
 from funcy import first
 
 
+def test_diff_no_commits(tmp_dir):
+    from scmrepo.git import Git
+
+    from dvc.repo import Repo
+
+    git = Git.init(tmp_dir.fs_path)
+    assert git.no_commits
+
+    assert Repo.init().experiments.diff() == {}
+
+
 def test_diff_empty(tmp_dir, scm, dvc, exp_stage):
     assert dvc.experiments.diff() == {"params": {}, "metrics": {}}
 

--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -36,6 +36,18 @@ def make_executor_info(**kwargs):
 
 
 @pytest.mark.vscode
+def test_show_no_commits(tmp_dir):
+    from scmrepo.git import Git
+
+    from dvc.repo import Repo
+
+    git = Git.init(tmp_dir.fs_path)
+    assert git.no_commits
+
+    assert Repo.init().experiments.show() == {}
+
+
+@pytest.mark.vscode
 def test_show_simple(tmp_dir, scm, dvc, exp_stage):
     assert dvc.experiments.show()["workspace"] == {
         "baseline": {

--- a/tests/func/plots/test_diff.py
+++ b/tests/func/plots/test_diff.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tests.utils.plots import get_plot
 
 
@@ -46,3 +48,15 @@ def test_diff_dirty(tmp_dir, scm, dvc, run_copy_metrics):
     assert get_plot(
         diff_result, "workspace", "definitions", file="", endkey="data"
     ) == {"metric.json": props}
+
+
+@pytest.mark.vscode
+def test_no_commits(tmp_dir):
+    from scmrepo.git import Git
+
+    from dvc.repo import Repo
+
+    git = Git.init(tmp_dir.fs_path)
+    assert git.no_commits
+
+    assert Repo.init().plots.diff() == {}

--- a/tests/unit/test_scm.py
+++ b/tests/unit/test_scm.py
@@ -1,0 +1,9 @@
+import pytest
+
+from dvc.exceptions import DvcException
+from dvc.scm import resolve_rev
+
+
+def test_resolve_rev_empty_git_repo(scm):
+    with pytest.raises(DvcException):
+        resolve_rev(scm, "HEAD")


### PR DESCRIPTION
Make it consistent with all the other commands that use `brancher` (i.e. `dvc diff`, `metrics diff`, `params diff`)

Closes #8163
