### PR TITLE
worktree push/fetch: support dirs

### DIFF
--- a/dvc/dependency/param.py
+++ b/dvc/dependency/param.py
@@ -47,7 +47,7 @@ class ParamsDependency(Dependency):
         super().__init__(stage, path, repo=repo)
         self.hash_info = hash_info
 
-    def dumpd(self):
+    def dumpd(self, **kwargs):
         ret = super().dumpd()
         if not self.hash_info:
             ret[self.PARAM_PARAMS] = self.params or {}

--- a/dvc/dependency/repo.py
+++ b/dvc/dependency/repo.py
@@ -59,7 +59,7 @@ class RepoDependency(Dependency):
     def save(self):
         pass
 
-    def dumpd(self):
+    def dumpd(self, **kwargs):
         return {self.PARAM_PATH: self.def_path, self.PARAM_REPO: self.def_repo}
 
     def download(self, to, jobs=None):

--- a/dvc/dvcfile.py
+++ b/dvc/dvcfile.py
@@ -198,7 +198,7 @@ class SingleStageFile(FileMixin):
         if self.verify:
             check_dvcfile_path(self.repo, self.path)
         logger.debug("Saving information to '%s'.", relpath(self.path))
-        dump_yaml(self.path, serialize.to_single_stage_file(stage))
+        dump_yaml(self.path, serialize.to_single_stage_file(stage, **kwargs))
         self.repo.scm_context.track_file(self.relpath)
 
     def remove_stage(self, stage):  # pylint: disable=unused-argument

--- a/dvc/output.py
+++ b/dvc/output.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from collections import defaultdict
-from typing import TYPE_CHECKING, Dict, Optional, Set, Tuple, Type
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Type
 from urllib.parse import urlparse
 
 from funcy import cached_property, collecting, project
@@ -34,6 +34,7 @@ from .utils import relpath
 from .utils.fs import path_isin
 
 if TYPE_CHECKING:
+    from dvc_data.hashfile.obj import HashFile
     from dvc_data.index import DataIndexKey
     from dvc_objects.db import ObjectDB
 
@@ -295,7 +296,7 @@ class Output:
         remote=None,
         repo=None,
         fs_config=None,
-        files=None,
+        files: List[Dict[str, Any]] = None,
     ):
         self.annot = Annotation(
             desc=desc, type=type, labels=labels or [], meta=meta or {}
@@ -344,7 +345,7 @@ class Output:
         # should be absolute and don't contain remote:// refs.
         self.stage = stage
         self.meta = meta
-        self._dump_files = files is not None
+        self._files = files
         self.use_cache = False if self.IS_DEPENDENCY else cache
         self.metric = False if self.IS_DEPENDENCY else metric
         self.plot = False if self.IS_DEPENDENCY else plot
@@ -353,7 +354,7 @@ class Output:
         self.live = live
 
         self.fs_path = self._parse_path(self.fs, fs_path)
-        self.obj = None
+        self.obj: Optional["HashFile"] = None
 
         self.remote = remote
 
@@ -374,10 +375,6 @@ class Output:
         )
         if self.hash_info and self.hash_info.isdir:
             self.meta.isdir = True
-            if files:
-                tree = Tree.from_list(files, hash_name=self.hash_name)
-                tree.digest()
-                self.obj = tree
 
     def _parse_path(self, fs, fs_path):
         parsed = urlparse(self.def_path)
@@ -423,6 +420,7 @@ class Output:
         self.hash_info = HashInfo.from_dict({})
         self.meta = Meta.from_dict({})
         self.obj = None
+        self._files = None
 
     @property
     def protocol(self):
@@ -622,6 +620,7 @@ class Output:
                 dry_run=True,
             )
             self.hash_info = obj.hash_info
+            self._files = None
             if not self.IS_DEPENDENCY:
                 logger.debug(
                     "Output '%s' doesn't use cache. Skipping saving.", self
@@ -638,6 +637,7 @@ class Output:
             ignore=self.dvcignore,
         )
         self.hash_info = self.obj.hash_info
+        self._files = None
 
     def set_exec(self):
         if self.isfile() and self.meta.isexec:
@@ -769,10 +769,13 @@ class Output:
             self.use_cache
             and self.is_in_repo
             and self.hash_info.isdir
-            and (kwargs.get("with_files") or self._dump_files)
+            and (kwargs.get("with_files") or self._files is not None)
         ):
-            assert self.obj
-            ret[self.PARAM_FILES] = self.obj.as_list(with_meta=True)
+            if self.obj:
+                obj = self.obj
+            else:
+                obj = self.get_obj()
+            ret[self.PARAM_FILES] = obj.as_list(with_meta=True)
 
         return ret
 
@@ -806,14 +809,22 @@ class Output:
         ) as cb:
             self.fs.get(self.fs_path, to.fs_path, batch_size=jobs, callback=cb)
 
-    def get_obj(self, filter_info=None, **kwargs):
+    def get_obj(
+        self, filter_info: Optional[str] = None, **kwargs
+    ) -> Optional["HashFile"]:
+        obj: Optional["HashFile"] = None
         if self.obj:
             obj = self.obj
         elif self.hash_info:
-            try:
-                obj = oload(self.odb, self.hash_info)
-            except (FileNotFoundError, ObjectFormatError):
-                return None
+            if self._files:
+                tree = Tree.from_list(self._files, hash_name=self.hash_name)
+                tree.digest()
+                obj = tree
+            else:
+                try:
+                    obj = oload(self.odb, self.hash_info)
+                except (FileNotFoundError, ObjectFormatError):
+                    return None
         else:
             return None
 
@@ -933,6 +944,7 @@ class Output:
         )
 
         self.hash_info = obj.hash_info
+        self._files = None
         return obj
 
     def get_files_number(self, filter_info=None):
@@ -1003,6 +1015,7 @@ class Output:
 
         obj = self.get_obj()
         if filter_info and filter_info != self.fs_path:
+            assert obj
             prefix = self.fs.path.parts(
                 self.fs.path.relpath(filter_info, self.fs_path)
             )
@@ -1139,6 +1152,7 @@ class Output:
         self.odb.add(merged.path, merged.fs, merged.oid)
 
         self.hash_info = merged.hash_info
+        self._files = None
         self.meta = Meta(
             size=du(self.odb, merged),
             nfiles=len(merged),

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -34,8 +34,8 @@ def _fetch_worktree(repo, remote):
             if not out.is_in_repo:
                 continue
 
-            key = repo.fs.path.relparts(out.fs_path, repo.root_dir)
-            entry = repo.index.data["repo"][key]
+            workspace, key = out.index_key
+            entry = repo.index.data[workspace][key]
             out.hash_info = entry.hash_info
             out.meta = entry.meta
 

--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -183,15 +183,7 @@ class Index:
             if not out.use_cache:
                 continue
 
-            if out.is_in_repo:
-                workspace = "repo"
-                key = self.repo.fs.path.relparts(
-                    out.fs_path, self.repo.root_dir
-                )
-            else:
-                workspace = out.fs.protocol
-                no_drive = out.fs.path.flavour.splitdrive(out.fs_path)[1]
-                key = out.fs.path.parts(no_drive)[1:]
+            workspace, key = out.index_key
 
             try:
                 remote = self.repo.cloud.get_remote_odb(out.remote)

--- a/dvc/repo/push.py
+++ b/dvc/repo/push.py
@@ -10,11 +10,14 @@ if TYPE_CHECKING:
 
 
 def _push_worktree(repo, remote):
-    from dvc_data.index import build, checkout
+    from dvc_data.hashfile.tree import tree_from_index
+    from dvc_data.index import build, checkout, collect
 
     index = repo.index.data["repo"]
-    checkout(index, remote.path, remote.fs)
+    checkout(index, remote.path, remote.fs, force=True)
     build(index, remote.path, remote.fs)
+    if any(out.isdir() for out in repo.index.outs):
+        collect(index, remote.path, remote.fs)
 
     for stage in repo.index.stages:
         for out in stage.outs:
@@ -24,12 +27,30 @@ def _push_worktree(repo, remote):
             if not out.is_in_repo:
                 continue
 
-            key = repo.fs.path.relparts(out.fs_path, repo.root_dir)
-            entry = repo.index.data["repo"][key]
-            out.hash_info = entry.hash_info
-            out.meta = entry.meta
-
-        stage.dvcfile.dump(stage)
+            workspace, key = out.index_key
+            index = repo.index.data[workspace]
+            entry = index[key]
+            if out.isdir():
+                old_tree = out.get_obj()
+                entry.hash_info = old_tree.hash_info
+                entry.meta = out.meta
+                for subkey, entry in index.iteritems(key):
+                    if entry.meta.isdir:
+                        continue
+                    fs_path = repo.fs.path.join(repo.root_dir, *subkey)
+                    _, hash_info = old_tree.get(
+                        repo.fs.path.relparts(fs_path, out.fs_path)
+                    )
+                    entry.hash_info = hash_info
+                tree_meta, new_tree = tree_from_index(index, key)
+                new_tree.digest()
+                out.obj = new_tree
+                out.hash_info = new_tree.hash_info
+                out.meta = tree_meta
+            else:
+                out.hash_info = entry.hash_info
+                out.meta = entry.meta
+        stage.dvcfile.dump(stage, with_files=True)
 
     return len(index)
 

--- a/dvc/schema.py
+++ b/dvc/schema.py
@@ -4,11 +4,10 @@ from voluptuous import Any, Optional, Required, Schema
 
 from dvc import dependency, output
 from dvc.annotations import ANNOTATION_SCHEMA
-from dvc.output import CHECKSUMS_SCHEMA, Output
+from dvc.output import CHECKSUMS_SCHEMA, DIR_FILES_SCHEMA, META_SCHEMA, Output
 from dvc.parsing import DO_KWD, FOREACH_KWD, VARS_KWD
 from dvc.parsing.versions import SCHEMA_KWD, lockfile_version_schema
 from dvc.stage.params import StageParams
-from dvc_data.hashfile.meta import Meta
 
 STAGES = "stages"
 SINGLE_STAGE_SCHEMA = {
@@ -26,10 +25,9 @@ SINGLE_STAGE_SCHEMA = {
 
 DATA_SCHEMA = {
     **CHECKSUMS_SCHEMA,
+    **META_SCHEMA,
     Required("path"): str,
-    Meta.PARAM_SIZE: int,
-    Meta.PARAM_NFILES: int,
-    Meta.PARAM_ISEXEC: bool,
+    Output.PARAM_FILES: [DIR_FILES_SCHEMA],
 }
 LOCK_FILE_STAGE_SCHEMA = {
     Required(StageParams.PARAM_CMD): Any(str, list),

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -461,8 +461,8 @@ class Stage(params.StageParams):
     def reload(self):
         return self.dvcfile.stage
 
-    def dumpd(self):
-        return get_dump(self)
+    def dumpd(self, **kwargs):
+        return get_dump(self, **kwargs)
 
     def compute_md5(self):
         # `dvc add`ed files don't need stage md5

--- a/dvc/stage/serialize.py
+++ b/dvc/stage/serialize.py
@@ -188,8 +188,8 @@ def to_lockfile(stage: "PipelineStage") -> dict:
     return {stage.name: to_single_stage_lockfile(stage)}
 
 
-def to_single_stage_file(stage: "Stage"):
-    state = stage.dumpd()
+def to_single_stage_file(stage: "Stage", **kwargs):
+    state = stage.dumpd(**kwargs)
 
     # When we load a stage we parse yaml with a fast parser, which strips
     # off all the comments and formatting. To retain those on update we do

--- a/dvc/stage/serialize.py
+++ b/dvc/stage/serialize.py
@@ -156,10 +156,12 @@ def to_single_stage_lockfile(stage: "Stage") -> dict:
     assert stage.cmd
 
     def _dumpd(item):
+        meta_d = item.meta.to_dict()
+        meta_d.pop("isdir", None)
         ret = [
             (item.PARAM_PATH, item.def_path),
             *item.hash_info.to_dict().items(),
-            *item.meta.to_dict().items(),
+            *meta_d.items(),
         ]
 
         return OrderedDict(ret)

--- a/dvc/stage/utils.py
+++ b/dvc/stage/utils.py
@@ -226,7 +226,7 @@ def resolve_paths(fs, path, wdir=None):
     return path, wdir
 
 
-def get_dump(stage):
+def get_dump(stage, **kwargs):
     return {
         key: value
         for key, value in {
@@ -235,8 +235,8 @@ def get_dump(stage):
             stage.PARAM_CMD: stage.cmd,
             stage.PARAM_WDIR: resolve_wdir(stage.wdir, stage.path),
             stage.PARAM_FROZEN: stage.frozen,
-            stage.PARAM_DEPS: [d.dumpd() for d in stage.deps],
-            stage.PARAM_OUTS: [o.dumpd() for o in stage.outs],
+            stage.PARAM_DEPS: [d.dumpd(**kwargs) for d in stage.deps],
+            stage.PARAM_OUTS: [o.dumpd(**kwargs) for o in stage.outs],
             stage.PARAM_ALWAYS_CHANGED: stage.always_changed,
             stage.PARAM_META: stage.meta,
         }.items()

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ install_requires =
     dvc-render==0.0.10
     dvc-task==0.1.2
     dvclive>=0.10.0
-    dvc-data==0.7.1
+    dvc-data==0.8.0
     dvc-http==2.19.1
     hydra-core>=1.1.0
 


### PR DESCRIPTION
* [ ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

requires https://github.com/iterative/dvc-data/pull/171

- adds directory support to the worktree/cloud versioning POC
- directory tree metadata is stored in `out.files` in the .dvc file after push
- directories can be fetched without existing .dir cache (and without a traditional DVC remote configured) as long as `files` entry is present in the .dvc file

[![asciicast](https://asciinema.org/a/PoZURjVidcU5B2YcvLoltTjOE.svg)](https://asciinema.org/a/PoZURjVidcU5B2YcvLoltTjOE)