### PR TITLE
build: fpm: don't create .build-id/* files

### DIFF
--- a/scripts/fpm/build.py
+++ b/scripts/fpm/build.py
@@ -44,6 +44,10 @@ if args.pkg == "osxpkg":
         ]
     )
 else:
+    if args.pkg == "rpm":
+        # https://github.com/jordansissel/fpm/issues/1503
+        flags.extend(["--rpm-rpmbuild-define", '"_build_id_links none"'])
+
     bash_dir = build / "etc" / "bash_completion.d"
     dirs = ["usr", "etc"]
     flags.extend(["--depends", "git >= 1.7.0"])  # needed for gitpython


### PR DESCRIPTION
These are leaking into our rpm packages.

Related https://github.com/iterative/dvc-s3-repo/issues/86

