### PR TITLE
exp: stop checking for unchanged experiments

### DIFF
--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -258,8 +258,7 @@ class Experiments:
             exp_ref = ExpRefInfo(baseline_sha=baseline_sha, name=name)
             check_ref_format(self.scm, exp_ref)
             force = kwargs.get("force", False)
-            reset = kwargs.get("reset", False)
-            if self.scm.get_ref(str(exp_ref)) and not (force or reset):
+            if self.scm.get_ref(str(exp_ref)) and not force:
                 raise ExperimentExistsError(exp_ref.name)
 
         return queue.put(*args, **kwargs)

--- a/dvc/repo/experiments/exceptions.py
+++ b/dvc/repo/experiments/exceptions.py
@@ -6,12 +6,6 @@ if TYPE_CHECKING:
     from .refs import ExpRefInfo
 
 
-class UnchangedExperimentError(DvcException):
-    def __init__(self, rev):
-        super().__init__(f"Experiment unchanged from '{rev[:7]}'.")
-        self.rev = rev
-
-
 class BaselineMismatchError(DvcException):
     def __init__(self, rev, expected):
         if hasattr(rev, "hexsha"):

--- a/dvc/repo/experiments/executor/base.py
+++ b/dvc/repo/experiments/executor/base.py
@@ -492,7 +492,6 @@ class BaseExecutor(ABC):
                     info,
                     stages,
                     exp_hash,
-                    checkpoint_reset,
                     auto_push,
                     git_remote,
                     repro_force,
@@ -513,17 +512,11 @@ class BaseExecutor(ABC):
         info,
         stages,
         exp_hash,
-        checkpoint_reset,
         auto_push,
         git_remote,
         repro_force,
     ) -> Tuple[Optional[str], Optional["ExpRefInfo"], bool]:
         is_checkpoint = any(stage.is_checkpoint for stage in stages)
-        if is_checkpoint and checkpoint_reset:
-            # For reset checkpoint stages, we need to force
-            # overwriting existing checkpoint refs even though
-            # repro may not have actually been run with --force
-            repro_force = True
         cls.commit(
             dvc.scm,
             exp_hash,

--- a/dvc/repo/experiments/save.py
+++ b/dvc/repo/experiments/save.py
@@ -2,7 +2,7 @@ import logging
 import os
 from typing import TYPE_CHECKING, List, Optional
 
-from .exceptions import ExperimentExistsError, UnchangedExperimentError
+from .exceptions import ExperimentExistsError
 from .refs import ExpRefInfo
 from .utils import check_ref_format, get_random_exp_name
 
@@ -70,9 +70,6 @@ def save(
             try:
                 if workspace is not None:
                     repo.scm.stash.apply(workspace)
-                else:
-                    if not (include_untracked or force):
-                        raise UnchangedExperimentError(orig_head)
 
                 exp_rev = _save_experiment(
                     repo, orig_head, force, name, include_untracked

--- a/tests/func/experiments/test_checkpoints.py
+++ b/tests/func/experiments/test_checkpoints.py
@@ -90,14 +90,11 @@ def test_resume_checkpoint(
 def test_reset_checkpoint(
     tmp_dir, scm, dvc, checkpoint_stage, caplog, workspace
 ):
-    dvc.experiments.run(
-        checkpoint_stage.addressing, name="foo", tmp_dir=not workspace
-    )
+    dvc.experiments.run(checkpoint_stage.addressing, tmp_dir=not workspace)
 
     results = dvc.experiments.run(
         checkpoint_stage.addressing,
         params=["foo=2"],
-        name="foo",
         tmp_dir=not workspace,
         reset=True,
     )
@@ -228,7 +225,8 @@ def test_auto_push_during_iterations(
     ref_info = first(exp_refs_by_rev(scm, exp))
     assert git_upstream.tmp_dir.scm.get_ref(str(ref_info)) == exp
 
-    assert auto_push_spy.call_count == 2
+    # Assert 3 pushes: 2 checkpoints and final commit
+    assert auto_push_spy.call_count == 3
     assert auto_push_spy.call_args[0][2] == remote
 
 
@@ -288,7 +286,8 @@ def test_tmp_dir_failed_checkpoint(
     exp = first(results)
 
     result = dvc.experiments.show()[baseline]
-    assert len(result) == 1 + 2
+    # Assert 4 rows: baseline, 2 checkpoints, and final commit
+    assert len(result) == 4
     assert exp in result
     assert (
         "Checkpoint stage 'failed-checkpoint-file' was interrupted remaining "

--- a/tests/func/experiments/test_experiments.py
+++ b/tests/func/experiments/test_experiments.py
@@ -731,3 +731,10 @@ def test_run_env(tmp_dir, dvc, scm, mocker):
     dvc.experiments.run(name="foo")
     assert (tmp_dir / "DVC_EXP_BASELINE_REV").read_text().strip() == baseline
     assert (tmp_dir / "DVC_EXP_NAME").read_text().strip() == "foo"
+
+
+def test_experiment_unchanged(tmp_dir, scm, dvc, exp_stage):
+    dvc.experiments.run(exp_stage.addressing)
+    dvc.experiments.run(exp_stage.addressing)
+
+    assert len(dvc.experiments.ls()["master"]) == 2

--- a/tests/func/experiments/test_save.py
+++ b/tests/func/experiments/test_save.py
@@ -4,7 +4,6 @@ from funcy import first
 from dvc.repo.experiments.exceptions import (
     ExperimentExistsError,
     InvalidArgumentError,
-    UnchangedExperimentError,
 )
 from dvc.repo.experiments.utils import exp_refs_by_rev
 from dvc.scm import resolve_rev
@@ -18,10 +17,7 @@ def modified_exp_stage(exp_stage, tmp_dir):
 
 
 def test_exp_save_unchanged(tmp_dir, dvc, scm, exp_stage):
-    with pytest.raises(UnchangedExperimentError):
-        dvc.experiments.save()
-
-    dvc.experiments.save(force=True)
+    dvc.experiments.save()
 
 
 @pytest.mark.parametrize("name", (None, "test"))

--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -245,7 +245,8 @@ def test_show_checkpoint(
     exp_rev = first(results)
 
     results = dvc.experiments.show()[baseline_rev]
-    assert len(results) == checkpoint_stage.iterations + 1
+    # Assert 4 rows: baseline, 2 checkpoints, and final commit
+    assert len(results) == checkpoint_stage.iterations + 2
 
     checkpoints = []
     for rev, exp in results.items():
@@ -1049,7 +1050,8 @@ def test_show_checkpoint_error(tmp_dir, scm, dvc, checkpoint_stage, mocker):
     exp_ref = str(first(exp_refs_by_rev(scm, exp_rev)))
 
     results = dvc.experiments.show()[baseline_rev]
-    assert len(results) == checkpoint_stage.iterations + 1
+    # Assert 4 rows: baseline, 2 checkpoints, and final commit
+    assert len(results) == checkpoint_stage.iterations + 2
 
     checkpoints = {}
     for rev in results:


### PR DESCRIPTION
Following up on https://github.com/iterative/dvc.org/pull/4200#discussion_r1057826738:

> > Or, if nothing
  has changed in the workspace, force saving an experiment anyway (identical to
  Git `HEAD`).
>
> @dtrifiro I missed this check in https://github.com/iterative/dvc/pull/8690. I don't think `--force` should be needed and it complicates this option. Can we drop it?
>
> Ideally, we want to make `dvc exp run` the same and not worry about creating duplicate experiments (see the discussion in https://github.com/iterative/dvc/pull/8659#issuecomment-1338499979).   
