### PR TITLE
deps: add testing group for dvc.testing requirements

### DIFF
--- a/dvc/testing/test_api.py
+++ b/dvc/testing/test_api.py
@@ -38,7 +38,7 @@ class TestAPI:
     )
     def test_filesystem(
         self,
-        M,
+        M,  # from `pytest-test-utils`
         tmp_dir,
         make_tmp_dir,
         scm,

--- a/setup.cfg
+++ b/setup.cfg
@@ -104,6 +104,8 @@ webhdfs = dvc-webhdfs==2.19.0
 # requests-kerberos requires krb5 & gssapi, which does not provide wheels Linux
 webhdfs_kerberos = dvc-webhdfs[kerberos]==2.19.0
 terraform = tpi[ssh]>=2.1.0
+testing =
+    pytest-test-utils==0.0.8
 tests =
     %(terraform)s
     dvc-ssh==2.19.0
@@ -113,7 +115,7 @@ tests =
     pytest-xdist==2.5.0
     pytest-mock==3.8.2
     pytest-lazy-fixture==0.6.3
-    pytest-test-utils==0.0.8
+    %(testing)s
     # https://github.com/docker/docker-py/issues/2902
     pytest-docker==0.11.0; python_version < '3.10' or sys_platform != 'win32'
     flaky==3.7.0


### PR DESCRIPTION
With a testing group we can easily include all dependencies required for dvc.testing (e.g. in dvc-plugins)

See https://github.com/iterative/dvc/pull/8296#discussion_r972667351