### PR TITLE
Make temp dir executed checkpoint experiment return result to workspace.

### DIFF
--- a/dvc/stage/exceptions.py
+++ b/dvc/stage/exceptions.py
@@ -9,6 +9,14 @@ class StageCmdFailedError(DvcException):
         super().__init__(msg)
 
 
+class CheckpointKilledError(DvcException):
+    def __init__(self, cmd, status=None):
+        msg = f"failed to finish: {cmd}"
+        if status is not None:
+            msg += f", exited with {status}"
+        super().__init__(msg)
+
+
 class StageFileDoesNotExistError(DvcException):
     DVC_IGNORED = "is dvc-ignored"
     DOES_NOT_EXIST = "does not exist"

--- a/tests/func/experiments/conftest.py
+++ b/tests/func/experiments/conftest.py
@@ -3,6 +3,7 @@ import pytest
 from tests.unit.repo.experiments.conftest import (  # noqa, pylint disable=unused-argument
     checkpoint_stage,
     exp_stage,
+    failed_checkpoint_stage,
     failed_exp_stage,
     test_queue,
 )

--- a/tests/func/experiments/test_checkpoints.py
+++ b/tests/func/experiments/test_checkpoints.py
@@ -275,3 +275,22 @@ def test_auto_push_self_remote(
             "automatically be pushed to the default DVC remote (if any) "
             "on each experiment commit." in caplog.text
         )
+
+
+def test_tmp_dir_failed_checkpoint(
+    tmp_dir, scm, dvc, failed_checkpoint_stage, caplog
+):
+    baseline = scm.get_rev()
+
+    results = dvc.experiments.run(
+        failed_checkpoint_stage.addressing, params=["foo=2"], tmp_dir=True
+    )
+    exp = first(results)
+
+    result = dvc.experiments.show()[baseline]
+    assert len(result) == 1 + 2
+    assert exp in result
+    assert (
+        "Checkpoint stage 'failed-checkpoint-file' was interrupted remaining "
+        "stages in pipeline will not be reproduced." in caplog.text
+    )


### PR DESCRIPTION
fix: #8612
For checkpoint experiments in some cases, users might want to give it an early stopping to reduce variance.  But currently, if we interrupt/kill the experiment it will be marked as failed, and all of the completed checkpoints will be removed as we clean up all the running directly after the process failed.

1. We raise CheckpointKilledError instead of StageCmdFailed error if at least one checkpoint had been committed.
2. Temp_dir executor will continue collecting data if the Checkpoint stage was interrupted.
3. Raise warnings if a checkpoint stage was incomplete and the other stages were not forwarded.
4. Add a new functional test for this

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
