### PR TITLE
remote: separate `worktree` vs `version_aware` behavior

### DIFF
--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Iterable, Optional
 
 from funcy import cached_property
 
+from dvc.config import RemoteConfigError
 from dvc_data.hashfile.db import get_index
 
 if TYPE_CHECKING:
@@ -23,6 +24,14 @@ class Remote:
 
         self.worktree = config.pop("worktree", False)
         self.config = config
+        if self.worktree:
+            version_aware = self.config.get("version_aware")
+            if version_aware is False:
+                raise RemoteConfigError(
+                    "worktree remotes require version_aware cloud"
+                )
+            if version_aware is None:
+                self.fs.version_aware = True
 
     @cached_property
     def odb(self):

--- a/dvc/repo/push.py
+++ b/dvc/repo/push.py
@@ -29,7 +29,7 @@ def push(
     from dvc.repo.worktree import push_worktree
 
     _remote = self.cloud.get_remote(name=remote)
-    if _remote.worktree:
+    if _remote.worktree or _remote.fs.version_aware:
         return push_worktree(self, _remote)
 
     used_run_cache = (

--- a/dvc/repo/worktree.py
+++ b/dvc/repo/worktree.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Optional
+import logging
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from dvc.fs.callbacks import Callback
 
@@ -9,12 +10,16 @@ if TYPE_CHECKING:
     from dvc.repo import Repo
     from dvc.stage import Stage
     from dvc.types import TargetType
+    from dvc_data.hashfile.meta import Meta
+
+logger = logging.getLogger(__name__)
 
 
 def worktree_view(
     index: "Index",
     targets: Optional["TargetType"] = None,
     push: bool = False,
+    latest_only: bool = True,
     **kwargs,
 ) -> "IndexView":
     """Return view of data that can be stored in worktree remotes.
@@ -37,6 +42,10 @@ def worktree_view(
             or not out.use_cache
             or (push and not out.can_push)
         ):
+            return False
+        # If we are not enforcing push to latest version and have a version
+        # for this out, we assume it still exists and can skip pushing it
+        if push and not latest_only and out.meta.version_id is not None:
             return False
         return True
 
@@ -68,32 +77,59 @@ def fetch_worktree(repo: "Repo", remote: "Remote") -> int:
 
 
 def push_worktree(repo: "Repo", remote: "Remote") -> int:
-    from dvc_data.index import checkout
-    from dvc_data.index.save import build_tree
+    from dvc_data.index import build, checkout
 
-    view = worktree_view(repo.index, push=True)
-    index = view.data["repo"]
-    total = len(index)
+    view = worktree_view(repo.index, push=True, latest_only=remote.worktree)
+    new_index = view.data["repo"]
+    if remote.worktree:
+        logger.debug("Indexing latest worktree for '%s'", remote.path)
+        old_index = build(remote.path, remote.fs)
+        logger.debug("Pushing worktree changes to '%s'", remote.path)
+    else:
+        old_index = None
+        logger.debug("Pushing version-aware files to '%s'", remote.path)
+
+    if remote.worktree:
+
+        # for files, if our version's checksum (etag) matches the latest remote
+        # checksum, we do not need to push, even if the version IDs don't match
+        def _checksum(meta: "Meta") -> Any:
+            if not meta or meta.isdir:
+                return meta
+            return getattr(meta, remote.fs.PARAM_CHECKSUM)
+
+        diff_kwargs: Dict[str, Any] = {
+            "meta_only": True,
+            "meta_cmp_key": _checksum,
+        }
+    else:
+        diff_kwargs = {}
+
+    total = len(new_index)
     with Callback.as_tqdm_callback(
         unit="file", desc="Push", disable=total == 0
     ) as cb:
         cb.set_size(total)
         pushed = checkout(
-            index,
+            new_index,
             remote.path,
             remote.fs,
-            latest_only=False,
+            old=old_index,
+            delete=remote.worktree,
             callback=cb,
+            latest_only=remote.worktree,
+            **diff_kwargs,
         )
+    if pushed:
+        _update_pushed_meta(repo, view)
+    return pushed
+
+
+def _update_pushed_meta(repo: "Repo", view: "IndexView"):
+    from dvc_data.index.save import build_tree
 
     for stage in view.stages:
         for out in stage.outs:
-            if not out.use_cache:
-                continue
-
-            if not out.is_in_repo:
-                continue
-
             workspace, key = out.index_key
             index = repo.index.data[workspace]
             entry = index[key]
@@ -105,17 +141,21 @@ def push_worktree(repo: "Repo", remote: "Remote") -> int:
                     if entry.meta.isdir:
                         continue
                     fs_path = repo.fs.path.join(repo.root_dir, *subkey)
-                    _, hash_info = old_tree.get(
+                    meta, hash_info = old_tree.get(
                         repo.fs.path.relparts(fs_path, out.fs_path)
                     )
                     entry.hash_info = hash_info
+                    if meta.version_id is not None:
+                        # preserve existing version IDs for unchanged files in
+                        # this dir (entry will have the latest remote version
+                        # ID after checkout)
+                        entry.meta = meta
                 tree_meta, new_tree = build_tree(index, key)
                 out.obj = new_tree
                 out.hash_info = new_tree.hash_info
                 out.meta = tree_meta
             else:
                 out.hash_info = entry.hash_info
-                out.meta = entry.meta
+                if out.meta.version_id is None:
+                    out.meta = entry.meta
         stage.dvcfile.dump(stage, with_files=True, update_pipeline=False)
-
-    return pushed


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will close https://github.com/iterative/dvc/issues/8409

- `worktree = true` now implies `version_aware = true` (a config error will be raised if a user explicitly configures a remote with `worktree = true` and `version_aware = false`)
- `version_aware = true` (and `worktree = false`) will result in pushing human-readable filenames to a cloud-versioned remote. DVC will not set DELETE flags and will not update the latest version of a file on the remote if an older version of the file has has already been pushed
- `worktree = true` will force `dvc push` to ensure that the "latest" version of a remote always reflects the pushed workspace. DVC will set DELETE flags for files that do not exist in the current workspace, and will force pushing an updated copy of a file if the latest version on the remote does not match what is in the user's workspace (even if a previously pushed version ID already exists in the .dvc file)
    - DVC will attempt to reduce pushing of duplicate copies when possible by checking etags (i.e. if the latest version of a file does not have the same version ID as the one in my .dvc file, but the etags match, DVC will not push another copy of the file)

cloud-versioned `fetch/pull` behavior is unchanged and essentially does the same thing regardless of whether or not `worktree` is set  - DVC will always fetch the version IDs specified in the .dvc file.