### PR TITLE
scm: add cause of clone errors

### DIFF
--- a/dvc/commands/get.py
+++ b/dvc/commands/get.py
@@ -4,6 +4,7 @@ import logging
 from dvc.cli import completion
 from dvc.cli.command import CmdBaseNoRepo
 from dvc.exceptions import DvcException
+from dvc.scm import CloneError
 
 from ..cli.utils import append_doc_link
 
@@ -44,6 +45,9 @@ class CmdGet(CmdBaseNoRepo):
                 jobs=self.args.jobs,
             )
             return 0
+        except CloneError:
+            logger.exception(f"failed to get '{self.args.path}'")
+            return 1
         except DvcException:
             logger.exception(
                 "failed to get '{}' from '{}'".format(

--- a/dvc/commands/imp.py
+++ b/dvc/commands/imp.py
@@ -5,6 +5,7 @@ from dvc.cli import completion
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
 from dvc.exceptions import DvcException
+from dvc.scm import CloneError
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +27,9 @@ class CmdImport(CmdBase):
                 meta=self.args.meta,
                 jobs=self.args.jobs,
             )
+        except CloneError:
+            logger.exception(f"failed to import '{self.args.path}'")
+            return 1
         except DvcException:
             logger.exception(
                 "failed to import '{}' from '{}'.".format(

--- a/dvc/scm.py
+++ b/dvc/scm.py
@@ -147,7 +147,7 @@ def clone(url: str, to_path: str, **kwargs):
                 fetch_all_exps(git, url, progress=pbar.update_git)
             return git
         except InternalCloneError as exc:
-            raise CloneError(str(exc))
+            raise CloneError("SCM error") from exc
 
 
 def resolve_rev(scm: "Git", rev: str) -> str:


### PR DESCRIPTION
This will show the cause of clone errors. e.g.

 ```bash
 dvc get https://github.com/dberenbaum/example-get-started-cp.git README.md -o deleteme
 ```
> ERROR: failed to get 'README.md' - SCM error: Failed to clone repo 'https://github.com/dberenbaum/example-get-started-cp.git' to '/tmp/tmp98x3h8g0dvc-clone': No valid credentials provided

related: #8654