### PR TITLE
update: drop worktree from cli

### DIFF
--- a/dvc/commands/update.py
+++ b/dvc/commands/update.py
@@ -31,8 +31,7 @@ class CmdUpdate(CmdBase):
 def add_parser(subparsers, parent_parser):
     UPDATE_HELP = (
         "Update data artifact imported (via dvc import or dvc import-url) "
-        "from an external DVC repository or URL, or update data from a "
-        "DVC worktree remote."
+        "from an external DVC repository or URL."
     )
     update_parser = subparsers.add_parser(
         "update",


### PR DESCRIPTION
Drops worktree from `dvc update` help text.