### PR TITLE
`exp apply` can accept exp names and failed exps as target

### DIFF
--- a/dvc/repo/experiments/queue/base.py
+++ b/dvc/repo/experiments/queue/base.py
@@ -86,6 +86,11 @@ class QueueDoneResult(NamedTuple):
     result: Optional[ExecutorResult]
 
 
+class ExpRefAndQueueEntry(NamedTuple):
+    exp_ref_info: Optional["ExpRefInfo"]
+    queue_entry: Optional["QueueEntry"]
+
+
 class BaseStashQueue(ABC):
     """Naive Git-stash based experiment queue.
 

--- a/tests/unit/repo/experiments/test_remove.py
+++ b/tests/unit/repo/experiments/test_remove.py
@@ -11,6 +11,7 @@ def test_remove_done_tasks(dvc, test_queue, scm, mocker):
     ref_info_dict = {}
     for name in success_test:
         ref_info_dict[name] = mocker.Mock()
+        ref_info_dict[name].name = name
     for name in failed_test:
         ref_info_dict[name] = None
 


### PR DESCRIPTION
fix: #8182

1. `exp apply` can apply to failed experiments.
2. `exp apply` can accept exp names as targets.
3. Add a new functional test for it.
4. Move `get_ref_and_entry_by_names` from `exp remove` to `utils` for other commands' usage.

* [ ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
