### PR TITLE
analytics: differentiate ci users

### DIFF
--- a/dvc/analytics.py
+++ b/dvc/analytics.py
@@ -102,17 +102,24 @@ def _runtime_info():
     """
     Gather information from the environment where DVC runs to fill a report.
     """
-    from iterative_telemetry import find_or_create_user_id
+    from iterative_telemetry import _generate_ci_id, find_or_create_user_id
 
     from dvc import __version__
     from dvc.utils import is_binary
+
+    ci_id = _generate_ci_id()
+    if ci_id:
+        group_id, user_id = ci_id
+    else:
+        group_id, user_id = None, find_or_create_user_id()
 
     return {
         "dvc_version": __version__,
         "is_binary": is_binary(),
         "scm_class": _scm_in_use(),
         "system_info": _system_info(),
-        "user_id": find_or_create_user_id(),
+        "user_id": user_id,
+        "group_id": group_id,
     }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "dvc-data==0.33.0",
     "dvc-http",
     "hydra-core>=1.1.0",
-    "iterative-telemetry==0.0.6",
+    "iterative-telemetry==0.0.7",
     "dvc-studio-client>=0.1.1"
 ]
 dynamic = ["version"]

--- a/tests/unit/test_analytics.py
+++ b/tests/unit/test_analytics.py
@@ -49,6 +49,7 @@ def test_runtime_info(tmp_global_dir):
             "scm_class": Any("Git", None),
             "user_id": str,
             "system_info": dict,
+            "group_id": Any(str, None),
         },
         required=True,
     )


### PR DESCRIPTION
This would help to separate CI users in analytics. Depends on https://github.com/iterative/telemetry-python/pull/53.

Also needs a docs update in https://dvc.org/doc/user-guide/analytics.
