### PR TITLE
Revert "scm: use dulwich backend when fetching exps during clone/pull"

### DIFF
--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -253,7 +253,7 @@ def _pull(git: "Git", unshallow: bool = False):
 
     git.fetch(unshallow=unshallow)
     _merge_upstream(git)
-    fetch_all_exps(git, "origin", backends=["dulwich"])
+    fetch_all_exps(git, "origin")
 
 
 def _merge_upstream(git: "Git"):

--- a/dvc/repo/experiments/utils.py
+++ b/dvc/repo/experiments/utils.py
@@ -5,7 +5,6 @@ from collections import defaultdict
 from functools import wraps
 from typing import (
     TYPE_CHECKING,
-    Any,
     Callable,
     Dict,
     Generator,
@@ -280,15 +279,17 @@ def check_ref_format(scm: "Git", ref: ExpRefInfo):
         )
 
 
-def fetch_all_exps(
-    scm: "Git", url: str, progress: Optional[Callable] = None, **kwargs: Any
-):
+def fetch_all_exps(scm: "Git", url: str, progress: Optional[Callable] = None):
     refspecs = [
         f"{ref}:{ref}"
-        for ref in iter_remote_refs(scm, url, base=EXPS_NAMESPACE, **kwargs)
+        for ref in iter_remote_refs(scm, url, base=EXPS_NAMESPACE)
         if not (ref.startswith(EXEC_NAMESPACE) or ref in STASHES)
     ]
-    scm.fetch_refspecs(url, refspecs, progress=progress, **kwargs)
+    scm.fetch_refspecs(
+        url,
+        refspecs,
+        progress=progress,
+    )
 
 
 def get_random_exp_name(scm, baseline_rev):

--- a/dvc/scm.py
+++ b/dvc/scm.py
@@ -179,7 +179,7 @@ def clone(url: str, to_path: str, **kwargs):
         try:
             git = Git.clone(url, to_path, progress=pbar.update_git, **kwargs)
             if "shallow_branch" not in kwargs:
-                fetch_all_exps(git, url, progress=pbar.update_git, backends=["dulwich"])
+                fetch_all_exps(git, url, progress=pbar.update_git)
             return git
         except InternalCloneError as exc:
             raise CloneError("SCM error") from exc


### PR DESCRIPTION
Reverts iterative/dvc#9023. Fixed upstream by https://github.com/iterative/scmrepo/pull/189 (that fallbacks to dulwich if users have credential helper set).

Also see #9039 where we bumped scmrepo with the above patch.