### PR TITLE
import-url: fix `pull` after `import-url --version-aware` with subdirs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "dvc-render==0.1.0",
     "dvc-task==0.1.11",
     "dvclive>=1.2.2",
-    "dvc-data==0.37.3",
+    "dvc-data==0.37.5",
     "dvc-http",
     "hydra-core>=1.1.0",
     "iterative-telemetry==0.0.7",


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Fixes https://github.com/iterative/dvc/issues/8932