### PR TITLE
exp status: Use worker info to confirm task status

### DIFF
--- a/dvc/commands/queue/status.py
+++ b/dvc/commands/queue/status.py
@@ -37,7 +37,7 @@ class CmdQueueStatus(CmdBase):
             ui.write("No experiment tasks in the queue.")
         ui.write()
 
-        worker_status = self.repo.experiments.celery_queue.worker_status()
+        worker_status = self.repo.experiments.celery_queue.worker_status
         active_count = len(
             [name for name, task in worker_status.items() if task]
         )

--- a/dvc/repo/experiments/queue/base.py
+++ b/dvc/repo/experiments/queue/base.py
@@ -202,12 +202,12 @@ class BaseStashQueue(ABC):
             }
 
         result.extend(
-            _format_entry(queue_entry, status="Running")
-            for queue_entry in self.iter_active()
-        )
-        result.extend(
             _format_entry(queue_entry, status="Queued")
             for queue_entry in self.iter_queued()
+        )
+        result.extend(
+            _format_entry(queue_entry, status="Running")
+            for queue_entry in self.iter_active()
         )
         result.extend(
             _format_entry(queue_entry, status="Failed")

--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -284,7 +284,6 @@ def _collect_active_experiment(
 def _collect_queued_experiment(
     repo: "Repo",
     found_revs: Dict[str, List[str]],
-    running: Dict[str, Any],
     **kwargs,
 ) -> Dict[str, Dict[str, Any]]:
     result: Dict[str, Dict] = defaultdict(OrderedDict)
@@ -295,7 +294,7 @@ def _collect_queued_experiment(
                 repo,
                 stash_rev,
                 status=ExpStatus.Queued,
-                running=running,
+                running=None,
                 **kwargs,
             )
             if _is_scm_error(collected_exp):
@@ -307,7 +306,6 @@ def _collect_queued_experiment(
 def _collect_failed_experiment(
     repo: "Repo",
     found_revs: Dict[str, List[str]],
-    running: Dict[str, Any],
     **kwargs,
 ) -> Dict[str, Dict[str, Any]]:
     result: Dict[str, Dict] = defaultdict(OrderedDict)
@@ -319,7 +317,7 @@ def _collect_failed_experiment(
                 repo,
                 stash_rev,
                 status=ExpStatus.Failed,
-                running=running,
+                running=None,
                 **kwargs,
             )
             if _is_scm_error(collected_exp):
@@ -369,20 +367,19 @@ def show(
         iter_revs(repo.scm, revs, num, all_branches, all_tags, all_commits)
     )
 
-    running: Dict[str, Dict] = repo.experiments.get_running_exps(
-        fetch_refs=fetch_running
-    )
-
     queued_experiment = (
         _collect_queued_experiment(
             repo,
             found_revs,
-            running,
             param_deps=param_deps,
             onerror=onerror,
         )
         if not hide_queued
         else {}
+    )
+
+    running: Dict[str, Dict] = repo.experiments.get_running_exps(
+        fetch_refs=fetch_running
     )
 
     active_experiment = _collect_active_experiment(
@@ -397,7 +394,6 @@ def show(
         _collect_failed_experiment(
             repo,
             found_revs,
-            running,
             param_deps=param_deps,
             onerror=onerror,
         )

--- a/tests/unit/command/test_queue.py
+++ b/tests/unit/command/test_queue.py
@@ -179,6 +179,7 @@ def test_worker_status(dvc, scm, worker_status, output, mocker, capsys):
     m = mocker.patch(
         "dvc.repo.experiments.queue.celery.LocalCeleryQueue.worker_status",
         return_value=worker_status,
+        new_callable=mocker.PropertyMock,
     )
 
     assert cmd.run() == 0


### PR DESCRIPTION
fix: #8461
1. Our current `_iter_active_task` use celery status as the status of running. But if the worker goes wrong this status might end in a 'PENDING' state and the `AsyncResult.ready()` will be False. This will make the status of this task to be shown as a False `RUNNING` state and prevent any operation on it.

1. Use worker_status to double check the status of active tasks.
2. Add a new unit test for `iter_active`
3. Move `iter_queued` before `iter_active` to prevent the `worker_status` failing to get a newly active experiment.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
