### PR TITLE
worktree: Fix `outs` filtering.

### DIFF
--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -386,7 +386,7 @@ class IndexView:
         self,
         index: Index,
         stage_infos: Iterable["StageInfo"],
-        outs_filter: Optional[Callable[["Output"], bool]],
+        outs_filter: Optional[Callable[["Output"], bool]] = None,
     ):
         self._index = index
         self._stage_infos = stage_infos

--- a/dvc/stage/serialize.py
+++ b/dvc/stage/serialize.py
@@ -169,7 +169,8 @@ def to_single_stage_lockfile(stage: "Stage", **kwargs) -> dict:
                 obj = item.obj
             else:
                 obj = item.get_obj()
-            ret.append((item.PARAM_FILES, obj.as_list(with_meta=True)))
+            if obj:
+                ret.append((item.PARAM_FILES, obj.as_list(with_meta=True)))
 
         return OrderedDict(ret)
 


### PR DESCRIPTION
The filter passed to `IndexView` is only applied when accessing `view.outs` property. Because we iterate on `stage.outs`, the filter was not being applied.

Closes #8760

---

Tested:

```yaml
stages:
  foo:
    cmd: echo foo > foo && echo bar > bar && mkdir data && echo data > data/file
    outs:
      - foo
      - data
      - bar:
          cache: false
```

```console
$ dvc repro
$ dvc push
Updating lock file 'dvc.lock'                                                                                                  
2 files pushed        
$ cat dvc.lock
```

```yaml
schema: '2.0'
stages:
  foo:
    cmd: echo foo > foo && echo bar > bar && mkdir data && echo data > data/file
    outs:
    - path: bar
      md5: c157a79031e1c40f85931829bc5fc552
      size: 4
    - path: data
      md5: b1bb6c905898b7fbf462c0aa04fd9ccd.dir
      size: 5
      nfiles: 1
      files:
      - size: 5
        version_id: w6oywzFYMC6Ux8IdxcRD4SJzrvt3i.a_
        etag: 6137cde4893c59f76f005a8123d8e8e6
        md5: 6137cde4893c59f76f005a8123d8e8e6
        relpath: file
    - path: foo
      md5: d3b07384d113edec49eaa6238ad5ff00
      size: 4
      version_id: U1cBl5b3WRTrWa4CXkFjIUgy84TqJYvw
      etag: d3b07384d113edec49eaa6238ad5ff00
```

```console
$ rm -rf .dvc/cache
$ rm foo
$ rm -r data
$ dvc pull
A       foo                                                                                                                    
A       data/
2 files added
```