### PR TITLE
metrics/params: diff: don't show diff if active branch is the same as workspace

### DIFF
--- a/dvc/repo/metrics/diff.py
+++ b/dvc/repo/metrics/diff.py
@@ -17,7 +17,8 @@ def diff(repo, *args, a_rev=None, b_rev=None, **kwargs):
     workspace_rev = (a_rev == "workspace") or (b_rev == "workspace")
     if workspace_rev and "workspace" not in metrics:
         active_branch = repo.scm.active_branch()
-        metrics["workspace"] = metrics[active_branch]
+        if active_branch in metrics:
+            metrics["workspace"] = metrics[active_branch]
 
     old = metrics.get(a_rev, {}).get("data", {})
     new = metrics.get(b_rev, {}).get("data", {})

--- a/dvc/repo/metrics/diff.py
+++ b/dvc/repo/metrics/diff.py
@@ -12,6 +12,13 @@ def diff(repo, *args, a_rev=None, b_rev=None, **kwargs):
     b_rev = b_rev or "workspace"
 
     metrics = repo.metrics.show(*args, **kwargs, revs=[a_rev, b_rev])
+
+    # workspace may have been replaced by active branch
+    workspace_rev = (a_rev == "workspace") or (b_rev == "workspace")
+    if workspace_rev and "workspace" not in metrics:
+        active_branch = repo.scm.active_branch()
+        metrics["workspace"] = metrics[active_branch]
+
     old = metrics.get(a_rev, {}).get("data", {})
     new = metrics.get(b_rev, {}).get("data", {})
 

--- a/dvc/repo/metrics/diff.py
+++ b/dvc/repo/metrics/diff.py
@@ -11,14 +11,9 @@ def diff(repo, *args, a_rev=None, b_rev=None, **kwargs):
     a_rev = a_rev or "HEAD"
     b_rev = b_rev or "workspace"
 
-    metrics = repo.metrics.show(*args, **kwargs, revs=[a_rev, b_rev])
-
-    # workspace may have been replaced by active branch
-    workspace_rev = (a_rev == "workspace") or (b_rev == "workspace")
-    if workspace_rev and "workspace" not in metrics:
-        active_branch = repo.scm.active_branch()
-        if active_branch in metrics:
-            metrics["workspace"] = metrics[active_branch]
+    metrics = repo.metrics.show(
+        *args, **kwargs, revs=[a_rev, b_rev], hide_workspace=False
+    )
 
     old = metrics.get(a_rev, {}).get("data", {})
     new = metrics.get(b_rev, {}).get("data", {})

--- a/dvc/repo/metrics/show.py
+++ b/dvc/repo/metrics/show.py
@@ -124,6 +124,7 @@ def show(
     revs=None,
     all_commits=False,
     onerror=None,
+    hide_workspace=True,
 ):
     if onerror is None:
         onerror = onerror_collect
@@ -142,16 +143,17 @@ def show(
             repo, targets, rev, recursive, onerror=onerror
         )
 
-    # Hide workspace metrics if they are the same as in the active branch
-    try:
-        active_branch = repo.scm.active_branch()
-    except (SCMError, NoSCMError):
-        # SCMError - detached head
-        # NoSCMError - no repo case
-        pass
-    else:
-        if res.get("workspace") == res.get(active_branch):
-            res.pop("workspace", None)
+    if hide_workspace:
+        # Hide workspace metrics if they are the same as in the active branch
+        try:
+            active_branch = repo.scm.active_branch()
+        except (SCMError, NoSCMError):
+            # SCMError - detached head
+            # NoSCMError - no repo case
+            pass
+        else:
+            if res.get("workspace") == res.get(active_branch):
+                res.pop("workspace", None)
 
     errored = errored_revisions(res)
     if errored:

--- a/dvc/repo/params/diff.py
+++ b/dvc/repo/params/diff.py
@@ -13,6 +13,12 @@ def diff(repo, *args, a_rev=None, b_rev=None, **kwargs):
 
     params = repo.params.show(*args, **kwargs, revs=[a_rev, b_rev])
 
+    # workspace may have been replaced by active branch
+    workspace_rev = (a_rev == "workspace") or (b_rev == "workspace")
+    if workspace_rev and "workspace" not in params:
+        active_branch = repo.scm.active_branch()
+        params["workspace"] = params[active_branch]
+
     old = params.get(a_rev, {}).get("data", {})
     new = params.get(b_rev, {}).get("data", {})
 

--- a/dvc/repo/params/diff.py
+++ b/dvc/repo/params/diff.py
@@ -17,7 +17,8 @@ def diff(repo, *args, a_rev=None, b_rev=None, **kwargs):
     workspace_rev = (a_rev == "workspace") or (b_rev == "workspace")
     if workspace_rev and "workspace" not in params:
         active_branch = repo.scm.active_branch()
-        params["workspace"] = params[active_branch]
+        if active_branch in params:
+            params["workspace"] = params[active_branch]
 
     old = params.get(a_rev, {}).get("data", {})
     new = params.get(b_rev, {}).get("data", {})

--- a/dvc/repo/params/diff.py
+++ b/dvc/repo/params/diff.py
@@ -11,14 +11,9 @@ def diff(repo, *args, a_rev=None, b_rev=None, **kwargs):
     a_rev = a_rev or "HEAD"
     b_rev = b_rev or "workspace"
 
-    params = repo.params.show(*args, **kwargs, revs=[a_rev, b_rev])
-
-    # workspace may have been replaced by active branch
-    workspace_rev = (a_rev == "workspace") or (b_rev == "workspace")
-    if workspace_rev and "workspace" not in params:
-        active_branch = repo.scm.active_branch()
-        if active_branch in params:
-            params["workspace"] = params[active_branch]
+    params = repo.params.show(
+        *args, **kwargs, revs=[a_rev, b_rev], hide_workspace=False
+    )
 
     old = params.get(a_rev, {}).get("data", {})
     new = params.get(b_rev, {}).get("data", {})

--- a/dvc/repo/params/show.py
+++ b/dvc/repo/params/show.py
@@ -144,6 +144,7 @@ def show(
     deps=False,
     onerror: Callable = None,
     stages=None,
+    hide_workspace=True,
 ):
     if onerror is None:
         onerror = onerror_collect
@@ -165,16 +166,17 @@ def show(
         if params:
             res[branch] = params
 
-    # Hide workspace params if they are the same as in the active branch
-    try:
-        active_branch = repo.scm.active_branch()
-    except (SCMError, NoSCMError):
-        # SCMError - detached head
-        # NoSCMError - no repo case
-        pass
-    else:
-        if res.get("workspace") == res.get(active_branch):
-            res.pop("workspace", None)
+    if hide_workspace:
+        # Hide workspace params if they are the same as in the active branch
+        try:
+            active_branch = repo.scm.active_branch()
+        except (SCMError, NoSCMError):
+            # SCMError - detached head
+            # NoSCMError - no repo case
+            pass
+        else:
+            if res.get("workspace") == res.get(active_branch):
+                res.pop("workspace", None)
 
     errored = errored_revisions(res)
     if errored:

--- a/tests/func/metrics/test_diff.py
+++ b/tests/func/metrics/test_diff.py
@@ -235,3 +235,20 @@ def test_diff_top_level_metrics(tmp_dir, dvc, scm, dvcfile, metrics_file):
             "foo": {"diff": 2, "new": 5, "old": 3}
         }
     }
+
+
+def test_metrics_diff_active_branch_unchanged(
+    tmp_dir, scm, dvc, run_copy_metrics
+):
+    def _gen(val):
+        metrics = {"a": {"b": {"c": val, "d": 1, "e": str(val)}}}
+        (tmp_dir / "m_temp.yaml").dump(metrics)
+        run_copy_metrics(
+            "m_temp.yaml", "m.yaml", metrics=["m.yaml"], commit=str(val)
+        )
+
+    _gen(1)
+    _gen(2)
+    _gen(1)
+
+    assert dvc.metrics.diff(a_rev=tmp_dir.scm.active_branch()) == {}

--- a/tests/func/params/test_diff.py
+++ b/tests/func/params/test_diff.py
@@ -268,3 +268,11 @@ def test_diff_top_level_params(tmp_dir, dvc, scm, dvcfile, params_file):
             "foo": {"diff": 2, "new": 5, "old": 3}
         }
     }
+
+
+def test_diff_active_branch_no_changes(tmp_dir, scm, dvc):
+    tmp_dir.gen("params.yaml", "foo: bar")
+    dvc.run(cmd="echo params.yaml", params=["foo"], single_stage=True)
+    scm.add(["params.yaml", "Dvcfile"])
+    scm.commit("bar")
+    assert dvc.params.diff(a_rev=tmp_dir.scm.active_branch()) == {}


### PR DESCRIPTION
Before, if you did `dvc metrics diff main` from the `main` branch, you would get:

```
$ dvc metrics diff main
Path                   Metric      main     workspace    Change
training/metrics.json  step        14       -            -
training/metrics.json  test.acc    0.7735   -            -
training/metrics.json  test.loss   0.95962  -            -
training/metrics.json  train.acc   0.7694   -            -
training/metrics.json  train.loss  0.9731   -            -
```

This made it look like the metrics were missing in the workspace and there was some difference from `main` even in a clean repo state.

After this PR, there will be no output from the command above.
