### PR TITLE
fix hydra_sweeps referenced before assignment

### DIFF
--- a/dvc/repo/experiments/run.py
+++ b/dvc/repo/experiments/run.py
@@ -32,6 +32,7 @@ def run(
         entries = list(repo.experiments.celery_queue.iter_queued())
         return repo.experiments.reproduce_celery(entries, jobs=jobs)
 
+    hydra_sweep = None
     if params:
         from dvc.utils.hydra import to_hydra_overrides
 

--- a/tests/func/experiments/test_set_params.py
+++ b/tests/func/experiments/test_set_params.py
@@ -110,6 +110,11 @@ def test_hydra_compose_and_dump(
             ["foo=bar,baz"],
             [{"params.yaml": ["foo=bar"]}, {"params.yaml": ["foo=baz"]}],
         ),
+        (
+            False,
+            [],
+            [{}],
+        ),
     ],
 )
 def test_hydra_sweep(


### PR DESCRIPTION
Queuing without overrides is broken due to referencing `hydra_sweeps` before assignment. Feel free to suggest a different place for the added test.