### PR TITLE
remove zip-safe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,6 @@ dvc = "dvc.cli:main"
 dvc = "dvc.api:DVCFileSystem"
 
 [tool.setuptools]
-zip-safe = false
 license-files = ["LICENSE"]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
See https://setuptools.pypa.io/en/latest/deprecated/zip_safe.html. `zip_safe` is not required these days.

* [ ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
