### PR TITLE
auto solve corrupted rwlock info

### DIFF
--- a/dvc/repo/experiments/queue/base.py
+++ b/dvc/repo/experiments/queue/base.py
@@ -31,7 +31,9 @@ from ..executor.base import (
     EXEC_PID_DIR,
     EXEC_TMP_DIR,
     BaseExecutor,
+    ExecutorInfo,
     ExecutorResult,
+    TaskStatus,
 )
 from ..executor.local import WorkspaceExecutor
 from ..refs import ExpRefInfo
@@ -706,3 +708,57 @@ class BaseStashQueue(ABC):
                 entry.stash_rev,
                 message=f"commit: {msg}",
             )
+
+    def _fetch_running_exp(
+        self, rev: str, infofile: str, fetch_refs: bool
+    ) -> Dict[str, Dict]:
+        from dvc.scm import InvalidRemoteSCMRepo
+        from dvc.utils.serialize import load_json
+
+        from ..executor.local import TempDirExecutor
+
+        result: Dict[str, Dict] = {}
+        try:
+            info = ExecutorInfo.from_dict(load_json(infofile))
+        except OSError:
+            return result
+        if info.status < TaskStatus.FAILED:
+            result[rev] = info.asdict()
+            if (
+                info.git_url
+                and fetch_refs
+                and info.status > TaskStatus.PREPARING
+            ):
+
+                def on_diverged(_ref: str, _checkpoint: bool):
+                    return False
+
+                executor = TempDirExecutor.from_info(info)
+                try:
+                    for ref in executor.fetch_exps(
+                        self.scm,
+                        on_diverged=on_diverged,
+                    ):
+                        logger.debug("Updated running experiment '%s'.", ref)
+                        last_rev = self.scm.get_ref(ref)
+                        result[rev]["last"] = last_rev
+                        if last_rev:
+                            result[last_rev] = info.asdict()
+                except InvalidRemoteSCMRepo:
+                    # ignore stale info files
+                    del result[rev]
+        return result
+
+    def get_running_exps(self, fetch_refs: bool = True) -> Dict[str, Dict]:
+        """Get the execution info of the currently running experiments
+
+        Args:
+            fetch_ref (bool): fetch completed checkpoints or not.
+        """
+        result: Dict[str, Dict] = {}
+        for entry in self.iter_active():
+            infofile = self.get_infofile_path(entry.stash_rev)
+            result.update(
+                self._fetch_running_exp(entry.stash_rev, infofile, fetch_refs)
+            )
+        return result

--- a/dvc/repo/experiments/queue/celery.py
+++ b/dvc/repo/experiments/queue/celery.py
@@ -31,6 +31,7 @@ from ..executor.base import (
 )
 from .base import BaseStashQueue, QueueDoneResult, QueueEntry, QueueGetResult
 from .tasks import run_exp
+from .utils import fetch_running_exp_from_temp_dir
 
 if TYPE_CHECKING:
     from dvc_task.app import FSApp
@@ -373,3 +374,18 @@ class LocalCeleryQueue(BaseStashQueue):
         from .remove import celery_remove
 
         return celery_remove(self, *args, **kwargs)
+
+    def get_running_exps(self, fetch_refs: bool = True) -> Dict[str, Dict]:
+        """Get the execution info of the currently running experiments
+
+        Args:
+            fetch_ref (bool): fetch completed checkpoints or not.
+        """
+        result: Dict[str, Dict] = {}
+        for entry in self.iter_active():
+            result.update(
+                fetch_running_exp_from_temp_dir(
+                    self, entry.stash_rev, fetch_refs
+                )
+            )
+        return result

--- a/dvc/repo/experiments/queue/tempdir.py
+++ b/dvc/repo/experiments/queue/tempdir.py
@@ -15,6 +15,7 @@ from ..executor.base import (
 )
 from ..executor.local import TempDirExecutor
 from .base import BaseStashQueue, QueueEntry, QueueGetResult
+from .utils import fetch_running_exp_from_temp_dir
 from .workspace import WorkspaceQueue
 
 if TYPE_CHECKING:
@@ -100,4 +101,11 @@ class TempDirQueue(WorkspaceQueue):
         return BaseStashQueue.collect_executor(exp, executor, exec_result)
 
     def get_running_exps(self, fetch_refs: bool = True) -> Dict[str, Dict]:
-        return super(WorkspaceQueue, self).get_running_exps(fetch_refs)
+        result: Dict[str, Dict] = {}
+        for entry in self.iter_active():
+            result.update(
+                fetch_running_exp_from_temp_dir(
+                    self, entry.stash_rev, fetch_refs
+                )
+            )
+        return result

--- a/dvc/repo/experiments/queue/tempdir.py
+++ b/dvc/repo/experiments/queue/tempdir.py
@@ -98,3 +98,6 @@ class TempDirQueue(WorkspaceQueue):
         exec_result: ExecutorResult,
     ) -> Dict[str, str]:
         return BaseStashQueue.collect_executor(exp, executor, exec_result)
+
+    def get_running_exps(self, fetch_refs: bool = True) -> Dict[str, Dict]:
+        return super(WorkspaceQueue, self).get_running_exps(fetch_refs)

--- a/dvc/repo/experiments/queue/utils.py
+++ b/dvc/repo/experiments/queue/utils.py
@@ -1,0 +1,58 @@
+import logging
+from typing import TYPE_CHECKING, Dict
+
+from ..executor.base import ExecutorInfo, TaskStatus
+
+logger = logging.getLogger(__name__)
+
+
+if TYPE_CHECKING:
+    from .base import BaseStashQueue
+
+
+def fetch_running_exp_from_temp_dir(
+    queue: "BaseStashQueue", rev: str, fetch_refs: bool
+) -> Dict[str, Dict]:
+    """Fetch status of running exps out of current working directory
+
+    Args:
+        queue (BaseStashQueue):
+        rev (str): stash revision of the experiment
+        fetch_refs (bool): fetch running checkpoint results to local or not.
+
+    Returns:
+        Dict[str, Dict]: _description_
+    """
+    from dvc.scm import InvalidRemoteSCMRepo
+    from dvc.utils.serialize import load_json
+
+    from ..executor.local import TempDirExecutor
+
+    result: Dict[str, Dict] = {}
+    infofile = queue.get_infofile_path(rev)
+    try:
+        info = ExecutorInfo.from_dict(load_json(infofile))
+    except OSError:
+        return result
+    if info.status < TaskStatus.FAILED:
+        result[rev] = info.asdict()
+        if info.git_url and fetch_refs and info.status > TaskStatus.PREPARING:
+
+            def on_diverged(_ref: str, _checkpoint: bool):
+                return False
+
+            executor = TempDirExecutor.from_info(info)
+            try:
+                for ref in executor.fetch_exps(
+                    queue.scm,
+                    on_diverged=on_diverged,
+                ):
+                    logger.debug("Updated running experiment '%s'.", ref)
+                    last_rev = queue.scm.get_ref(ref)
+                    result[rev]["last"] = last_rev
+                    if last_rev:
+                        result[last_rev] = info.asdict()
+            except InvalidRemoteSCMRepo:
+                # ignore stale info files
+                del result[rev]
+    return result

--- a/dvc/repo/experiments/queue/workspace.py
+++ b/dvc/repo/experiments/queue/workspace.py
@@ -157,11 +157,15 @@ class WorkspaceQueue(BaseStashQueue):
         raise NotImplementedError
 
     def get_running_exps(self, fetch_refs: bool = True) -> Dict[str, Dict]:
+        from dvc.rwlock import check_rwlock
         from dvc.utils.serialize import load_json
 
         assert self._EXEC_NAME
-
         result: Dict[str, Dict] = {}
+
+        if not check_rwlock(self.repo.tmp_dir, self.repo.fs, autocorrect=True):
+            return result
+
         infofile = self.get_infofile_path(self._EXEC_NAME)
 
         try:

--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -287,7 +287,9 @@ def show(
         iter_revs(repo.scm, revs, num, all_branches, all_tags, all_commits)
     )
 
-    running = repo.experiments.get_running_exps(fetch_refs=fetch_running)
+    running: Dict[str, Dict] = repo.experiments.get_running_exps(
+        fetch_refs=fetch_running
+    )
 
     queued_experiment = (
         _collect_queued_experiment(

--- a/dvc/rwlock.py
+++ b/dvc/rwlock.py
@@ -1,14 +1,25 @@
 import json
+import logging
 import os
 from collections import defaultdict
 from contextlib import contextmanager
+from typing import TYPE_CHECKING, Dict, List
 
+import psutil
+from funcy import first
 from voluptuous import Invalid, Optional, Required, Schema
 
 from .exceptions import DvcException
 from .fs import localfs
 from .lock import make_lock
 from .utils import relpath
+from .utils.fs import remove
+
+if TYPE_CHECKING:
+    from .fs import FileSystem
+
+logger = logging.getLogger(__name__)
+
 
 INFO_SCHEMA = {Required("pid"): int, Required("cmd"): str}
 
@@ -18,6 +29,9 @@ SCHEMA = Schema(
         Optional("read", default={}): {str: [INFO_SCHEMA]},
     }
 )
+
+RWLOCK_FILE = "rwlock"
+RWLOCK_LOCK = "rwlock.lock"
 
 
 class RWLockFileCorruptedError(DvcException):
@@ -35,10 +49,10 @@ class RWLockFileFormatError(DvcException):
 
 @contextmanager
 def _edit_rwlock(lock_dir, fs, hardlink):
-    path = fs.path.join(lock_dir, "rwlock")
+    path = fs.path.join(lock_dir, RWLOCK_FILE)
 
     rwlock_guard = make_lock(
-        fs.path.join(lock_dir, "rwlock.lock"),
+        fs.path.join(lock_dir, RWLOCK_LOCK),
         tmp_dir=lock_dir,
         hardlink_lock=hardlink,
     )
@@ -176,3 +190,62 @@ def rwlock(tmp_dir, fs, cmd, read, write, hardlink):
         with _edit_rwlock(tmp_dir, fs, hardlink) as lock:
             _release_write(lock, info, wchanges)
             _release_read(lock, info, rchanges)
+
+
+def check_rwlock(
+    tmp_dir: str,
+    fs: "FileSystem",
+    hardlink: bool = False,
+    autocorrect: bool = False,
+) -> bool:
+    """Check and autocorrect the RWLock status for file paths.
+
+    Args:
+        tmp_dir (str): existing directory where to create the rwlock file.
+        fs (FileSystem): fs instance that tmp_dir belongs to.
+        hardlink (bool): use hardlink lock to guard rwlock file when on edit.
+        autocorrect (bool): autocorrect corrupted rwlock file.
+
+    Return:
+        (bool): if the pid alive.
+    """
+    path = fs.path.join(tmp_dir, RWLOCK_FILE)
+
+    rwlock_guard = make_lock(
+        fs.path.join(tmp_dir, RWLOCK_LOCK),
+        tmp_dir=tmp_dir,
+        hardlink_lock=hardlink,
+    )
+    with rwlock_guard:
+        try:
+            with fs.open(path, encoding="utf-8") as fobj:
+                lock: Dict[str, List[Dict]] = SCHEMA(json.load(fobj))
+            file_path = first(lock["read"])
+            if not file_path:
+                return False
+            lock_info = first(lock["read"][file_path])
+            pid = int(lock_info["pid"])
+            if psutil.pid_exists(pid):
+                return True
+            cmd = lock_info["cmd"]
+            logger.warning(
+                "Process '%s' with (Pid %s), in RWLock-file '%s'"
+                " had been killed.",
+                cmd,
+                pid,
+                relpath(path),
+            )
+        except FileNotFoundError:
+            return False
+        except json.JSONDecodeError:
+            logger.warning(
+                "Unable to read RWLock-file '%s'. JSON structure is"
+                " corrupted",
+                relpath(path),
+            )
+        except Invalid:
+            logger.warning("RWLock-file '%s' format error.", relpath(path))
+        if autocorrect:
+            logger.warning("Delete corrupted RWLock-file '%s'", relpath(path))
+            remove(path)
+        return False

--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -524,13 +524,13 @@ def test_show_running_tempdir(tmp_dir, scm, dvc, exp_stage, mocker):
     (tmp_dir / pidfile).dump_json(info.asdict())
     mock_fetch = mocker.patch.object(
         dvc.experiments.tempdir_queue,
-        "_fetch_running_exp",
+        "get_running_exps",
         return_value={exp_rev: info.asdict()},
     )
 
     results = dvc.experiments.show()
     mock_fetch.assert_has_calls(
-        [mocker.call(stash_rev, pidfile, True)],
+        [mocker.call(True)],
     )
     exp_data = get_in(results, [baseline_rev, exp_rev, "data"])
     assert exp_data["status"] == "Running"

--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -487,7 +487,7 @@ def test_show_running_tempdir(tmp_dir, scm, dvc, exp_stage, mocker):
     makedirs(os.path.dirname(pidfile), True)
     (tmp_dir / pidfile).dump_json(info.asdict())
     mock_fetch = mocker.patch.object(
-        dvc.experiments,
+        dvc.experiments.tempdir_queue,
         "_fetch_running_exp",
         return_value={exp_rev: info.asdict()},
     )


### PR DESCRIPTION
fix: #8450

1. Add a new function check_rwlock to check and autocorrect rwlock info.
2. `dvc exp show` will check pid info.
3. Add related tests for it.



* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
