### PR TITLE
Solve the on_diverged function not executed error.

### DIFF
--- a/dvc/repo/experiments/executor/base.py
+++ b/dvc/repo/experiments/executor/base.py
@@ -324,11 +324,12 @@ class BaseExecutor(ABC):
                 logger.debug("Replacing existing experiment '%s'", orig_ref)
                 return True
 
+            if on_diverged:
+                return on_diverged(orig_ref, has_checkpoint)
+
             self._raise_ref_conflict(
                 dest_scm, orig_ref, new_rev, has_checkpoint
             )
-            if on_diverged:
-                on_diverged(orig_ref, has_checkpoint)
             logger.debug("Reproduced existing experiment '%s'", orig_ref)
             return False
 


### PR DESCRIPTION
fix: #8348

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

In previous, 

https://github.com/iterative/dvc/blob/c617769a1d4206bfaf0573e5ae9cac6d7fc6f692/dvc/repo/experiments/__init__.py#L475-L483

`on_diverge` was not executed. After this PR, no more `invalid ref`

[![asciicast](https://asciinema.org/a/UWs1KnJD3QPsnbAukPloosPpr.svg)](https://asciinema.org/a/UWs1KnJD3QPsnbAukPloosPpr)