### PR TITLE
ignore: solve re.error on group name redefinition in pathspec 0.10.x

### DIFF
--- a/dvc/ignore.py
+++ b/dvc/ignore.py
@@ -40,7 +40,7 @@ class DvcIgnorePatterns(DvcIgnore):
         ]
 
         self.ignore_spec = [
-            (ignore, re.compile("|".join(item[0] for item in group)))
+            (ignore, [re.compile(item[0]) for item in group])
             for ignore, group in groupby(
                 self.regex_pattern_list, lambda x: x[1]
             )
@@ -107,8 +107,8 @@ class DvcIgnorePatterns(DvcIgnore):
 
         result = False
 
-        for ignore, pattern in self.ignore_spec[::-1]:
-            if matches(pattern, path, is_dir):
+        for ignore, patterns in self.ignore_spec[::-1]:
+            if any(matches(pattern, path, is_dir) for pattern in patterns):
                 result = ignore
                 break
         return result


### PR DESCRIPTION
Fixes #8217 by getting rid of regex concatenation that causes `ERROR: unexpected error - redefinition of group name 'ps_d' as group 2; was group 1 at position 46` when latest pathspec (0.10.x) is installed.

Instead of concatenating regexes with `|`,  run `matches()` for each regular expression and take `any()`.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
