### PR TITLE
stage.save: Remove `merge_versioned` option.

### DIFF
--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -194,7 +194,7 @@ def add(  # noqa: C901
                 stage.transfer(source, to_remote=to_remote, odb=odb, **kwargs)
             else:
                 try:
-                    stage.save(merge_versioned=True)
+                    stage.save()
                     if not no_commit:
                         stage.commit()
                 except CacheLinkError:

--- a/dvc/repo/worktree.py
+++ b/dvc/repo/worktree.py
@@ -228,7 +228,7 @@ def update_worktree_stages(
                 )
                 continue
             _fetch_out_changes(out, local_index, remote_index, remote)
-        stage.save(merge_versioned=True)
+        stage.save()
         for out in stage.outs:
             _update_out_meta(out, remote_index)
         stage.dump(with_files=True, update_pipeline=False)

--- a/tests/func/test_commit.py
+++ b/tests/func/test_commit.py
@@ -245,3 +245,61 @@ def test_imported_entries_unchanged(tmp_dir, dvc, erepo_dir):
     stage = dvc.imp(os.fspath(erepo_dir), "file")
 
     assert stage.changed_entries() == ([], [], None)
+
+
+def test_commit_updates_to_cloud_versioning_dir(tmp_dir, dvc):
+    data_dvc = tmp_dir / "data.dvc"
+    data_dvc.dump(
+        {
+            "outs": [
+                {
+                    "path": "data",
+                    "files": [
+                        {
+                            "size": 3,
+                            "version_id": "WYRG4BglP7pD.gEoJP6a4AqOhl.FRA.h",
+                            "etag": "acbd18db4cc2f85cedef654fccc4a4d8",
+                            "md5": "acbd18db4cc2f85cedef654fccc4a4d8",
+                            "relpath": "bar",
+                        },
+                        {
+                            "size": 3,
+                            "version_id": "0vL53tFVY5vVAoJ4HG2jCS1mEcohDPE0",
+                            "etag": "acbd18db4cc2f85cedef654fccc4a4d8",
+                            "md5": "acbd18db4cc2f85cedef654fccc4a4d8",
+                            "relpath": "foo",
+                        },
+                    ],
+                }
+            ]
+        }
+    )
+
+    data = tmp_dir / "data"
+    data.mkdir()
+    (data / "foo").write_text("foo")
+    (data / "bar").write_text("bar2")
+
+    dvc.commit("data", force=True)
+
+    assert (tmp_dir / "data.dvc").parse() == {
+        "outs": [
+            {
+                "path": "data",
+                "files": [
+                    {
+                        "size": 4,
+                        "md5": "224e2539f52203eb33728acd228b4432",
+                        "relpath": "bar",
+                    },
+                    {
+                        "size": 3,
+                        "version_id": "0vL53tFVY5vVAoJ4HG2jCS1mEcohDPE0",
+                        "etag": "acbd18db4cc2f85cedef654fccc4a4d8",
+                        "md5": "acbd18db4cc2f85cedef654fccc4a4d8",
+                        "relpath": "foo",
+                    },
+                ],
+            }
+        ]
+    }


### PR DESCRIPTION
If we want `add`, `commit` and `move` to work for cloud versioning, the option must be always True so it is the same as not having it.

Closes #8828
(We were not passing `merge_versioned=True` in `dvc commit`)

---

After the first `push`:

```console
$ mkdir data
$ echo bar > data/bar
$ echo foo > data/foo
$ dvc add data
$ dvc push -v
```

Tracking local updates:

```console
$ echo bar2 > data/bar
```

Works as expected with either `dvc add data` or `dvc commit`:

```console
$ dvc add data
$ cat data.dvc
outs:
- path: data
  files:
  - size: 5
    md5: 042967ff088f7f436015fbebdcad1f28
    relpath: bar
  - size: 4
    version_id: Vnu6l9_ECdLGrp6B5iK6YmQTm87UaDzP
    etag: d3b07384d113edec49eaa6238ad5ff00
    md5: d3b07384d113edec49eaa6238ad5ff00
    relpath: foo
```

```console
$ dvc commit
$ cat data.dvc
outs:
- path: data
  files:
  - size: 5
    md5: 042967ff088f7f436015fbebdcad1f28
    relpath: bar
  - size: 4
    version_id: Vnu6l9_ECdLGrp6B5iK6YmQTm87UaDzP
    etag: d3b07384d113edec49eaa6238ad5ff00
    md5: d3b07384d113edec49eaa6238ad5ff00
    relpath: foo
```
