### PR TITLE
add metadata fields: label, type to data

### DIFF
--- a/dvc/annotations.py
+++ b/dvc/annotations.py
@@ -1,0 +1,32 @@
+from dataclasses import asdict, dataclass, field, fields
+from typing import ClassVar, Dict, List, Optional
+
+from funcy import compact
+
+
+@dataclass
+class Annotation:
+    PARAM_DESC: ClassVar[str] = "desc"
+    PARAM_TYPE: ClassVar[str] = "type"
+    PARAM_LABELS: ClassVar[str] = "labels"
+
+    desc: Optional[str] = None
+    type: Optional[str] = None
+    labels: List[str] = field(default_factory=list)
+
+    def update(self, **kwargs) -> "Annotation":
+        for attr, value in kwargs.items():
+            if value and hasattr(self, attr):
+                setattr(self, attr, value)
+        return self
+
+    def to_dict(self) -> Dict[str, str]:
+        return compact(asdict(self))
+
+
+ANNOTATION_FIELDS = [field.name for field in fields(Annotation)]
+ANNOTATION_SCHEMA = {
+    Annotation.PARAM_DESC: str,
+    Annotation.PARAM_TYPE: str,
+    Annotation.PARAM_LABELS: [str],
+}

--- a/dvc/commands/add.py
+++ b/dvc/commands/add.py
@@ -8,6 +8,32 @@ from dvc.cli.utils import append_doc_link
 logger = logging.getLogger(__name__)
 
 
+def _add_annotating_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--desc",
+        type=str,
+        metavar="<text>",
+        help=(
+            "User description of the data (optional). "
+            "This doesn't affect any DVC operations."
+        ),
+    )
+    parser.add_argument(
+        "--label",
+        dest="labels",
+        type=str,
+        action="append",
+        metavar="<str>",
+        help="Comma separated list of labels for the data (optional).",
+    )
+    parser.add_argument(
+        "--type",
+        type=str,
+        metavar="<str>",
+        help="Type of the data (optional).",
+    )
+
+
 class CmdAdd(CmdBase):
     def run(self):
         from dvc.exceptions import (
@@ -28,6 +54,8 @@ class CmdAdd(CmdBase):
                 glob=self.args.glob,
                 desc=self.args.desc,
                 out=self.args.out,
+                type=self.args.type,
+                labels=self.args.labels,
                 remote=self.args.remote,
                 to_remote=self.args.to_remote,
                 jobs=self.args.jobs,
@@ -109,15 +137,8 @@ def add_parser(subparsers, parent_parser):
         ),
         metavar="<number>",
     )
-    parser.add_argument(
-        "--desc",
-        type=str,
-        metavar="<text>",
-        help=(
-            "User description of the data (optional). "
-            "This doesn't affect any DVC operations."
-        ),
-    )
+
+    _add_annotating_args(parser)
     parser.add_argument(
         "targets", nargs="+", help="Input files/directories to add."
     ).complete = completion.FILE

--- a/dvc/commands/imp.py
+++ b/dvc/commands/imp.py
@@ -21,6 +21,8 @@ class CmdImport(CmdBase):
                 no_exec=self.args.no_exec,
                 no_download=self.args.no_download,
                 desc=self.args.desc,
+                type=self.args.type,
+                labels=self.args.labels,
                 jobs=self.args.jobs,
             )
         except DvcException:
@@ -34,6 +36,8 @@ class CmdImport(CmdBase):
 
 
 def add_parser(subparsers, parent_parser):
+    from .add import _add_annotating_args
+
     IMPORT_HELP = (
         "Download file or directory tracked by DVC or by Git "
         "into the workspace, and track it."
@@ -85,15 +89,6 @@ def add_parser(subparsers, parent_parser):
         " but do not actually download the file(s).",
     )
     import_parser.add_argument(
-        "--desc",
-        type=str,
-        metavar="<text>",
-        help=(
-            "User description of the data (optional). "
-            "This doesn't affect any DVC operations."
-        ),
-    )
-    import_parser.add_argument(
         "-j",
         "--jobs",
         type=int,
@@ -103,4 +98,6 @@ def add_parser(subparsers, parent_parser):
         ),
         metavar="<number>",
     )
+
+    _add_annotating_args(import_parser)
     import_parser.set_defaults(func=CmdImport)

--- a/dvc/commands/imp_url.py
+++ b/dvc/commands/imp_url.py
@@ -21,6 +21,8 @@ class CmdImportUrl(CmdBase):
                 remote=self.args.remote,
                 to_remote=self.args.to_remote,
                 desc=self.args.desc,
+                type=self.args.type,
+                labels=self.args.labels,
                 jobs=self.args.jobs,
             )
         except DvcException:
@@ -35,6 +37,8 @@ class CmdImportUrl(CmdBase):
 
 
 def add_parser(subparsers, parent_parser):
+    from .add import _add_annotating_args
+
     IMPORT_HELP = (
         "Download or copy file from URL and take it under DVC control."
     )
@@ -103,13 +107,5 @@ def add_parser(subparsers, parent_parser):
         ),
         metavar="<number>",
     )
-    import_parser.add_argument(
-        "--desc",
-        type=str,
-        metavar="<text>",
-        help=(
-            "User description of the data (optional). "
-            "This doesn't affect any DVC operations."
-        ),
-    )
+    _add_annotating_args(import_parser)
     import_parser.set_defaults(func=CmdImportUrl)

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -264,6 +264,7 @@ def create_stages(
             outs=[out],
             external=external,
         )
-        if kwargs.get("desc"):
-            stage.outs[0].desc = kwargs["desc"]
+
+        out_obj = stage.outs[0]
+        out_obj.annot.update(**kwargs)
         yield stage

--- a/dvc/repo/imp_url.py
+++ b/dvc/repo/imp_url.py
@@ -22,6 +22,8 @@ def imp_url(
     remote=None,
     to_remote=False,
     desc=None,
+    type=None,  # pylint: disable=redefined-builtin
+    labels=None,
     jobs=None,
 ):
     from dvc.dvcfile import Dvcfile
@@ -61,9 +63,8 @@ def imp_url(
     )
     restore_fields(stage)
 
-    if desc:
-        stage.outs[0].desc = desc
-
+    out_obj = stage.outs[0]
+    out_obj.annot.update(desc=desc, type=type, labels=labels)
     dvcfile = Dvcfile(self, stage.path)
     dvcfile.remove()
 

--- a/dvc/schema.py
+++ b/dvc/schema.py
@@ -3,6 +3,7 @@ from collections.abc import Mapping
 from voluptuous import Any, Optional, Required, Schema
 
 from dvc import dependency, output
+from dvc.annotations import Annotation
 from dvc.output import CHECKSUMS_SCHEMA, Output
 from dvc.parsing import DO_KWD, FOREACH_KWD, VARS_KWD
 from dvc.parsing.versions import SCHEMA_KWD, lockfile_version_schema
@@ -50,7 +51,7 @@ OUT_PSTAGE_DETAILED_SCHEMA = {
         Output.PARAM_CACHE: bool,
         Output.PARAM_PERSIST: bool,
         Output.PARAM_CHECKPOINT: bool,
-        Output.PARAM_DESC: str,
+        Annotation.PARAM_DESC: str,
         Output.PARAM_REMOTE: str,
     }
 }

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -110,16 +110,13 @@ def restore_fields(stage):
     # will be used to restore comments later
     # noqa, pylint: disable=protected-access
     stage._stage_text = old._stage_text
-
     stage.meta = old.meta
     stage.desc = old.desc
 
-    old_fields = {out.def_path: (out.desc, out.remote) for out in old.outs}
-
+    old_fields = {out.def_path: (out.annot, out.remote) for out in old.outs}
     for out in stage.outs:
-        out_fields = old_fields.get(out.def_path, None)
-        if out_fields:
-            out.desc, out.remote = out_fields
+        if out_fields := old_fields.get(out.def_path, None):
+            out.annot, out.remote = out_fields
 
 
 class Stage(params.StageParams):

--- a/dvc/stage/serialize.py
+++ b/dvc/stage/serialize.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, List, no_type_check
 from funcy import post_processing
 
 from dvc.dependency import ParamsDependency
-from dvc.output import Output
+from dvc.output import Annotation, Output
 from dvc.utils.collections import apply_diff
 from dvc.utils.serialize import parse_yaml_for_update
 
@@ -27,7 +27,7 @@ PARAM_METRIC = Output.PARAM_METRIC
 PARAM_PLOT = Output.PARAM_PLOT
 PARAM_PERSIST = Output.PARAM_PERSIST
 PARAM_CHECKPOINT = Output.PARAM_CHECKPOINT
-PARAM_DESC = Output.PARAM_DESC
+PARAM_DESC = Annotation.PARAM_DESC
 PARAM_REMOTE = Output.PARAM_REMOTE
 
 DEFAULT_PARAMS_FILE = ParamsDependency.DEFAULT_PARAMS_FILE
@@ -38,8 +38,8 @@ sort_by_path = partial(sorted, key=attrgetter("def_path"))
 
 @post_processing(OrderedDict)
 def _get_flags(out):
-    if out.desc:
-        yield PARAM_DESC, out.desc
+    if out.annot.desc:
+        yield PARAM_DESC, out.annot.desc
     if not out.use_cache:
         yield PARAM_CACHE, False
     if out.checkpoint:

--- a/dvc/stage/utils.py
+++ b/dvc/stage/utils.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Union
 
 from funcy import concat, first, lsplit, rpartial, without
 
+from dvc.annotations import ANNOTATION_FIELDS
 from dvc.exceptions import InvalidArgumentError
 from dvc_data.hashfile.meta import Meta
 
@@ -194,9 +195,9 @@ def compute_md5(stage):
     return dict_md5(
         d,
         exclude=[
+            *ANNOTATION_FIELDS,
             stage.PARAM_LOCKED,  # backward compatibility
             stage.PARAM_FROZEN,
-            Output.PARAM_DESC,
             Output.PARAM_METRIC,
             Output.PARAM_PERSIST,
             Output.PARAM_CHECKPOINT,

--- a/tests/func/test_commit.py
+++ b/tests/func/test_commit.py
@@ -47,6 +47,10 @@ def test_commit_preserve_fields(tmp_dir, dvc):
         outs:
         - path: foo # out comment
           desc: out desc
+          type: mytype
+          labels:
+          - label1
+          - label2
           remote: testremote
         meta: some metadata
     """
@@ -61,6 +65,10 @@ def test_commit_preserve_fields(tmp_dir, dvc):
         outs:
         - path: foo # out comment
           desc: out desc
+          type: mytype
+          labels:
+          - label1
+          - label2
           remote: testremote
           md5: acbd18db4cc2f85cedef654fccc4a4d8
           size: 3

--- a/tests/func/test_dvcfile.py
+++ b/tests/func/test_dvcfile.py
@@ -335,7 +335,7 @@ def test_dvcfile_dump_preserves_desc(tmp_dir, dvc, run_copy):
     (tmp_dir / dvcfile.path).dump(data)
 
     assert stage.desc == stage_desc
-    stage.outs[0].desc = out_desc
+    stage.outs[0].annot.desc = out_desc
     dvcfile.dump(stage)
     loaded = dvcfile._load()[0]
     assert loaded == data
@@ -401,7 +401,7 @@ def test_dvcfile_load_dump_stage_with_desc_meta(tmp_dir, dvc):
     stage = dvc.stage.load_one(name="stage1")
     assert stage.meta == {"key1": "value1", "key2": "value2"}
     assert stage.desc == "stage desc"
-    assert stage.outs[0].desc == "bar desc"
+    assert stage.outs[0].annot.desc == "bar desc"
 
     # sanity check
     stage.dump()

--- a/tests/func/test_run_single_stage.py
+++ b/tests/func/test_run_single_stage.py
@@ -972,6 +972,10 @@ def test_run_force_preserves_comments_and_meta(tmp_dir, dvc, run_copy):
       # comment preserved
       - path: bar
         desc: out desc
+        type: mytype
+        labels:
+        - label1
+        - label2
       meta:
         name: copy-foo-bar
     """
@@ -996,6 +1000,10 @@ def test_run_force_preserves_comments_and_meta(tmp_dir, dvc, run_copy):
         # comment preserved
         - path: bar
           desc: out desc
+          type: mytype
+          labels:
+          - label1
+          - label2
           md5: acbd18db4cc2f85cedef654fccc4a4d8
           size: 3
         meta:

--- a/tests/unit/command/test_add.py
+++ b/tests/unit/command/test_add.py
@@ -37,6 +37,8 @@ def test_add(mocker, dvc):
         remote=None,
         to_remote=False,
         desc="stage description",
+        type=None,
+        labels=None,
         jobs=None,
     )
 
@@ -71,6 +73,8 @@ def test_add_to_remote(mocker):
         remote="remote",
         to_remote=True,
         desc=None,
+        type=None,
+        labels=None,
         jobs=None,
     )
 

--- a/tests/unit/command/test_annotations_flags.py
+++ b/tests/unit/command/test_annotations_flags.py
@@ -1,0 +1,42 @@
+import pytest
+
+from dvc.cli import parse_args
+from tests.utils.asserts import called_once_with_subset
+
+
+@pytest.mark.parametrize(
+    "func, args",
+    [
+        ("add", ("add", "model.pkl")),
+        ("imp", ("import", "https://github.com/org/repo", "model.pkl")),
+        ("imp_url", ("import-url", "https://dvc.org/data.xml", "data.xml")),
+    ],
+    ids=["add", "import", "import-url"],
+)
+def test_add_annotations(mocker, func, args):
+    mocker.patch("dvc.repo.Repo")
+    cli_args = parse_args(
+        [
+            *args,
+            "--label",
+            "example-get-started",
+            "--label",
+            "model-registry",
+            "--type",
+            "model",
+            "--desc",
+            "description",
+        ]
+    )
+
+    _, *posargs = args
+    cmd = cli_args.func(cli_args)
+
+    assert cmd.run() == 0
+    assert called_once_with_subset(
+        getattr(cmd.repo, func),
+        posargs,
+        desc="description",
+        type="model",
+        labels=["example-get-started", "model-registry"],
+    )

--- a/tests/unit/command/test_imp.py
+++ b/tests/unit/command/test_imp.py
@@ -36,6 +36,8 @@ def test_import(mocker):
         no_exec=False,
         no_download=False,
         desc="description",
+        type=None,
+        labels=None,
         jobs=3,
     )
 
@@ -72,6 +74,8 @@ def test_import_no_exec(mocker):
         no_exec=True,
         no_download=False,
         desc="description",
+        type=None,
+        labels=None,
         jobs=None,
     )
 
@@ -108,5 +112,7 @@ def test_import_no_download(mocker):
         no_exec=False,
         no_download=True,
         desc="description",
+        type=None,
+        labels=None,
         jobs=None,
     )

--- a/tests/unit/command/test_imp_url.py
+++ b/tests/unit/command/test_imp_url.py
@@ -37,6 +37,8 @@ def test_import_url(mocker):
         remote=None,
         to_remote=False,
         desc="description",
+        type=None,
+        labels=None,
         jobs=4,
     )
 
@@ -92,6 +94,8 @@ def test_import_url_no_exec_download_flags(mocker, flag, expected):
         to_remote=False,
         desc="description",
         jobs=None,
+        type=None,
+        labels=None,
         **expected
     )
 
@@ -125,6 +129,8 @@ def test_import_url_to_remote(mocker):
         remote="remote",
         to_remote=True,
         desc="description",
+        type=None,
+        labels=None,
         jobs=None,
     )
 

--- a/tests/unit/output/test_annotations.py
+++ b/tests/unit/output/test_annotations.py
@@ -1,0 +1,22 @@
+import pytest
+
+from dvc.annotations import Annotation
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"desc": "desc", "type": "type", "labels": ["label1", "label2"]},
+        {"desc": "desc", "type": "type"},
+    ],
+)
+def test_annotation_to_dict(kwargs):
+    annot = Annotation(**kwargs)
+    assert annot.to_dict() == kwargs
+
+
+def test_annotation_update():
+    annot = Annotation(desc="desc", labels=["label1", "label2"])
+    annot.update(labels=["label"], type="type", new="new")
+
+    assert vars(annot) == {"desc": "desc", "type": "type", "labels": ["label"]}

--- a/tests/utils/asserts.py
+++ b/tests/utils/asserts.py
@@ -11,7 +11,7 @@ def called_once_with_subset(m: Mock, *args: Any, **kwargs: Any) -> bool:
     m.assert_called_once()
     m_args, m_kwargs = m.call_args
 
-    expected_args = m_args + (ANY,) * (len(m_args) - len(args))
+    expected_args = m_args + (ANY,) * (len(m_args) - len(args) - 1)
     expected_kwargs = {k: kwargs.get(k, ANY) for k in m_kwargs}
     m.assert_called_with(*expected_args, **expected_kwargs)
 


### PR DESCRIPTION
Related: #8214, Closes #8243

This PR:
- adds `labels` - a list type, and `type` - a string type to `.dvc` schema.
- adds support for `--type` flag in `add/import/import-url`.
- adds support for `--labels` flag in `add/import/import-url`. You can specify the flag multiple times, and also can specify labels as comma-separated list.
  ```console
  $ dvc add model.pkl --labels model,get-started --labels dataset-registry
  ```
- `type`/`labels` are preserved on rewrites/overwrites.


### Example `.dvc` file
```console
$ dvc add model.pkl  --desc "My model" --type model --labels get-started,dataset-registry > /dev/null
$ cat model.pkl.dvc
```
```yaml
outs:
- md5: d3b07384d113edec49eaa6238ad5ff00
  size: 4
  path: model.pkl
  desc: My model
  type: model
  labels:
  - get-started
  - dataset-registry
```

