### PR TITLE
deps: bump dvc-data to 0.29.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     "dvc-render==0.0.17",
     "dvc-task==0.1.9",
     "dvclive>=1.2.2",
-    "dvc-data==0.28.6",
+    "dvc-data==0.29.0",
     "dvc-http",
     "hydra-core>=1.1.0",
     "iterative-telemetry==0.0.6",


### PR DESCRIPTION
Should also help with https://github.com/iterative/dvc/issues/8359 , as we've sped up meta serialization which is used when writing directories to dvcfiles.