### PR TITLE
repo: introduce data_index

### DIFF
--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -358,31 +358,13 @@ class Index:
         prefix: "DataIndexKey"
         loaded = False
 
-        if self.repo.config["feature"].get("data_index_cache"):
-            import os
-
-            from appdirs import user_cache_dir
-            from fsspec.utils import tokenize
-
-            cache_dir = user_cache_dir(
-                self.repo.config.APPNAME, self.repo.config.APPAUTHOR
-            )
-            index_dir = os.path.join(
-                cache_dir,
-                "index",
-                "data",
-                # scm.root_dir and repo.root_dir don't match for subrepos
-                tokenize((self.repo.scm.root_dir, self.repo.root_dir)),
-            )
-            os.makedirs(index_dir, exist_ok=True)
-
-            index = DataIndex.open(os.path.join(index_dir, "db.db"))
-            prefix = (self.data_tree.hash_info.value,)
-            if prefix in index.ls((), detail=False):
-                loaded = True
-        else:
+        index = self.repo.data_index
+        if index is None:
             index = DataIndex()
-            prefix = ()
+
+        prefix = (self.data_tree.hash_info.value,)
+        if prefix in index.ls((), detail=False):
+            loaded = True
 
         try:
             if not loaded:

--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -199,7 +199,8 @@ def test_verify_hashes(tmp_dir, scm, dvc, mocker, tmp_path_factory, local_remote
     hash_spy = mocker.spy(dvc_data.hashfile.hash, "file_md5")
 
     dvc.pull()
-    assert hash_spy.call_count == 0
+    # NOTE: 1 is for index.data_tree building
+    assert hash_spy.call_count == 1
 
     # Removing cache will invalidate existing state entries
     dvc.cache.local.clear()
@@ -207,7 +208,7 @@ def test_verify_hashes(tmp_dir, scm, dvc, mocker, tmp_path_factory, local_remote
     dvc.config["remote"]["upstream"]["verify"] = True
 
     dvc.pull()
-    assert hash_spy.call_count == 4
+    assert hash_spy.call_count == 6
 
 
 @flaky(max_runs=3, min_passes=1)


### PR DESCRIPTION
Extracting from `index.data` as a "root" data index that contains indexes for different revisions/workspaces.

This is a setup for putting cloud versioning remote indexes and also replacing old state.
