### PR TITLE
add metadata support to dvc.yaml

### DIFF
--- a/dvc/output.py
+++ b/dvc/output.py
@@ -188,7 +188,7 @@ def load_from_pipeline(stage, data, typ="outs"):
                 Output.PARAM_PERSIST,
                 Output.PARAM_CHECKPOINT,
                 Output.PARAM_REMOTE,
-                Annotation.PARAM_DESC,
+                *ANNOTATION_FIELDS,
             ],
         )
 

--- a/dvc/schema.py
+++ b/dvc/schema.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping
 from voluptuous import Any, Optional, Required, Schema
 
 from dvc import dependency, output
-from dvc.annotations import Annotation
+from dvc.annotations import ANNOTATION_SCHEMA
 from dvc.output import CHECKSUMS_SCHEMA, Output
 from dvc.parsing import DO_KWD, FOREACH_KWD, VARS_KWD
 from dvc.parsing.versions import SCHEMA_KWD, lockfile_version_schema
@@ -48,10 +48,10 @@ LOCKFILE_V2_SCHEMA = {
 
 OUT_PSTAGE_DETAILED_SCHEMA = {
     str: {
+        **ANNOTATION_SCHEMA,  # type: ignore
         Output.PARAM_CACHE: bool,
         Output.PARAM_PERSIST: bool,
         Output.PARAM_CHECKPOINT: bool,
-        Annotation.PARAM_DESC: str,
         Output.PARAM_REMOTE: str,
     }
 }

--- a/dvc/stage/serialize.py
+++ b/dvc/stage/serialize.py
@@ -38,8 +38,9 @@ sort_by_path = partial(sorted, key=attrgetter("def_path"))
 
 @post_processing(OrderedDict)
 def _get_flags(out):
-    if out.annot.desc:
-        yield PARAM_DESC, out.annot.desc
+    annot = out.annot.to_dict()
+    yield from annot.items()
+
     if not out.use_cache:
         yield PARAM_CACHE, False
     if out.checkpoint:

--- a/tests/func/test_dvcfile.py
+++ b/tests/func/test_dvcfile.py
@@ -3,6 +3,7 @@ import textwrap
 
 import pytest
 
+from dvc.annotations import Annotation
 from dvc.dvcfile import (
     PIPELINE_FILE,
     PIPELINE_LOCK,
@@ -392,7 +393,9 @@ def test_dvcfile_load_dump_stage_with_desc_meta(tmp_dir, dvc):
                 "desc": "stage desc",
                 "meta": {"key1": "value1", "key2": "value2"},
                 "deps": ["foo"],
-                "outs": [{"bar": {"desc": "bar desc"}}],
+                "outs": [
+                    {"bar": {"desc": "bar desc", "meta": {"key": "value"}}}
+                ],
             }
         }
     }
@@ -401,7 +404,9 @@ def test_dvcfile_load_dump_stage_with_desc_meta(tmp_dir, dvc):
     stage = dvc.stage.load_one(name="stage1")
     assert stage.meta == {"key1": "value1", "key2": "value2"}
     assert stage.desc == "stage desc"
-    assert stage.outs[0].annot.desc == "bar desc"
+    assert stage.outs[0].annot == Annotation(
+        desc="bar desc", meta={"key": "value"}
+    )
 
     # sanity check
     stage.dump()


### PR DESCRIPTION
Adds a `meta`/`type`/`labels` field to `outs` in `dvc.yaml` file.

Closes #8244. Part of #8214.