### PR TITLE
push: use update_pipeline=False for cloud versioning

### DIFF
--- a/dvc/repo/push.py
+++ b/dvc/repo/push.py
@@ -50,7 +50,7 @@ def _push_worktree(repo, remote):
             else:
                 out.hash_info = entry.hash_info
                 out.meta = entry.meta
-        stage.dvcfile.dump(stage, with_files=True)
+        stage.dvcfile.dump(stage, with_files=True, update_pipeline=False)
 
     return len(index)
 


### PR DESCRIPTION
Otherwise, you get

```
$ dvc push
ERROR: failed to push data to the cloud - cannot dump a parametrized stage: 'data_split'
```

when trying to dump parametrized stages.