### PR TITLE
`dvc update`: support worktree update

### DIFF
--- a/dvc/commands/update.py
+++ b/dvc/commands/update.py
@@ -31,7 +31,8 @@ class CmdUpdate(CmdBase):
 def add_parser(subparsers, parent_parser):
     UPDATE_HELP = (
         "Update data artifact imported (via dvc import or dvc import-url) "
-        "from an external DVC repository or URL."
+        "from an external DVC repository or URL, or update data from a "
+        "DVC worktree remote."
     )
     update_parser = subparsers.add_parser(
         "update",

--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -166,7 +166,7 @@ class Index:
             )
         )
 
-    def _collect_targets(
+    def collect_targets(
         self, targets: Optional["TargetType"], **kwargs: Any
     ) -> List["StageInfo"]:
         from itertools import chain
@@ -214,7 +214,7 @@ class Index:
         """
         stage_infos = [
             stage_info
-            for stage_info in self._collect_targets(targets, **kwargs)
+            for stage_info in self.collect_targets(targets, **kwargs)
             if not stage_filter or stage_filter(stage_info.stage)
         ]
         return IndexView(self, stage_infos, outs_filter=outs_filter)
@@ -310,7 +310,7 @@ class Index:
         from collections import defaultdict
 
         used: "ObjectContainer" = defaultdict(set)
-        pairs = self._collect_targets(
+        pairs = self.collect_targets(
             targets, recursive=recursive, with_deps=with_deps
         )
         for stage, filter_info in pairs:

--- a/dvc/repo/update.py
+++ b/dvc/repo/update.py
@@ -64,6 +64,18 @@ def update(
         remote_obj = self.cloud.get_remote(name=remote)
         if not remote_obj.worktree:
             raise StageUpdateError(other_stage_infos[0].stage.relpath)
+        if rev:
+            raise InvalidArgumentError(
+                "--rev can't be used with worktree update"
+            )
+        if no_download:
+            raise InvalidArgumentError(
+                "--no-download can't be used with worktree update"
+            )
+        if to_remote:
+            raise InvalidArgumentError(
+                "--to-remote can't be used with worktree update"
+            )
         update_worktree_stages(
             self,
             other_stage_infos,

--- a/dvc/repo/update.py
+++ b/dvc/repo/update.py
@@ -1,6 +1,12 @@
+from typing import TYPE_CHECKING, List
+
 from dvc.exceptions import InvalidArgumentError
+from dvc.stage.exceptions import StageUpdateError
 
 from . import locked
+
+if TYPE_CHECKING:
+    from dvc.repo.stage import StageInfo
 
 
 @locked
@@ -15,6 +21,7 @@ def update(
     jobs=None,
 ):
     from ..dvcfile import Dvcfile
+    from .worktree import update_worktree_stages
 
     if not targets:
         targets = [None]
@@ -28,15 +35,21 @@ def update(
         )
 
     if not to_remote and remote:
-        raise InvalidArgumentError(
-            "--remote can't be used without --to-remote"
-        )
+        if not self.cloud.get_remote(name=remote).worktree:
+            raise InvalidArgumentError(
+                "--remote can't be used without --to-remote"
+            )
 
-    stages = set()
-    for target in targets:
-        stages.update(self.stage.collect(target, recursive=recursive))
+    import_stages = set()
+    other_stage_infos: List["StageInfo"] = []
 
-    for stage in stages:
+    for stage_info in self.index.collect_targets(targets, recursive=recursive):
+        if stage_info.stage.is_import:
+            import_stages.add(stage_info.stage)
+        else:
+            other_stage_infos.append(stage_info)
+
+    for stage in import_stages:
         stage.update(
             rev,
             to_remote=to_remote,
@@ -47,4 +60,17 @@ def update(
         dvcfile = Dvcfile(self, stage.path)
         dvcfile.dump(stage)
 
+    if other_stage_infos:
+        remote_obj = self.cloud.get_remote(name=remote)
+        if not remote_obj.worktree:
+            raise StageUpdateError(other_stage_infos[0].stage.relpath)
+        update_worktree_stages(
+            self,
+            other_stage_infos,
+            remote_obj,
+        )
+
+    stages = import_stages | {
+        stage_info.stage for stage_info in other_stage_infos
+    }
     return list(stages)

--- a/dvc/repo/worktree.py
+++ b/dvc/repo/worktree.py
@@ -1,5 +1,6 @@
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from functools import partial
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Union, cast
 
 from dvc.fs.callbacks import Callback
 
@@ -8,11 +9,23 @@ if TYPE_CHECKING:
     from dvc.index import Index, IndexView
     from dvc.output import Output
     from dvc.repo import Repo
+    from dvc.repo.stage import StageInfo
     from dvc.stage import Stage
     from dvc.types import TargetType
     from dvc_data.hashfile.meta import Meta
+    from dvc_data.hashfile.tree import Tree
+    from dvc_data.index import DataIndex, DataIndexView
+    from dvc_objects.fs.base import FileSystem
 
 logger = logging.getLogger(__name__)
+
+
+# for files, if our version's checksum (etag) matches the latest remote
+# checksum, we do not need to push, even if the version IDs don't match
+def _meta_checksum(fs: "FileSystem", meta: "Meta") -> Any:
+    if not meta or meta.isdir:
+        return meta
+    return getattr(meta, fs.PARAM_CHECKSUM)
 
 
 def worktree_view(
@@ -82,7 +95,7 @@ def push_worktree(repo: "Repo", remote: "Remote") -> int:
     view = worktree_view(repo.index, push=True, latest_only=remote.worktree)
     new_index = view.data["repo"]
     if remote.worktree:
-        logger.debug("Indexing latest worktree for '%s'", remote.path)
+        logger.debug("indexing latest worktree for '%s'", remote.path)
         old_index = build(remote.path, remote.fs)
         logger.debug("Pushing worktree changes to '%s'", remote.path)
     else:
@@ -90,17 +103,9 @@ def push_worktree(repo: "Repo", remote: "Remote") -> int:
         logger.debug("Pushing version-aware files to '%s'", remote.path)
 
     if remote.worktree:
-
-        # for files, if our version's checksum (etag) matches the latest remote
-        # checksum, we do not need to push, even if the version IDs don't match
-        def _checksum(meta: "Meta") -> Any:
-            if not meta or meta.isdir:
-                return meta
-            return getattr(meta, remote.fs.PARAM_CHECKSUM)
-
         diff_kwargs: Dict[str, Any] = {
             "meta_only": True,
-            "meta_cmp_key": _checksum,
+            "meta_cmp_key": partial(_meta_checksum, remote.fs),
         }
     else:
         diff_kwargs = {}
@@ -121,41 +126,125 @@ def push_worktree(repo: "Repo", remote: "Remote") -> int:
             **diff_kwargs,
         )
     if pushed:
-        _update_pushed_meta(repo, view)
+        for stage in view.stages:
+            for out in stage.outs:
+                workspace, _key = out.index_key
+                _update_out_meta(out, repo.index.data[workspace])
+            stage.dvcfile.dump(stage, with_files=True, update_pipeline=False)
     return pushed
 
 
-def _update_pushed_meta(repo: "Repo", view: "IndexView"):
+def _update_out_meta(
+    out: "Output", index: Union["DataIndex", "DataIndexView"]
+):
     from dvc_data.index.save import build_tree
 
+    _, key = out.index_key
+    entry = index[key]
+    repo = out.stage.repo
+    if out.isdir():
+        old_tree = cast("Tree", out.get_obj())
+        entry.hash_info = old_tree.hash_info
+        entry.meta = out.meta
+        for subkey, entry in index.iteritems(key):
+            if entry.meta.isdir:
+                continue
+            fs_path = repo.fs.path.join(repo.root_dir, *subkey)
+            meta, hash_info = old_tree.get(
+                repo.fs.path.relparts(fs_path, out.fs_path)
+            )
+            entry.hash_info = hash_info
+            if meta.version_id is not None:
+                # preserve existing version IDs for unchanged files in
+                # this dir (entry will have the latest remote version
+                # ID after checkout)
+                entry.meta = meta
+        tree_meta, new_tree = build_tree(index, key)
+        out.obj = new_tree
+        out.hash_info = new_tree.hash_info
+        out.meta = tree_meta
+    else:
+        if entry.hash_info:
+            out.hash_info = entry.hash_info
+        if out.meta.version_id is None:
+            out.meta = entry.meta
+
+
+def update_worktree_stages(
+    repo: "Repo",
+    stage_infos: Iterable["StageInfo"],
+    remote: "Remote",
+):
+    from dvc.repo.index import IndexView
+    from dvc_data.index import build
+
+    def outs_filter(out: "Output") -> bool:
+        return out.is_in_repo and out.use_cache and out.can_push
+
+    view = IndexView(
+        repo.index,
+        stage_infos,
+        outs_filter=outs_filter,
+    )
+    local_index = view.data["repo"]
+    logger.debug("indexing latest worktree for '%s'", remote.path)
+    remote_index = build(remote.path, remote.fs)
     for stage in view.stages:
         for out in stage.outs:
-            workspace, key = out.index_key
-            index = repo.index.data[workspace]
-            entry = index[key]
-            if out.isdir():
-                old_tree = out.get_obj()
-                entry.hash_info = old_tree.hash_info
-                entry.meta = out.meta
-                for subkey, entry in index.iteritems(key):
-                    if entry.meta.isdir:
-                        continue
-                    fs_path = repo.fs.path.join(repo.root_dir, *subkey)
-                    meta, hash_info = old_tree.get(
-                        repo.fs.path.relparts(fs_path, out.fs_path)
+            _workspace, key = out.index_key
+            if key not in remote_index:
+                logger.warning(
+                    "Could not update '%s', it does not exist in the remote",
+                    out,
+                )
+                continue
+            entry = remote_index[key]
+            if entry.meta and entry.meta.isdir:
+                if not any(
+                    subkey != key and subentry.meta and not subentry.meta.isdir
+                    for subkey, subentry in remote_index.iteritems(key)
+                ):
+                    logger.warning(
+                        "Could not update '%s', directory is empty in the "
+                        "remote",
+                        out,
                     )
-                    entry.hash_info = hash_info
-                    if meta.version_id is not None:
-                        # preserve existing version IDs for unchanged files in
-                        # this dir (entry will have the latest remote version
-                        # ID after checkout)
-                        entry.meta = meta
-                tree_meta, new_tree = build_tree(index, key)
-                out.obj = new_tree
-                out.hash_info = new_tree.hash_info
-                out.meta = tree_meta
-            else:
-                out.hash_info = entry.hash_info
-                if out.meta.version_id is None:
-                    out.meta = entry.meta
+                    continue
+            _fetch_out_changes(out, local_index, remote_index, remote)
+        stage.save(merge_versioned=True)
+        for out in stage.outs:
+            _update_out_meta(out, remote_index)
         stage.dvcfile.dump(stage, with_files=True, update_pipeline=False)
+
+
+def _fetch_out_changes(
+    out: "Output",
+    local_index: "DataIndex",
+    remote_index: "DataIndex",
+    remote: "Remote",
+):
+    from dvc_data.index import DataIndex, checkout
+
+    _, key = out.index_key
+    old = DataIndex()
+    new = DataIndex()
+    for _, entry in local_index.iteritems(key):
+        old.add(entry)
+    for _, entry in remote_index.iteritems(key):
+        new.add(entry)
+    total = len(new)
+    with Callback.as_tqdm_callback(
+        unit="file", desc=f"Updating '{out}'", disable=total == 0
+    ) as cb:
+        cb.set_size(total)
+        checkout(
+            new,
+            out.repo.root_dir,
+            out.fs,
+            old=old,
+            delete=True,
+            update_meta=False,
+            meta_only=True,
+            meta_cmp_key=partial(_meta_checksum, remote.fs),
+            callback=cb,
+        )


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will close https://github.com/iterative/dvc/issues/8382

- When using a `worktree` remote, `dvc update <target>...` will update the specified targets to get the latest modifications from the remote
- If a file is unmodified (and etags match), the version ID from the local .dvc file will not be modified even if the latest remote version ID does not match (to prevent merge conflicts and be consistent with `dvc push` for worktrees)
- For a file output, if the file does not exist in the remote, `dvc update` will output a warning and will not make local modifications
- For a dir output, if the directory does not exist in the remote, or is empty in the remote (and contains no actual files within the dir), `dvc update` will output a warning and will not make local modifications
- For dir outputs that are not empty in the remote, all other file updates within the dir will be reflected in the update (i.e. newly added files, deleted files, modified files)
- `dvc update` for worktrees will only download new and modified files from the remote (it does not re-download an entire remote directory like we do for updating imports)

Also note that `dvc update` will only update one target at a time in sequence. When passed multiple targets it updates one target at a time, rather than attempting to batch all of the updates together (this is the same behavior as updating imports with multiple targets)