### PR TITLE
ci: run dvc-s3 tests on DVC pull requests

### DIFF
--- a/.github/workflows/plugin_tests.yaml
+++ b/.github/workflows/plugin_tests.yaml
@@ -1,0 +1,54 @@
+name: Remote Plugin Tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    timeout-minutes: 45
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04]
+        pyv: ["3.10"]
+        plugin: ["dvc-s3"]
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        path: dvc
+
+    - uses: actions/checkout@v3
+      with:
+        repository: iterative/${{ matrix.plugin }}
+        ref: main
+        path: ${{ matrix.plugin }}
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.pyv }}
+        cache: pip
+        cache-dependency-path: |
+          dvc/pyproject.toml
+          ${{ matrix.plugin }}/setup.cfg
+
+    - name: Install plugin + DVC@PR
+      run: |
+        pip install --upgrade pip wheel
+        pip install "./dvc[testing]"
+        pip install -e "./${{ matrix.plugin }}[tests]"
+
+    - name: Run plugin tests
+      timeout-minutes: 15
+      working-directory: ${{ matrix.plugin }}
+      run: pytest -v -n=auto


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Related to https://github.com/iterative/dvc/issues/8850

- Adds workflow for running remote plugin tests against PR's (useful since the plugin tests are normally only run against DVC main on a cron schedule)
- Currently only runs dvc-s3 tests on ubuntu + py3.10 but this can be expanded later if needed