### PR TITLE
repo: move data_index to .dvc/tmp/index

### DIFF
--- a/dvc/cachemgr.py
+++ b/dvc/cachemgr.py
@@ -31,21 +31,8 @@ class CacheManager:
         self._odb = {}
 
         default = None
-        if repo and repo.dvc_dir:
-            if isinstance(repo.fs, GitFileSystem):
-                relparts = ()
-                if repo.root_dir != "/":
-                    # subrepo
-                    relparts = repo.fs.path.relparts(repo.root_dir, "/")
-                dvc_dir = os.path.join(
-                    repo.scm.root_dir,
-                    *relparts,
-                    repo.DVC_DIR,
-                )
-                if os.path.exists(dvc_dir):
-                    default = os.path.join(dvc_dir, self.CACHE_DIR)
-            else:
-                default = repo.fs.path.join(repo.dvc_dir, self.CACHE_DIR)
+        if repo and repo.local_dvc_dir:
+            default = os.path.join(repo.local_dvc_dir, self.CACHE_DIR)
 
         local = config.get("local")
 

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -379,23 +379,16 @@ class Repo:
 
     @property
     def data_index(self) -> Optional["DataIndex"]:
-        from appdirs import user_cache_dir
-        from fsspec.utils import tokenize
-
         from dvc_data.index import DataIndex
 
         if not self.config["feature"].get("data_index_cache"):
             return None
 
+        if not self.index_db_dir:
+            return None
+
         if self._data_index is None:
-            cache_dir = user_cache_dir(self.config.APPNAME, self.config.APPAUTHOR)
-            index_dir = os.path.join(
-                cache_dir,
-                "index",
-                "data",
-                # scm.root_dir and repo.root_dir don't match for subrepos
-                tokenize((self.scm.root_dir, self.root_dir)),
-            )
+            index_dir = os.path.join(self.index_db_dir, "data")
             os.makedirs(index_dir, exist_ok=True)
 
             self._data_index = DataIndex.open(os.path.join(index_dir, "db.db"))

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -100,17 +100,15 @@ class Repo:
         fs: Optional["FileSystem"] = None,
         uninitialized: bool = False,
         scm: Optional[Union["Git", "NoSCM"]] = None,
-    ) -> Tuple[str, Optional[str], Optional[str]]:
+    ) -> Tuple[str, Optional[str]]:
         from dvc.fs import localfs
         from dvc.scm import SCM, SCMError
 
         dvc_dir: Optional[str] = None
-        tmp_dir: Optional[str] = None
         try:
             root_dir = self.find_root(root_dir, fs)
             fs = fs or localfs
             dvc_dir = fs.path.join(root_dir, self.DVC_DIR)
-            tmp_dir = fs.path.join(dvc_dir, "tmp")
         except NotDvcRepoError:
             if not uninitialized:
                 raise
@@ -125,7 +123,7 @@ class Repo:
                 root_dir = scm.root_dir
 
         assert root_dir
-        return root_dir, dvc_dir, tmp_dir
+        return root_dir, dvc_dir
 
     def _get_database_dir(self, db_name: str) -> Optional[str]:
         # NOTE: by default, store SQLite-based remote indexes and state's
@@ -189,8 +187,10 @@ class Repo:
 
         self.root_dir: str
         self.dvc_dir: Optional[str]
-        self.tmp_dir: Optional[str]
-        self.root_dir, self.dvc_dir, self.tmp_dir = self._get_repo_dirs(
+        (
+            self.root_dir,
+            self.dvc_dir,
+        ) = self._get_repo_dirs(
             root_dir=root_dir,
             fs=self.fs,
             uninitialized=uninitialized,
@@ -213,11 +213,10 @@ class Repo:
             self.lock = LockNoop()
             self.state = StateNoop()
             self.cache = CacheManager(self)
-            self.tmp_dir = None
         else:
-            self.fs.makedirs(cast(str, self.tmp_dir), exist_ok=True)
-
             if isinstance(self.fs, LocalFileSystem):
+                self.fs.makedirs(cast(str, self.tmp_dir), exist_ok=True)
+
                 self.lock = make_lock(
                     self.fs.path.join(self.tmp_dir, "lock"),
                     tmp_dir=self.tmp_dir,
@@ -247,6 +246,41 @@ class Repo:
 
     def __str__(self):
         return self.url or self.root_dir
+
+    @cached_property
+    def local_dvc_dir(self):
+        from dvc.fs import GitFileSystem, LocalFileSystem
+
+        if not self.dvc_dir:
+            return None
+
+        if isinstance(self.fs, LocalFileSystem):
+            return self.dvc_dir
+
+        if not isinstance(self.fs, GitFileSystem):
+            return None
+
+        relparts = ()
+        if self.root_dir != "/":
+            # subrepo
+            relparts = self.fs.path.relparts(self.root_dir, "/")
+
+        dvc_dir = os.path.join(
+            self.scm.root_dir,
+            *relparts,
+            self.DVC_DIR,
+        )
+        if os.path.exists(dvc_dir):
+            return dvc_dir
+
+        return None
+
+    @cached_property
+    def tmp_dir(self):
+        if self.local_dvc_dir is None:
+            return None
+
+        return os.path.join(self.local_dvc_dir, "tmp")
 
     @cached_property
     def index(self) -> "Index":


### PR DESCRIPTION
Same as https://github.com/iterative/dvc/pull/9044 but without making persistent index enabled by default (should've just reverted last commit, but oh well 🤷 )

See https://github.com/iterative/dvc/pull/9045