### PR TITLE
update rich

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "pygtrie>=2.3.2",
     "dpath>=2.0.2,<3",
     "shtab>=1.3.4,<2",
-    "rich>=10.13.0",
+    "rich>=12.0.0",
     "pyparsing>=2.4.7",
     "typing-extensions>=3.7.4",
     "scmrepo==0.1.9",


### PR DESCRIPTION
Update `rich` requirement because https://github.com/iterative/dvc/blob/561a375b489f5ee528cbd1773a35cc109d64b8e3/dvc/ui/_rich_progress.py#L5 requires >=[12.0.0](https://github.com/Textualize/rich/releases/tag/v12.0.0).