### PR TITLE
output.get_obj: catch ObjectCorruptedError

### DIFF
--- a/dvc/output.py
+++ b/dvc/output.py
@@ -737,7 +737,7 @@ class Output:
         elif self.hash_info:
             try:
                 obj = oload(self.odb, self.hash_info)
-            except FileNotFoundError:
+            except (FileNotFoundError, ObjectFormatError):
                 return None
         else:
             return None


### PR DESCRIPTION
In `data status`, for example, a corrupted cache would raise `ObjectFormatError` instead of returning `None`.
