### PR TITLE
add support for output-specific remotes

### DIFF
--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -8,6 +8,7 @@ from dvc.utils.objects import cached_property
 from dvc_data.hashfile.db import get_index
 
 if TYPE_CHECKING:
+    from dvc.fs import FileSystem
     from dvc_data.hashfile.db import HashFileDB
     from dvc_data.hashfile.hash_info import HashInfo
     from dvc_data.hashfile.status import CompareStatusResult
@@ -17,11 +18,12 @@ logger = logging.getLogger(__name__)
 
 
 class Remote:
-    def __init__(self, path, fs, **config):
+    def __init__(self, name: str, path: str, fs: "FileSystem", **config):
         self.path = path
         self.fs = fs
+        self.name = name
 
-        self.worktree = config.pop("worktree", False)
+        self.worktree: bool = config.pop("worktree", False)
         self.config = config
         if self.worktree:
             version_aware = self.config.get("version_aware")
@@ -71,7 +73,7 @@ class DataCloud:
             cls, config, fs_path = get_cloud_fs(self.repo, name=name)
             fs = cls(**config)
             config["tmp_dir"] = self.repo.index_db_dir
-            return Remote(fs_path, fs, **config)
+            return Remote(name, fs_path, fs, **config)
 
         if bool(self.repo.config["remote"]):
             error_msg = (

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -212,7 +212,7 @@ class Repo:
         # used by DVCFileSystem to determine if it should traverse subrepos
         self.subrepos = subrepos
 
-        self.cloud = DataCloud(self)
+        self.cloud: "DataCloud" = DataCloud(self)
         self.stage: "StageLoad" = StageLoad(self)
 
         self.lock: "LockBase"

--- a/dvc/stage/serialize.py
+++ b/dvc/stage/serialize.py
@@ -2,11 +2,13 @@ from collections import OrderedDict
 from operator import attrgetter
 from typing import (
     TYPE_CHECKING,
+    Any,
     Dict,
     Iterable,
     List,
     Optional,
     Union,
+    cast,
     no_type_check,
 )
 
@@ -22,6 +24,7 @@ from .utils import resolve_wdir, split_params_deps
 
 if TYPE_CHECKING:
     from dvc.stage import PipelineStage, Stage
+    from dvc_data.hashfile.tree import Tree
 
 PARAM_PARAMS = ParamsDependency.PARAM_PARAMS
 PARAM_PATH = ParamsDependency.PARAM_PATH
@@ -153,23 +156,26 @@ def to_pipeline_file(stage: "PipelineStage"):
 
 
 def to_single_stage_lockfile(stage: "Stage", **kwargs) -> dict:
+    from dvc.output import split_file_meta_from_cloud
+
     assert stage.cmd
 
-    def _dumpd(item):
-        meta_d = item.meta.to_dict()
-        meta_d.pop("isdir", None)
-
+    def _dumpd(item: "Output"):
+        ret: Dict[str, Any] = {item.PARAM_PATH: item.def_path}
         if item.hash_info.isdir and kwargs.get("with_files"):
-            if item.obj:
-                obj = item.obj
-            else:
-                obj = item.get_obj()
-            ret = [((item.PARAM_FILES, obj.as_list(with_meta=True)))]
+            obj = item.obj or item.get_obj()
+            if obj:
+                obj = cast("Tree", obj)
+                ret[item.PARAM_FILES] = [
+                    split_file_meta_from_cloud(f)
+                    for f in obj.as_list(with_meta=True)
+                ]
         else:
-            ret = [*item.hash_info.to_dict().items(), *meta_d.items()]
-        ret.insert(0, (item.PARAM_PATH, item.def_path))
-
-        return OrderedDict(ret)
+            meta_d = item.meta.to_dict()
+            meta_d.pop("isdir", None)
+            ret.update(item.hash_info.to_dict())
+            ret.update(split_file_meta_from_cloud(meta_d))
+        return ret
 
     res = OrderedDict([("cmd", stage.cmd)])
     params, deps = split_params_deps(stage)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "dvc-render==0.0.17",
     "dvc-task==0.1.11",
     "dvclive>=1.2.2",
-    "dvc-data==0.35.3",
+    "dvc-data==0.35.4",
     "dvc-http",
     "hydra-core>=1.1.0",
     "iterative-telemetry==0.0.6",


### PR DESCRIPTION
Requires https://github.com/iterative/dvc-data/pull/280.

Also splits metadata in `files` to cloud vs local. But this happens
during dump/load, so actual behaviour is changed. During runtime,
the metadata is merged and loaded. During dump, the metadata
are split if there is a `remote` set.

The metadata will look as follows:
```yaml
files:
  - size: 75570
    relpath: 0.txt
    md5: c7d28800060176f0438fb0774a00b3be
    cloud:
      remote1:
         version_id: 02e850d5-5dc9-40ee-8969-24c098c99c7e
         etag: c7d28800060176f0438fb0774a00b3be
```


## TODO:
- [ ] add tests