### PR TITLE
repro dry: show information if the stage is cached

### DIFF
--- a/dvc/stage/cache.py
+++ b/dvc/stage/cache.py
@@ -181,7 +181,7 @@ class StageCache:
         dump_yaml(tmp, cache)
         self.repo.odb.local.move(tmp, path)
 
-    def restore(self, stage, run_cache=True, pull=False):
+    def restore(self, stage, run_cache=True, pull=False, dry=False):
         from .serialize import to_single_stage_lockfile
 
         if not _can_hash(stage):
@@ -196,14 +196,15 @@ class StageCache:
         else:
             if not run_cache:  # backward compatibility
                 raise RunCacheNotFoundError(stage)
-            stage.save_deps()
+            if not dry:
+                stage.save_deps()
             cache = self._load(stage)
             if not cache:
                 raise RunCacheNotFoundError(stage)
 
         cached_stage = self._create_stage(cache, wdir=stage.wdir)
 
-        if pull:
+        if pull and not dry:
             for objs in cached_stage.get_used_objs().values():
                 self.repo.cloud.pull(objs)
 
@@ -214,7 +215,8 @@ class StageCache:
             "Stage '%s' is cached - skipping run, checking out outputs",
             stage.addressing,
         )
-        cached_stage.checkout()
+        if not dry:
+            cached_stage.checkout()
 
     def transfer(self, from_odb, to_odb):
         from dvc.fs import HTTPFileSystem, LocalFileSystem

--- a/dvc/stage/run.py
+++ b/dvc/stage/run.py
@@ -139,14 +139,16 @@ def cmd_run(stage, dry=False, checkpoint_func=None, run_env=None):
 def run_stage(
     stage, dry=False, force=False, checkpoint_func=None, run_env=None, **kwargs
 ):
-    if not (dry or force or checkpoint_func):
+    if not (force or checkpoint_func):
         from .cache import RunCacheNotFoundError
 
         try:
-            stage.repo.stage_cache.restore(stage, **kwargs)
-            return
+            stage.repo.stage_cache.restore(stage, dry=dry, **kwargs)
+            if not dry:
+                return
         except RunCacheNotFoundError:
-            stage.save_deps()
+            if not dry:
+                stage.save_deps()
 
     run = cmd_run if dry else unlocked_repo(cmd_run)
     run(stage, dry=dry, checkpoint_func=checkpoint_func, run_env=run_env)

--- a/tests/func/test_run_cache.py
+++ b/tests/func/test_run_cache.py
@@ -33,7 +33,7 @@ def test_restore(tmp_dir, dvc, run_copy, mocker):
 
     (stage,) = dvc.reproduce("copy-foo-bar")
 
-    mock_restore.assert_called_once_with(stage)
+    mock_restore.assert_called_once_with(stage, dry=False)
     mock_run.assert_not_called()
     assert (tmp_dir / "bar").exists() and not (tmp_dir / "foo").unlink()
     assert (tmp_dir / PIPELINE_LOCK).exists()
@@ -100,7 +100,7 @@ def test_memory_for_multiple_runs_of_same_stage(
     assert (tmp_dir / PIPELINE_LOCK).exists()
     assert (tmp_dir / "bar").read_text() == "foobar"
     mock_run.assert_not_called()
-    mock_restore.assert_called_once_with(stage)
+    mock_restore.assert_called_once_with(stage, dry=False)
     mock_restore.reset_mock()
 
     (tmp_dir / PIPELINE_LOCK).unlink()
@@ -109,7 +109,7 @@ def test_memory_for_multiple_runs_of_same_stage(
 
     assert (tmp_dir / "bar").read_text() == "foo"
     mock_run.assert_not_called()
-    mock_restore.assert_called_once_with(stage)
+    mock_restore.assert_called_once_with(stage, dry=False)
     assert (tmp_dir / "bar").exists() and not (tmp_dir / "foo").unlink()
     assert (tmp_dir / PIPELINE_LOCK).exists()
 
@@ -138,7 +138,7 @@ def test_memory_runs_of_multiple_stages(tmp_dir, dvc, run_copy, mocker):
     assert (tmp_dir / "foo.bak").read_text() == "foo"
     assert (tmp_dir / PIPELINE_LOCK).exists()
     mock_run.assert_not_called()
-    mock_restore.assert_called_once_with(stage)
+    mock_restore.assert_called_once_with(stage, dry=False)
     mock_restore.reset_mock()
 
     (stage,) = dvc.reproduce("backup-bar")
@@ -146,7 +146,7 @@ def test_memory_runs_of_multiple_stages(tmp_dir, dvc, run_copy, mocker):
     assert (tmp_dir / "bar.bak").read_text() == "bar"
     assert (tmp_dir / PIPELINE_LOCK).exists()
     mock_run.assert_not_called()
-    mock_restore.assert_called_once_with(stage)
+    mock_restore.assert_called_once_with(stage, dry=False)
 
 
 def test_restore_pull(tmp_dir, dvc, run_copy, mocker, local_remote):
@@ -168,7 +168,7 @@ def test_restore_pull(tmp_dir, dvc, run_copy, mocker, local_remote):
 
     (stage,) = dvc.reproduce("copy-foo-bar", pull=True)
 
-    mock_restore.assert_called_once_with(stage, pull=True)
+    mock_restore.assert_called_once_with(stage, pull=True, dry=False)
     mock_run.assert_not_called()
     assert mock_checkout.call_count == 2
     assert (tmp_dir / "bar").exists() and not (tmp_dir / "foo").unlink()

--- a/tests/unit/stage/test_run.py
+++ b/tests/unit/stage/test_run.py
@@ -13,9 +13,9 @@ from dvc.stage.run import run_stage
         (["mycmd1 arg1", "mycmd2 arg2"], ["> mycmd1 arg1", "> mycmd2 arg2"]),
     ],
 )
-def test_run_stage_dry(caplog, cmd, expected):
+def test_run_stage_dry(caplog, dvc, cmd, expected):
     with caplog.at_level(level=logging.INFO, logger="dvc"):
-        stage = Stage(None, "stage.dvc", cmd=cmd)
+        stage = Stage(dvc, "stage.dvc", cmd=cmd)
         run_stage(stage, dry=True)
 
     expected.insert(0, "Running stage 'stage.dvc':")


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏


Output of script provided by @pared in [https://github.com/iterative/dvc/issues/8342](https://github.com/iterative/dvc/issues/8342)

The output of `dvc repro --dry` is the same as `dvc repro` but without side effects. this way users will know if the stage is cached. 

```
+ pushd /var/folders/2_/8wzmxgd96lz31gp705ghksnr0000gn/T/
/var/folders/2_/8wzmxgd96lz31gp705ghksnr0000gn/T ~/Documents/dvc_test
+ wsp=test_wspace
+ rep=test_repo
+ rm -rf test_wspace
+ mkdir test_wspace
+ pushd test_wspace
/var/folders/2_/8wzmxgd96lz31gp705ghksnr0000gn/T/test_wspace /var/folders/2_/8wzmxgd96lz31gp705ghksnr0000gn/T ~/Documents/dvc_test
++ pwd
+ main=/var/folders/2_/8wzmxgd96lz31gp705ghksnr0000gn/T/test_wspace
+ mkdir test_repo
+ pushd test_repo
/var/folders/2_/8wzmxgd96lz31gp705ghksnr0000gn/T/test_wspace/test_repo /var/folders/2_/8wzmxgd96lz31gp705ghksnr0000gn/T/test_wspace /var/folders/2_/8wzmxgd96lz31gp705ghksnr0000gn/T ~/Documents/dvc_test
++ pwd
+ orig=/var/folders/2_/8wzmxgd96lz31gp705ghksnr0000gn/T/test_wspace/test_repo
+ git init
Initialized empty Git repository in /private/var/folders/2_/8wzmxgd96lz31gp705ghksnr0000gn/T/test_wspace/test_repo/.git/
+ dvc init
Initialized DVC repository.

You can now commit the changes to git.

+---------------------------------------------------------------------+
|                                                                     |
|        DVC has enabled anonymous aggregate usage analytics.         |
|     Read the analytics documentation (and how to opt-out) here:     |
|             <https://dvc.org/doc/user-guide/analytics>              |
|                                                                     |
+---------------------------------------------------------------------+

What's next?
------------
- Check out the documentation: <https://dvc.org/doc>
- Get help and share ideas: <https://dvc.org/chat>
- Star us on GitHub: <https://github.com/iterative/dvc>
+ echo data
+ dvc add data
100% Adding...|██████████████████████████████████████████████████████████████████████████████████|1/1 [00:00, 26.83file/s]

To track the changes with git, run:

        git add data.dvc .gitignore

To enable auto staging, run:

        dvc config core.autostage true
+ dvc run -d data -o out -n train 'cp data out'
Running stage 'train':
> cp data out
Creating 'dvc.yaml'
Adding stage 'train' in 'dvc.yaml'
Generating lock file 'dvc.lock'
Updating lock file 'dvc.lock'

To track the changes with git, run:

        git add dvc.yaml dvc.lock .gitignore

To enable auto staging, run:

        dvc config core.autostage true
+ git add -A
+ git commit -am initial
[main (root-commit) 6db0a26] initial
 7 files changed, 31 insertions(+)
 create mode 100644 .dvc/.gitignore
 create mode 100644 .dvc/config
 create mode 100644 .dvcignore
 create mode 100644 .gitignore
 create mode 100644 data.dvc
 create mode 100644 dvc.lock
 create mode 100644 dvc.yaml
+ popd
/var/folders/2_/8wzmxgd96lz31gp705ghksnr0000gn/T/test_wspace /var/folders/2_/8wzmxgd96lz31gp705ghksnr0000gn/T ~/Documents/dvc_test
+ git clone test_repo new_repo
Cloning into 'new_repo'...
done.
+ pushd new_repo
/var/folders/2_/8wzmxgd96lz31gp705ghksnr0000gn/T/test_wspace/new_repo /var/folders/2_/8wzmxgd96lz31gp705ghksnr0000gn/T/test_wspace /var/folders/2_/8wzmxgd96lz31gp705ghksnr0000gn/T ~/Documents/dvc_test
+ dvc cache dir /var/folders/2_/8wzmxgd96lz31gp705ghksnr0000gn/T/test_wspace/test_repo/.dvc/cache
+ dvc checkout data.dvc
A       data
+ dvc repro --dry
'data.dvc' didn't change, skipping
Stage 'train' is cached - skipping run, checking out outputs
Running stage 'train':
> cp data out
Use `dvc push` to send your updates to remote storage.
+ dvc repro
'data.dvc' didn't change, skipping
Stage 'train' is cached - skipping run, checking out outputs
Use `dvc push` to send your updates to remote storage.

```
