### PR TITLE
index/stage: move repo collection logic to index

### DIFF
--- a/dvc/dvcfile.py
+++ b/dvc/dvcfile.py
@@ -1,16 +1,7 @@
 import contextlib
 import logging
 import os
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    List,
-    Tuple,
-    TypeVar,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, List, Tuple, TypeVar, Union
 
 from funcy import cached_property
 
@@ -192,7 +183,7 @@ class SingleStageFile(FileMixin):
     from dvc.stage.loader import SingleStageLoader as LOADER
 
     metrics: List[str] = []
-    plots: Dict[str, Any] = {}
+    plots: Any = {}
     params: List[str] = []
 
     @property
@@ -242,6 +233,7 @@ class PipelineFile(FileMixin):
         self.__dict__.pop("contents", None)
         self.__dict__.pop("lockfile_contents", None)
         self.__dict__.pop("resolver", None)
+        self.__dict__.pop("stages", None)
 
     def dump(
         self, stage, update_pipeline=True, update_lock=True, **kwargs
@@ -313,7 +305,7 @@ class PipelineFile(FileMixin):
         wdir = self.repo.fs.path.parent(self.path)
         return DataResolver(self.repo, wdir, self.contents)
 
-    @property
+    @cached_property
     def stages(self):
         return self.LOADER(self, self.contents, self.lockfile_contents)
 

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -239,7 +239,14 @@ class Repo:
     def index(self):
         from dvc.repo.index import Index
 
-        return Index(self)
+        return Index.from_repo(self)
+
+    def ensure_graph_correctness_with(self, stages=None, callback=None):
+        if not getattr(self, "_skip_graph_checks", False):
+            new = self.index.update(stages)
+            if callable(callback):
+                callback()
+            new.check_graph()
 
     @staticmethod
     def open(url, *args, **kwargs):

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -180,9 +180,9 @@ def add(  # noqa: C901
     with translate_graph_error(stages), ui.status(msg) as status:
         # remove existing stages that are to-be replaced with these
         # new stages for the graph checks.
-        new_index = repo.index.update(stages)
-        status.update("Checking graph")
-        new_index.check_graph()
+        repo.ensure_graph_correctness_with(
+            stages=stages, callback=lambda: status.update("Checking graph")
+        )
 
     odb = None
     if to_remote:

--- a/dvc/repo/imp_url.py
+++ b/dvc/repo/imp_url.py
@@ -78,8 +78,7 @@ def imp_url(  # noqa: C901
     dvcfile.remove()
 
     try:
-        new_index = self.index.add(stage)
-        new_index.check_graph()
+        self.ensure_graph_correctness_with(stages={stage})
     except OutputDuplicationError as exc:
         raise OutputDuplicationError(  # noqa: B904
             exc.output, set(exc.stages) - {stage}

--- a/dvc/repo/metrics/show.py
+++ b/dvc/repo/metrics/show.py
@@ -34,7 +34,7 @@ def _to_fs_paths(metrics: List[Output]) -> StrPaths:
 
 
 def _collect_top_level_metrics(repo):
-    top_metrics = repo.index._top_metrics  # pylint: disable=protected-access
+    top_metrics = repo.index._metrics  # pylint: disable=protected-access
     for dvcfile, metrics in top_metrics.items():
         wdir = repo.fs.path.relpath(
             repo.fs.path.parent(dvcfile), repo.root_dir

--- a/dvc/repo/params/show.py
+++ b/dvc/repo/params/show.py
@@ -41,7 +41,7 @@ def _is_params(dep: "Output"):
 
 
 def _collect_top_level_params(repo):
-    top_params = repo.index._top_params  # pylint: disable=protected-access
+    top_params = repo.index._params  # pylint: disable=protected-access
     for dvcfile, params in top_params.items():
         wdir = repo.fs.path.relpath(
             repo.fs.path.parent(dvcfile), repo.root_dir

--- a/dvc/repo/plots/__init__.py
+++ b/dvc/repo/plots/__init__.py
@@ -453,7 +453,7 @@ def _resolve_definitions(
 
 def _collect_pipeline_files(repo, targets: List[str], props, onerror=None):
     result: Dict[str, Dict] = {}
-    top_plots = repo.index._top_plots  # pylint: disable=protected-access
+    top_plots = repo.index._plots  # pylint: disable=protected-access
     for dvcfile, plots_def in top_plots.items():
         dvcfile_path = _relpath(repo.dvcfs, dvcfile)
         dvcfile_defs_dict: Dict[str, Union[Dict, None]] = {}

--- a/tests/func/test_remove.py
+++ b/tests/func/test_remove.py
@@ -26,7 +26,7 @@ def test_remove(tmp_dir, scm, dvc, run_copy, remove_outs):
     for stage in [stage1, stage2, stage3]:
         dvc.remove(stage.addressing, outs=remove_outs)
         out_exists = (out.exists for out in stage.outs)
-        assert stage not in dvc.stage.collect_repo()
+        assert stage not in dvc.index.stages
         if remove_outs:
             assert not any(out_exists)
         else:

--- a/tests/func/test_stage.py
+++ b/tests/func/test_stage.py
@@ -239,13 +239,6 @@ def test_parent_repo_collect_stages(tmp_dir, scm, dvc):
     assert deep_subrepo_stages != []
 
 
-def test_collect_repo_ignored_dir_unignored_pattern(tmp_dir, dvc, scm):
-    tmp_dir.gen({".gitignore": "data/**\n!data/**/\n!data/**/*.dvc"})
-    scm.add([".gitignore"])
-    (stage,) = tmp_dir.dvc_gen({"data/raw/tracked.csv": "5,6,7,8"})
-    assert dvc.stage.collect_repo() == [stage]
-
-
 @pytest.mark.parametrize("with_deps", (False, True))
 def test_collect_symlink(tmp_dir, dvc, with_deps):
     tmp_dir.gen({"data": {"foo": "foo contents"}})

--- a/tests/func/test_stage_load.py
+++ b/tests/func/test_stage_load.py
@@ -391,7 +391,7 @@ def test_collect_optimization(tmp_dir, dvc, mocker):
     # Forget cached stages and graph and error out on collection
     dvc._reset()
     mocker.patch(
-        "dvc.repo.index.Index.stages",
+        "dvc.repo.Repo.index",
         property(raiser(Exception("Should not collect"))),
     )
 
@@ -406,7 +406,7 @@ def test_collect_optimization_on_stage_name(tmp_dir, dvc, mocker, run_copy):
     # Forget cached stages and graph and error out on collection
     dvc._reset()
     mocker.patch(
-        "dvc.repo.index.Index.stages",
+        "dvc.repo.Repo.index",
         property(raiser(Exception("Should not collect"))),
     )
 
@@ -429,17 +429,6 @@ def test_collect_repo_callback(tmp_dir, dvc, mocker):
     file_path, exc = mock.call_args[0]
     assert file_path == PIPELINE_FILE
     assert isinstance(exc, YAMLValidationError)
-
-
-def test_gitignored_collect_repo(tmp_dir, dvc, scm):
-    (stage,) = tmp_dir.dvc_gen({"data": {"foo": "foo", "bar": "bar"}})
-
-    assert dvc.stage.collect_repo() == [stage]
-
-    scm.ignore(stage.path)
-    scm._reset()
-
-    assert not dvc.stage.collect_repo()
 
 
 def test_gitignored_file_try_collect_granular_for_data_files(

--- a/tests/unit/command/test_status.py
+++ b/tests/unit/command/test_status.py
@@ -76,12 +76,14 @@ def test_status_quiet(dvc, mocker, caplog, capsys, status, ret):
 
 
 def test_status_empty(dvc, mocker, capsys):
+    from dvc.repo.index import Index
+
     cli_args = parse_args(["status"])
     assert cli_args.func == CmdDataStatus
 
     cmd = cli_args.func(cli_args)
 
-    spy = mocker.spy(cmd.repo.stage, "_collect_all_from_repo")
+    spy = mocker.spy(Index, "from_repo")
 
     assert cmd.run() == 0
 
@@ -100,6 +102,8 @@ def test_status_empty(dvc, mocker, capsys):
     ],
 )
 def test_status_up_to_date(dvc, mocker, capsys, cloud_opts, expected_message):
+    from dvc.repo.index import Index
+
     cli_args = parse_args(["status", *cloud_opts])
     assert cli_args.func == CmdDataStatus
 
@@ -107,12 +111,8 @@ def test_status_up_to_date(dvc, mocker, capsys, cloud_opts, expected_message):
 
     mocker.patch.dict(cmd.repo.config, {"core": {"remote": "default"}})
     mocker.patch.object(cmd.repo, "status", autospec=True, return_value={})
-    mocker.patch.object(
-        cmd.repo.stage,
-        "_collect_all_from_repo",
-        return_value=[[object()], {}, {}, {}],
-        autospec=True,
-    )
+    mocker.patch("dvc.repo.Repo.index", return_value=Index(dvc, [object()]))
+    cmd.repo._reset = mocker.Mock()
 
     assert cmd.run() == 0
     captured = capsys.readouterr()


### PR DESCRIPTION
Haven't made many changes here, but now the Index collection happens eagerly (although index is still created lazily) when `Index.from_repo()` or `Index.from_file()` is called.

* The collection of stages happen inside `Index` rather than as part of `Repo.stage.collect_repo`.
* `repo._skip_graph_checks` was broken, it has been fixed by introducing `Repo.ensure_graph_correctness_with(stages=stages)` API that honors that attribute.
* Stage collection is eager during `Index.from_repo()`.
* Minor cleanups in `Repo`/`StageLoad`/`Index`.

### Motivation

The Index had `stages` cached property, which was lazily loaded. We extended this and added `metrics`/`params`/`plots` property which was also a `cached_property`. It was not possible to collect and fill all of these properties at the same time, but for performance reasons, we wanted to load everything at once.

So I changed the implementation of all these properties to invoke `Index._collect()`, which would collect and fill all of the properties at the same time (even if you ask for just one).

https://github.com/iterative/dvc/blob/1d5de9c5ba5909f6eaa0911c3b2a691bbf4ea254/dvc/repo/index.py#L117-L127

But that felt hackish, the performance issue is solved but the way we collect feels odd.
It does seem like we are not collecting a unit of things, but multiple things. At least, the cached property makes me think in that way.

So not only in implementation, but to make it look like a single unit of thing to load, the interface also has to match that. So we needed to unify this collection logic.

With this PR, the Index is loaded eagerly when `Index.from_repo()` is invoked, and it returns a single unit `Index` that has all `stages`/`metrics`/`params`/`plots` in it.

The other reason was the realization that the collection logic belonged in `Index` rather than in `StageLoad`, but that's more obvious.

