### PR TITLE
remove setup.py file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup(name="dvc")


### PR DESCRIPTION
GH seems to be able to show dependencies from `pyproject.toml` files. I am not sure if it'll be able to show dependencies without this, but I am removing this to check whether it does or not. Will revert if it does not work. :)

Otherwise, we don't need this file.