### PR TITLE
exp show :Add `--hide-queued` and  `--hide-failed` flag 

### DIFF
--- a/dvc/commands/experiments/show.py
+++ b/dvc/commands/experiments/show.py
@@ -95,11 +95,8 @@ def _collect_rows(
 
         exp = results.get("data", {})
 
-        if exp.get("running"):
-            state = "Running"
-        elif exp.get("queued"):
-            state = "Queued"
-        else:
+        state = exp.get("status")
+        if state == "Success":
             state = fill_value
 
         is_baseline = rev == "baseline"
@@ -476,6 +473,8 @@ class CmdExperimentsShow(CmdBase):
                 all_branches=self.args.all_branches,
                 all_tags=self.args.all_tags,
                 all_commits=self.args.all_commits,
+                hide_queued=self.args.hide_queued,
+                hide_failed=self.args.hide_failed,
                 revs=self.args.rev,
                 num=self.args.num,
                 sha_only=self.args.sha,
@@ -593,6 +592,18 @@ def add_parser(experiments_subparsers, parent_parser):
         action="store_true",
         default=False,
         help="Always show git commit SHAs instead of branch/tag names.",
+    )
+    experiments_show_parser.add_argument(
+        "--hide-failed",
+        action="store_true",
+        default=False,
+        help="Hide failed experiments in the table.",
+    )
+    experiments_show_parser.add_argument(
+        "--hide-queued",
+        action="store_true",
+        default=False,
+        help="Hide queued experiments in the table.",
     )
     experiments_show_parser.add_argument(
         "--json",

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -427,6 +427,8 @@ class Experiments:
                 pass
         if rev in self.stash_revs:
             return self.stash_revs[rev].name
+        if rev in self.celery_queue.failed_stash.stash_revs:
+            return self.celery_queue.failed_stash.stash_revs[rev].name
         return None
 
     def get_running_exps(self, fetch_refs: bool = True) -> Dict[str, Any]:

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -95,6 +95,8 @@ def test_experiments_show(dvc, scm, mocker):
             "--all-tags",
             "--all-branches",
             "--all-commits",
+            "--hide-queued",
+            "--hide-failed",
             "--sha",
             "--param-deps",
             "-n",
@@ -115,6 +117,8 @@ def test_experiments_show(dvc, scm, mocker):
         all_tags=True,
         all_branches=True,
         all_commits=True,
+        hide_queued=True,
+        hide_failed=True,
         num=1,
         revs="foo",
         sha_only=True,
@@ -433,8 +437,7 @@ def test_show_experiments_csv(capsys):
                             }
                         }
                     },
-                    "queued": False,
-                    "running": False,
+                    "status": "Success",
                     "executor": None,
                     "metrics": {
                         "scores.json": {
@@ -470,8 +473,7 @@ def test_show_experiments_csv(capsys):
                             }
                         }
                     },
-                    "queued": False,
-                    "running": False,
+                    "status": "Success",
                     "executor": None,
                     "metrics": {
                         "scores.json": {
@@ -506,8 +508,7 @@ def test_show_experiments_csv(capsys):
                             }
                         }
                     },
-                    "queued": True,
-                    "running": True,
+                    "status": "Running",
                     "executor": None,
                     "metrics": {
                         "scores.json": {
@@ -561,8 +562,7 @@ def test_show_experiments_md(capsys):
                 "data": {
                     "timestamp": None,
                     "params": {"params.yaml": {"data": {"foo": 1}}},
-                    "queued": False,
-                    "running": False,
+                    "status": "Success",
                     "executor": None,
                     "metrics": {
                         "scores.json": {"data": {"bar": 0.9544670443829399}}
@@ -599,8 +599,7 @@ def test_show_experiments_sort_by(capsys, sort_order):
                             }
                         }
                     },
-                    "queued": False,
-                    "running": False,
+                    "status": "Success",
                     "executor": None,
                     "metrics": {},
                 }
@@ -617,8 +616,7 @@ def test_show_experiments_sort_by(capsys, sort_order):
                             }
                         }
                     },
-                    "queued": False,
-                    "running": False,
+                    "status": "Success",
                     "executor": None,
                     "metrics": {},
                     "name": "master",
@@ -634,8 +632,7 @@ def test_show_experiments_sort_by(capsys, sort_order):
                             }
                         }
                     },
-                    "queued": False,
-                    "running": False,
+                    "status": "Success",
                     "executor": None,
                     "metrics": {},
                     "name": "exp-89140",
@@ -651,8 +648,7 @@ def test_show_experiments_sort_by(capsys, sort_order):
                             }
                         }
                     },
-                    "queued": False,
-                    "running": False,
+                    "status": "Success",
                     "executor": None,
                     "metrics": {},
                     "name": "exp-43537",
@@ -668,8 +664,7 @@ def test_show_experiments_sort_by(capsys, sort_order):
                             }
                         }
                     },
-                    "queued": False,
-                    "running": False,
+                    "status": "Success",
                     "executor": None,
                     "metrics": {},
                     "name": "exp-4f89e",
@@ -915,8 +910,7 @@ def test_show_experiments_pcp(tmp_dir, mocker):
                 "data": {
                     "timestamp": None,
                     "params": {"params.yaml": {"data": {"foo": 1}}},
-                    "queued": False,
-                    "running": False,
+                    "status": "Success",
                     "executor": None,
                     "metrics": {
                         "scores.json": {"data": {"bar": 0.9544670443829399}}


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

fix: #7986

1. Add "status" to replace "running" and "queued" in output of `exp show`.
2. Add flags `--hide-queued` and  `--hide-failed` to `exp show`
3. Allow `exp show` to show failed experiments.
4. Add unit test for the failed experiments shown.
5. Add error msg to the `exp show` output

Need a coordinate with VS-CODE extension. @mattseddon 

Example of current output in JSON:
for failed exp
```json
"data": {
    "timestamp": ANY,
    "params": {"params.yaml": {"data": {"foo": 2}}},
    "deps": {"copy.py": {"hash": None, "size": None, "nfiles": None}},
    "outs": {},
    "status": "Failed",
    "executor": None,
    "error": {
        "msg": "ERROR: failed to reproduce 'failed-copy-file': "
        "failed to run: python -c 'import sys; sys.exit(1)', "
        "exited with 1",
        "type": "",
    },
}
```
for other 
```json
"data": {
    "deps": {
        "copy.py": {
            "hash": ANY,
            "size": ANY,
            "nfiles": None,
        }
    },
    "metrics": {},
    "outs": {},
    "params": {"params.yaml": {"data": {"foo": 1}}},
    "status": "Success",
    "executor": None,
    "timestamp": timestamp,
    "name": "master",
    "error": {}, 
}
```

1. ["data"]["error"]["type"] is now only a placeholder. Need to define different types and other info.
2.["data"]["error"]["msg"] will show the last line of the output log.
3. The old ["data"]["running"] and ["data"]["queued"] were obsolete because they will show the wrong status on the failed experiment to the user. 
4.   Current status list in `dvc/repo/experiments/show.py`
```python
class ExpStatus(Enum):
    Success = 0
    Queued = 1
    Running = 2
    Failed = 3
```

[![asciicast](https://asciinema.org/a/6wO7d04mGKxQX3KyiGP6upd3E.svg)](https://asciinema.org/a/6wO7d04mGKxQX3KyiGP6upd3E)