### PR TITLE
fix exception on dvc stage add with non-existing dirs

### DIFF
--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -520,6 +520,7 @@ class Stage(params.StageParams):
 
     def ignore_outs(self):
         for out in self.outs:
+            out.fs.makedirs(out.fs.path.parent(out.fspath), exist_ok=True)
             out.ignore()
 
     @staticmethod


### PR DESCRIPTION
Running `dvc stage add <..> -o nonexisting_dir/file` would fail with a `FileNotFoundError` for the `.gitignore` file in `nonexisting_dir`. This happened because the outputs are added to the `.gitignore` when creating the stage.

To reproduce:
```bash
mkdir tmp
cd tmp

git init
dvc init
dvc stage add -f -n prepare \
                -p prepare.seed,prepare.split \
                -d src/prepare.py -d data/data.xml \
                -o data/prepared --pdb \
                python src/prepare.py data/data.xml
```

this will raise `FileNotFoundError: data/.gitignore`

fixes https://github.com/iterative/dvc/issues/5802