### PR TITLE
worktree: support push: false

### DIFF
--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -17,20 +17,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _fetch_worktree(repo, remote):
-    from dvc_data.index import save
-
-    index = repo.index.data["repo"]
-    for key, entry in index.iteritems():
-        entry.fs = remote.fs
-        entry.path = remote.fs.path.join(
-            remote.path,
-            *key,
-        )
-    save(index)
-    return len(index)
-
-
 @locked
 def fetch(
     self,
@@ -59,6 +45,7 @@ def fetch(
             remote is configured
     """
     from dvc.repo.imports import save_imports
+    from dvc.repo.worktree import fetch as fetch_worktree
     from dvc_data.hashfile.transfer import TransferResult
 
     if isinstance(targets, str):
@@ -67,7 +54,7 @@ def fetch(
     with suppress(NoRemoteError):
         _remote = self.cloud.get_remote(name=remote)
         if _remote.worktree:
-            return _fetch_worktree(self, _remote)
+            return fetch_worktree(self, _remote)
 
     failed_count = 0
 

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -45,7 +45,7 @@ def fetch(
             remote is configured
     """
     from dvc.repo.imports import save_imports
-    from dvc.repo.worktree import fetch as fetch_worktree
+    from dvc.repo.worktree import fetch_worktree
     from dvc_data.hashfile.transfer import TransferResult
 
     if isinstance(targets, str):

--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -152,7 +152,7 @@ class Index:
 
     def targets_view(
         self,
-        targets: "TargetType",
+        targets: Optional["TargetType"],
         stage_filter: Optional[Callable[["Stage"], bool]] = None,
         outs_filter: Optional[Callable[["Output"], bool]] = None,
         **kwargs: Any,

--- a/dvc/repo/push.py
+++ b/dvc/repo/push.py
@@ -26,7 +26,7 @@ def push(
     odb: Optional["ObjectDB"] = None,
     include_imports=False,
 ):
-    from dvc.repo.worktree import push as push_worktree
+    from dvc.repo.worktree import push_worktree
 
     _remote = self.cloud.get_remote(name=remote)
     if _remote.worktree:

--- a/dvc/repo/worktree.py
+++ b/dvc/repo/worktree.py
@@ -1,0 +1,61 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from dvc.cloud import Remote
+    from dvc.repo import Repo
+
+
+def fetch(repo: "Repo", remote: "Remote") -> int:
+    from dvc_data.index import save
+
+    index = repo.index.data["repo"]
+    for key, entry in index.iteritems():
+        entry.fs = remote.fs
+        entry.path = remote.fs.path.join(
+            remote.path,
+            *key,
+        )
+    save(index)
+    return len(index)
+
+
+def push(repo: "Repo", remote: "Remote") -> int:
+    from dvc_data.index import checkout
+    from dvc_data.index.save import build_tree
+
+    index = repo.index.data["repo"]
+    checkout(index, remote.path, remote.fs)
+
+    for stage in repo.index.stages:
+        for out in stage.outs:
+            if not out.use_cache:
+                continue
+
+            if not out.is_in_repo:
+                continue
+
+            workspace, key = out.index_key
+            index = repo.index.data[workspace]
+            entry = index[key]
+            if out.isdir():
+                old_tree = out.get_obj()
+                entry.hash_info = old_tree.hash_info
+                entry.meta = out.meta
+                for subkey, entry in index.iteritems(key):
+                    if entry.meta.isdir:
+                        continue
+                    fs_path = repo.fs.path.join(repo.root_dir, *subkey)
+                    _, hash_info = old_tree.get(
+                        repo.fs.path.relparts(fs_path, out.fs_path)
+                    )
+                    entry.hash_info = hash_info
+                tree_meta, new_tree = build_tree(index, key)
+                out.obj = new_tree
+                out.hash_info = new_tree.hash_info
+                out.meta = tree_meta
+            else:
+                out.hash_info = entry.hash_info
+                out.meta = entry.meta
+        stage.dvcfile.dump(stage, with_files=True, update_pipeline=False)
+
+    return len(index)


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Follow up to #8578.
Related to https://github.com/iterative/dvc/issues/8464.

- Moves worktree push/fetch logic into `dvc.repo.worktree`
- Disables pushing `dvc import` data to worktree remotes
- Disables pushing `push: false` data to worktree remotes