### PR TITLE
8998 exp run include new staged files

### DIFF
--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -96,19 +96,9 @@ class Experiments:
     def reproduce_one(
         self,
         tmp_dir: bool = False,
-        machine: Optional[str] = None,
         **kwargs,
     ):
         """Reproduce and checkout a single (standalone) experiment."""
-        if not (tmp_dir or machine):
-            staged, _, _ = self.scm.status(untracked_files="no")
-            if staged:
-                logger.warning(
-                    "Your workspace contains staged Git changes which will be "
-                    "unstaged before running this experiment."
-                )
-                self.scm.reset()
-
         exp_queue: "BaseStashQueue" = (
             self.tempdir_queue if tmp_dir else self.workspace_queue
         )

--- a/dvc/repo/experiments/queue/base.py
+++ b/dvc/repo/experiments/queue/base.py
@@ -323,12 +323,12 @@ class BaseStashQueue(ABC):
         .. _Hydra Override:
             https://hydra.cc/docs/next/advanced/override_grammar/basic/
         """
-        with self.scm.detach_head(client="dvc") as orig_head:
-            stash_head = orig_head
-            if baseline_rev is None:
-                baseline_rev = orig_head
+        with self.scm.stash_workspace(reinstate_index=True) as workspace:
+            with self.scm.detach_head(client="dvc") as orig_head:
+                stash_head = orig_head
+                if baseline_rev is None:
+                    baseline_rev = orig_head
 
-            with self.scm.stash_workspace() as workspace:
                 try:
                     if workspace:
                         self.stash.apply(workspace)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "rich>=12.0.0",
     "pyparsing>=2.4.7",
     "typing-extensions>=3.7.4",
-    "scmrepo==0.1.9",
+    "scmrepo==0.1.10",
     "dvc-render>=0.1.2",
     "dvc-task==0.1.11",
     "dvclive>=1.2.2",

--- a/tests/func/experiments/test_stash_exp.py
+++ b/tests/func/experiments/test_stash_exp.py
@@ -1,0 +1,68 @@
+import logging
+
+import pytest
+from funcy import first
+
+
+@pytest.mark.xfail(reason="TODO: https://github.com/iterative/dvc/issues/6297")
+@pytest.mark.parametrize("tmp", [True, False])
+@pytest.mark.parametrize("staged", [True, False])
+def test_deleted(tmp_dir, scm, dvc, caplog, tmp, staged):
+    tmp_dir.scm_gen("file", "file", commit="commit file")
+    stage = dvc.stage.add(
+        cmd="cat file",
+        name="foo",
+    )
+    scm.add_commit(["dvc.yaml"], message="add dvc.yaml")
+
+    file = tmp_dir / "file"
+    file.unlink()
+    if staged:
+        scm.add(["file"])
+
+    with caplog.at_level(logging.ERROR):
+        results = dvc.experiments.run(stage.addressing, tmp_dir=tmp)
+        assert "Failed to reproduce experiment" in caplog.text
+        assert not results
+
+    assert not file.exists()
+
+
+@pytest.mark.parametrize("tmp", [True, False])
+@pytest.mark.parametrize("staged", [True, False])
+def test_modified(tmp_dir, scm, dvc, caplog, tmp, staged):
+    tmp_dir.scm_gen("file", "file", commit="commit file")
+    stage = dvc.stage.add(
+        cmd="cat file",
+        name="foo",
+    )
+    scm.add_commit(["dvc.yaml"], message="add dvc.yaml")
+
+    (tmp_dir / "file").write_text("modified_file")
+    if staged:
+        scm.add(["file"])
+
+    results = dvc.experiments.run(stage.addressing, tmp_dir=tmp)
+
+    exp = first(results)
+    scm.checkout(exp, force=True)
+    assert (tmp_dir / "file").read_text() == "modified_file"
+
+
+@pytest.mark.parametrize("tmp", [True, False])
+def test_staged_new_file(tmp_dir, scm, dvc, tmp):
+    if not tmp:
+        pytest.xfail("TODO: https://github.com/iterative/dvc/issues/8998")
+    stage = dvc.stage.add(
+        cmd="cat file",
+        name="foo",
+    )
+    scm.add_commit(["dvc.yaml"], message="add dvc.yaml")
+
+    (tmp_dir / "file").write_text("file")
+    scm.add(["file"])
+
+    results = dvc.experiments.run(stage.addressing, tmp_dir=tmp)
+    exp = first(results)
+    fs = scm.get_fs(exp)
+    assert fs.exists("file")


### PR DESCRIPTION
Closes #8998 

- Detach head after stashing workspace.
- Use reinstate_index from https://github.com/iterative/scmrepo/releases/tag/0.1.10.