### PR TITLE
internal: hoist resolver/top-level metrics/plots/params data to file level

### DIFF
--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -775,6 +775,7 @@ class PipelineStage(Stage):
         return f"{super().addressing}:{self.name}"
 
     def reload(self):
+        self.dvcfile._reset()  # pylint: disable=protected-access
         return self.dvcfile.stages[self.name]
 
     def _status_stage(self, ret):

--- a/tests/func/test_stage.py
+++ b/tests/func/test_stage.py
@@ -317,6 +317,8 @@ def test_stage_remove_pipeline_stage(tmp_dir, dvc, run_copy):
 
     with dvc.lock:
         stage.remove()
+
+    dvc_file._reset()
     assert stage.name not in dvc_file.stages
     assert "copy-bar-foobar" in dvc_file.stages
 

--- a/tests/unit/stage/test_loader_pipeline_file.py
+++ b/tests/unit/stage/test_loader_pipeline_file.py
@@ -247,11 +247,11 @@ def test_load_stage_wdir_and_path_correctly(dvc, stage_data, lock_data):
 
 def test_load_stage_mapping(dvc, stage_data, lock_data):
     dvcfile = Dvcfile(dvc, PIPELINE_FILE)
-    loader = StageLoader(
-        dvcfile, {"stages": {"stage": stage_data}}, {"stage": lock_data}
-    )
-    assert len(loader) == 1
-    assert "stage" in loader
-    assert "stage1" not in loader
-    assert loader.keys() == {"stage"}
-    assert isinstance(loader["stage"], PipelineStage)
+    dvcfile.contents = {"stages": {"stage": stage_data}}
+    dvcfile.lockfile_contents = {"stage": lock_data}
+
+    assert len(dvcfile.stages) == 1
+    assert "stage" in dvcfile.stages
+    assert "stage1" not in dvcfile.stages
+    assert dvcfile.stages.keys() == {"stage"}
+    assert isinstance(dvcfile.stages["stage"], PipelineStage)


### PR DESCRIPTION
where it makes sense, since it is a part of file rather than "StageLoader".