### PR TITLE
info: Include subprojects.

### DIFF
--- a/dvc/info.py
+++ b/dvc/info.py
@@ -14,6 +14,14 @@ from dvc.scm import SCMError
 from dvc.utils import error_link
 from dvc.utils.pkg import PKG
 
+SUBPROJECTS = (
+    "dvc_data",
+    "dvc_objects",
+    "dvc_render",
+    "dvc_task",
+    "dvclive",
+    "scmrepo",
+)
 package = "" if PKG is None else f"({PKG})"
 
 
@@ -23,6 +31,7 @@ def get_dvc_info():
         "---------------------------------",
         f"Platform: Python {platform.python_version()} on "
         f"{platform.platform()}",
+        f"Subprojects:{_get_subprojects()}",
         f"Supports:{_get_supported_remotes()}",
     ]
 
@@ -86,6 +95,16 @@ def _get_linktype_support_info(repo):
     )
 
     return ", ".join(links)
+
+
+def _get_subprojects():
+    subprojects = []
+    for subproject in SUBPROJECTS:
+        subprojects.append(
+            f"{subproject} = " f"{importlib_metadata.version(subproject)}"
+        )
+
+    return "\n\t" + "\n\t".join(subprojects)
 
 
 def _get_supported_remotes():

--- a/tests/func/test_version.py
+++ b/tests/func/test_version.py
@@ -4,6 +4,7 @@ from dvc.cli import main
 from tests.unit.test_info import (
     DVC_VERSION_REGEX,
     PYTHON_VERSION_REGEX,
+    SUBPROJECTS,
     find_supported_remotes,
 )
 
@@ -14,6 +15,9 @@ def test_(tmp_dir, dvc, scm, capsys):
     out, _ = capsys.readouterr()
     assert re.search(rf"DVC version: {DVC_VERSION_REGEX}", out)
     assert re.search(f"Platform: {PYTHON_VERSION_REGEX} on .*", out)
+    for subproject in SUBPROJECTS:
+        assert re.search(rf"{subproject} = {DVC_VERSION_REGEX}", out)
+
     assert find_supported_remotes(out)
     assert re.search(r"Cache types: .*", out)
     assert re.search(r"Caches: local", out)

--- a/tests/unit/test_info.py
+++ b/tests/unit/test_info.py
@@ -4,7 +4,7 @@ import shutil
 
 import pytest
 
-from dvc.info import get_dvc_info
+from dvc.info import SUBPROJECTS, get_dvc_info
 
 # Python's version is in the shape of:
 # <major>.<minor>.<patch>[{a|b|rc}N][.postN][.devN]
@@ -53,6 +53,9 @@ def test_info_in_repo(scm_init, tmp_dir):
 
     assert re.search(rf"DVC version: {DVC_VERSION_REGEX}", dvc_info)
     assert re.search(f"Platform: {PYTHON_VERSION_REGEX} on .*", dvc_info)
+    for subproject in SUBPROJECTS:
+        assert re.search(rf"{subproject} = {DVC_VERSION_REGEX}", dvc_info)
+
     assert find_supported_remotes(dvc_info)
     assert re.search(r"Cache types: .*", dvc_info)
 


### PR DESCRIPTION
Include a list of versions of internal subprojects. Helpful for support duty and bisecting without going through release notes.