### PR TITLE
metrics: Use "metrics.json" as DEFAULT_METRICS_FILE.

### DIFF
--- a/dvc/repo/metrics/show.py
+++ b/dvc/repo/metrics/show.py
@@ -17,6 +17,9 @@ from dvc.utils.serialize import load_path
 logger = logging.getLogger(__name__)
 
 
+DEFAULT_METRICS_FILE = "metrics.json"
+
+
 def _is_metric(out: Output) -> bool:
     return bool(out.metric) or bool(out.live)
 
@@ -41,6 +44,13 @@ def _collect_metrics(repo, targets, revision, recursive):
         recursive=recursive,
         rev=revision,
     )
+    if not targets:
+        default_metrics = repo.fs.path.join(
+            repo.root_dir, DEFAULT_METRICS_FILE
+        )
+        if default_metrics not in fs_paths and repo.fs.exists(default_metrics):
+            fs_paths.append(repo.dvcfs.from_os_path(default_metrics))
+
     return _to_fs_paths(metrics) + list(fs_paths)
 
 

--- a/tests/func/metrics/test_show.py
+++ b/tests/func/metrics/test_show.py
@@ -11,6 +11,16 @@ from dvc.utils.fs import remove
 from dvc.utils.serialize import JSONFileCorruptedError, YAMLFileCorruptedError
 
 
+def test_show_default_file(tmp_dir, dvc):
+    from dvc.repo.metrics.show import DEFAULT_METRICS_FILE
+
+    default_file = tmp_dir / DEFAULT_METRICS_FILE
+    default_file.dump({"foo": 1.0})
+    assert dvc.metrics.show() == {
+        "": {"data": {DEFAULT_METRICS_FILE: {"data": {"foo": 1.0}}}}
+    }
+
+
 def test_show_simple(tmp_dir, dvc, run_copy_metrics):
     tmp_dir.gen("metrics_t.yaml", "1.1")
     run_copy_metrics(


### PR DESCRIPTION
Closes #6168
