### PR TITLE
perf: remove fs exists check in plots, parallel data collect

### DIFF
--- a/dvc/repo/collect.py
+++ b/dvc/repo/collect.py
@@ -28,7 +28,6 @@ def _collect_paths(
     repo: "Repo",
     targets: Iterable[str],
     recursive: bool = False,
-    rev: str = None,
 ) -> StrPaths:
     from dvc.fs.dvc import DVCFileSystem
 
@@ -39,13 +38,6 @@ def _collect_paths(
     for fs_path in fs_paths:
         if recursive and fs.isdir(fs_path):
             target_paths.extend(fs.find(fs_path))
-
-        rel = fs.path.relpath(fs_path)
-        if not fs.exists(fs_path):
-            if rev == "workspace" or rev == "":
-                logger.warning("'%s' was not found in current workspace.", rel)
-            else:
-                logger.warning("'%s' was not found at: '%s'.", rel, rev)
         target_paths.append(fs_path)
 
     return target_paths
@@ -73,7 +65,6 @@ def collect(
     deps: bool = False,
     targets: Iterable[str] = None,
     output_filter: FilterFn = None,
-    rev: str = None,
     recursive: bool = False,
     duplicates: bool = False,
 ) -> Tuple[Outputs, StrPaths]:
@@ -85,6 +76,6 @@ def collect(
         fs_paths: StrPaths = []
         return outs, fs_paths
 
-    target_paths = _collect_paths(repo, targets, recursive=recursive, rev=rev)
+    target_paths = _collect_paths(repo, targets, recursive=recursive)
 
     return _filter_outs(outs, target_paths, duplicates=duplicates)

--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -78,7 +78,7 @@ def collect_experiment_commit(
             result["timestamp"] = datetime.fromtimestamp(commit.commit_time)
 
         params = _gather_params(
-            repo, rev=rev, targets=None, deps=param_deps, onerror=onerror
+            repo, targets=None, deps=param_deps, onerror=onerror
         )
         if params:
             result["params"] = params

--- a/dvc/repo/metrics/show.py
+++ b/dvc/repo/metrics/show.py
@@ -44,13 +44,9 @@ def _collect_top_level_metrics(repo):
             yield repo.fs.path.normpath(path)
 
 
-def _collect_metrics(repo, targets, revision, recursive):
+def _collect_metrics(repo, targets, recursive):
     metrics, fs_paths = collect(
-        repo,
-        targets=targets,
-        output_filter=_is_metric,
-        recursive=recursive,
-        rev=revision,
+        repo, targets=targets, output_filter=_is_metric, recursive=recursive
     )
     return _to_fs_paths(metrics) + list(fs_paths)
 
@@ -109,7 +105,7 @@ def _read_metrics(repo, metrics, rev, onerror=None):
 
 
 def _gather_metrics(repo, targets, rev, recursive, onerror=None):
-    metrics = _collect_metrics(repo, targets, rev, recursive)
+    metrics = _collect_metrics(repo, targets, recursive)
     metrics.extend(_collect_top_level_metrics(repo))
     return _read_metrics(repo, metrics, rev, onerror=onerror)
 

--- a/dvc/repo/params/show.py
+++ b/dvc/repo/params/show.py
@@ -52,7 +52,7 @@ def _collect_top_level_params(repo):
 
 
 def _collect_configs(
-    repo: "Repo", rev, targets=None, deps=False, stages=None
+    repo: "Repo", targets=None, deps=False, stages=None
 ) -> Tuple[List["Output"], List[str]]:
 
     params, fs_paths = collect(
@@ -60,7 +60,6 @@ def _collect_configs(
         targets=targets or [],
         deps=True,
         output_filter=_is_params,
-        rev=rev,
         duplicates=deps or stages is not None,
     )
     all_fs_paths = fs_paths + [p.fs_path for p in params]
@@ -156,7 +155,6 @@ def show(
     for branch in repo.brancher(revs=revs):
         params = error_handler(_gather_params)(
             repo=repo,
-            rev=branch,
             targets=targets,
             deps=deps,
             onerror=onerror,
@@ -188,11 +186,9 @@ def show(
     return res
 
 
-def _gather_params(
-    repo, rev, targets=None, deps=False, onerror=None, stages=None
-):
+def _gather_params(repo, targets=None, deps=False, onerror=None, stages=None):
     param_outs, params_fs_paths = _collect_configs(
-        repo, rev, targets=targets, deps=deps, stages=stages
+        repo, targets=targets, deps=deps, stages=stages
     )
     params_fs_paths.extend(_collect_top_level_params(repo=repo))
     params = _read_params(

--- a/tests/func/metrics/test_show.py
+++ b/tests/func/metrics/test_show.py
@@ -1,4 +1,3 @@
-import logging
 import os
 
 import pytest
@@ -258,13 +257,8 @@ def test_show_malformed_metric(tmp_dir, scm, dvc, caplog):
     )
 
 
-def test_metrics_show_no_target(tmp_dir, dvc, caplog):
-    with caplog.at_level(logging.WARNING):
-        assert dvc.metrics.show(targets=["metrics.json"]) == {"": {}}
-
-    assert (
-        "'metrics.json' was not found in current workspace." in caplog.messages
-    )
+def test_metrics_show_no_target(tmp_dir, dvc, capsys):
+    assert dvc.metrics.show(targets=["metrics.json"]) == {"": {}}
 
 
 def test_show_no_metrics_files(tmp_dir, dvc, caplog):

--- a/tests/func/plots/test_show.py
+++ b/tests/func/plots/test_show.py
@@ -128,14 +128,18 @@ def test_show_from_subdir(tmp_dir, dvc, capsys):
     assert (subdir / "dvc_plots" / "index.html").is_file()
 
 
-def test_plots_show_non_existing(tmp_dir, dvc, caplog):
+def test_plots_show_non_existing(tmp_dir, dvc, capsys):
     result = dvc.plots.show(targets=["plot.json"])
     assert isinstance(
         get_plot(result, "workspace", file="plot.json", endkey="error"),
         FileNotFoundError,
     )
 
-    assert "'plot.json' was not found in current workspace." in caplog.text
+    cap = capsys.readouterr()
+    assert (
+        "DVC failed to load some plots for following revisions: 'workspace'"
+        in cap.err
+    )
 
 
 @pytest.mark.parametrize("clear_before_run", [True, False])

--- a/tests/unit/test_collect.py
+++ b/tests/unit/test_collect.py
@@ -1,13 +1,4 @@
-import logging
-
 from dvc.repo.collect import collect
-
-
-def test_no_file_on_target_rev(tmp_dir, scm, dvc, caplog):
-    with caplog.at_level(logging.WARNING, "dvc"):
-        collect(dvc, targets=["file.yaml"], rev="current_branch")
-
-    assert "'file.yaml' was not found at: 'current_branch'." in caplog.text
 
 
 def test_collect_duplicates(tmp_dir, scm, dvc):


### PR DESCRIPTION
Related https://github.com/iterative/dvc/issues/8786

## Before:

/Users/ivan/Projects/vscode-dvc-demo/.venv/bin/python -m dvc plots diff 11295f0 9aa0603 e29c9be workspace -o .dvc/tmp/plots --split --json - COMPLETED (**53199ms**)

## After:

/Users/ivan/Projects/vscode-dvc-demo/.venv/bin/python -m dvc plots diff 11295f0 9aa0603 e29c9be workspace -o .dvc/tmp/plots --split --json - COMPLETED (9404ms)

.. and not a huge change to maintain to my mind.

still very slow though, but I think it now goes into brancher, path collection, etc - which also should be parallelized, indexed and cached.

---------

* [X] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [X] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
