### PR TITLE
push: check if versioning is supported or not during checkout on cloud versioning (#8949)Fixes https://github.com/iterative/dvc/issues/8824

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "dvc-render==0.1.1",
     "dvc-task==0.1.11",
     "dvclive>=1.2.2",
-    "dvc-data==0.38.3",
+    "dvc-data==0.38.4",
     "dvc-http",
     "hydra-core>=1.1.0",
     "iterative-telemetry==0.0.7",


### PR DESCRIPTION
Fixes https://github.com/iterative/dvc/issues/8824.
Requires https://github.com/iterative/dvc-data/pull/296.

### Example output
```console
$ dvc push
ERROR: while uploading 'unversioned/foo', support for versioning was not detected
ERROR: failed to push data to the cloud - remote 'minio' does not support versioning
```
