### PR TITLE
exp show: Use batch call on `scm.describe`

### DIFF
--- a/dvc/commands/experiments/ls.py
+++ b/dvc/commands/experiments/ls.py
@@ -16,13 +16,17 @@ class CmdExperimentsList(CmdBase):
             num=self.args.num,
             git_remote=self.args.git_remote,
         )
+        tags = self.repo.scm.describe(exps)
+        remained = {baseline for baseline, tag in tags.items() if tag is None}
+        base = "refs/heads/"
+        ref_heads = self.repo.scm.describe(remained, base=base)
+
         for baseline in exps:
-            tag = self.repo.scm.describe(baseline)
-            if not tag:
-                branch = self.repo.scm.describe(baseline, base="refs/heads")
-                if branch:
-                    tag = branch.split("/")[-1]
-            name = tag if tag else baseline[:7]
+            name = (
+                tags[baseline]
+                or ref_heads[baseline][len(base) :]
+                or baseline[:7]
+            )
             if not name_only:
                 print(f"{name}:")
             for exp_name in exps[baseline]:

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ install_requires =
     rich>=10.13.0
     pyparsing>=2.4.7
     typing-extensions>=3.7.4
-    scmrepo==0.1.1
+    scmrepo==0.1.2
     dvc-render==0.0.12
     dvc-task==0.1.4
     dvclive>=0.10.0

--- a/tests/func/experiments/test_experiments.py
+++ b/tests/func/experiments/test_experiments.py
@@ -38,7 +38,7 @@ def test_new_simple(tmp_dir, scm, dvc, exp_stage, mocker, name, workspace):
         assert (tmp_dir / "metrics.yaml").read_text().strip() == "foo: 2"
 
     exp_name = name if name else ref_info.name
-    assert dvc.experiments.get_exact_name(exp) == exp_name
+    assert dvc.experiments.get_exact_name([exp])[exp] == exp_name
     assert resolve_rev(scm, exp_name) == exp
 
 
@@ -481,7 +481,7 @@ def test_subdir(tmp_dir, scm, dvc, workspace):
     with fs.open("dir/metrics.yaml", mode="r", encoding="utf-8") as fobj:
         assert fobj.read().strip() == "foo: 2"
 
-    assert dvc.experiments.get_exact_name(exp) == ref_info.name
+    assert dvc.experiments.get_exact_name([exp])[exp] == ref_info.name
     assert resolve_rev(scm, ref_info.name) == exp
 
 
@@ -525,7 +525,7 @@ def test_subrepo(tmp_dir, scm, workspace):
     with fs.open("dir/repo/metrics.yaml", mode="r", encoding="utf-8") as fobj:
         assert fobj.read().strip() == "foo: 2"
 
-    assert subrepo.dvc.experiments.get_exact_name(exp) == ref_info.name
+    assert subrepo.dvc.experiments.get_exact_name([exp])[exp] == ref_info.name
     assert resolve_rev(scm, ref_info.name) == exp
 
 

--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -245,7 +245,7 @@ def test_show_checkpoint(
 
     for i, rev in enumerate(checkpoints):
         if i == 0:
-            name = dvc.experiments.get_exact_name(rev)
+            name = dvc.experiments.get_exact_name([rev])[rev]
             name = f"{rev[:7]} [{name}]"
             fs = "╓"
         elif i == len(checkpoints) - 1:


### PR DESCRIPTION
wait for https://github.com/iterative/scmrepo/pull/145 to merge first. 
fix: #8451

nearly five times faster in my local workspace for an `exp show`, no primary time costing method in `exp show` for now.

![image](https://user-images.githubusercontent.com/6745454/196648376-e4a76d30-b717-4f20-92c0-f52128cf65ae.png)



1. Change the call of scm.describe from individual revision to a collection of them. Accelerate the run speed of `exp show`

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
