### PR TITLE
build: bump pyinstaller packages python version to 3.10

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -29,10 +29,10 @@ jobs:
       with:
           fetch-depth: 0
 
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.10
         cache: pip
         cache-dependency-path: |
           pyproject.toml


### PR DESCRIPTION
As 3.11 is now released, let's bump pyinstaller packages to 3.10 (we always keep them 1 version behind).

Note that pyinstaller already supports 3.11 since v5.5.
