### PR TITLE
add/import/import-url: update help message for labels/type/desc

### DIFF
--- a/dvc/commands/add.py
+++ b/dvc/commands/add.py
@@ -14,17 +14,14 @@ def _add_annotating_args(parser: argparse.ArgumentParser) -> None:
         "--desc",
         type=str,
         metavar="<text>",
-        help=(
-            "User description of the data (optional). "
-            "This doesn't affect any DVC operations."
-        ),
+        help="User description of the data.",
     )
     parser.add_argument(
         "--meta",
         metavar="key=value",
         nargs=1,
         action=KeyValueArgs,
-        help="Custom metadata to add to the data",
+        help="Custom metadata to add to the data.",
     )
     parser.add_argument(
         "--label",
@@ -32,13 +29,13 @@ def _add_annotating_args(parser: argparse.ArgumentParser) -> None:
         type=str,
         action="append",
         metavar="<str>",
-        help="Comma separated list of labels for the data (optional).",
+        help="Label for the data.",
     )
     parser.add_argument(
         "--type",
         type=str,
         metavar="<str>",
-        help="Type of the data (optional).",
+        help="Type of the data.",
     )
 
 


### PR DESCRIPTION
See https://github.com/iterative/dvc/pull/8232#issuecomment-1238583321.

> Finally, do the descriptions all need to end in (optional)? Other options like --file are also optional, but I don't think it needs to be explicitly stated in the help text.