### PR TITLE
Support setting a exp name prefix in hydra sweeps

### DIFF
--- a/dvc/repo/experiments/run.py
+++ b/dvc/repo/experiments/run.py
@@ -61,20 +61,19 @@ def run(  # noqa: C901
         )
 
     if hydra_sweep:
-        if kwargs.get("name"):
-            raise InvalidArgumentError(
-                "Sweep overrides can't be used alongside `--name`"
-            )
         from dvc.utils.hydra import get_hydra_sweeps
 
         sweeps = get_hydra_sweeps(path_overrides)
+        name_prefix = kwargs.get("name")
     else:
         sweeps = [path_overrides]
 
     if not kwargs.get("checkpoint_resume", None):
         kwargs["reset"] = True
 
-    for sweep_overrides in sweeps:
+    for idx, sweep_overrides in enumerate(sweeps):
+        if hydra_sweep and name_prefix is not None:
+            kwargs["name"] = f"{name_prefix}-{idx+1}"
         queue_entry = repo.experiments.queue_one(
             repo.experiments.celery_queue,
             targets=targets,

--- a/tests/func/experiments/test_set_params.py
+++ b/tests/func/experiments/test_set_params.py
@@ -131,9 +131,12 @@ def test_hydra_sweep_requires_queue(params_repo, dvc):
         dvc.experiments.run(params=["db=mysql,postgresql"])
 
 
-def test_hydra_sweep_cant_use_name(tmp_dir, params_repo, dvc):
-    with pytest.raises(
-        InvalidArgumentError,
-        match="Sweep overrides can't be used alongside `--name`",
-    ):
-        dvc.experiments.run(params=["db=mysql,postgresql"], queue=True, name="foo")
+def test_hydra_sweep_prefix_name(tmp_dir, params_repo, dvc):
+    prefix = "foo"
+    db_values = ["mysql", "postgresql"]
+    param = "+db=" + ",".join(db_values)
+    dvc.experiments.run(params=[param], queue=True, name=prefix)
+    expected_names = [f"{prefix}-{i+1}" for i, _ in enumerate(db_values)]
+    exp_names = [entry.name for entry in dvc.experiments.celery_queue.iter_queued()]
+    for name, expected in zip(exp_names, expected_names):
+        assert name == expected


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

This allows naming a batch of experiments when sweeping over parameters. Instead of each having a random name, when setting `--name myname` they'll be called `myname1`, `myname2`, etc.
