### PR TITLE
serialization: reorder files section metadata (#8950

### DIFF
--- a/dvc/stage/serialize.py
+++ b/dvc/stage/serialize.py
@@ -154,7 +154,7 @@ def to_pipeline_file(stage: "PipelineStage"):
 
 
 def to_single_stage_lockfile(stage: "Stage", **kwargs) -> dict:
-    from dvc.output import split_file_meta_from_cloud
+    from dvc.output import _serialize_tree_obj_to_files, split_file_meta_from_cloud
 
     assert stage.cmd
 
@@ -165,7 +165,8 @@ def to_single_stage_lockfile(stage: "Stage", **kwargs) -> dict:
             if obj:
                 obj = cast("Tree", obj)
                 ret[item.PARAM_FILES] = [
-                    split_file_meta_from_cloud(f) for f in obj.as_list(with_meta=True)
+                    split_file_meta_from_cloud(f)
+                    for f in _serialize_tree_obj_to_files(obj)
                 ]
         else:
             meta_d = item.meta.to_dict()


### PR DESCRIPTION
Fixes partially https://github.com/iterative/dvc/issues/8941. 

I copy-pasted what we do in `dvc-data` for now, as I think the serialization story belongs in dvc, not in `dvc-data`. Also, `obj.as_list()` is probably doing too much than required.


#### Example Output
```yaml
outs:
- path: models
  files:
  - relpath: 0.txt
    md5: bd5fe549afd3fa36ca22225a21ab899d
    size: 377846
    cloud:
      minio:
        etag: bd5fe549afd3fa36ca22225a21ab899d
        version_id: 0f6cece1-574f-40ed-8d7f-9182c39b5908
  - relpath: dir0/0.txt
    md5: 8adc00306d1db55a12388ca3b9871ea1
    size: 417716
    cloud:
      minio:
        etag: 8adc00306d1db55a12388ca3b9871ea1
        version_id: 88a7e774-2ae0-4b68-8a45-5e0b027790d7
  - relpath: dir0/dir0/0.txt
    md5: ed40848698ce65ddb61ecf7e8f94239d
    size: 437141
    cloud:
      minio:
        etag: ed40848698ce65ddb61ecf7e8f94239d
        version_id: b867e5c1-3406-44df-88b2-5791c2066c74
  - relpath: dir0/dir1/0.txt
    md5: 096eddd82212eb360fbafe8655e00503
    size: 544619
    cloud:
      minio:
        etag: 096eddd82212eb360fbafe8655e00503
        version_id: cbefc487-ee8e-40e4-92eb-0268f9c09ad3
  - relpath: dir0/dir2/0.txt
    md5: c6ec032ec4dbb1abecfc5db805104941
    size: 456447
    cloud:
      minio:
        etag: c6ec032ec4dbb1abecfc5db805104941
        version_id: cbcd6cc3-4083-44a6-9e9c-20dc1052969e
```

Note that, the order for single file tracking `.dvc` files are not changed, so it'll look same as before.
```yaml
outs:
- md5: d3b07384d113edec49eaa6238ad5ff00
  size: 4
  path: foo
  cloud:
    minio:
      etag: d3b07384d113edec49eaa6238ad5ff00
      version_id: 7f8c85ee-48fc-49ab-845b-2533276bcd3e
```