### PR TITLE
queue kill: we can manually mark problematic tasks as failure

### DIFF
--- a/dvc/repo/experiments/queue/exceptions.py
+++ b/dvc/repo/experiments/queue/exceptions.py
@@ -1,0 +1,12 @@
+from typing import Collection
+
+from dvc.exceptions import DvcException
+
+
+class CannotKillTasksError(DvcException):
+    def __init__(self, revs: Collection[str]):
+        rev_str = ",".join(revs)
+        super().__init__(
+            f"Task '{rev_str}' is initializing, please wait a few seconds "
+            "until the experiments start running to retry the kill operation."
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "typing-extensions>=3.7.4",
     "scmrepo==0.1.3",
     "dvc-render==0.0.14",
-    "dvc-task==0.1.5",
+    "dvc-task==0.1.6",
     "dvclive>=1.0",
     "dvc-data==0.27.0",
     "dvc-http==2.27.2",


### PR DESCRIPTION
fix: #8461
fix: #8473
For now, for those inactive but uncompleted tasks, they still shown as Running in `exp show` and `task queue`, we cannot remove them because they are regarded as running, we cann't kill them because their are no real process behind them.

1. Now we can examine these false running tasks and mark them as failure in `queue kill` command. #8461
2. Better msg handle for initliaizing tasks in `queue kill`#8473
3. Add new unit tests for both cases.

wait for https://github.com/iterative/dvc-task/pull/97 to be merged first.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
