### PR TITLE
index: introduce data_keys

### DIFF
--- a/tests/func/test_repo_index.py
+++ b/tests/func/test_repo_index.py
@@ -199,6 +199,13 @@ def test_view_granular_dir(tmp_dir, scm, dvc, run_copy):
     # view should include the specific target, parent dirs, and children
     # view should exclude any siblings of the target
     view = index.targets_view("dir/subdir")
+
+    assert view.data_keys == {
+        "repo": {
+            ("dir", "subdir"),
+        }
+    }
+
     data_index = view.data["repo"]
     assert ("dir",) in data_index
     assert (


### PR DESCRIPTION
`data_keys` are similar to `outs`, but they provide more granularity, so we can use them in `build_data_index` to rebuild index views with filtered outputs. E.g. when running `dvc diff dir/file`, workspace index should only have `dir/file` in it.

This also could be used for standalone (non-output) data in the future.

Pre-requisite for #8930
