### PR TITLE
logging: log pkg version/type, platform info and cli arguments

### DIFF
--- a/dvc/cli/__init__.py
+++ b/dvc/cli/__init__.py
@@ -180,6 +180,21 @@ def main(argv=None):  # noqa: C901
         if level is not None:
             set_loggers_level(level)
 
+        if level and level <= logging.DEBUG:
+            from platform import (
+                platform,
+                python_implementation,
+                python_version,
+            )
+
+            from dvc import __version__
+            from dvc.utils.pkg import PKG
+
+            pyv = " ".join([python_implementation(), python_version()])
+            pkg = f" ({PKG})" if PKG else ""
+            logger.debug("v%s%s, %s on %s", __version__, pkg, pyv, platform())
+            logger.debug("command: %s", " ".join(argv or sys.argv))
+
         logger.trace(args)  # type: ignore[attr-defined]
 
         if not sys.stdout.closed and not args.quiet:


### PR DESCRIPTION
```console
$ dvc stage list --all -vv
2023-01-31 13:10:14,052 DEBUG: v2.43.1 (pip), CPython 3.11.0 on Linux-6.1.6-arch1-3-x86_64-with-glibc2.36
2023-01-31 13:10:14,052 DEBUG: command: /home/saugat/projects/iterative/dvc/venv/bin/dvc stage list --all -vv
```