### PR TITLE
import-url: disable push by default for cloud-versioned imports

### DIFF
--- a/dvc/output.py
+++ b/dvc/output.py
@@ -1043,8 +1043,14 @@ class Output:
         if not self.use_cache:
             return {}
 
+        push: bool = kwargs.pop("push", False)
         if self.stage.is_repo_import:
+            if push:
+                return {}
             return self.get_used_external(**kwargs)
+
+        if push and not self.can_push:
+            return {}
 
         if not self.hash_info:
             msg = (

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -401,6 +401,7 @@ class Repo:
         used_run_cache=None,
         revs=None,
         num=1,
+        push: bool = False,
     ):
         """Get the stages related to the given target and collect
         the `info` of its outputs.
@@ -435,6 +436,7 @@ class Repo:
                 jobs=jobs,
                 recursive=recursive,
                 with_deps=with_deps,
+                push=push,
             ).items():
                 used[odb].update(objs)
 

--- a/dvc/repo/imp_url.py
+++ b/dvc/repo/imp_url.py
@@ -97,6 +97,9 @@ def imp_url(
     else:
         stage.run(jobs=jobs, no_download=no_download)
 
+    if not no_exec and stage.deps[0].fs.version_aware:
+        stage.outs[0].can_push = False
+
     stage.frozen = frozen
 
     dvcfile.dump(stage)

--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -268,6 +268,7 @@ class Index:
         force: bool = False,
         recursive: bool = False,
         jobs: int = None,
+        push: bool = False,
     ) -> "ObjectContainer":
         from collections import defaultdict
 
@@ -281,6 +282,7 @@ class Index:
                 force=force,
                 jobs=jobs,
                 filter_info=filter_info,
+                push=push,
             ).items():
                 used[odb].update(objs)
         return used

--- a/dvc/repo/push.py
+++ b/dvc/repo/push.py
@@ -93,6 +93,7 @@ def push(
         recursive=recursive,
         used_run_cache=used_run_cache,
         revs=revs,
+        push=True,
     )
 
     pushed = len(used_run_cache)

--- a/dvc/repo/status.py
+++ b/dvc/repo/status.py
@@ -89,6 +89,7 @@ def _cloud_status(
         remote=remote,
         jobs=jobs,
         recursive=recursive,
+        push=True,
     )
 
     ret = {}

--- a/dvc/schema.py
+++ b/dvc/schema.py
@@ -51,6 +51,7 @@ OUT_PSTAGE_DETAILED_SCHEMA = {
         Output.PARAM_PERSIST: bool,
         Output.PARAM_CHECKPOINT: bool,
         Output.PARAM_REMOTE: str,
+        Output.PARAM_PUSH: bool,
     }
 }
 

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -113,10 +113,12 @@ def restore_fields(stage):
     stage.meta = old.meta
     stage.desc = old.desc
 
-    old_fields = {out.def_path: (out.annot, out.remote) for out in old.outs}
+    old_fields = {
+        out.def_path: (out.annot, out.remote, out.can_push) for out in old.outs
+    }
     for out in stage.outs:
         if out_fields := old_fields.get(out.def_path, None):
-            out.annot, out.remote = out_fields
+            out.annot, out.remote, out.can_push = out_fields
 
 
 class Stage(params.StageParams):

--- a/dvc/stage/serialize.py
+++ b/dvc/stage/serialize.py
@@ -29,6 +29,7 @@ PARAM_PERSIST = Output.PARAM_PERSIST
 PARAM_CHECKPOINT = Output.PARAM_CHECKPOINT
 PARAM_DESC = Annotation.PARAM_DESC
 PARAM_REMOTE = Output.PARAM_REMOTE
+PARAM_PUSH = Output.PARAM_PUSH
 
 DEFAULT_PARAMS_FILE = ParamsDependency.DEFAULT_PARAMS_FILE
 
@@ -54,6 +55,8 @@ def _get_flags(out):
         yield from out.plot.items()
     if out.remote:
         yield PARAM_REMOTE, out.remote
+    if not out.can_push:
+        yield PARAM_PUSH, False
 
 
 def _serialize_out(out):

--- a/tests/func/test_used_objs.py
+++ b/tests/func/test_used_objs.py
@@ -51,3 +51,16 @@ def test_from_gitfs_when_pwd_not_in_root(
 
     with wdir.chdir():
         assert dvc.used_objs([target], revs=[scm.get_rev()])
+
+
+def test_used_objs_push(tmp_dir, scm, dvc):
+    stage = tmp_dir.dvc_gen("foo", "foo")[0]
+    hash_info = stage.outs[0].hash_info
+
+    stage.outs[0].can_push = True
+    assert stage.get_used_objs(push=False) == {None: {hash_info}}
+    assert stage.get_used_objs(push=True) == {None: {hash_info}}
+
+    stage.outs[0].can_push = False
+    assert stage.get_used_objs(push=False) == {None: {hash_info}}
+    assert stage.get_used_objs(push=True) == {}


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will close https://github.com/iterative/dvc/issues/8429

- Outs now support a `push:` param that defaults to `true`
    - If `push: false` is used, the given file will be dvc-tracked and cached locally, but will never be pushed to a remote on `dvc push`
    - The output will still be included when using `dvc status -c` and `dvc pull` (i.e. we will still try to pull it from a DVC remote when possible, and will report whether or not the file is exists in a DVC remote on `status -c`)
- For `import-url` with cloud-versioned URLs (or explicit `--version-aware` flag), the output will be generated with `push: false`
    - If the user overrides this with `push: true` or by removing the `push:` line in the .dvc file (to use the default true value) this will be preserved on `dvc update`
- For `import-url` without cloud-versioning, the output defaults to `push: true` like any regular output (preserving the current behavior for non-versioned `import-url`)

Also, this PR does not address https://github.com/iterative/dvc/issues/4527. DVC repo imports (`dvc import`) are essentially always considered `push: false` regardless of whether or not the user explicitly tries to set `push: true` in the dvc file. (But in the future using explicit `push: true` in the .dvc file could be used to support 4527)