### PR TITLE
stage: use repo.fs directly without copying

### DIFF
--- a/dvc/repo/stage.py
+++ b/dvc/repo/stage.py
@@ -96,7 +96,10 @@ def locked(f):
 class StageLoad:
     def __init__(self, repo: "Repo") -> None:
         self.repo: "Repo" = repo
-        self.fs = repo.fs
+
+    @property
+    def fs(self):
+        return self.repo.fs
 
     @locked
     def add(

--- a/tests/func/test_repo_index.py
+++ b/tests/func/test_repo_index.py
@@ -296,6 +296,16 @@ def test_view_combined_filter(tmp_dir, scm, dvc, run_copy):
     }
 
 
+def test_view_brancher(tmp_dir, scm, dvc):
+    tmp_dir.dvc_gen({"foo": "foo"}, commit="init")
+    index = Index.from_repo(dvc)
+
+    for _ in dvc.brancher(revs=["HEAD"]):
+        view = index.targets_view("foo")
+        data = view.data["repo"]
+        assert data[("foo",)]
+
+
 def test_with_gitignore(tmp_dir, dvc, scm):
     (stage,) = tmp_dir.dvc_gen({"data": {"foo": "foo", "bar": "bar"}})
 


### PR DESCRIPTION
Otherwise when using brancher we end up in a strange situation where even though we are collecting targets from `gitfs`, we are still using `localfs` as `self.fs`, which make operations like `self.fs.abspath` in `collect_granular` return invalid paths.
