### PR TITLE
index: experimental persistent data index

### DIFF
--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -262,6 +262,7 @@ SCHEMA = {
     # section for experimental features
     "feature": {
         Optional("machine", default=False): Bool,
+        Optional("data_index_cache", default=False): Bool,
         # enabled by default. It's of no use, kept for backward compatibility.
         Optional("parametrization", default=True): Bool,
     },


### PR DESCRIPTION
Putting https://github.com/iterative/dvc-data/issues/208 to use.

Note that this is `experimental` for now and needs to be enabled with `dvc config feature.data_index_cache true`.

For example, sequential run of

```
dvc list . data/mnist/dataset/ --recursive --rev HEAD
```

goes down from ~16sec to ~8sec (2x improvement)

and 

```
dvc list . data/mnist/dataset/ --rev HEAD
```

goes down from ~11sec to ~1.5sec (7x improvement)
