### PR TITLE
config: don't set default cache dir

### DIFF
--- a/dvc/config.py
+++ b/dvc/config.py
@@ -170,10 +170,6 @@ class Config(dict):
         self.clear()
         self.update(conf)
 
-        # Add resolved default cache.dir
-        if not self["cache"].get("dir") and self.dvc_dir:
-            self["cache"]["dir"] = os.path.join(self.dvc_dir, "cache")
-
     def _get_fs(self, level):
         # NOTE: this might be a Gitfs, which doesn't see things outside of
         # the repo.


### PR DESCRIPTION
Setting default values is very untypical for all other applications and the info config has is not enough to make a decision on the default cache dir, especially when dealing with gitfs.

Fixes #8705
