### PR TITLE
silence flake8 errors

### DIFF
--- a/dvc/parsing/context.py
+++ b/dvc/parsing/context.py
@@ -159,7 +159,7 @@ class Value(Node):
 PRIMITIVES = (int, float, str, bytes, bool)
 
 
-class Container(Node, ABC):
+class Container(Node, ABC):  # noqa: B024
     meta: Meta
     data: Union[list, dict]
     _key_transform = staticmethod(identity)

--- a/dvc/repo/experiments/executor/manager/base.py
+++ b/dvc/repo/experiments/executor/manager/base.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class BaseExecutorManager(ABC, Mapping):
+class BaseExecutorManager(ABC, Mapping):  # noqa: B024
     """Manages executors for a collection of experiments to be run."""
 
     EXECUTOR_CLS: Type = BaseExecutor


### PR DESCRIPTION
CI is failing due to an update in `flake8-bugbear`, see https://github.com/PyCQA/flake8-bugbear/releases/tag/22.8.23

```console
dvc/repo/experiments/executor/manager/base.py:24:1: B024 BaseExecutorManager is an abstract base class, 
but it has no abstract methods. 
Remember to use @abstractmethod, @abstractclassmethod and/or @abstractproperty decorators.
class BaseExecutorManager(ABC, Mapping):
^

dvc/parsing/context.py:162:1: B024 Container is an abstract base class, but it has no abstract methods.
Remember to use @abstractmethod, @abstractclassmethod and/or @abstractproperty decorators.
class Container(Node, ABC):
^
```