### PR TITLE
Add locks to all experiments related operations.

### DIFF
--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -28,11 +28,12 @@ from .refs import (
     EXEC_CHECKPOINT,
     EXEC_NAMESPACE,
     EXPS_NAMESPACE,
+    STASHES,
     WORKSPACE_STASH,
     ExpRefInfo,
 )
 from .stash import ExpStashEntry
-from .utils import exp_refs_by_rev, scm_locked, unlocked_repo
+from .utils import exp_refs_by_rev, exp_rwlocked, unlocked_repo
 
 logger = logging.getLogger(__name__)
 
@@ -50,18 +51,12 @@ class Experiments:
     )
 
     def __init__(self, repo):
-        from dvc.lock import make_lock
         from dvc.scm import NoSCMError
 
         if repo.config["core"].get("no_scm", False):
             raise NoSCMError
 
         self.repo = repo
-        self.scm_lock = make_lock(
-            os.path.join(self.repo.tmp_dir, "exp_scm_lock"),
-            tmp_dir=self.repo.tmp_dir,
-            hardlink_lock=repo.config["core"].get("hardlink_lock", False),
-        )
 
     @property
     def scm(self):
@@ -239,7 +234,7 @@ class Experiments:
         if self.scm.get_ref(str(exp_ref)):
             raise ExperimentExistsError(exp_ref.name)
 
-    @scm_locked
+    @exp_rwlocked(writes=list(STASHES))
     def new(
         self,
         queue: BaseStashQueue,

--- a/dvc/repo/experiments/branch.py
+++ b/dvc/repo/experiments/branch.py
@@ -1,18 +1,24 @@
 import logging
 
+from funcy import retry
+
 from dvc.exceptions import InvalidArgumentError
+from dvc.lock import LockError
 from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
 from dvc.scm import RevError
 
 from .exceptions import InvalidExpRevError
-from .utils import exp_refs_by_rev
+from .refs import COMPLETE_NAMESPACE
+from .utils import exp_refs_by_rev, exp_rwlocked
 
 logger = logging.getLogger(__name__)
 
 
 @locked
 @scm_context
+@retry(3, errors=LockError, timeout=0.5)
+@exp_rwlocked(writes=[COMPLETE_NAMESPACE])
 def branch(repo, exp_rev, branch_name, *args, **kwargs):
     from dvc.scm import resolve_rev
 

--- a/dvc/repo/experiments/diff.py
+++ b/dvc/repo/experiments/diff.py
@@ -1,11 +1,19 @@
 import logging
 
+from funcy import retry
+
+from dvc.lock import LockError
 from dvc.utils.diff import diff as _diff
 from dvc.utils.diff import format_dict
+
+from .refs import COMPLETE_NAMESPACE
+from .utils import exp_rwlocked
 
 logger = logging.getLogger(__name__)
 
 
+@retry(3, errors=LockError, timeout=0.5)
+@exp_rwlocked(reads=[COMPLETE_NAMESPACE])
 def diff(repo, *args, a_rev=None, b_rev=None, param_deps=False, **kwargs):
     from dvc.repo.experiments.show import _collect_experiment_commit
     from dvc.scm import resolve_rev

--- a/dvc/repo/experiments/executor/base.py
+++ b/dvc/repo/experiments/executor/base.py
@@ -58,10 +58,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-EXEC_TMP_DIR = "exps"
-EXEC_PID_DIR = "run"
-
-
 class ExecutorResult(NamedTuple):
     exp_hash: Optional[str]
     ref_info: Optional["ExpRefInfo"]

--- a/dvc/repo/experiments/executor/local.py
+++ b/dvc/repo/experiments/executor/local.py
@@ -19,7 +19,8 @@ from ..refs import (
     EXEC_MERGE,
     EXEC_NAMESPACE,
 )
-from .base import EXEC_TMP_DIR, BaseExecutor, TaskStatus
+from ..utils import EXEC_TMP_DIR
+from .base import BaseExecutor, TaskStatus
 
 if TYPE_CHECKING:
     from scmrepo.git import Git

--- a/dvc/repo/experiments/gc.py
+++ b/dvc/repo/experiments/gc.py
@@ -1,14 +1,20 @@
 import logging
 from typing import Optional
 
+from funcy import retry
+
+from dvc.lock import LockError
 from dvc.repo import locked
 
-from .utils import exp_refs, remove_exp_refs
+from .refs import COMPLETE_NAMESPACE, STASHES
+from .utils import exp_refs, exp_rwlocked, remove_exp_refs
 
 logger = logging.getLogger(__name__)
 
 
 @locked
+@retry(3, errors=LockError, timeout=0.5)
+@exp_rwlocked(writes=[COMPLETE_NAMESPACE] + list(STASHES))
 def gc(
     repo,
     all_branches: Optional[bool] = False,

--- a/dvc/repo/experiments/ls.py
+++ b/dvc/repo/experiments/ls.py
@@ -1,18 +1,24 @@
 import logging
 from collections import defaultdict
 
+from funcy import retry
+
+from dvc.lock import LockError
 from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
 from dvc.scm import iter_revs
 from dvc.types import Optional
 
-from .utils import exp_refs, exp_refs_by_baseline
+from .refs import COMPLETE_NAMESPACE
+from .utils import exp_refs, exp_refs_by_baseline, exp_rwlocked
 
 logger = logging.getLogger(__name__)
 
 
 @locked
 @scm_context
+@retry(3, errors=LockError, timeout=0.5)
+@exp_rwlocked(reads=[COMPLETE_NAMESPACE])
 def ls(
     repo,
     rev: Optional[str] = None,

--- a/dvc/repo/experiments/push.py
+++ b/dvc/repo/experiments/push.py
@@ -1,19 +1,30 @@
 import logging
-from typing import Iterable, List, Mapping, Optional, Set, Union
+from typing import TYPE_CHECKING, Iterable, List, Mapping, Optional, Set, Union
 
-from funcy import group_by
+from funcy import group_by, retry
 from scmrepo.git.backend.base import SyncStatus
 
+from dvc.lock import LockError
 from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
 from dvc.scm import TqdmGit, iter_revs
 from dvc.ui import ui
 
 from .exceptions import UnresolvedExpNamesError
-from .refs import ExpRefInfo
-from .utils import exp_commits, exp_refs, exp_refs_by_baseline, resolve_name
+from .refs import COMPLETE_NAMESPACE, ExpRefInfo
+from .utils import (
+    exp_commits,
+    exp_refs,
+    exp_refs_by_baseline,
+    exp_rwlocked,
+    resolve_name,
+)
 
 logger = logging.getLogger(__name__)
+
+
+if TYPE_CHECKING:
+    from dvc.repo import Repo
 
 
 @locked
@@ -29,35 +40,15 @@ def push(
     push_cache: bool = False,
     **kwargs,
 ) -> Iterable[str]:
-
-    exp_ref_set: Set["ExpRefInfo"] = set()
-    if all_commits:
-        exp_ref_set.update(exp_refs(repo.scm))
-
-    else:
-        if exp_names:
-            if isinstance(exp_names, str):
-                exp_names = [exp_names]
-            exp_ref_dict = resolve_name(repo.scm, exp_names)
-
-            unresolved_exp_names = []
-            for exp_name, exp_ref in exp_ref_dict.items():
-                if exp_ref is None:
-                    unresolved_exp_names.append(exp_name)
-                else:
-                    exp_ref_set.add(exp_ref)
-
-            if unresolved_exp_names:
-                raise UnresolvedExpNamesError(unresolved_exp_names)
-
-        if rev:
-            rev_dict = iter_revs(repo.scm, [rev], num)
-            rev_set = set(rev_dict.keys())
-            ref_info_dict = exp_refs_by_baseline(repo.scm, rev_set)
-            for _, ref_info_list in ref_info_dict.items():
-                exp_ref_set.update(ref_info_list)
-
-    push_result = _push(repo, git_remote, exp_ref_set, force)
+    push_result = _push_git_ref(
+        repo,
+        git_remote,
+        exp_names,
+        all_commits=all_commits,
+        rev=rev,
+        num=num,
+        force=force,
+    )
     if push_result[SyncStatus.DIVERGED]:
         diverged_refs = [ref.name for ref in push_result[SyncStatus.DIVERGED]]
         ui.warn(
@@ -106,6 +97,57 @@ def _push(
     )
 
     return pull_result
+
+
+def _find_exp_refs(
+    repo: "Repo",
+    exp_names: Union[Iterable[str], str],
+    all_commits=False,
+    rev: Optional[str] = None,
+    num=1,
+) -> Set["ExpRefInfo"]:
+    exp_ref_set: Set["ExpRefInfo"] = set()
+    if all_commits:
+        exp_ref_set.update(exp_refs(repo.scm))
+
+    else:
+        if exp_names:
+            if isinstance(exp_names, str):
+                exp_names = [exp_names]
+            exp_ref_dict = resolve_name(repo.scm, exp_names)
+
+            unresolved_exp_names = []
+            for exp_name, exp_ref in exp_ref_dict.items():
+                if exp_ref is None:
+                    unresolved_exp_names.append(exp_name)
+                else:
+                    exp_ref_set.add(exp_ref)
+
+            if unresolved_exp_names:
+                raise UnresolvedExpNamesError(unresolved_exp_names)
+
+        if rev:
+            rev_dict = iter_revs(repo.scm, [rev], num)
+            rev_set = set(rev_dict.keys())
+            ref_info_dict = exp_refs_by_baseline(repo.scm, rev_set)
+            for _, ref_info_list in ref_info_dict.items():
+                exp_ref_set.update(ref_info_list)
+    return exp_ref_set
+
+
+@retry(3, errors=LockError, timeout=0.5)
+@exp_rwlocked(reads=[COMPLETE_NAMESPACE])
+def _push_git_ref(
+    repo: "Repo",
+    git_remote: str,
+    exp_names: Union[Iterable[str], str],
+    all_commits=False,
+    rev: Optional[str] = None,
+    num=1,
+    force: bool = False,
+):
+    exp_ref_set = _find_exp_refs(repo, exp_names, all_commits, rev, num)
+    return _push(repo, git_remote, exp_ref_set, force)
 
 
 def _push_cache(

--- a/dvc/repo/experiments/queue/base.py
+++ b/dvc/repo/experiments/queue/base.py
@@ -29,7 +29,7 @@ from dvc.ui import ui
 from ..exceptions import CheckpointExistsError, ExperimentExistsError
 from ..executor.base import BaseExecutor, ExecutorResult
 from ..executor.local import WorkspaceExecutor
-from ..refs import EXEC_NAMESPACE, EXPS_NAMESPACE, STASHES, ExpRefInfo
+from ..refs import COMPLETE_NAMESPACE, EXEC_NAMESPACE, STASHES, ExpRefInfo
 from ..stash import ExpStash, ExpStashEntry
 from ..utils import EXEC_PID_DIR, EXEC_TMP_DIR, exp_refs_by_rev, exp_rwlocked
 
@@ -620,7 +620,7 @@ class BaseStashQueue(ABC):
 
     @staticmethod
     @retry(180, errors=LockError, timeout=1)
-    @exp_rwlocked(writes=[EXPS_NAMESPACE])
+    @exp_rwlocked(writes=[COMPLETE_NAMESPACE])
     def collect_git(
         exp: "Experiments",
         executor: BaseExecutor,

--- a/dvc/repo/experiments/queue/celery.py
+++ b/dvc/repo/experiments/queue/celery.py
@@ -23,12 +23,8 @@ from dvc.exceptions import DvcException
 from dvc.ui import ui
 
 from ..exceptions import UnresolvedQueueExpNamesError
-from ..executor.base import (
-    EXEC_TMP_DIR,
-    ExecutorInfo,
-    ExecutorResult,
-    TaskStatus,
-)
+from ..executor.base import ExecutorInfo, ExecutorResult, TaskStatus
+from ..utils import EXEC_TMP_DIR
 from .base import BaseStashQueue, QueueDoneResult, QueueEntry, QueueGetResult
 from .tasks import run_exp
 from .utils import fetch_running_exp_from_temp_dir

--- a/dvc/repo/experiments/queue/tasks.py
+++ b/dvc/repo/experiments/queue/tasks.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import TYPE_CHECKING, Any, Dict
 
 from celery import shared_task
 from celery.utils.log import get_task_logger
@@ -7,11 +7,15 @@ from ..executor.base import ExecutorInfo
 from ..executor.local import TempDirExecutor
 from .base import BaseStashQueue, QueueEntry
 
+if TYPE_CHECKING:
+    from ..executor.base import BaseExecutor
+
+
 logger = get_task_logger(__name__)
 
 
 @shared_task
-def setup_exp(entry_dict: Dict[str, Any]) -> TempDirExecutor:
+def setup_exp(entry_dict: Dict[str, Any]) -> "BaseExecutor":
     """Setup an experiment.
 
     Arguments:

--- a/dvc/repo/experiments/queue/tempdir.py
+++ b/dvc/repo/experiments/queue/tempdir.py
@@ -6,14 +6,13 @@ from funcy import cached_property, first
 
 from ..exceptions import ExpQueueEmptyError
 from ..executor.base import (
-    EXEC_PID_DIR,
-    EXEC_TMP_DIR,
     BaseExecutor,
     ExecutorInfo,
     ExecutorResult,
     TaskStatus,
 )
 from ..executor.local import TempDirExecutor
+from ..utils import EXEC_PID_DIR, EXEC_TMP_DIR
 from .base import BaseStashQueue, QueueEntry, QueueGetResult
 from .utils import fetch_running_exp_from_temp_dir
 from .workspace import WorkspaceQueue

--- a/dvc/repo/experiments/refs.py
+++ b/dvc/repo/experiments/refs.py
@@ -5,6 +5,7 @@ from .exceptions import InvalidExpRefError
 # Experiment refs are stored according baseline git SHA:
 #   refs/exps/01/234abcd.../<exp_name>
 EXPS_NAMESPACE = "refs/exps"
+COMPLETE_NAMESPACE = f"{EXPS_NAMESPACE}/complete"  # used for rwlock
 EXPS_STASH = f"{EXPS_NAMESPACE}/stash"
 WORKSPACE_STASH = EXPS_STASH
 CELERY_STASH = f"{EXPS_NAMESPACE}/celery/stash"

--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -8,15 +8,17 @@ from funcy import first, get_in
 
 from dvc.cli import main
 from dvc.repo.experiments.executor.base import (
-    EXEC_PID_DIR,
-    EXEC_TMP_DIR,
     BaseExecutor,
     ExecutorInfo,
     TaskStatus,
 )
 from dvc.repo.experiments.queue.base import QueueEntry
 from dvc.repo.experiments.refs import CELERY_STASH, ExpRefInfo
-from dvc.repo.experiments.utils import exp_refs_by_rev
+from dvc.repo.experiments.utils import (
+    EXEC_PID_DIR,
+    EXEC_TMP_DIR,
+    exp_refs_by_rev,
+)
 from dvc.utils import relpath
 from dvc.utils.fs import makedirs
 from dvc.utils.serialize import YAMLFileCorruptedError


### PR DESCRIPTION
fix #8448

1. Make a more granular control on `exp lock`.
2. Make error message compatible with other path.
3. Add rwlock to all experiment operations.
4. Add retry to exp rwlock.

I didn't add precise locks to every single experiments like what we do on the output and dependency side. This is because only after we do not know what experiments are now in our workspace before we do operations on them. 

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
