### PR TITLE
index: expose rev property

### DIFF
--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -128,10 +128,14 @@ class Index:
         self._params = params or {}
         self._collected_targets: Dict[int, List["StageInfo"]] = {}
 
-    def __repr__(self) -> str:
-        rev = "workspace"
+    @cached_property
+    def rev(self) -> Optional[str]:
         if not isinstance(self.repo.fs, LocalFileSystem):
-            rev = self.repo.get_rev()[:7]
+            return self.repo.get_rev()[:7]
+        return None
+
+    def __repr__(self) -> str:
+        rev = self.rev or "workspace"
         return f"Index({self.repo}, fs@{rev})"
 
     @classmethod


### PR DESCRIPTION
This is very useful to identify indexes that are built from git revisions and so are describing an immutable state and can be used for caching.

We were already using this for `__repr__`.