### PR TITLE
output: Pass `version_aware=True` to `fs` if `files` is present.

### DIFF
--- a/dvc/output.py
+++ b/dvc/output.py
@@ -327,7 +327,9 @@ class Output:
         meta = Meta.from_dict(info or {})
         # NOTE: when version_aware is not passed into get_cloud_fs, it will be
         # set based on whether or not path is versioned
-        fs_kwargs = {"version_aware": True} if meta.version_id else {}
+        fs_kwargs = {}
+        if meta.version_id or files:
+            fs_kwargs["version_aware"] = True
 
         if fs_config is not None:
             fs_kwargs.update(**fs_config)

--- a/tests/unit/output/test_output.py
+++ b/tests/unit/output/test_output.py
@@ -176,3 +176,30 @@ def test_dumpd_cloud_versioning_dir(mocker):
 
     dumpd = out.dumpd()
     assert dumpd == {"path": "path", "files": files}
+
+
+def test_version_aware_is_set_based_on_files(mocker):
+    import dvc.fs as dvc_fs
+
+    get_fs_config = mocker.spy(dvc_fs, "get_fs_config")
+
+    stage = mocker.MagicMock()
+    stage.repo.fs.version_aware = False
+    stage.repo.fs.PARAM_CHECKSUM = "etag"
+    files = [
+        {
+            "size": 3,
+            "version_id": "WYRG4BglP7pD.gEoJP6a4AqOhl.FRA.h",
+            "etag": "acbd18db4cc2f85cedef654fccc4a4d8",
+            "md5": "acbd18db4cc2f85cedef654fccc4a4d8",
+            "relpath": "bar",
+        }
+    ]
+    Output(stage, "path", files=files)
+    # version_aware is passed as `True` if `files` is present`.
+    # This will be intentionally ignored in filesystems that don't handle it
+    # in `_prepare_credentials`.
+    assert get_fs_config.call_args_list[0][1] == {
+        "url": "path",
+        "version_aware": True,
+    }


### PR DESCRIPTION
This will be ignored by filesystems that don't support `version_aware`.

Closes #8853

---

From the initial state:

```console 
$ dvc import-url --version-aware s3://diglesia-bucket/data
$ cat data/goo 
goo
$ cat data.dvc
md5: 3a8c037877cf0a60e34e3a22498d2b7e
frozen: true
deps:
- path: s3://diglesia-bucket/data
  files:
  - size: 4
    version_id: Ce2wcT8cyQY8XvjH2ySVKrtsFsFy.M8a
    etag: c157a79031e1c40f85931829bc5fc552
    relpath: bar
  - size: 4
    version_id: 07q_0VQgMOzQU_1l4q_4qVWSmH9KtoaN
    etag: d3b07384d113edec49eaa6238ad5ff00
    relpath: foo
  - size: 4
    version_id: VhK8GEPzz9p5TXNtl0gXMMrZTgbR93UY
    etag: 7361528e901ca2f2f1952a68ad242d79
    relpath: goo
outs:
- md5: bb5c48ab712b680ad28fd8d7bda8fb4f.dir
  size: 12
  nfiles: 3
  path: data
  push: false
```

After updating the remote:

```console
$ echo gooupdated > goo
$ aws s3 cp goo s3://diglesia-bucket/data/goo
```

The updates are now correctly downloaded and metadata is serialized without losing the versioning info:

```console
$ dvc update data.dvc
$ cat data/goo
gooupdated
$ cat data.dvc
md5: 925f4c157e9a7133459eb8bfba40c9c4
frozen: true
deps:
- path: s3://diglesia-bucket/data
  files:
  - size: 4
    version_id: Ce2wcT8cyQY8XvjH2ySVKrtsFsFy.M8a
    etag: c157a79031e1c40f85931829bc5fc552
    relpath: bar
  - size: 4
    version_id: 07q_0VQgMOzQU_1l4q_4qVWSmH9KtoaN
    etag: d3b07384d113edec49eaa6238ad5ff00
    relpath: foo
  - size: 11
    version_id: DxlImaSonv4p1gtD9t__ozqhUEqvOU5H
    etag: 04d10a54f0d3165221599b95795f5a2d
    relpath: goo
outs:
- md5: 364ddf5dc5729ce3c27335b409ccca51.dir
  size: 19
  nfiles: 3
  path: data
  push: false
```
