### PR TITLE
dvc.yaml: preserve outputs' desc on rewrites/updates to the stage

### DIFF
--- a/dvc/output.py
+++ b/dvc/output.py
@@ -187,6 +187,7 @@ def load_from_pipeline(stage, data, typ="outs"):
                 Output.PARAM_PERSIST,
                 Output.PARAM_CHECKPOINT,
                 Output.PARAM_REMOTE,
+                Output.PARAM_DESC,
             ],
         )
 

--- a/tests/func/test_dvcfile.py
+++ b/tests/func/test_dvcfile.py
@@ -382,3 +382,27 @@ def test_dvcfile_try_dumping_parametrized_stage(tmp_dir, dvc, data, name):
         dvcfile.dump(stage)
 
     assert str(exc.value) == f"cannot dump a parametrized stage: '{name}'"
+
+
+def test_dvcfile_load_dump_stage_with_desc_meta(tmp_dir, dvc):
+    data = {
+        "stages": {
+            "stage1": {
+                "cmd": "cp foo bar",
+                "desc": "stage desc",
+                "meta": {"key1": "value1", "key2": "value2"},
+                "deps": ["foo"],
+                "outs": [{"bar": {"desc": "bar desc"}}],
+            }
+        }
+    }
+    (tmp_dir / "dvc.yaml").dump(data)
+
+    stage = dvc.stage.load_one(name="stage1")
+    assert stage.meta == {"key1": "value1", "key2": "value2"}
+    assert stage.desc == "stage desc"
+    assert stage.outs[0].desc == "bar desc"
+
+    # sanity check
+    stage.dump()
+    assert (tmp_dir / "dvc.yaml").parse() == data


### PR DESCRIPTION
We were not loading `desc` of the output, and as a result, we were not preserving the desc field over rewrites. Note that the rewrite only happens in select commands for `dvc.yaml`: `freeze`/`unfreeze`/`run`/`stage-add`, so we did not notice this before.