### PR TITLE
import-url: fix `update` after cloud versioned `import-url --no-download`

### DIFF
--- a/dvc/output.py
+++ b/dvc/output.py
@@ -577,6 +577,8 @@ class Output:
                 if not dep.obj and dep.files:
                     dep.obj = dep.get_obj()
                 entry.obj = dep.obj
+                if not entry.hash_info and dep.obj:
+                    entry.hash_info = dep.obj.hash_info
         return entry
 
     def changed_checksum(self):

--- a/dvc/repo/imports.py
+++ b/dvc/repo/imports.py
@@ -77,6 +77,7 @@ def unpartial_imports(index: Union["Index", "IndexView"]) -> int:
             else:
                 out.hash_info = cast("HashInfo", entry.hash_info)
                 out.meta = entry.meta
+            out.stage.md5 = out.stage.compute_md5()
             out.stage.dump()
             updated += out.meta.nfiles if out.meta.nfiles is not None else 1
     return updated

--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -466,7 +466,7 @@ class IndexView:
             workspace, key = out.index_key
             if filter_info and out.fs.path.isin(filter_info, out.fs_path):
                 key = key + out.fs.path.relparts(filter_info, out.fs_path)
-            if out.meta.isdir:
+            if out.meta.isdir or out.stage.is_import and out.stage.deps[0].meta.isdir:
                 prefixes[workspace].recursive.add(key)
             prefixes[workspace].explicit.update(key[:i] for i in range(len(key), 0, -1))
         return prefixes

--- a/dvc/testing/workspace_tests.py
+++ b/dvc/testing/workspace_tests.py
@@ -140,6 +140,16 @@ class TestImportURLVersionAware:
         assert (tmp_dir / "data_dir" / "subdir" / "file").read_text() == "modified"
         assert (tmp_dir / "data_dir" / "new_file").read_text() == "new"
 
+    def test_import_no_download(self, tmp_dir, dvc, remote_version_aware):
+        remote_version_aware.gen({"data_dir": {"subdir": {"file": "file"}}})
+        dvc.imp_url("remote://upstream/data_dir", version_aware=True, no_download=True)
+        stage = first(dvc.index.stages)
+        assert not stage.outs[0].can_push
+
+        dvc.pull()
+        assert (tmp_dir / "data_dir" / "subdir" / "file").read_text() == "file"
+        assert dvc.status() == {}
+
 
 class TestAdd:
     @pytest.fixture


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Fixes https://github.com/iterative/dvc/issues/8954
Should also resolve the "files are downloaded after `dvc update` with no changes" problem in https://github.com/iterative/dvc/issues/8464