### PR TITLE
cachemgr: don't use tmp_dir

### DIFF
--- a/dvc/cachemgr.py
+++ b/dvc/cachemgr.py
@@ -9,7 +9,6 @@ def _get_odb(repo, settings, fs=None):
         return None
 
     cls, config, fs_path = get_cloud_fs(repo, **settings)
-    config["tmp_dir"] = repo.tmp_dir
     fs = fs or cls(**config)
     return get_odb(fs, fs_path, state=repo.state, **config)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ tests = [
     "types-appdirs",
     "types-colorama",
     "types-psutil",
-    "types-tqdm",
+    "types-tqdm<4.64.7.13",
 ]
 all = ["dvc[azure,gdrive,gs,hdfs,oss,s3,ssh,webdav,webhdfs]"]
 dev = ["dvc[azure,gdrive,gs,hdfs,oss,s3,ssh,webdav,webhdfs,tests]"]


### PR DESCRIPTION
We used to use it in gdrive before https://github.com/iterative/PyDrive2/pull/211
