### PR TITLE
config: expose http timeout in config schema

### DIFF
--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -97,6 +97,8 @@ HTTP_COMMON = {
     "ask_password": Bool,
     "ssl_verify": Any(Bool, str),
     "method": str,
+    "connect_timeout": All(Coerce(float), Range(0, min_included=True)),
+    "read_timeout": All(Coerce(float), Range(0, min_included=True)),
     Optional("verify", default=False): Bool,
 }
 WEBDAV_COMMON = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
     "dvc-task==0.1.9",
     "dvclive>=1.2.2",
     "dvc-data==0.28.4",
-    "dvc-http==2.27.2",
+    "dvc-http",
     "hydra-core>=1.1.0",
     "iterative-telemetry==0.0.6",
     "dvc-studio-client>=0.1.1"


### PR DESCRIPTION
- `read_timeout` maps to `aiohttp`'s `sock_read` timeout (read timeout while waiting for a new portion of data from the peer)
- `connect_timeout` applies to `aiohttp`'s `connect`,  `sock_connect` timeouts

For more information:
 https://docs.aiohttp.org/en/stable/client_reference.html?highlight=clienttimeout#clienttimeout
