### PR TITLE
stage.loader: Fix directories tracked as external deps.

### DIFF
--- a/dvc/stage/loader.py
+++ b/dvc/stage/loader.py
@@ -75,6 +75,10 @@ class StageLoader(Mapping):
             info = info.copy()
             info.pop("path", None)
             item.meta = Meta.from_dict(info)
+
+            if item.meta.nfiles and item.hash_name != "md5":
+                item.hash_name = "md5"
+
             hash_value = getattr(item.meta, item.hash_name, None)
             item.hash_info = HashInfo(item.hash_name, hash_value)
             if item.hash_info and item.hash_info.isdir:

--- a/tests/unit/stage/test_loader_pipeline_file.py
+++ b/tests/unit/stage/test_loader_pipeline_file.py
@@ -128,12 +128,16 @@ def test_fill_from_lock_use_appropriate_checksum(dvc, lock_data):
         PipelineStage,
         dvc,
         PROJECT_FILE,
-        deps=["s3://dvc-temp/foo"],
+        deps=["s3://dvc-temp/foo", "s3://dvc-temp/foodir"],
         outs=["bar"],
     )
-    lock_data["deps"] = [{"path": "s3://dvc-temp/foo", "etag": "e-tag"}]
+    lock_data["deps"] = [
+        {"path": "s3://dvc-temp/foo", "etag": "e-tag"},
+        {"path": "s3://dvc-temp/foodir", "md5": "foodir_md5", "nfiles": 2},
+    ]
     StageLoader.fill_from_lock(stage, lock_data)
     assert stage.deps[0].hash_info == HashInfo("etag", "e-tag")
+    assert stage.deps[1].hash_info == HashInfo("md5", "foodir_md5")
     assert stage.outs[0].hash_info == HashInfo("md5", "bar_checksum")
 
 


### PR DESCRIPTION
For filesystems using `PARAM_CHECKSUM` different from "md5",  `hash_name` is being set to `PARAM_CHECKSUM` when instantiating the `Dependency` class.

However, for the case of directories the lock file actually contains `md5` (of the `.dir` file) instead of `PARAM_CHECKSUM`.

`fill_from_lock` was failing to load the actual `hash_info` for those dependencies, falsely reporting them as changed in any case.

Closes #8783