### PR TITLE
Make exp show handle errors better

### DIFF
--- a/dvc/repo/experiments/diff.py
+++ b/dvc/repo/experiments/diff.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 
 def diff(repo, *args, a_rev=None, b_rev=None, param_deps=False, **kwargs):
-    from dvc.repo.experiments.show import _collect_experiment_commit
+    from dvc.repo.experiments.show import collect_experiment_commit
     from dvc.scm import resolve_rev
 
     if repo.scm.no_commits:
@@ -15,15 +15,15 @@ def diff(repo, *args, a_rev=None, b_rev=None, param_deps=False, **kwargs):
 
     if a_rev:
         rev = resolve_rev(repo.scm, a_rev)
-        old = _collect_experiment_commit(repo, rev, param_deps=param_deps)
+        old = collect_experiment_commit(repo, rev, param_deps=param_deps)
     else:
-        old = _collect_experiment_commit(repo, "HEAD", param_deps=param_deps)
+        old = collect_experiment_commit(repo, "HEAD", param_deps=param_deps)
 
     if b_rev:
         rev = resolve_rev(repo.scm, b_rev)
-        new = _collect_experiment_commit(repo, rev, param_deps=param_deps)
+        new = collect_experiment_commit(repo, rev, param_deps=param_deps)
     else:
-        new = _collect_experiment_commit(
+        new = collect_experiment_commit(
             repo, "workspace", param_deps=param_deps
         )
 

--- a/dvc/repo/experiments/queue/utils.py
+++ b/dvc/repo/experiments/queue/utils.py
@@ -1,6 +1,8 @@
 import logging
 from typing import TYPE_CHECKING, Dict
 
+from scmrepo.exceptions import SCMError
+
 from ..executor.base import ExecutorInfo, TaskStatus
 
 logger = logging.getLogger(__name__)
@@ -52,7 +54,7 @@ def fetch_running_exp_from_temp_dir(
                     result[rev]["last"] = last_rev
                     if last_rev:
                         result[last_rev] = info.asdict()
-            except InvalidRemoteSCMRepo:
+            except (InvalidRemoteSCMRepo, SCMError):
                 # ignore stale info files
                 del result[rev]
     return result


### PR DESCRIPTION
fix: #8350

We shouldn't add locks to exp show to prevent race conditions as this command is calling continuously by the extension. So we make a better way to handle all kinds of reference failures.

1. Drop all based experiments if got a SCMError in baseline.
2. Drop all checkpoint experiments if any commit got a SCMError in one of checkpoint commit.
3. Drop the entire experiments if got a SCMError.
4. Add tests for each of the conditions above.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
