### PR TITLE
dvcfs: prevent opening file object in write mode

### DIFF
--- a/dvc/fs/dvc.py
+++ b/dvc/fs/dvc.py
@@ -1,3 +1,4 @@
+import errno
 import logging
 import ntpath
 import os
@@ -222,6 +223,9 @@ class _DvcFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
     def _open(
         self, path, mode="rb", **kwargs
     ):  # pylint: disable=arguments-renamed, arguments-differ
+        if mode != "rb":
+            raise OSError(errno.EROFS, os.strerror(errno.EROFS))
+
         key = self._get_key_from_relative(path)
         fs_path = self._from_key(key)
         try:


### PR DESCRIPTION
So that we don't accidentally corrupt cache/local files/remote files.