### PR TITLE
logging: do not disable other loggers

### DIFF
--- a/dvc/cli/__init__.py
+++ b/dvc/cli/__init__.py
@@ -153,7 +153,7 @@ def main(argv=None):  # noqa: C901
     from dvc._debug import debugtools
     from dvc.config import ConfigError
     from dvc.exceptions import DvcException, NotDvcRepoError
-    from dvc.logger import disable_other_loggers, set_loggers_level
+    from dvc.logger import set_loggers_level
 
     # NOTE: stderr/stdout may be closed if we are running from dvc.daemon.
     # On Linux we directly call cli.main after double forking and closing
@@ -166,7 +166,6 @@ def main(argv=None):  # noqa: C901
         logging.disable(logging.INFO)
 
     args = None
-    disable_other_loggers()
 
     outerLogLevel = logger.level
     try:

--- a/dvc/logger.py
+++ b/dvc/logger.py
@@ -180,14 +180,6 @@ def _iter_causes(exc):
         exc = exc.__cause__
 
 
-def disable_other_loggers():
-    logging.captureWarnings(True)
-    loggerDict = logging.root.manager.loggerDict  # pylint: disable=no-member
-    for logger_name, logger in loggerDict.items():
-        if logger_name != "dvc" and not logger_name.startswith("dvc."):
-            logger.disabled = True  # type: ignore[union-attr]
-
-
 def set_loggers_level(level: int = logging.INFO) -> None:
     for name in ["dvc", "dvc_objects", "dvc_data"]:
         logging.getLogger(name).setLevel(level)

--- a/dvc/repo/experiments/executor/base.py
+++ b/dvc/repo/experiments/executor/base.py
@@ -716,13 +716,10 @@ class BaseExecutor(ABC):
 
     @staticmethod
     def _set_log_level(level):
-        from dvc.logger import disable_other_loggers
-
         # When executor.reproduce is run in a multiprocessing child process,
         # dvc.cli.main will not be called for that child process so we need to
         # setup logging ourselves
         dvc_logger = logging.getLogger("dvc")
-        disable_other_loggers()
         if level is not None:
             dvc_logger.setLevel(level)
 

--- a/tests/dir_helpers.py
+++ b/tests/dir_helpers.py
@@ -49,8 +49,6 @@ import pathlib
 
 import pytest
 
-from dvc.logger import disable_other_loggers
-
 __all__ = [
     "run_copy",
     "run_head",
@@ -59,9 +57,6 @@ __all__ = [
     "git_upstream",
     "git_downstream",
 ]
-
-# see https://github.com/iterative/dvc/issues/3167
-disable_other_loggers()
 
 
 @pytest.fixture


### PR DESCRIPTION
Since we lazy load most of the packages, running this has no effect except to disable tqdm, tqdm.cli, asyncio, aiohttp, dvc-data, and dvc-objects. The former two don't have any impact, the other two are changed to CRITICAL during setup, and dvc-data/dvc-objects are set to log same as dvc's logger.

So, we don't need to disable other loggers here. Also, I am not sure if other loggers output to stderr/stdout, as they are not supposed to by default AFAIK (except when they are warning/error).
Closes #8631.

