### PR TITLE
plots: fix regressions to top-level plots

### DIFF
--- a/dvc/render/converter/vega.py
+++ b/dvc/render/converter/vega.py
@@ -126,25 +126,26 @@ class VegaConverter(Converter):
                     break
 
     def _infer_x_y(self):
-        def _infer_files(from_name, to_name):
-            from_value = self.properties.get(from_name, None)
-            to_value = self.properties.get(to_name, None)
+        x = self.properties.get("x", None)
+        y = self.properties.get("y", None)
 
-            if isinstance(to_value, str):
-                self.inferred_properties[to_name] = {}
-                if isinstance(from_value, dict):
-                    for file in from_value.keys():
-                        self.inferred_properties[to_name][file] = to_value
-                else:
-                    self.inferred_properties[to_name][self.plot_id] = to_value
+        # Infer x.
+        if isinstance(x, str):
+            self.inferred_properties["x"] = {}
+            # If multiple y files, duplicate x for each file.
+            if isinstance(y, dict):
+                for file in y.keys():
+                    self.inferred_properties["x"][file] = x
+            # Otherwise use plot ID as file.
             else:
-                self.inferred_properties[to_name] = to_value
+                self.inferred_properties["x"][self.plot_id] = x
 
-        _infer_files("y", "x")
-        _infer_files("x", "y")
-
-        if self.inferred_properties.get("y", None) is None:
+        # Infer y.
+        if y is None:
             self._infer_y_from_data()
+        # If y files not provided, use plot ID as file.
+        elif not isinstance(y, dict):
+            self.inferred_properties["y"] = {self.plot_id: y}
 
     def _find_datapoints(self):
         result = {}

--- a/dvc/render/converter/vega.py
+++ b/dvc/render/converter/vega.py
@@ -134,8 +134,12 @@ class VegaConverter(Converter):
             self.inferred_properties["x"] = {}
             # If multiple y files, duplicate x for each file.
             if isinstance(y, dict):
-                for file in y.keys():
-                    self.inferred_properties["x"][file] = x
+                for file, fields in y.items():
+                    # Duplicate x for each y.
+                    if isinstance(fields, list):
+                        self.inferred_properties["x"][file] = [x] * len(fields)
+                    else:
+                        self.inferred_properties["x"][file] = x
             # Otherwise use plot ID as file.
             else:
                 self.inferred_properties["x"][self.plot_id] = x

--- a/tests/unit/render/test_vega_converter.py
+++ b/tests/unit/render/test_vega_converter.py
@@ -331,6 +331,54 @@ def test_finding_lists(dictionary, expected_result):
             },
             id="y_list",
         ),
+        pytest.param(
+            {
+                "f": {"metric": [{"v": 1, "v2": 0.1, "v3": 0.01}]},
+                "f2": {"metric": [{"v": 1, "v2": 0.1}]},
+            },
+            {"y": {"f": ["v2", "v3"], "f2": ["v2"]}, "x": "v"},
+            [
+                {
+                    "dvc_inferred_y_value": 0.1,
+                    "v": 1,
+                    "v2": 0.1,
+                    "v3": 0.01,
+                    VERSION_FIELD: {
+                        "revision": "r",
+                        "filename": "f",
+                        "field": "v2",
+                    },
+                },
+                {
+                    "dvc_inferred_y_value": 0.01,
+                    "v": 1,
+                    "v2": 0.1,
+                    "v3": 0.01,
+                    VERSION_FIELD: {
+                        "revision": "r",
+                        "filename": "f",
+                        "field": "v3",
+                    },
+                },
+                {
+                    "dvc_inferred_y_value": 0.1,
+                    "v": 1,
+                    "v2": 0.1,
+                    VERSION_FIELD: {
+                        "revision": "r",
+                        "filename": "f2",
+                        "field": "v2",
+                    },
+                },
+            ],
+            {
+                "x": "v",
+                "y": "dvc_inferred_y_value",
+                "x_label": "v",
+                "y_label": "y",
+            },
+            id="multi_source_y_single_x",
+        ),
     ],
 )
 def test_convert(

--- a/tests/unit/render/test_vega_converter.py
+++ b/tests/unit/render/test_vega_converter.py
@@ -274,6 +274,63 @@ def test_finding_lists(dictionary, expected_result):
             {"x": "v", "y": "v2", "x_label": "v", "y_label": "v2"},
             id="multi_file_json",
         ),
+        pytest.param(
+            {"f": {"metric": [{"v": 1, "v2": 0.1}, {"v": 2, "v2": 0.2}]}},
+            {"y": ["v", "v2"]},
+            [
+                {
+                    "dvc_inferred_y_value": 1,
+                    "v": 1,
+                    "v2": 0.1,
+                    "step": 0,
+                    VERSION_FIELD: {
+                        "revision": "r",
+                        "filename": "f",
+                        "field": "v",
+                    },
+                },
+                {
+                    "dvc_inferred_y_value": 2,
+                    "v": 2,
+                    "v2": 0.2,
+                    "step": 1,
+                    VERSION_FIELD: {
+                        "revision": "r",
+                        "filename": "f",
+                        "field": "v",
+                    },
+                },
+                {
+                    "dvc_inferred_y_value": 0.1,
+                    "v": 1,
+                    "v2": 0.1,
+                    "step": 0,
+                    VERSION_FIELD: {
+                        "revision": "r",
+                        "filename": "f",
+                        "field": "v2",
+                    },
+                },
+                {
+                    "dvc_inferred_y_value": 0.2,
+                    "v": 2,
+                    "v2": 0.2,
+                    "step": 1,
+                    VERSION_FIELD: {
+                        "revision": "r",
+                        "filename": "f",
+                        "field": "v2",
+                    },
+                },
+            ],
+            {
+                "x": "step",
+                "y": "dvc_inferred_y_value",
+                "x_label": "step",
+                "y_label": "y",
+            },
+            id="y_list",
+        ),
     ],
 )
 def test_convert(


### PR DESCRIPTION
Fixes regressions in https://github.com/iterative/dvc/pull/8421. 

1. Makes plots work again when `y` is a list.

```yaml
plots:
  plot1.csv:
    y:
      - acc
      - loss
    x: epoch
```

2. Supports `y` lists as one of multiple data sources like:

```yaml
plots:
  plot:
    y:
      plot1.csv:
        - acc
        - loss
      plot2.csv:
        - loss
    x:
      epoch
```

@amritghimire @ssachkovskaya I tested with https://studio.iterative.ai/user/dberenbaum/projects/dvc_plots_tests-cvls4xeliq and 1 looks broken (2 seems okay). Not sure if it will get automatically fixed with this change or if something is needed on your end.