### PR TITLE
dvcfs tests: copy pytest param instead of in-place update

### DIFF
--- a/dvc/testing/api_tests.py
+++ b/dvc/testing/api_tests.py
@@ -47,6 +47,8 @@ class TestAPI:
         fs_kwargs,
         clear_cache,
     ):
+        fs_kwargs = fs_kwargs.copy()
+
         tmp_dir.scm_gen({"scripts": {"script1": "script1"}}, commit="scripts")
         tmp_dir.dvc_gen({"data": {"foo": "foo", "bar": "bar"}}, commit="data")
         dvc.push()


### PR DESCRIPTION
The param was being modified in-place, due to which successive runs would fail.
Since we use run plugins' tests on multiple processes, our CI did not catch this. If you'd run this with plain `pytest`, it'd fail. Noticed when debugging dvc-webdav tests.