### PR TITLE
ci: run only single macOS job

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -76,6 +76,14 @@ jobs:
       with:
         file: ./coverage.xml
         fail_ci_if_error: false
+  check:
+    if: always()
+    needs: [lint, tests]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
   notify:
     if: github.ref == 'refs/heads/main' && failure()
     needs: [lint, tests]

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,13 +45,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-latest, macos-latest]
+        os: [ubuntu-20.04, windows-latest]
         pyv: ["3.8", "3.9", "3.10"]
         pytest-filter:
         - "import or plot or live or experiment"
         - "not (import or plot or live or experiment)"
         include:
-        - {os: ubuntu-latest, pyv: "3.11-dev"}
+        - {os: ubuntu-latest, pyv: "3.11"}
+        - {os: macos-latest, pyv: "3.8"}
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
`macOS` runners` are very slow to provision.