### PR TITLE
index: store data index under tree prefix

### DIFF
--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -363,7 +363,7 @@ class Index:
         if index is None:
             index = DataIndex()
 
-        prefix = (self.data_tree.hash_info.value,)
+        prefix = ("tree", self.data_tree.hash_info.value)
         if prefix in index.ls((), detail=False):
             loaded = True
 


### PR DESCRIPTION
Tidying it up, so root of the index will look like this:

```
tree/
remote/
```

This hasn't been released yet, so we are not breaking anything.

