### PR TITLE
data status: fix for scmrepo 0.1.0

### DIFF
--- a/dvc/repo/data.py
+++ b/dvc/repo/data.py
@@ -153,6 +153,8 @@ def _git_info(scm: "Base", untracked_files: str = "all") -> GitInfo:
         empty_repo = False
 
     staged, unstaged, untracked = scm.status(untracked_files=untracked_files)
+    if os.name == "nt":
+        untracked = [posixpath_to_os_path(path) for path in untracked]
     # NOTE: order is important here.
     return GitInfo(
         staged=staged,

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,8 +62,7 @@ install_requires =
     rich>=10.13.0
     pyparsing>=2.4.7
     typing-extensions>=3.7.4
-    scmrepo==0.0.25
-    dulwich<0.20.46
+    scmrepo==0.1.0
     dvc-render==0.0.10
     dvc-task==0.1.2
     dvclive>=0.10.0

--- a/tests/func/test_data_status.py
+++ b/tests/func/test_data_status.py
@@ -4,7 +4,7 @@ from os.path import join
 import pytest
 
 from dvc.repo import Repo
-from dvc.repo.data import _transform_git_paths_to_dvc
+from dvc.repo.data import _transform_git_paths_to_dvc, posixpath_to_os_path
 from dvc.testing.tmp_dir import make_subrepo
 from dvc.utils.fs import remove
 
@@ -31,7 +31,7 @@ def test_git_to_dvc_path_wdir_transformation(tmp_dir, scm, path):
         subdir.gen(struct)
         _, _, untracked = scm.status(untracked_files="all")
         # make order independent of the platforms for easier test assertions
-        untracked = sorted(untracked, reverse=True)
+        untracked = sorted(map(posixpath_to_os_path, untracked), reverse=True)
         assert _transform_git_paths_to_dvc(dvc, untracked) == [
             "file",
             join("dir", "foo"),


### PR DESCRIPTION
`dulwich>=0.20.46` no longer returns nt-style paths on Windows for untracked files when using `porcelain.status` (https://github.com/jelmer/dulwich/pull/995)