### PR TITLE
deps: temporarily limit dulwich to <0.20.46

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,7 @@ install_requires =
     pyparsing>=2.4.7
     typing-extensions>=3.7.4
     scmrepo==0.0.25
+    dulwich<0.20.46
     dvc-render==0.0.10
     dvc-task==0.1.2
     dvclive>=0.10.0


### PR DESCRIPTION
Looks like the new release broke some data status logic.

