### PR TITLE
pull: Add `allow_missing` flag.

### DIFF
--- a/dvc/commands/data_sync.py
+++ b/dvc/commands/data_sync.py
@@ -40,6 +40,7 @@ class CmdDataPull(CmdDataBase):
                 recursive=self.args.recursive,
                 run_cache=self.args.run_cache,
                 glob=self.args.glob,
+                allow_missing=self.args.allow_missing,
             )
             self.log_summary(stats)
         except (CheckoutError, DvcException) as exc:
@@ -196,6 +197,12 @@ def add_parser(subparsers, _parent_parser):
         action="store_true",
         default=False,
         help=argparse.SUPPRESS,
+    )
+    pull_parser.add_argument(
+        "--allow-missing",
+        action="store_true",
+        default=False,
+        help="Ignore errors if some of the files or directories are missing.",
     )
     pull_parser.set_defaults(func=CmdDataPull)
 

--- a/dvc/repo/pull.py
+++ b/dvc/repo/pull.py
@@ -25,6 +25,7 @@ def pull(  # noqa: PLR0913
     run_cache=False,
     glob=False,
     odb: Optional["ObjectDB"] = None,
+    allow_missing=False,
 ):
     if isinstance(targets, str):
         targets = [targets]
@@ -48,6 +49,7 @@ def pull(  # noqa: PLR0913
         with_deps=with_deps,
         force=force,
         recursive=recursive,
+        allow_missing=allow_missing,
     )
 
     stats["fetched"] = processed_files_count

--- a/tests/unit/command/test_data_sync.py
+++ b/tests/unit/command/test_data_sync.py
@@ -58,6 +58,7 @@ def test_pull(mocker):
             "--recursive",
             "--run-cache",
             "--glob",
+            "--allow-missing",
         ]
     )
     assert cli_args.func == CmdDataPull
@@ -79,6 +80,7 @@ def test_pull(mocker):
         recursive=True,
         run_cache=True,
         glob=True,
+        allow_missing=True,
     )
 
 


### PR DESCRIPTION
Allows `pull` to succeed even if some files or directories are missing.

Closes #4746
