### PR TITLE
testing: add tests for cloud versioned update and import-url

### DIFF
--- a/dvc/repo/imp_url.py
+++ b/dvc/repo/imp_url.py
@@ -90,10 +90,9 @@ def imp_url(  # noqa: C901
         stage.save_deps()
         stage.md5 = stage.compute_md5()
     else:
+        if stage.deps[0].fs.version_aware:
+            stage.outs[0].can_push = False
         stage.run(jobs=jobs, no_download=no_download)
-
-    if not no_exec and stage.deps[0].fs.version_aware:
-        stage.outs[0].can_push = False
 
     stage.frozen = frozen
     stage.dump()

--- a/dvc/testing/remote_tests.py
+++ b/dvc/testing/remote_tests.py
@@ -243,3 +243,26 @@ class TestRemoteWorktree:
         scm.checkout(v1)
         dvc.pull()
         assert (tmp_dir / "data_dir" / "data").read_text() == "data"
+
+    def test_update(
+        self, tmp_dir, dvc, remote_worktree  # pylint: disable=W0613
+    ):
+        tmp_dir.dvc_gen("foo", "foo")
+        tmp_dir.dvc_gen(
+            {
+                "data_dir": {
+                    "data_sub_dir": {"data_sub": "data_sub"},
+                    "data": "data",
+                    "empty": "",
+                }
+            }
+        )
+        dvc.push()
+        (remote_worktree / "foo").write_text("bar")
+        (remote_worktree / "data_dir" / "data").write_text("modified")
+        (remote_worktree / "data_dir" / "new_data").write_text("new data")
+
+        dvc.update([str(tmp_dir / "foo.dvc"), str(tmp_dir / "data_dir.dvc")])
+        assert (tmp_dir / "foo").read_text() == "bar"
+        assert (tmp_dir / "data_dir" / "data").read_text() == "modified"
+        assert (tmp_dir / "data_dir" / "new_data").read_text() == "new data"


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Closes #8850

- Fixes `import-url` bug where version-aware import status would be reported as `changed checksum` due to computing stage checksum before we set `push: false`
- Adds tests for worktree `dvc update`
- Adds tests for version-aware `dvc import-url`, `dvc update`