### PR TITLE
api: add metrics_show()

### DIFF
--- a/dvc/api/__init__.py
+++ b/dvc/api/__init__.py
@@ -3,6 +3,7 @@ from dvc.fs.dvc import _DVCFileSystem as DVCFileSystem
 from .data import open  # pylint: disable=redefined-builtin
 from .data import get_url, read
 from .experiments import make_checkpoint
+from .metrics import metrics_show
 from .params import params_show
 
 __all__ = [
@@ -10,6 +11,7 @@ __all__ = [
     "make_checkpoint",
     "open",
     "params_show",
+    "metrics_show",
     "read",
     "DVCFileSystem",
 ]

--- a/dvc/api/__init__.py
+++ b/dvc/api/__init__.py
@@ -3,8 +3,10 @@ from dvc.fs.dvc import _DVCFileSystem as DVCFileSystem
 from .data import open  # pylint: disable=redefined-builtin
 from .data import get_url, read
 from .experiments import make_checkpoint
-from .metrics import metrics_show
-from .params import params_show
+
+# from .metrics import metrics_show
+# from .params import params_show
+from .show import metrics_show, params_show
 
 __all__ = [
     "get_url",

--- a/dvc/api/metrics.py
+++ b/dvc/api/metrics.py
@@ -1,14 +1,16 @@
 from collections import Counter
 from typing import Dict, Optional
 
-from funcy import first
-
 from dvc.exceptions import DvcException
 from dvc.repo import Repo
 
 
 def metrics_show(
     *targets: str,
+    all_branches: Optional[bool] = False,
+    all_tags: Optional[bool] = False,
+    all_commits: Optional[bool] = False,
+    recursive: Optional[bool] = False,
     repo: Optional[str] = None,
     rev: Optional[str] = None,
 ) -> Dict:
@@ -25,6 +27,15 @@ def metrics_show(
         If no `targets` are provided, all metric files tracked in `dvc.yaml`
         will be used.
         Note that targets don't necessarily have to be defined in `dvc.yaml`.
+        all_branches (bool, optional): Whether to show for all repo branches
+            or not.
+            Defaults to `False`.
+        all_tags (bool, optional): Whether to show for all repo tags or not.
+            Defaults to `False`.
+        all_commits (bool, optional): Whether to show for all commits or not.
+            Defaults to `False`.
+        recursive (bool, optional): Whether to recurse directories or not.
+            Defaults to `False`.
         repo (str, optional): Location of the DVC repository.
             Defaults to the current project (found by walking up from the
             current working directory tree).
@@ -129,18 +140,19 @@ def metrics_show(
                 }
                 processed[rev] = {**processed[rev], **to_merge}
 
-        if "workspace" in processed:
-            del processed["workspace"]
-
         if not processed:
             raise DvcException("No metrics found")
 
-        return processed[first(processed)]
+        return processed
 
     with Repo.open(repo) as _repo:
         metrics = _repo.metrics.show(
             targets=targets,
+            all_branches=all_branches,
+            all_tags=all_tags,
+            recursive=recursive,
             revs=rev if rev is None else [rev],
+            all_commits=all_commits,
             onerror=_onerror_raise,
         )
 

--- a/dvc/api/metrics.py
+++ b/dvc/api/metrics.py
@@ -9,14 +9,105 @@ from dvc.repo import Repo
 
 def metrics_show(
     *targets: str,
-    all_branches: Optional[bool] = False,
-    all_tags: Optional[bool] = False,
-    all_commits: Optional[bool] = False,
-    recursive: Optional[bool] = False,
     repo: Optional[str] = None,
     rev: Optional[str] = None,
 ) -> Dict:
-    """Get metrics tracked in `repo`"""
+    """Get metrics tracked in `repo`.
+
+    Without arguments, this function will retrieve all metrics from all tracked
+    metric files, for the current working tree.
+
+    See the options below to restrict the metrics retrieved.
+
+    Args:
+        *targets (str, optional): Names of the metric files to retrieve
+        params from. For example, "classifier_eval.json, clustering_eval.json".
+        If no `targets` are provided, all metric files tracked in `dvc.yaml`
+        will be used.
+        Note that targets don't necessarily have to be defined in `dvc.yaml`.
+        repo (str, optional): Location of the DVC repository.
+            Defaults to the current project (found by walking up from the
+            current working directory tree).
+            It can be a URL or a file system path.
+            Both HTTP and SSH protocols are supported for online Git repos
+            (e.g. [user@]server:project.git).
+        rev (str, optional): Name of the `Git revision`_ to retrieve metrics
+            from.
+            Defaults to `None`.
+            An example of git revision can be a branch or tag name, a commit
+            hash or a dvc experiment name.
+            If `repo` is not a Git repo, this option is ignored.
+            If `None`, the current working tree will be used.
+
+    Returns:
+        Dict: See Examples below.
+
+    Raises:
+        DvcException: If no params are found in `repo`.
+
+    Examples:
+
+        - No arguments.
+
+        Working on https://github.com/iterative/example-get-started
+
+        >>> import dvc.api
+        >>> metrics = dvc.api.metrics_show()
+        >>> print(json.dumps(metrics, indent=4))
+        {
+            "avg_prec": 0.9249974999612706,
+            "roc_auc": 0.9460213440787918
+        }
+
+        ---
+
+        - Using `rev`.
+
+        Working on https://github.com/iterative/example-get-started
+
+        >>> import json
+        >>> import dvc.api
+        >>> metrics = dvc.api.metrics_show(rev="tune-hyperparams")
+        >>> print(json.dumps(metrics, indent=4))
+        {
+            "avg_prec": 0.9268792615819422,
+            "roc_auc": 0.945093365854111
+        }
+
+        ---
+
+        - Using `targets`.
+
+        Working on https://github.com/iterative/example-get-started
+
+        >>> import json
+        >>> import dvc.api
+        >>> metrics = dvc.api.metrics_show("evaluation.json")
+        >>> print(json.dumps(metrics, indent=4))
+        {
+            "avg_prec": 0.9249974999612706,
+            "roc_auc": 0.9460213440787918
+        }
+
+        ---
+
+        - Git URL as `repo`.
+
+        >>> import json
+        >>> import dvc.api
+        >>> metrics = dvc.api.metrics_show(
+        ...     repo="https://github.com/iterative/demo-fashion-mnist")
+        >>> print(json.dumps(metrics, indent=4))
+        {
+            "loss": 0.25284987688064575,
+            "accuracy": 0.9071000218391418
+        }
+
+
+    .. _Git revision:
+        https://git-scm.com/docs/revisions
+
+    """
 
     def _onerror_raise(result: Dict, exception: Exception, *args, **kwargs):
         raise exception
@@ -49,11 +140,7 @@ def metrics_show(
     with Repo.open(repo) as _repo:
         metrics = _repo.metrics.show(
             targets=targets,
-            all_branches=all_branches,
-            all_tags=all_tags,
-            recursive=recursive,
             revs=rev if rev is None else [rev],
-            all_commits=all_commits,
             onerror=_onerror_raise,
         )
 

--- a/dvc/api/metrics.py
+++ b/dvc/api/metrics.py
@@ -56,5 +56,5 @@ def metrics_show(
             all_commits=all_commits,
             onerror=_onerror_raise,
         )
-    print(metrics)
+
     return _postprocess(metrics)

--- a/dvc/api/metrics.py
+++ b/dvc/api/metrics.py
@@ -23,7 +23,8 @@ def metrics_show(
 
     Args:
         *targets (str, optional): Names of the metric files to retrieve
-        params from. For example, "classifier_eval.json, clustering_eval.json".
+        metrics from. For example, "classifier_eval.json,
+        clustering_eval.json".
         If no `targets` are provided, all metric files tracked in `dvc.yaml`
         will be used.
         Note that targets don't necessarily have to be defined in `dvc.yaml`.
@@ -54,7 +55,7 @@ def metrics_show(
         Dict: See Examples below.
 
     Raises:
-        DvcException: If no params are found in `repo`.
+        DvcException: If no metrics are found in `repo`.
 
     Examples:
 
@@ -117,7 +118,6 @@ def metrics_show(
 
     .. _Git revision:
         https://git-scm.com/docs/revisions
-
     """
 
     def _onerror_raise(result: Dict, exception: Exception, *args, **kwargs):

--- a/dvc/api/metrics.py
+++ b/dvc/api/metrics.py
@@ -1,0 +1,60 @@
+from collections import Counter
+from typing import Dict, Optional
+
+from funcy import first
+
+from dvc.exceptions import DvcException
+from dvc.repo import Repo
+
+
+def metrics_show(
+    *targets: str,
+    all_branches: Optional[bool] = False,
+    all_tags: Optional[bool] = False,
+    all_commits: Optional[bool] = False,
+    recursive: Optional[bool] = False,
+    repo: Optional[str] = None,
+    rev: Optional[str] = None,
+) -> Dict:
+    """Get metrics tracked in `repo`"""
+
+    def _onerror_raise(result: Dict, exception: Exception, *args, **kwargs):
+        raise exception
+
+    def _postprocess(metrics):
+        processed = {}
+        for rev, rev_data in metrics.items():
+            processed[rev] = {}
+
+            counts = Counter()
+            for file_data in rev_data["data"].values():
+                for k in file_data["data"]:
+                    counts[k] += 1
+
+            for file_name, file_data in rev_data["data"].items():
+                to_merge = {
+                    (k if counts[k] == 1 else f"{file_name}:{k}"): v
+                    for k, v in file_data["data"].items()
+                }
+                processed[rev] = {**processed[rev], **to_merge}
+
+        if "workspace" in processed:
+            del processed["workspace"]
+
+        if not processed:
+            raise DvcException("No metrics found")
+
+        return processed[first(processed)]
+
+    with Repo.open(repo) as _repo:
+        metrics = _repo.metrics.show(
+            targets=targets,
+            all_branches=all_branches,
+            all_tags=all_tags,
+            recursive=recursive,
+            revs=rev if rev is None else [rev],
+            all_commits=all_commits,
+            onerror=_onerror_raise,
+        )
+    print(metrics)
+    return _postprocess(metrics)

--- a/dvc/api/metrics.py
+++ b/dvc/api/metrics.py
@@ -126,6 +126,9 @@ def metrics_show(
     def _postprocess(metrics):
         processed = {}
         for rev, rev_data in metrics.items():
+            if not rev_data:
+                continue
+
             processed[rev] = {}
 
             counts = Counter()

--- a/dvc/api/show.py
+++ b/dvc/api/show.py
@@ -1,0 +1,402 @@
+from collections import Counter
+from typing import Dict, Iterable, Optional, Union
+
+from funcy import first
+
+from dvc.exceptions import DvcException
+from dvc.repo import Repo
+
+
+def _onerror_raise(result: Dict, exception: Exception, *args, **kwargs):
+    raise exception
+
+
+def _postprocess(results):
+    processed = {}
+    for rev, rev_data in results.items():
+        if not rev_data:
+            continue
+
+        processed[rev] = {}
+
+        counts = Counter()
+        for file_data in rev_data["data"].values():
+            for k in file_data["data"]:
+                counts[k] += 1
+
+        for file_name, file_data in rev_data["data"].items():
+            to_merge = {
+                (k if counts[k] == 1 else f"{file_name}:{k}"): v
+                for k, v in file_data["data"].items()
+            }
+            processed[rev] = {**processed[rev], **to_merge}
+
+    if "workspace" in processed:
+        del processed["workspace"]
+
+    return processed
+
+
+def metrics_show(
+    *targets: str,
+    repo: Optional[str] = None,
+    rev: Optional[str] = None,
+) -> Dict:
+    """Get metrics tracked in `repo`.
+
+    Without arguments, this function will retrieve all metrics from all tracked
+    metric files, for the current working tree.
+
+    See the options below to restrict the metrics retrieved.
+
+    Args:
+        *targets (str, optional): Names of the metric files to retrieve
+        metrics from. For example, "classifier_eval.json,
+        clustering_eval.json".
+        If no `targets` are provided, all metric files tracked in `dvc.yaml`
+        will be used.
+        Note that targets don't necessarily have to be defined in `dvc.yaml`.
+        repo (str, optional): Location of the DVC repository.
+            Defaults to the current project (found by walking up from the
+            current working directory tree).
+            It can be a URL or a file system path.
+            Both HTTP and SSH protocols are supported for online Git repos
+            (e.g. [user@]server:project.git).
+        rev (str, optional): Name of the `Git revision`_ to retrieve metrics
+            from.
+            Defaults to `None`.
+            An example of git revision can be a branch or tag name, a commit
+            hash or a dvc experiment name.
+            If `repo` is not a Git repo, this option is ignored.
+            If `None`, the current working tree will be used.
+
+    Returns:
+        Dict: See Examples below.
+
+    Raises:
+        DvcException: If no metrics are found in `repo`.
+
+    Examples:
+
+        - No arguments.
+
+        Working on https://github.com/iterative/example-get-started
+
+        >>> import dvc.api
+        >>> metrics = dvc.api.metrics_show()
+        >>> print(json.dumps(metrics, indent=4))
+        {
+            "avg_prec": 0.9249974999612706,
+            "roc_auc": 0.9460213440787918
+        }
+
+        ---
+
+        - Using `rev`.
+
+        Working on https://github.com/iterative/example-get-started
+
+        >>> import json
+        >>> import dvc.api
+        >>> metrics = dvc.api.metrics_show(rev="tune-hyperparams")
+        >>> print(json.dumps(metrics, indent=4))
+        {
+            "avg_prec": 0.9268792615819422,
+            "roc_auc": 0.945093365854111
+        }
+
+        ---
+
+        - Using `targets`.
+
+        Working on https://github.com/iterative/example-get-started
+
+        >>> import json
+        >>> import dvc.api
+        >>> metrics = dvc.api.metrics_show("evaluation.json")
+        >>> print(json.dumps(metrics, indent=4))
+        {
+            "avg_prec": 0.9249974999612706,
+            "roc_auc": 0.9460213440787918
+        }
+
+        ---
+
+        - Git URL as `repo`.
+
+        >>> import json
+        >>> import dvc.api
+        >>> metrics = dvc.api.metrics_show(
+        ...     repo="https://github.com/iterative/demo-fashion-mnist")
+        >>> print(json.dumps(metrics, indent=4))
+        {
+            "loss": 0.25284987688064575,
+            "accuracy": 0.9071000218391418
+        }
+
+
+    .. _Git revision:
+        https://git-scm.com/docs/revisions
+    """
+
+    with Repo.open(repo) as _repo:
+        metrics = _repo.metrics.show(
+            targets=targets,
+            revs=rev if rev is None else [rev],
+            onerror=_onerror_raise,
+        )
+
+    metrics = _postprocess(metrics)
+
+    if not metrics:
+        raise DvcException("No metrics found")
+
+    return metrics[first(metrics)]
+
+
+def params_show(
+    *targets: str,
+    repo: Optional[str] = None,
+    stages: Optional[Union[str, Iterable[str]]] = None,
+    rev: Optional[str] = None,
+    deps: bool = False,
+) -> Dict:
+    """Get parameters tracked in `repo`.
+
+    Without arguments, this function will retrieve all params from all tracked
+    parameter files, for the current working tree.
+
+    See the options below to restrict the parameters retrieved.
+
+    Args:
+        *targets (str, optional): Names of the parameter files to retrieve
+        params from. For example, "params.py, myparams.toml".
+        If no `targets` are provided, all parameter files tracked in `dvc.yaml`
+        will be used.
+        Note that targets don't necessarily have to be defined in `dvc.yaml`.
+        repo (str, optional): location of the DVC repository.
+            Defaults to the current project (found by walking up from the
+            current working directory tree).
+            It can be a URL or a file system path.
+            Both HTTP and SSH protocols are supported for online Git repos
+            (e.g. [user@]server:project.git).
+        stages (Union[str, Iterable[str]], optional): Name or names of the
+            stages to retrieve parameters from.
+            Defaults to `None`.
+            If `None`, all parameters from all stages will be retrieved.
+            If this method is called from a different location to the one where
+            the `dvc.yaml` is found, the relative path to the `dvc.yaml` must
+            be provided as a prefix with the syntax `{relpath}:{stage}`.
+            For example: `subdir/dvc.yaml:stage-0` or `../dvc.yaml:stage-1`.
+        rev (str, optional): Name of the `Git revision`_ to retrieve parameters
+            from.
+            Defaults to `None`.
+            An example of git revision can be a branch or tag name, a commit
+            hash or a dvc experiment name.
+            If `repo` is not a Git repo, this option is ignored.
+            If `None`, the current working tree will be used.
+        deps (bool, optional): Whether to retrieve only parameters that are
+            stage dependencies or not.
+            Defaults to `False`.
+
+    Returns:
+        Dict: See Examples below.
+
+    Raises:
+        DvcException: If no params are found in `repo`.
+
+    Examples:
+
+        - No arguments.
+
+        Working on https://github.com/iterative/example-get-started
+
+        >>> import json
+        >>> import dvc.api
+        >>> params = dvc.api.params_show()
+        >>> print(json.dumps(params, indent=4))
+        {
+            "prepare": {
+                "split": 0.2,
+                "seed": 20170428
+            },
+            "featurize": {
+                "max_features": 200,
+                "ngrams": 2
+            },
+            "train": {
+                "seed": 20170428,
+                "n_est": 50,
+                "min_split": 0.01
+            }
+        }
+
+        ---
+
+        - Filtering with `stages`.
+
+        Working on https://github.com/iterative/example-get-started
+
+        `stages` can a single string:
+
+        >>> import json
+        >>> import dvc.api
+        >>> params = dvc.api.params_show(stages="prepare")
+        >>> print(json.dumps(params, indent=4))
+        {
+            "prepare": {
+                "split": 0.2,
+                "seed": 20170428
+            }
+        }
+
+        Or an iterable of strings:
+
+        >>> import json
+        >>> import dvc.api
+        >>> params = dvc.api.params_show(stages=["prepare", "train"])
+        >>> print(json.dumps(params, indent=4))
+        {
+            "prepare": {
+                "split": 0.2,
+                "seed": 20170428
+            },
+            "train": {
+                "seed": 20170428,
+                "n_est": 50,
+                "min_split": 0.01
+            }
+        }
+
+        ---
+
+        - Using `rev`.
+
+        Working on https://github.com/iterative/example-get-started
+
+        >>> import json
+        >>> import dvc.api
+        >>> params = dvc.api.params_show(rev="tune-hyperparams")
+        >>> print(json.dumps(params, indent=4))
+        {
+            "prepare": {
+                "split": 0.2,
+                "seed": 20170428
+            },
+            "featurize": {
+                "max_features": 200,
+                "ngrams": 2
+            },
+            "train": {
+                "seed": 20170428,
+                "n_est": 100,
+                "min_split": 8
+            }
+        }
+
+        ---
+
+        - Using `targets`.
+
+        Working on `multi-params-files` folder of
+        https://github.com/iterative/pipeline-conifguration
+
+        You can pass a single target:
+
+        >>> import json
+        >>> import dvc.api
+        >>> params = dvc.api.params_show("params.yaml")
+        >>> print(json.dumps(params, indent=4))
+        {
+            "run_mode": "prod",
+            "configs": {
+                "dev": "configs/params_dev.yaml",
+                "test": "configs/params_test.yaml",
+                "prod": "configs/params_prod.yaml"
+            },
+            "evaluate": {
+                "dataset": "micro",
+                "size": 5000,
+                "metrics": ["f1", "roc-auc"],
+                "metrics_file": "reports/metrics.json",
+                "plots_cm": "reports/plot_confusion_matrix.png"
+            }
+        }
+
+
+        Or multiple targets:
+
+        >>> import json
+        >>> import dvc.api
+        >>> params = dvc.api.params_show(
+        ...     "configs/params_dev.yaml", "configs/params_prod.yaml")
+        >>> print(json.dumps(params, indent=4))
+        {
+            "configs/params_prod.yaml:run_mode": "prod",
+            "configs/params_prod.yaml:config_file": "configs/params_prod.yaml",
+            "configs/params_prod.yaml:data_load": {
+                "dataset": "large",
+                "sampling": {
+                "enable": true,
+                "size": 50000
+                }
+            },
+            "configs/params_prod.yaml:train": {
+                "epochs": 1000
+            },
+            "configs/params_dev.yaml:run_mode": "dev",
+            "configs/params_dev.yaml:config_file": "configs/params_dev.yaml",
+            "configs/params_dev.yaml:data_load": {
+                "dataset": "development",
+                "sampling": {
+                "enable": true,
+                "size": 1000
+                }
+            },
+            "configs/params_dev.yaml:train": {
+                "epochs": 10
+            }
+        }
+
+        ---
+
+        - Git URL as `repo`.
+
+        >>> import json
+        >>> import dvc.api
+        >>> params = dvc.api.params_show(
+        ...     repo="https://github.com/iterative/demo-fashion-mnist")
+        {
+            "train": {
+                "batch_size": 128,
+                "hidden_units": 64,
+                "dropout": 0.4,
+                "num_epochs": 10,
+                "lr": 0.001,
+                "conv_activation": "relu"
+            }
+        }
+
+
+    .. _Git revision:
+        https://git-scm.com/docs/revisions
+
+    """
+    if isinstance(stages, str):
+        stages = [stages]
+
+    with Repo.open(repo) as _repo:
+        params = _repo.params.show(
+            revs=rev if rev is None else [rev],
+            targets=targets,
+            deps=deps,
+            onerror=_onerror_raise,
+            stages=stages,
+        )
+
+    params = _postprocess(params)
+
+    if not params:
+        raise DvcException("No params found.")
+
+    return params[first(params)]


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Closes #8076

This is a draft PR because I wanted to ask a question about intended behavior and tests: 
1) For tests, would you like me to try to reproduce: `tests/func/api/test_params.py` for this new command?  There are a few tests in there like `test_params_show_while_running_stage` which I'm not sure I totally follow but I can spend some time in here and get it sorted.
2) I've included the `all_commits`, `all_branches`, and `all_tags` booleans from the underlying `metrics.show()` function.  This also matches the cli version.  I wasn't sure what the output should look like though so I've made it nested dictionaries.  I noticed there seems to be some ordering of precedence.  For example, if I toggle all the flags on it will use only the commits in the brancher.  This is confirmed in scm.py around line 227 but isn't immediately obvious to a caller.  So the question is, does that behavior and structure of the output seem okay?  I'll document the precedence of `all_commits` in the docstring.

Here's some output from the `example-get-started` repo (I added a `add-top-k` branch):

all_branches only:
```
In [27]: api.metrics_show(repo='/home/hedeer/code/gh/example-get-started', all_branches=True)

Out[27]: 
{'workspace': {'avg_prec': 0.9249974999612706, 'roc_auc': 0.9460213440787918},
 'add-top-k': {'avg_prec': 0.9249974999612706,
  'roc_auc': 0.9460213440787918,
  'topk': 1.0},
 'main': {'avg_prec': 0.9249974999612706, 'roc_auc': 0.9460213440787918}}
```

all_branches and all_tags:
```
In [28]: api.metrics_show(repo='/home/hedeer/code/gh/example-get-started', all_branches=True, all_tags=True)

Out[28]: 
{'workspace': {'avg_prec': 0.9249974999612706, 'roc_auc': 0.9460213440787918},
 'add-top-k': {'avg_prec': 0.9249974999612706,
  'roc_auc': 0.9460213440787918,
  'topk': 1.0},
 'main': {'avg_prec': 0.9249974999612706, 'roc_auc': 0.9460213440787918},
 '10-bigrams-experiment,bigrams-experiment': {'avg_prec': 0.9249974999612706,
  'roc_auc': 0.9460213440787918},
 '11-random-forest-experiments,random-forest-experiments': {'avg_prec': 0.9268792615819422,
  'roc_auc': 0.945093365854111},
 '8-evaluation,baseline-experiment': {'avg_prec': 0.9014016422240393,
  'roc_auc': 0.9319648794149968},
 '9-bigrams-model': {'avg_prec': 0.9014016422240393,
  'roc_auc': 0.9319648794149968}}
```

all_commits, all_branches, and all_tags:
```
In [29]: api.metrics_show(repo='/home/hedeer/code/gh/example-get-started', all_branches=True, all_tags=True, all_commits=True)

Out[29]: 
{'workspace': {'avg_prec': 0.9249974999612706, 'roc_auc': 0.9460213440787918},
 'a4be8e6c0d41f6b38e68d176fb758f421ab737e9': {'avg_prec': 0.9249974999612706,
  'roc_auc': 0.9460213440787918},
 'a700c555f5dcd3668ebdef811068b50b7399b959': {'avgerage_precision': 0.9249974999612706,
  'roc_auc': 0.9460213440787918},
 '10461042fe0b14598b2aa7bdb12de0af01dc1b76': {'avg_prec': 0.9249974999612706,
  'roc_auc': 0.9460213440787918},
 '7ff0969e12f0e3c703a552b8c6f6a0cd1f05eaff': {'avg_prec': 0.9249974999612706,
  'roc_auc': 0.9460213440787918,
  'topk': 1.0},
 '1ea2d246b3b7ffdb6e8b1f5f593f51b6477e59d0': {'avg_prec': 0.9249974999612706,
  'roc_auc': 0.9460213440787918},
 '0d1e8cb9f58528d2f46d0580352b3d48d14d6497': {'avg_prec': 0.9249974999612706,
  'roc_auc': 0.9460213440787918},
 'd05d9f36ef8983835fe43e4636372c2e945029e2': {'avg_prec': 0.9249974999612706,
  'roc_auc': 0.9460213440787918},
 'b96de9db2494724639545702a374659ad579971e': {'avg_prec': 0.9249974999612706,
  'roc_auc': 0.9460213440787918},
 '4c515e59d49b7faffc557b91fedc51cf25fc806a': {'avg_prec': 0.9249974999612706,
  'roc_auc': 0.9460213440787918},
 'cb3951eda21c5b3156db3f3795972c681fd3412f': {'avg_prec': 0.9249974999612706,
  'roc_auc': 0.9460213440787918},
 'f3030bec1ab27e7e855564ae9b36e35c614f4c7f': {'avg_prec': 0.9249974999612706,
  'roc_auc': 0.9460213440787918},
 '3a4e255e18f929f574d8cec58d92c7009c4f590c': {'avg_prec': 0.9249974999612706,
  'roc_auc': 0.9460213440787918},
 'b30b0a0e785dfebfd4fd5debbbeca19de43d0677': {'avg_prec': 0.9249974999612706,
  'roc_auc': 0.9460213440787918},
 'fabbc359f11c18b5bff70c7500c95b4ca49362f4': {'avg_prec': 0.9249974999612706,
  'roc_auc': 0.9460213440787918},
 'c3b04d0af303c38801b3840e4e27042c17b7db33': {'avg_prec': 0.9249974999612706,
  'roc_auc': 0.9460213440787918},
 '7fe0949204cdef55886ef23b4ed697a311b500b5': {'avg_prec': 0.9249974999612706,
  'roc_auc': 0.9460213440787918},
 '75898e52bca3f8705d27af95b7933a4cb20899c0': {'avg_prec': 0.9249974999612706,
  'roc_auc': 0.9460213440787918},
 '63fca82b040611d3ab77c4dfb1865ae078b557ae': {'avg_prec': 0.9249974999612706,
  'roc_auc': 0.9460213440787918},
 '8f92a3be5b2fe369195c5393bd5c136c2a14c581': {'avg_prec': 0.9249974999612706,
  'roc_auc': 0.9460213440787918},
 'a138cda5c138272f7d4084e051bf67572f3d9b65': {'avg_prec': 0.9268792615819422,
  'roc_auc': 0.945093365854111},
 '9911db87c44dfb381b27cebed2720af8eff67ed3': {'avg_prec': 0.9449556493816984,
  'roc_auc': 0.9619097316125981},
 '799c9ad3c06dcfce2afd60440c4216278d2b08f6': {'avg_prec': 0.9249974999612706,
  'roc_auc': 0.9460213440787918},
 '022c781130988fdffb53a33a12120273a049faa7': {'avg_prec': 0.9014016422240393,
  'roc_auc': 0.9319648794149968},
 '11984ad16f7bbafd1b6170da5fe001823978ca83': {'avg_prec': 0.9014016422240393,
  'roc_auc': 0.9319648794149968}}
```
