### PR TITLE
Add more explicit UI for unchanged data for dvc update

### DIFF
--- a/dvc/repo/experiments/queue/celery.py
+++ b/dvc/repo/experiments/queue/celery.py
@@ -349,9 +349,7 @@ class LocalCeleryQueue(BaseStashQueue):
                         remained_entries[entry],
                     )
                     backend = self.celery.backend
-                    backend.mark_as_failure(  # type: ignore[attr-defined]
-                        task_id, None
-                    )
+                    backend.mark_as_failure(task_id, None)  # type: ignore[attr-defined]
 
         if remained_revs:
             raise CannotKillTasksError(remained_revs)

--- a/dvc/repo/experiments/queue/celery.py
+++ b/dvc/repo/experiments/queue/celery.py
@@ -348,7 +348,10 @@ class LocalCeleryQueue(BaseStashQueue):
                         task_id,
                         remained_entries[entry],
                     )
-                    self.celery.backend.mark_as_failure(task_id, None)
+                    backend = self.celery.backend
+                    backend.mark_as_failure(  # type: ignore[attr-defined]
+                        task_id, None
+                    )
 
         if remained_revs:
             raise CannotKillTasksError(remained_revs)

--- a/dvc/repo/experiments/queue/remove.py
+++ b/dvc/repo/experiments/queue/remove.py
@@ -40,7 +40,7 @@ def remove_tasks(  # noqa: C901
             msg,
             queue_entry,
         ) in celery_queue._iter_queued():  # pylint: disable=protected-access
-            if queue_entry.stash_rev in stash_revs:
+            if queue_entry.stash_rev in stash_revs and msg.delivery_tag:
                 celery_queue.celery.reject(msg.delivery_tag)
     finally:
         celery_queue.stash.remove_revs(list(stash_revs.values()))
@@ -58,7 +58,8 @@ def remove_tasks(  # noqa: C901
             result: AsyncResult = AsyncResult(task_id)
             if result is not None:
                 result.forget()
-            celery_queue.celery.purge(msg.delivery_tag)
+            if msg.delivery_tag:
+                celery_queue.celery.purge(msg.delivery_tag)
     finally:
         if celery_queue.failed_stash:
             celery_queue.failed_stash.remove_revs(failed_stash_revs)

--- a/dvc/repo/worktree.py
+++ b/dvc/repo/worktree.py
@@ -284,9 +284,7 @@ def update_worktree_stages(
     for stage in view.stages:
         transferred: int = 0
         for out in stage.outs:
-            transferred += _update_worktree_out(
-                repo, out, local_index, remote_indexes
-            )
+            transferred += _update_worktree_out(repo, out, local_index, remote_indexes)
 
         if not transferred:
             ui.write(f"'{stage.addressing}' didn't change, skipping")

--- a/dvc/repo/worktree.py
+++ b/dvc/repo/worktree.py
@@ -344,7 +344,7 @@ def _update_worktree_out(
 
     transferred = _fetch_out_changes(out, local_index, remote_index, remote)
     logger.debug(
-        "Update %s files to out '%s' from worktree of '%s'",
+        "Updated %s files in '%s' from worktree '%s'",
         transferred,
         out,
         remote.path,


### PR DESCRIPTION
partly fix: #8464
1. Add some UI message in `dvc update` for unchanged data pushed to some worktree remotes

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
