### PR TITLE
index: use has_node instead of ls

### DIFF
--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -364,7 +364,7 @@ class Index:
             index = DataIndex()
 
         prefix = ("tree", self.data_tree.hash_info.value)
-        if prefix in index.ls((), detail=False):
+        if index.has_node(prefix):
             loaded = True
 
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "configobj>=5.0.6",
     "distro>=1.3",
     "dpath<3,>=2.0.2",
-    "dvc-data>=0.41.0,<0.42",
+    "dvc-data>=0.41.1,<0.42",
     "dvc-http",
     "dvc-render>=0.1.2",
     "dvc-studio-client>=0.1.1",


### PR DESCRIPTION
Current code doesn't work for prefixes longer than one, which makes index cache effectively not work and it should've used has_node from the very start anyway.

