### PR TITLE
Solve the crash on getting name of applied experiment branch

### DIFF
--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -248,8 +248,7 @@ def get_names(repo: "Repo", result: Dict[str, Dict[str, Any]]):
                 rev = baseline
                 if rev == "workspace":
                     continue
-                name = names.get(rev, None)
-            name = name or exact_name[rev]
+            name = names.get(rev, None) or exact_name[rev]
             if name:
                 rev_result["data"]["name"] = name
 

--- a/tests/unit/repo/experiments/test_show.py
+++ b/tests/unit/repo/experiments/test_show.py
@@ -1,0 +1,27 @@
+from funcy import first
+from scmrepo.git import Git
+
+from dvc.repo.experiments.show import get_names
+
+
+def test_get_show_branch(tmp_dir, scm: "Git", dvc, exp_stage):
+    new_branch = "new"
+
+    baseline = scm.get_rev()
+    base_branch = scm.active_branch()
+    results = dvc.experiments.run(exp_stage.addressing, params=["foo=2"])
+    exp_a = first(results)
+    dvc.experiments.branch(exp_a, new_branch)
+
+    scm.checkout(new_branch, force=True)
+
+    result = {
+        "workspace": {"baseline": {"data": {}}},
+        exp_a: {"baseline": {"data": {}}},
+        baseline: {"baseline": {"data": {}}, exp_a: {"data": {}}},
+    }
+
+    get_names(dvc, result)
+    assert result[exp_a]["baseline"]["data"] == {"name": new_branch}
+    assert result[baseline]["baseline"]["data"] == {"name": base_branch}
+    assert result[baseline][exp_a]["data"] == {"name": new_branch}


### PR DESCRIPTION
The original problem is that the applied/branched experiments have a new name in the workspace. But getting this name only happens for baselines. If we use `-n` flag to traverse to some old commits, they will be shown as experiments instead of baselines, and will cause this problem. 

fix: #8526
1. The current `get_names` will crash if an experiment branch had already been given a new branch name to it.

1. Solve the crash when we getting the name of a newly fixed experiment branch.
2. Add a new unit test to it.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
