### PR TITLE
render: avoid deepcopying

### DIFF
--- a/dvc/render/convert.py
+++ b/dvc/render/convert.py
@@ -29,10 +29,8 @@ def _group_by_rev(datapoints):
 
 
 def to_json(renderer, split: bool = False) -> List[Dict]:
-    from copy import deepcopy
-
     if renderer.TYPE == "vega":
-        grouped = _group_by_rev(deepcopy(renderer.datapoints))
+        grouped = _group_by_rev(renderer.datapoints)
         if split:
             content = renderer.get_filled_template(skip_anchors=["data"])
         else:

--- a/dvc/render/converter/vega.py
+++ b/dvc/render/converter/vega.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 from funcy import first, last
@@ -233,7 +232,8 @@ class VegaConverter(Converter):
         for i, (y_file, y_field) in enumerate(ys):
             if num_xs > 1:
                 x_file, x_field = xs[i]
-            datapoints = deepcopy(file2datapoints.get(y_file, []))
+
+            datapoints = [d.copy() for d in file2datapoints.get(y_file, [])]
 
             if props_update.get("y", None) == "dvc_inferred_y_value":
                 _update_from_field(

--- a/dvc/render/converter/vega.py
+++ b/dvc/render/converter/vega.py
@@ -232,7 +232,6 @@ class VegaConverter(Converter):
         for i, (y_file, y_field) in enumerate(ys):
             if num_xs > 1:
                 x_file, x_field = xs[i]
-
             datapoints = [d.copy() for d in file2datapoints.get(y_file, [])]
 
             if props_update.get("y", None) == "dvc_inferred_y_value":


### PR DESCRIPTION
A low hanging fruit that reduces 20% of runtime when run in [`vscode-dvc-demo`](https://github.com/iterative/vscode-dvc-demo) with:
```console
dvc plots diff $(git log --oneline --pretty=format:"%h")
```

![Screenshot from 2023-02-15 13-11-43](https://user-images.githubusercontent.com/18718008/218960527-72a7bc08-79a9-4cae-9ef7-32f5050ed17a.png)
