### PR TITLE
output: quote filepath

### DIFF
--- a/dvc/output.py
+++ b/dvc/output.py
@@ -375,6 +375,8 @@ class Output:
                     self.hash_info = HashInfo("md5", md5)
 
     def _parse_path(self, fs, fs_path):
+        from urllib.parse import quote, unquote
+
         parsed = urlparse(self.def_path)
         if (
             parsed.scheme != "remote"
@@ -390,7 +392,9 @@ class Output:
             # then we have #2059 bug and can't really handle that.
             fs_path = fs.path.join(self.stage.wdir, fs_path)
 
-        return fs.path.abspath(fs.path.normpath(fs_path))
+        return unquote(
+            fs.path.abspath(fs.path.normpath(quote(fs_path, safe="/\\:")))
+        )
 
     def __repr__(self):
         return "{class_name}: '{def_path}'".format(

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -1143,3 +1143,11 @@ def test_add_with_annotations(M, tmp_dir, dvc):
     (stage,) = dvc.add("foo", type="t2")
     assert stage.outs[0].annot == Annotation(**annot)
     assert (tmp_dir / "foo.dvc").parse() == M.dict(outs=[M.dict(**annot)])
+
+
+@pytest.mark.skipif(
+    os.name == "nt", reason="A file name can't contain ? on Windows"
+)
+def test_add_file_startswith_question(tmp_dir, dvc):
+    tmp_dir.gen({"?foo": "foo"})
+    assert main(["add", "?foo"]) == 0


### PR DESCRIPTION
Fixes #8180

As mentioned in the issue, `dvc add` fails for files whose filename begins with a question mark.
Applying `urllib.parse.quote` and `urllib.parse.unquote` before and after the `normpath()` solves this issue.
Corresponding test functions are also added.


* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
