### PR TITLE
ci: push package to test.pypi.org

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -77,21 +77,29 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.8
-        cache: pip
-        cache-dependency-path: pyproject.toml
 
     - name: Install
-      run: |
-        pip install -U wheel pip build setuptools
-        pip install ".[all,tests]"
+      run: pip install -U wheel pip build setuptools_scm
+
+    - name: Force version for Test PyPI uploads
+      if: ${{ !startsWith(github.ref, 'refs/tags') }}
+      run: echo version=$(python -m setuptools_scm | awk -F+ '{print $1}' | tail -1) >> $GITHUB_ENV
 
     - name: Build packages
-      run: |
-        pip install -U pip
-        ./scripts/build_package.sh
+      run: ./scripts/build_package.sh
+      env:
+        SETUPTOOLS_SCM_PRETEND_VERSION: ${{ env.version }}
 
     - name: Publish packages to PyPI
       if: github.event_name == 'release'
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_TOKEN }}
+
+    - name: Publish to Test PyPI
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.TEST_PYPI_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+        skip_existing: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
     "collaboration",
     "ai",
 ]
-license = { file = "LICENSE" }
+license = { text = "Apache License 2.0" }
 authors = [{ name = "Dmitry Petrov", email = "dmitry@dvc.org" }]
 maintainers = [{ name = "Iterative", email = "support@dvc.org" }]
 requires-python = ">=3.8"
@@ -131,9 +131,10 @@ dvc = "dvc.api:DVCFileSystem"
 
 [tool.setuptools]
 zip-safe = false
+license-files = ["LICENSE"]
 
 [tool.setuptools.packages.find]
-exclude = ["dvc.testing", "dvc.testing.*", "tests", "tests.*"]
+exclude = ["tests", "tests.*"]
 
 [tool.setuptools_scm]
 write_to = "dvc/_dvc_version.py"

--- a/scripts/build_package.sh
+++ b/scripts/build_package.sh
@@ -10,5 +10,5 @@ fi
 
 echo 'PKG = "pip"' >dvc/utils/build.py
 
-python -m pip install -U build setuptools>=58.2
-python -m build --sdist --wheel --outdir dist/
+python -m pip install -U build setuptools>=61
+python -m build


### PR DESCRIPTION
Will help us test package uploads, etc.

Users will be able to install `dvc` as follows:
```console
python3 -m pip install \
    --index-url https://test.pypi.org/simple/ \
    --extra-index-url https://pypi.org/simple/ \
    dvc
```

The version number will be `x.x.y.devN` where `n` is distance (in term of commits) from last git tag, and `y` is `+1` from last tag. If the version is same as tag, it won't have the latter part. Eg: latest upload may be `2.22.3.dev9`.

As a test, I uploaded https://test.pypi.org/project/dvc/2.33.2.dev10/ via GHA.