### PR TITLE
output: Don't serialize `hash_info` or `meta` in cloud versioning.

### DIFF
--- a/dvc/stage/serialize.py
+++ b/dvc/stage/serialize.py
@@ -158,18 +158,16 @@ def to_single_stage_lockfile(stage: "Stage", **kwargs) -> dict:
     def _dumpd(item):
         meta_d = item.meta.to_dict()
         meta_d.pop("isdir", None)
-        ret = [
-            (item.PARAM_PATH, item.def_path),
-            *item.hash_info.to_dict().items(),
-            *meta_d.items(),
-        ]
 
         if item.hash_info.isdir and kwargs.get("with_files"):
             if item.obj:
                 obj = item.obj
             else:
                 obj = item.get_obj()
-            ret.append((item.PARAM_FILES, obj.as_list(with_meta=True)))
+            ret = [((item.PARAM_FILES, obj.as_list(with_meta=True)))]
+        else:
+            ret = [*item.hash_info.to_dict().items(), *meta_d.items()]
+        ret.insert(0, (item.PARAM_PATH, item.def_path))
 
         return OrderedDict(ret)
 

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -1142,3 +1142,61 @@ def test_add_with_annotations(M, tmp_dir, dvc):
     (stage,) = dvc.add("foo", type="t2")
     assert stage.outs[0].annot == Annotation(**annot)
     assert (tmp_dir / "foo.dvc").parse() == M.dict(outs=[M.dict(**annot)])
+
+
+def test_add_updates_to_cloud_versioning_dir(tmp_dir, dvc):
+    data_dvc = tmp_dir / "data.dvc"
+    data_dvc.dump(
+        {
+            "outs": [
+                {
+                    "path": "data",
+                    "files": [
+                        {
+                            "size": 3,
+                            "version_id": "WYRG4BglP7pD.gEoJP6a4AqOhl.FRA.h",
+                            "etag": "acbd18db4cc2f85cedef654fccc4a4d8",
+                            "md5": "acbd18db4cc2f85cedef654fccc4a4d8",
+                            "relpath": "bar",
+                        },
+                        {
+                            "size": 3,
+                            "version_id": "0vL53tFVY5vVAoJ4HG2jCS1mEcohDPE0",
+                            "etag": "acbd18db4cc2f85cedef654fccc4a4d8",
+                            "md5": "acbd18db4cc2f85cedef654fccc4a4d8",
+                            "relpath": "foo",
+                        },
+                    ],
+                }
+            ]
+        }
+    )
+
+    data = tmp_dir / "data"
+    data.mkdir()
+    (data / "foo").write_text("foo")
+    (data / "bar").write_text("bar2")
+
+    dvc.add("data")
+
+    assert (tmp_dir / "data.dvc").parse() == {
+        "outs": [
+            {
+                "path": "data",
+                "files": [
+                    {
+                        "size": 4,
+                        "md5": "224e2539f52203eb33728acd228b4432",
+                        "relpath": "bar",
+                    },
+                    {
+                        "size": 3,
+                        "version_id": "0vL53tFVY5vVAoJ4HG2jCS1mEcohDPE0",
+                        "etag": "acbd18db4cc2f85cedef654fccc4a4d8",
+                        "md5": "acbd18db4cc2f85cedef654fccc4a4d8",
+                        "relpath": "foo",
+                    },
+                ],
+            }
+        ]
+    }

--- a/tests/unit/output/test_output.py
+++ b/tests/unit/output/test_output.py
@@ -121,3 +121,58 @@ def test_remote_missing_dependency_on_dir_pull(tmp_dir, scm, dvc, mocker):
     )
     with pytest.raises(RemoteMissingDepsError):
         dvc.pull()
+
+
+def test_hash_info_cloud_versioning_dir(mocker):
+    stage = mocker.MagicMock()
+    stage.repo.fs.version_aware = False
+    stage.repo.fs.PARAM_CHECKSUM = "etag"
+    files = [
+        {
+            "size": 3,
+            "version_id": "WYRG4BglP7pD.gEoJP6a4AqOhl.FRA.h",
+            "etag": "acbd18db4cc2f85cedef654fccc4a4d8",
+            "md5": "acbd18db4cc2f85cedef654fccc4a4d8",
+            "relpath": "bar",
+        },
+        {
+            "size": 3,
+            "version_id": "0vL53tFVY5vVAoJ4HG2jCS1mEcohDPE0",
+            "etag": "acbd18db4cc2f85cedef654fccc4a4d8",
+            "md5": "acbd18db4cc2f85cedef654fccc4a4d8",
+            "relpath": "foo",
+        },
+    ]
+    out = Output(stage, "path", files=files)
+    # `hash_info`` and `meta`` constructed from `files``
+    assert out.hash_info.name == "md5"
+    assert out.hash_info.value == "77e8000f532886eef8ee1feba82e9bad.dir"
+    assert out.meta.isdir
+    assert out.meta.nfiles == 2
+    assert out.meta.size == 6
+
+
+def test_dumpd_cloud_versioning_dir(mocker):
+    stage = mocker.MagicMock()
+    stage.repo.fs.version_aware = False
+    stage.repo.fs.PARAM_CHECKSUM = "md5"
+    files = [
+        {
+            "size": 3,
+            "version_id": "WYRG4BglP7pD.gEoJP6a4AqOhl.FRA.h",
+            "etag": "acbd18db4cc2f85cedef654fccc4a4d8",
+            "md5": "acbd18db4cc2f85cedef654fccc4a4d8",
+            "relpath": "bar",
+        },
+        {
+            "size": 3,
+            "version_id": "0vL53tFVY5vVAoJ4HG2jCS1mEcohDPE0",
+            "etag": "acbd18db4cc2f85cedef654fccc4a4d8",
+            "md5": "acbd18db4cc2f85cedef654fccc4a4d8",
+            "relpath": "foo",
+        },
+    ]
+    out = Output(stage, "path", files=files)
+
+    dumpd = out.dumpd()
+    assert dumpd == {"path": "path", "files": files}

--- a/tests/unit/stage/test_serialize_pipeline_lock.py
+++ b/tests/unit/stage/test_serialize_pipeline_lock.py
@@ -255,3 +255,28 @@ def test_to_lockfile(dvc):
             ]
         )
     }
+
+
+def test_to_single_stage_lockfile_cloud_versioning_dir(dvc):
+    stage = create_stage(PipelineStage, dvc, outs=["dir"], **kwargs)
+    stage.outs[0].hash_info = HashInfo("md5", "md-five.dir")
+    files = [
+        {
+            "size": 3,
+            "version_id": "WYRG4BglP7pD.gEoJP6a4AqOhl.FRA.h",
+            "etag": "acbd18db4cc2f85cedef654fccc4a4d8",
+            "md5": "acbd18db4cc2f85cedef654fccc4a4d8",
+            "relpath": "bar",
+        },
+        {
+            "size": 3,
+            "version_id": "0vL53tFVY5vVAoJ4HG2jCS1mEcohDPE0",
+            "etag": "acbd18db4cc2f85cedef654fccc4a4d8",
+            "md5": "acbd18db4cc2f85cedef654fccc4a4d8",
+            "relpath": "foo",
+        },
+    ]
+    stage.outs[0].files = files
+    e = _to_single_stage_lockfile(stage, with_files=True)
+    assert Schema(e)
+    assert e["outs"][0] == {"path": "dir", "files": files}


### PR DESCRIPTION
Closes #8357

---

Here is how the `.dvc` file looks for `2.42.0` / `this P.R` at different steps of the workflow (click details to expand):

## Importing with `--version-aware`

```
$ dvc import-url --version-aware $VERSIONED_BUCKET/data
$ cat data.dvc
```

<details>
<table>
<tr>
<td> 2.42.0 </td> <td> #8849 </td>
</tr>
<tr>
<td>

```yaml
md5: 677db99135cf82ed1b726b6be7abef49
frozen: true
deps:
- md5: a042035f7fb17fc84a42e33787ae4b6a.dir
  size: 13
  nfiles: 3
  path: s3://diglesia-bucket/data
  files:
  - size: 5
    version_id: dQymcW0EvEqy23qfrksrqo0ni2zGtPMG
    etag: 042967ff088f7f436015fbebdcad1f28
    relpath: bar
  - size: 4
    version_id: pd67.5YcvjqDm7jfmiHbpeQsXnprrXtf
    etag: d3b07384d113edec49eaa6238ad5ff00
    relpath: foo
  - size: 4
    version_id: 2ruNQaorqjnsFQZ5cinHsZSHEw7cz26J
    etag: 7361528e901ca2f2f1952a68ad242d79
    relpath: goo
outs:
- md5: b5c587798f2c0f599ef935244b290bf1.dir
  size: 13
  nfiles: 3
  path: data
  push: false
```

</td>
<td>

```yaml
md5: f642080c781ca41a33a3e6bf77959af5
frozen: true
deps:
- files:
  - size: 5
    version_id: dQymcW0EvEqy23qfrksrqo0ni2zGtPMG
    etag: 042967ff088f7f436015fbebdcad1f28
    relpath: bar
  - size: 4
    version_id: pd67.5YcvjqDm7jfmiHbpeQsXnprrXtf
    etag: d3b07384d113edec49eaa6238ad5ff00
    relpath: foo
  - size: 4
    version_id: 2ruNQaorqjnsFQZ5cinHsZSHEw7cz26J
    etag: 7361528e901ca2f2f1952a68ad242d79
    relpath: goo
  path: s3://diglesia-bucket/data
outs:
- md5: b5c587798f2c0f599ef935244b290bf1.dir
  size: 13
  nfiles: 3
  path: data
  push: false
```

</td>
</tr>
</table>
</details>

## Tracking local folder with `dvc add` and running the first `dvc push`

```
$ mkdir data
$ echo bar > data/bar
$ echo foo > data/foo
$ dvc add data
$ dvc push -v
$ cat data.dvc
```

<details>
<table>
<tr>
<td> 2.42.0 </td> <td> #8849 </td>
</tr>
<tr>
<td>

```yaml
outs:
- md5: 168fd6761b9c3f2c081085b51fd7bf15.dir
  size: 8
  nfiles: 2
  path: data
  files:
  - size: 4
    version_id: iGoUk9Wlb95nNOw6iPHUrnNWq9E898YO
    etag: c157a79031e1c40f85931829bc5fc552
    md5: c157a79031e1c40f85931829bc5fc552
    relpath: bar
  - size: 4
    version_id: DwITkoYE8ipINKzK2QcGKvlwlqaS4oER
    etag: d3b07384d113edec49eaa6238ad5ff00
    md5: d3b07384d113edec49eaa6238ad5ff00
    relpath: foo
```

</td>
<td>

```yaml
outs:
- path: data
  files:
  - size: 4
    version_id: DhE9omrAq7IXC5wGIIGqruq9JyP_Nwhm
    etag: c157a79031e1c40f85931829bc5fc552
    md5: c157a79031e1c40f85931829bc5fc552
    relpath: bar
  - size: 4
    version_id: Vnu6l9_ECdLGrp6B5iK6YmQTm87UaDzP
    etag: d3b07384d113edec49eaa6238ad5ff00
    md5: d3b07384d113edec49eaa6238ad5ff00
    relpath: foo
```

</td>
</tr>
</table>
</details>

## Tracking a local update with `dvc add` on that folder

```
$ echo bar2 > data/bar
$ dvc add data
$ cat data.dvc
```

<details>
<table>
<tr>
<td> 2.42.0 </td> <td> #8849 </td>
</tr>
<tr>
<td>

```yaml
outs:
- md5: 43f06a6517d71d0267bed23cfb1a53fb.dir
  size: 9
  nfiles: 2
  path: data
  files:
  - size: 5
    md5: 042967ff088f7f436015fbebdcad1f28
    relpath: bar
  - size: 4
    version_id: DwITkoYE8ipINKzK2QcGKvlwlqaS4oER
    etag: d3b07384d113edec49eaa6238ad5ff00
    md5: d3b07384d113edec49eaa6238ad5ff00
    relpath: foo
```

</td>
<td>

```yaml
outs:
- path: data
  files:
  - size: 5
    md5: 042967ff088f7f436015fbebdcad1f28
    relpath: bar
  - size: 4
    version_id: Vnu6l9_ECdLGrp6B5iK6YmQTm87UaDzP
    etag: d3b07384d113edec49eaa6238ad5ff00
    md5: d3b07384d113edec49eaa6238ad5ff00
    relpath: foo
```

</td>
</tr>
</table>
</details>

## After pushing the local update with `dvc push`

```
$ dvc push 
$ cat data.dvc
```

<details>
<table>
<tr>
<td> 2.42.0 </td> <td> #8849 </td>
</tr>
<tr>
<td>

```yaml
outs:
- md5: 43f06a6517d71d0267bed23cfb1a53fb.dir
  size: 9
  nfiles: 2
  path: data
  files:
  - size: 5
    md5: 042967ff088f7f436015fbebdcad1f28
    relpath: bar
    version_id: QLNufQhPEwlSlNSfauemR5D23RRMSbfF
    etag: 042967ff088f7f436015fbebdcad1f28
  - size: 4
    version_id: DwITkoYE8ipINKzK2QcGKvlwlqaS4oER
    etag: d3b07384d113edec49eaa6238ad5ff00
    md5: d3b07384d113edec49eaa6238ad5ff00
    relpath: foo
```

</td>
<td>

```yaml
outs:
- path: data
  files:
  - size: 5
    md5: 042967ff088f7f436015fbebdcad1f28
    relpath: bar
  - size: 4
    version_id: Vnu6l9_ECdLGrp6B5iK6YmQTm87UaDzP
    etag: d3b07384d113edec49eaa6238ad5ff00
    md5: d3b07384d113edec49eaa6238ad5ff00
    relpath: foo
```

</td>
</tr>
</table>
</details>

## Tracking a modification in the remote with `dvc update`

```
$ echo goo > goo
$ aws s3 cp goo $REMOTE/data/goo
$ dvc update data.dvc -v
$ cat data.dvc
```

<details>
<table>
<tr>
<td> 2.42.0 </td> <td> #8849 </td>
</tr>
<tr>
<td>

```yaml
outs:
- md5: b5c587798f2c0f599ef935244b290bf1.dir
  size: 13
  nfiles: 3
  path: data
  files:
  - size: 5
    version_id: QLNufQhPEwlSlNSfauemR5D23RRMSbfF
    etag: 042967ff088f7f436015fbebdcad1f28
    md5: 042967ff088f7f436015fbebdcad1f28
    relpath: bar
  - size: 4
    version_id: DwITkoYE8ipINKzK2QcGKvlwlqaS4oER
    etag: d3b07384d113edec49eaa6238ad5ff00
    md5: d3b07384d113edec49eaa6238ad5ff00
    relpath: foo
  - size: 4
    version_id: xktZ1CcLphMaZheT_O9QrxFpmd9GrgK1
    etag: 7361528e901ca2f2f1952a68ad242d79
    md5: 7361528e901ca2f2f1952a68ad242d79
    relpath: goo
```

</td>
<td>

```yaml
outs:
- path: data
  files:
  - size: 5
    version_id: dQymcW0EvEqy23qfrksrqo0ni2zGtPMG
    etag: 042967ff088f7f436015fbebdcad1f28
    md5: 042967ff088f7f436015fbebdcad1f28
    relpath: bar
  - size: 4
    version_id: pd67.5YcvjqDm7jfmiHbpeQsXnprrXtf
    etag: d3b07384d113edec49eaa6238ad5ff00
    md5: d3b07384d113edec49eaa6238ad5ff00
    relpath: foo
  - size: 4
    version_id: 2ruNQaorqjnsFQZ5cinHsZSHEw7cz26J
    etag: 7361528e901ca2f2f1952a68ad242d79
    md5: 7361528e901ca2f2f1952a68ad242d79
    relpath: goo
```

</td>
</tr>
</table>
</details>