### PR TITLE
exp save: Use `pathspec` to handle `include_untracked`.

### DIFF
--- a/dvc/repo/experiments/save.py
+++ b/dvc/repo/experiments/save.py
@@ -2,6 +2,8 @@ import logging
 import os
 from typing import TYPE_CHECKING, List, Optional
 
+from pathspec import PathSpec
+
 from dvc.scm import Git
 
 from .exceptions import ExperimentExistsError
@@ -59,7 +61,8 @@ def save(
 
     _, _, untracked = repo.scm.status()
     if include_untracked:
-        untracked = [file for file in untracked if file not in include_untracked]
+        spec = PathSpec.from_lines("gitwildmatch", include_untracked)
+        untracked = [file for file in untracked if not spec.match_file(file)]
     if untracked:
         logger.warning(
             (

--- a/tests/func/experiments/test_save.py
+++ b/tests/func/experiments/test_save.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 from funcy import first
 
@@ -91,3 +93,15 @@ def test_exp_save_include_untracked(tmp_dir, dvc, scm, exp_stage):
 
     dvc.experiments.apply("exp-0")
     assert new_file.read_text() == "exp-0"
+
+
+def test_exp_save_include_untracked_warning(tmp_dir, dvc, scm, caplog, exp_stage):
+    """Regression test for https://github.com/iterative/dvc/issues/9061"""
+    new_dir = tmp_dir / "new_dir"
+    new_dir.mkdir()
+    (new_dir / "foo").write_text("foo")
+    (new_dir / "bar").write_text("bar")
+
+    with caplog.at_level(logging.WARNING, logger="dvc.repo.experiments.save"):
+        dvc.experiments.save(name="exp", include_untracked=["new_dir"])
+        assert not caplog.records


### PR DESCRIPTION
Closes #9061
