### PR TITLE
Reset all indices on the brancher iteration

### DIFF
--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -536,11 +536,16 @@ class Repo:
         self.scm.close()
         self.state.close()
 
+    def _reset_cached_indecies(self):
+        self.__dict__.pop("index", None)
+        self.__dict__.pop("dvcignore", None)
+        self.__dict__.pop("dvcfs", None)
+        self.__dict__.pop("datafs", None)
+
     def _reset(self):
         self.state.close()
         self.scm._reset()  # pylint: disable=protected-access
-        self.__dict__.pop("index", None)
-        self.__dict__.pop("dvcignore", None)
+        self._reset_cached_indecies()
 
     def __enter__(self):
         return self

--- a/dvc/repo/brancher.py
+++ b/dvc/repo/brancher.py
@@ -77,7 +77,7 @@ def brancher(  # noqa: E302
         from dvc.fs import GitFileSystem
 
         for sha, names in found_revs.items():
-            self.__dict__.pop("index", None)
+            self._reset_cached_indecies()  # pylint: disable=W0212
             self.fs = GitFileSystem(scm=scm, rev=sha)
             self.root_dir = self.fs.path.join("/", *repo_root_parts)
 


### PR DESCRIPTION
This alone speedups plots collection in certain repos and cases 10x+ (e.g. from 65s+ to 5s or less). 

Fixes repo and brancher to reset `dvcfs`, `data` and other indices.

Otherwise, at the very least if we had a directory with plots in a revision:

```yaml
plots:
    - mispredicted
```

where:

```
(.venv) √ Projects/hackathon % tree mispredicted
mispredicted
├── cat
├── croissant
│   └── muffin-16115-13825-26827-1d8e67e0bffdfebcdb3b337787823ab6.jpeg
├── dog
└── muffin
    ├── croissant-0295ed7610487b3118febb5563bc58fd.jpg
    ├── croissant-3f488b602f2a668e-3fd6af132b0dceafe014dfcf7809d2ff.jpg
    └── dog-bec8602c36317744-1827c47f8ae15e6a3c4ee660035781a4.jpg
```

and would try to collect multiple revisions, where previous one doesn't have the same directory content, or doesn't have `.dir` fine in cache to unpack, it would still trying to fetch same plots to check for existence (this should be fixed separately):

```
(.venv) √ Projects/hackathon % dvc plots diff e7a5cd4 workspace
WARNING: 'mispredicted/muffin/croissant-3f488b602f2a668e-3fd6af132b0dceafe014dfcf7809d2ff.jpg' was not found at: 'e7a5cd4'.
WARNING: 'mispredicted/muffin/dog-bec8602c36317744-1827c47f8ae15e6a3c4ee660035781a4.jpg' was not found at: 'e7a5cd4'.
WARNING: 'mispredicted/croissant/muffin-16115-13825-26827-1d8e67e0bffdfebcdb3b337787823ab6.jpeg' was not found at: 'e7a5cd4'.
WARNING: 'mispredicted/muffin/croissant-0295ed7610487b3118febb5563bc58fd.jpg' was not found at: 'e7a5cd4'.
DVC failed to load some plots for following revisions: 'e7a5cd4'.
```

Let me know if that was intentional, we can alternatively create a new FS everytime in the plots call. But it feels wrong and it's not clear if we have other places. In some other places where we create FS it should be replaced with `repo.fs` I think after this fix.


-----------

* [X] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [X] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
