### PR TITLE
repo: add MemoryRepo as an experiment

### DIFF
--- a/tests/unit/repo/test_memory_repo.py
+++ b/tests/unit/repo/test_memory_repo.py
@@ -1,0 +1,25 @@
+import os
+
+from dvc.repo import MemoryRepo
+from dvc.utils.fs import remove
+
+
+def test_memory_repo(tmp_dir, dvc, remote, run_copy):
+    tmp_dir.gen({"data": {"foo": "foo", "bar": "bar"}, "lorem": "lorem"})
+    run_copy("lorem", "ipsum", name="copy-lorem-ipsum", no_exec=True)
+
+    m = MemoryRepo(tmp_dir)
+    m.add("data")
+    m.reproduce()
+
+    # StageCache requires local odb.
+    assert os.listdir(".dvc/cache") == ["runs"]
+    m.push(run_cache=True)
+
+    remove("data")
+    remove(".dvc/cache")
+    m.pull(run_cache=True)
+
+    assert not m.status()
+    assert not m.reproduce()
+    assert os.listdir(".dvc/cache") == ["runs"]


### PR DESCRIPTION
Might be useful in the future for testing, but for now, this is an experiment to play with. :)

Not everything works of course right now. We are not making a distinction between `output.fs` and `odb.fs`, so this may break.