### PR TITLE
Use pygit2 backend for fetch_refspecs

### DIFF
--- a/dvc/repo/experiments/executor/base.py
+++ b/dvc/repo/experiments/executor/base.py
@@ -334,21 +334,17 @@ class BaseExecutor(ABC):
 
         # fetch experiments
         try:
-            dest_scm.fetch_refspecs(
-                self.git_url,
-                [f"{ref}:{ref}" for ref in refs],
-                on_diverged=on_diverged_ref,
-                force=force,
-                **kwargs,
-            )
+            refspecs = [f"{ref}:{ref}" for ref in refs]
             # update last run checkpoint (if it exists)
             if has_checkpoint:
-                dest_scm.fetch_refspecs(
-                    self.git_url,
-                    [f"{EXEC_CHECKPOINT}:{EXEC_CHECKPOINT}"],
-                    force=True,
-                    **kwargs,
-                )
+                refspecs.append(f"{EXEC_CHECKPOINT}:{EXEC_CHECKPOINT}")
+            dest_scm.fetch_refspecs(
+                self.git_url,
+                refspecs,
+                on_diverged=on_diverged_ref,
+                force=force or has_checkpoint,
+                **kwargs,
+            )
         except SCMError:
             pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "rich>=10.13.0",
     "pyparsing>=2.4.7",
     "typing-extensions>=3.7.4",
-    "scmrepo==0.1.7",
+    "scmrepo==0.1.9",
     "dvc-render==0.1.0",
     "dvc-task==0.1.11",
     "dvclive>=1.2.2",


### PR DESCRIPTION
fix: #8762
partly solve #8787 and #8477
Improve the performance

Wait for https://github.com/iterative/scmrepo/pull/169

The performance improvement are shown in https://github.com/iterative/scmrepo/pull/169. 

For the benchmark because the fetch operation only happens during `temp` or `queue` experiment running progress. We don't have this kind of benchmark and also hard to build one. 


* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
