### PR TITLE
output: support version ID

### DIFF
--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -79,6 +79,7 @@ REMOTE_COMMON = {
     "checksum_jobs": All(Coerce(int), Range(1)),
     "jobs": All(Coerce(int), Range(1)),
     Optional("no_traverse"): Bool,  # obsoleted
+    Optional("version_aware"): Bool,
 }
 LOCAL_COMMON = {
     "type": supported_cache_type,

--- a/tests/unit/output/test_output.py
+++ b/tests/unit/output/test_output.py
@@ -90,6 +90,7 @@ def test_get_used_objs(exists, expected_message, mocker, caplog):
     mocker.patch.object(
         stage.repo.dvcignore, "check_ignore", return_value=_no_match("path")
     )
+    stage.repo.fs.version_aware = False
 
     output = Output(stage, "path")
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

related to https://github.com/iterative/dvc/pull/8164

This PR does not address import behavior. When using `dvc import-url azure://container/file?versionid=1234`, the pre-existing behavior will still occur, so the resulting import will be permanently pinned to `azure://container/file?versionid=1234`. `dvc update` will not check for a new version of `azure://container/file`.

The only import related change is that the version_id will be captured in the `.dvc` file like:

```yml
md5: b332f7591398ef3d5e32c97f2ff689f9
frozen: true
deps:
- etag: '0x8DA79D118EC7839'
  size: 2
  version_id: '2022-08-09T06:33:39.9632713Z'
  path: azure://test-container/dir/file?versionid=2022-08-09T06:33:06.7654238Z
outs:
- md5: 6654c734ccab8f440ff0825eb443dc7f
  size: 2
  path: file
```

(whereas the old .dvc file would just contain `path: azure://container/dir/file?versionid=2022-08-09T06:33:06.7654238Z` and no `version_id` field)