### PR TITLE
deps: bump dvc-data to 0.40.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "dvc-render>=0.1.2",
     "dvc-task==0.1.11",
     "dvclive>=1.2.2",
-    "dvc-data==0.40.3",
+    "dvc-data==0.40.4",
     "dvc-http",
     "hydra-core>=1.1.0",
     "iterative-telemetry==0.0.7",


### PR DESCRIPTION
Improves index view related performance (e.g. `dvc diff`).

