### PR TITLE
import-url: use dvc-data `index.save()` for fetching imports

### DIFF
--- a/dvc/commands/imp_url.py
+++ b/dvc/commands/imp_url.py
@@ -25,6 +25,7 @@ class CmdImportUrl(CmdBase):
                 labels=self.args.labels,
                 meta=self.args.meta,
                 jobs=self.args.jobs,
+                version_aware=self.args.version_aware,
             )
         except DvcException:
             logger.exception(
@@ -107,6 +108,15 @@ def add_parser(subparsers, parent_parser):
             "The default value is 4 * cpu_count(). "
         ),
         metavar="<number>",
+    )
+    import_parser.add_argument(
+        "--version-aware",
+        action="store_true",
+        default=False,
+        help=(
+            "Import using cloud versioning. Implied if the URL contains a "
+            "version ID."
+        ),
     )
     _add_annotating_args(import_parser)
     import_parser.set_defaults(func=CmdImportUrl)

--- a/dvc/output.py
+++ b/dvc/output.py
@@ -26,6 +26,7 @@ from dvc_data.hashfile.hash_info import HashInfo
 from dvc_data.hashfile.istextfile import istextfile
 from dvc_data.hashfile.meta import Meta
 from dvc_data.hashfile.transfer import transfer as otransfer
+from dvc_data.index import DataIndexEntry
 from dvc_objects.errors import ObjectFormatError
 
 from .annotations import ANNOTATION_FIELDS, ANNOTATION_SCHEMA, Annotation
@@ -513,6 +514,23 @@ class Output:
             no_drive = self.fs.path.flavour.splitdrive(self.fs_path)[1]
             key = self.fs.path.parts(no_drive)[1:]
         return workspace, key
+
+    def get_entry(self) -> "DataIndexEntry":
+        from dvc.config import NoRemoteError
+
+        try:
+            remote = self.repo.cloud.get_remote_odb(self.remote)
+        except NoRemoteError:
+            remote = None
+
+        return DataIndexEntry(
+            meta=self.meta,
+            obj=self.obj,
+            hash_info=self.hash_info,
+            odb=self.odb,
+            cache=self.odb,
+            remote=remote,
+        )
 
     def changed_checksum(self):
         return self.hash_info != self.get_hash()

--- a/dvc/output.py
+++ b/dvc/output.py
@@ -551,7 +551,7 @@ class Output:
 
     def changed_meta(self) -> bool:
         if self.fs.version_aware and self.meta.version_id:
-            return self.meta.version_id == self.get_meta().version_id
+            return self.meta.version_id != self.get_meta().version_id
         return False
 
     def workspace_status(self):

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -3,7 +3,7 @@ import os
 from collections import defaultdict
 from contextlib import contextmanager
 from functools import wraps
-from typing import TYPE_CHECKING, Callable, List, Optional
+from typing import TYPE_CHECKING, Callable, Optional
 
 from funcy import cached_property
 
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
     from dvc.fs import FileSystem
     from dvc.repo.scm_context import SCMContext
     from dvc.scm import Base
-    from dvc.stage import Stage
 
 logger = logging.getLogger(__name__)
 
@@ -446,44 +445,6 @@ class Repo:
                 used[odb].update(objs)
 
         return used
-
-    def partial_imports(
-        self,
-        targets=None,
-        all_branches=False,
-        all_tags=False,
-        all_commits=False,
-        all_experiments=False,
-        commit_date: Optional[str] = None,
-        recursive=False,
-        revs=None,
-        num=1,
-    ) -> List["Stage"]:
-        """Get the stages related to the given target and collect dependencies
-        which are missing outputs.
-
-        This is useful to retrieve files which have been imported to the repo
-        using --no-download.
-
-        Returns:
-            A list of partially imported stages
-        """
-        from itertools import chain
-
-        partial_imports = chain.from_iterable(
-            self.index.partial_imports(targets, recursive=recursive)
-            for _ in self.brancher(
-                revs=revs,
-                all_branches=all_branches,
-                all_tags=all_tags,
-                all_commits=all_commits,
-                all_experiments=all_experiments,
-                commit_date=commit_date,
-                num=num,
-            )
-        )
-
-        return list(partial_imports)
 
     @property
     def stages(self):  # obsolete, only for backward-compatibility

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -108,7 +108,7 @@ def fetch(
         imported = save_imports(
             self,
             targets,
-            unpartial=rev == "workspace",
+            unpartial=not rev or rev == "workspace",
             recursive=recursive,
         )
         result.transferred.update(imported)

--- a/dvc/repo/imports.py
+++ b/dvc/repo/imports.py
@@ -1,0 +1,108 @@
+import logging
+from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING, List, Set, Tuple, Union
+
+if TYPE_CHECKING:
+    from dvc.dependency.base import Dependency
+    from dvc.repo import Repo
+    from dvc.repo.index import Index, IndexView
+    from dvc.stage import Stage
+    from dvc.types import TargetType
+    from dvc_data.hashfile import HashInfo
+
+logger = logging.getLogger(__name__)
+
+
+def unfetched_view(
+    index: "Index", targets: "TargetType", **kwargs
+) -> Tuple["IndexView", List["Dependency"]]:
+    """Return index view of imports which have not been fetched.
+
+    Returns:
+        Tuple in the form (view, changed_deps) where changed_imports is a list
+        of import dependencies that cannot be fetched due to changed data
+        source.
+    """
+    changed_deps: List["Dependency"] = []
+
+    def need_fetch(stage: "Stage") -> bool:
+        out = stage.outs[0]
+        if not out.changed_cache():
+            return False
+
+        dep = stage.deps[0]
+        if dep.changed_checksum():
+            changed_deps.append(dep)
+            return False
+
+        return True
+
+    unfetched = index.targets_view(targets, filter_fn=need_fetch, **kwargs)
+    return unfetched, changed_deps
+
+
+def unpartial_imports(index: Union["Index", "IndexView"]) -> int:
+    """Update any outs in the index which are no longer partial imports.
+
+    Returns:
+        Total number of files which were unpartialed.
+    """
+    updated = 0
+    for out in index.outs:
+        # we need to use view[key] here and since the out fields have not been
+        # updated yet (out.get_entry() would return the partial-import state)
+        workspace, key = out.index_key
+        entry = index.data[workspace][key]
+        if out.stage.is_partial_import:
+            out.hash_info = entry.hash_info
+            out.meta = entry.meta
+            out.stage.dump()
+            updated += out.meta.nfiles if out.meta.nfiles is not None else 1
+    return updated
+
+
+def save_imports(
+    repo: "Repo", targets: "TargetType", unpartial: bool = False, **kwargs
+) -> Set["HashInfo"]:
+    """Save (download) imports from their original source location.
+
+    Imports which are already cached will not be downloaded.
+
+    Returns:
+        Objects which were downloaded from source location.
+    """
+    from dvc.stage.exceptions import DataSourceChanged
+    from dvc.utils.fs import makedirs
+    from dvc_data.index import checkout, md5, save
+    from dvc_objects.fs.callbacks import Callback
+
+    downloaded: Set["HashInfo"] = set()
+
+    unfetched, changed = unfetched_view(repo.index, targets, **kwargs)
+    for dep in changed:
+        logger.warning(str(DataSourceChanged(f"{dep.stage} ({dep})")))
+
+    data_view = unfetched.data["repo"]
+    if len(data_view):
+        cache = repo.odb.local
+        if not cache.fs.exists(cache.path):
+            makedirs(cache.path)
+        with TemporaryDirectory(dir=cache.path) as tmpdir:
+            with Callback.as_tqdm_callback(
+                desc="Downloading imports from source",
+                unit="files",
+            ) as cb:
+                checkout(data_view, tmpdir, cache.fs, callback=cb)
+            md5(data_view)
+            save(data_view, odb=cache, hardlink=True)
+
+        if unpartial:
+            unpartial_imports(unfetched)
+
+        downloaded.update(
+            entry.hash_info
+            for _, entry in data_view.iteritems()
+            if not entry.meta.isdir and entry.hash_info is not None
+        )
+
+    return downloaded

--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -279,14 +279,6 @@ class Index:
                 used[odb].update(objs)
         return used
 
-    def partial_imports(
-        self,
-        targets: "TargetType" = None,
-        recursive: bool = False,
-    ) -> List["Stage"]:
-        pairs = self._collect_targets(targets, recursive=recursive)
-        return [stage for stage, _ in pairs if stage.is_partial_import]
-
     # Following methods help us treat the collection as a set-like structure
     # and provides faux-immutability.
     # These methods do not preserve stages order.

--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -252,7 +252,7 @@ class Index:
             if out.files:
                 out.obj = out.get_obj()
 
-            data_index[key] = DataIndexEntry(
+            entry = DataIndexEntry(
                 meta=out.meta,
                 obj=out.obj,
                 hash_info=out.hash_info,
@@ -260,6 +260,11 @@ class Index:
                 cache=out.odb,
                 remote=remote,
             )
+            if out.stage.is_import and not out.stage.is_repo_import:
+                entry.fs = out.stage.deps[0].fs
+                entry.path = out.stage.deps[0].fs_path
+                entry.cache = out.odb
+            data_index[key] = entry
 
         return dict(by_workspace)
 

--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -228,8 +228,7 @@ class Index:
     def data(self) -> "Dict[str, DataIndex]":
         from collections import defaultdict
 
-        from dvc.config import NoRemoteError
-        from dvc_data.index import DataIndex, DataIndexEntry
+        from dvc_data.index import DataIndex
 
         by_workspace: dict = defaultdict(DataIndex)
 
@@ -241,29 +240,16 @@ class Index:
                 continue
 
             workspace, key = out.index_key
-
-            try:
-                remote = self.repo.cloud.get_remote_odb(out.remote)
-            except NoRemoteError:
-                remote = None
-
             data_index = by_workspace[workspace]
 
             if out.files:
                 out.obj = out.get_obj()
 
-            entry = DataIndexEntry(
-                meta=out.meta,
-                obj=out.obj,
-                hash_info=out.hash_info,
-                odb=out.odb,
-                cache=out.odb,
-                remote=remote,
-            )
+            entry = out.get_entry()
             if out.stage.is_import and not out.stage.is_repo_import:
                 entry.fs = out.stage.deps[0].fs
                 entry.path = out.stage.deps[0].fs_path
-                entry.cache = out.odb
+                entry.meta = out.stage.deps[0].meta
             data_index[key] = entry
 
         return dict(by_workspace)

--- a/dvc/repo/status.py
+++ b/dvc/repo/status.py
@@ -14,7 +14,9 @@ def _joint_status(pairs):
     status_info = {}
 
     for stage, filter_info in pairs:
-        if stage.frozen and not stage.is_repo_import:
+        if stage.frozen and not (
+            stage.is_repo_import or stage.is_versioned_import
+        ):
             logger.warning(
                 "%s is frozen. Its dependencies are"
                 " not going to be shown in the status output.",

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -258,6 +258,10 @@ class Stage(params.StageParams):
         return isinstance(self.deps[0], RepoDependency)
 
     @property
+    def is_versioned_import(self):
+        return self.is_import and self.deps[0].fs.version_aware
+
+    @property
     def is_checkpoint(self):
         """
         A stage containing checkpoint outs is always considered as changed
@@ -620,7 +624,9 @@ class Stage(params.StageParams):
     @rwlocked(read=["deps", "outs"])
     def status(self, check_updates=False, filter_info=None):
         ret = []
-        show_import = self.is_repo_import and check_updates
+        show_import = (
+            self.is_repo_import or self.is_versioned_import
+        ) and check_updates
 
         if not self.frozen or show_import:
             self._status_deps(ret)

--- a/tests/unit/command/test_imp_url.py
+++ b/tests/unit/command/test_imp_url.py
@@ -41,6 +41,7 @@ def test_import_url(mocker):
         labels=None,
         meta=None,
         jobs=4,
+        version_aware=False,
     )
 
 
@@ -98,6 +99,7 @@ def test_import_url_no_exec_download_flags(mocker, flag, expected):
         type=None,
         labels=None,
         meta=None,
+        version_aware=False,
         **expected
     )
 
@@ -135,6 +137,7 @@ def test_import_url_to_remote(mocker):
         labels=None,
         meta=None,
         jobs=None,
+        version_aware=False,
     )
 
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

- Implements cloud versioning support in `import-url`
    - When the imported URL contains a version ID, DVC will import that specific version (and the version ID will be capture din the .dvc file).
    - When the imported URL does not contain a version ID, DVC will not capture version information unless the `--version-aware` flag is provided (regardless of whether or not the bucket/container has versioning enabled).
    - When using `--version-aware` flag, DVC will capture the latest/current version of the imported file.
- Implements support for fetching imports from source
    - DVC will first try to fetch/pull imports from a DVC remote
    - If there is no remote configured or the imported object failed to be fetched, DVC will fetch from the original source location
    - When fetching from source, DVC will verify that metadata (etag/versionid/etc) still matches the original import metadata. If the source has changed, DVC will error out with `DataSourceChangedError` (same as when `import-url --no-download` data source has changed)
    - Closes https://github.com/iterative/dvc/issues/8274
- Fixes https://github.com/iterative/dvc/issues/8435
