### PR TITLE
dvcfs: ls: don't call info()

### DIFF
--- a/tests/func/test_ls.py
+++ b/tests/func/test_ls.py
@@ -587,4 +587,10 @@ def test_broken_symlink(tmp_dir, dvc):
             "isexec": False,
             "path": ".dvcignore",
         },
+        {
+            "isout": False,
+            "isdir": False,
+            "isexec": False,
+            "path": "link",
+        },
     ]


### PR DESCRIPTION
Cuts down `dvc ls . data/mnist/dataset --recursive` for me from ~37 to ~25 seconds.

Note that this also changes behaviour for ls with a broken symlink, as we were not able to see it before because of a failing `info()` call, but now we can follow a normal UNIX ls behaviour more closely.
