### PR TITLE
gc: fix usage with --date

### DIFF
--- a/dvc/repo/brancher.py
+++ b/dvc/repo/brancher.py
@@ -32,7 +32,16 @@ def brancher(  # noqa: E302
             - empty string it there is no branches to iterate over
             - "workspace" if there are uncommitted changes in the SCM repo
     """
-    if not any([revs, all_branches, all_tags, all_commits, all_experiments]):
+    if not any(
+        [
+            revs,
+            all_branches,
+            all_tags,
+            all_commits,
+            all_experiments,
+            commit_date,
+        ]
+    ):
         yield ""
         return
 

--- a/dvc/scm.py
+++ b/dvc/scm.py
@@ -242,9 +242,9 @@ def iter_revs(  # noqa: C901
 
             def _time_filter(rev):
                 try:
-                    if scm.resolve_commit(rev).commit_date >= commit_datestamp:
-                        return True
-                    return False
+                    return (
+                        scm.resolve_commit(rev).commit_time >= commit_datestamp
+                    )
                 except _SCMError:
                     return True
 

--- a/tests/unit/scm/test_scm.py
+++ b/tests/unit/scm/test_scm.py
@@ -67,16 +67,30 @@ def test_iter_revs(
         rev_root: [rev_root],
     }
 
-    def _func(rev):
+    def _resolve_commit(rev):
+        from scmrepo.git.objects import GitCommit
 
         if rev == rev_root:
-            return mocker.Mock(commit_date=datetime(2022, 6, 28).timestamp())
+            return GitCommit(
+                "dummy",
+                commit_time=datetime(2022, 6, 28).timestamp(),
+                commit_time_offset=0,
+                message="dummy",
+                parents=["dummy"],
+            )
         if rev == rev_old:
             raise SCMError
-        return mocker.Mock(commit_date=datetime(2022, 6, 30).timestamp())
+        return GitCommit(
+            "dummy",
+            commit_time=datetime(2022, 6, 30).timestamp(),
+            commit_time_offset=0,
+            message="dummy",
+            parents=["dummy"],
+        )
 
     mocker.patch(
-        "scmrepo.git.Git.resolve_commit", mocker.MagicMock(side_effect=_func)
+        "scmrepo.git.Git.resolve_commit",
+        mocker.MagicMock(side_effect=_resolve_commit),
     )
 
     gen = iter_revs(scm, commit_date="2022-06-29")


### PR DESCRIPTION
- `gc --date` was broken because the wrong attribute was being accessed resulting in an unexpected exception.
- `--date` was being ignored by `brancher` unless one of `--all-branches`, `--all-tags`, `--all-commits`, `--all-experiments` was also provided.
- added test for `--date`

Originally reported on [discord](https://discord.com/channels/485586884165107732/485596304961962003/1067801969214902273)