### PR TITLE
lint: run lint checks on all platforms

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,44 +12,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-permissions:  # added using https://github.com/step-security/secure-workflows
+permissions:
   contents: read
 
 jobs:
-  lint:
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.8
-        cache: pip
-        cache-dependency-path: pyproject.toml
-    - name: Install requirements
-      run: |
-        pip install --upgrade pip wheel
-        pip install ".[dev]"
-    - uses: pre-commit/action@v3.0.0
   tests:
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-latest]
+        os: [ubuntu-20.04, windows-latest, macos-latest]
         pyv: ["3.8", "3.9", "3.10", "3.11"]
-        pytest-filter:
-        - "import or plot or live or experiment"
-        - "not (import or plot or live or experiment)"
-        include:
-        - {os: macos-latest, pyv: "3.8"}
-        - {os: macos-latest, pyv: "3.9"}
-        - {os: macos-latest, pyv: "3.10"}
-        - {os: macos-latest, pyv: "3.11"}
 
     steps:
     - uses: actions/checkout@v3
@@ -65,12 +39,12 @@ jobs:
       run: |
         pip install --upgrade pip wheel
         pip install -e ".[dev]"
+    - uses: pre-commit/action@v3.0.0
     - name: run tests
       timeout-minutes: 30
       run: >
         pytest -nauto --timeout=300 --durations=100
         --cov --cov-report=xml --cov-report=term
-        -k "${{ matrix.pytest-filter }}"
     - name: upload coverage report
       uses: codecov/codecov-action@v3
       with:
@@ -78,7 +52,7 @@ jobs:
         fail_ci_if_error: false
   check:
     if: always()
-    needs: [lint, tests]
+    needs: [tests]
     runs-on: ubuntu-latest
     steps:
       - uses: re-actors/alls-green@release/v1
@@ -86,7 +60,7 @@ jobs:
           jobs: ${{ toJSON(needs) }}
   notify:
     if: github.ref == 'refs/heads/main' && failure()
-    needs: [lint, tests]
+    needs: [tests]
     runs-on: ubuntu-latest
     steps:
     - name: Slack Notification

--- a/dvc/_debug.py
+++ b/dvc/_debug.py
@@ -139,8 +139,11 @@ def _sigshow(_, frame: Optional["FrameType"]) -> None:
 def show_stack():
     r"""Show stack trace on SIGQUIT (Ctrl-\) or SIGINFO (Ctrl-T on macOS)."""
     import signal
+    import sys
 
-    signal.signal(signal.SIGQUIT, _sigshow)
+    if sys.platform != "win32":
+        signal.signal(signal.SIGQUIT, _sigshow)
+
     try:
         signal.signal(signal.SIGINFO, _sigshow)  # only available on macOS
     except AttributeError:

--- a/dvc/daemon.py
+++ b/dvc/daemon.py
@@ -52,17 +52,19 @@ def _spawn_posix(cmd, env):
     # with PyInstaller has trouble with SystemExit exception and throws
     # errors such as "[26338] Failed to execute script __main__"
     try:
-        pid = os.fork()  # pylint: disable=no-member
+        # pylint: disable-next=no-member
+        pid = os.fork()  # type: ignore[attr-defined]
         if pid > 0:
             return
     except OSError:
         logger.exception("failed at first fork")
         os._exit(1)  # pylint: disable=protected-access
 
-    os.setsid()  # pylint: disable=no-member
+    os.setsid()  # type: ignore[attr-defined]  # pylint: disable=no-member
 
     try:
-        pid = os.fork()  # pylint: disable=no-member
+        # pylint: disable-next=no-member
+        pid = os.fork()  # type: ignore[attr-defined]
         if pid > 0:
             os._exit(0)  # pylint: disable=protected-access
     except OSError:

--- a/dvc/proc/manager.py
+++ b/dvc/proc/manager.py
@@ -118,7 +118,7 @@ class ProcessManager:
         if sys.platform == "win32":
             self.send_signal(name, signal.SIGTERM)
         else:
-            self.send_signal(name, signal.SIGKILL)
+            self.send_signal(name, signal.SIGKILL)  # pylint: disable=no-member
 
     def remove(self, name: str, force: bool = False):
         """Remove the specified named process from this manager.

--- a/dvc/testing/fixtures.py
+++ b/dvc/testing/fixtures.py
@@ -204,6 +204,8 @@ def docker_services(
     # only launch docker images once.
 
     from filelock import FileLock
+
+    # pylint: disable-next=import-error
     from pytest_docker.plugin import DockerComposeExecutor, Services
 
     executor = DockerComposeExecutor(


### PR DESCRIPTION
We already have `pre-commit.ci` running for quick feedback. We actually want to run mypy/pylint checks (and others) across multiple python versions and platforms.
So, this PR changes the workflow and makes them run before running tests in all platforms and versions. This does add 3-4 minutes to our jobs.

Also merged the test split that we had before. 