### PR TITLE
cli: remove version action

### DIFF
--- a/dvc/cli/parser.py
+++ b/dvc/cli/parser.py
@@ -2,8 +2,8 @@
 import argparse
 import logging
 import os
-import sys
 
+from dvc import __version__
 from dvc.commands import (
     add,
     cache,
@@ -128,17 +128,6 @@ class DvcParser(argparse.ArgumentParser):
         return args
 
 
-class VersionAction(argparse.Action):  # pragma: no cover
-    # pylint: disable=too-few-public-methods
-    """Shows DVC version and exits."""
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        from dvc import __version__
-
-        print(__version__)
-        sys.exit(0)
-
-
 def get_parent_parser():
     """Create instances of a parser containing common arguments shared among
     all the commands.
@@ -186,13 +175,11 @@ def get_main_parser():
         help="Show this help message and exit.",
     )
 
-    # NOTE: On some python versions action='version' prints to stderr
-    # instead of stdout https://bugs.python.org/issue18920
     parser.add_argument(
         "-V",
         "--version",
-        action=VersionAction,
-        nargs=0,
+        action="version",
+        version=__version__,
         help="Show program's version.",
     )
 


### PR DESCRIPTION
The issue seems to have been fixed in Python 3.4.