### PR TITLE
plots: Fix plots defined with windows syntax

### DIFF
--- a/dvc/commands/plots.py
+++ b/dvc/commands/plots.py
@@ -76,10 +76,6 @@ class CmdPlots(CmdBase):
         props = {p: getattr(self.args, p) for p in PLOT_PROPS}
         return {k: v for k, v in props.items() if v is not None}
 
-    def _config_files(self):
-        if self.args.from_config:
-            return {self.args.from_config}
-
     def _html_template_path(self):
         html_template_path = self.args.html_template
         if not html_template_path:
@@ -114,7 +110,6 @@ class CmdPlots(CmdBase):
             plots_data = self._func(
                 targets=self.args.targets,
                 props=self._props(),
-                config_files=self._config_files(),
             )
 
             if not plots_data:
@@ -411,10 +406,4 @@ def _add_ui_arguments(parser):
         default=None,
         help="Custom HTML template for VEGA visualization.",
         metavar="<path>",
-    )
-    parser.add_argument(
-        "--from-config",
-        default=None,
-        metavar="<path>",
-        help=argparse.SUPPRESS,
     )

--- a/dvc/render/match.py
+++ b/dvc/render/match.py
@@ -1,3 +1,4 @@
+import os
 from collections import defaultdict
 from typing import TYPE_CHECKING, Dict, List, Optional
 
@@ -5,7 +6,7 @@ import dpath
 import dpath.options
 from funcy import last
 
-from dvc.repo.plots import infer_data_sources
+from dvc.repo.plots import _normpath, infer_data_sources
 from dvc.utils.plots import get_plot_id
 
 from .convert import _get_converter
@@ -43,17 +44,20 @@ class PlotsData:
 
     def get_definition_data(self, target_files, rev):
         result = {}
-        for file in target_files:
+        for definition_file in target_files:
+            if os.name == "nt":
+                source_file = _normpath(definition_file).replace("\\", "/")
+            else:
+                source_file = definition_file
             file_content = (
                 self.data.get(rev, {})
                 .get("sources", {})
                 .get("data", {})
-                .get(file, {})
+                .get(source_file, {})
                 .get("data", {})
             )
             if file_content:
-                result[file] = file_content
-
+                result[definition_file] = file_content
         return result
 
 

--- a/dvc/repo/plots/__init__.py
+++ b/dvc/repo/plots/__init__.py
@@ -2,7 +2,7 @@ import csv
 import io
 import logging
 import os
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from copy import deepcopy
 from functools import partial
 from multiprocessing import cpu_count
@@ -581,21 +581,14 @@ def _load_sv(path, fs, delimiter=",", header=True):
     with fs.open(path, "r") as fd:
         content = fd.read()
 
-    first_row = first(csv.reader(io.StringIO(content)))
-
     if header:
         reader = csv.DictReader(io.StringIO(content), delimiter=delimiter)
     else:
+        first_row = first(csv.reader(io.StringIO(content)))
         reader = csv.DictReader(
             io.StringIO(content),
             delimiter=delimiter,
             fieldnames=[str(i) for i in range(len(first_row))],
         )
 
-    fieldnames = reader.fieldnames or []
-    data = list(reader)
-
-    return [
-        OrderedDict([(field, data_point[field]) for field in fieldnames])
-        for data_point in data
-    ]
+    return list(reader)

--- a/dvc/repo/plots/__init__.py
+++ b/dvc/repo/plots/__init__.py
@@ -74,7 +74,6 @@ class Plots:
         recursive: bool = False,
         onerror: Optional[Callable] = None,
         props: Optional[Dict] = None,
-        config_files: Optional[Set[str]] = None,
     ) -> Iterator[Dict]:
         """Collects plots definitions and data sources.
 
@@ -131,7 +130,6 @@ class Plots:
                 targets=targets,
                 revision=rev,
                 onerror=onerror,
-                config_files=config_files,
                 props=props,
             )
             if definitions:
@@ -186,7 +184,6 @@ class Plots:
         props=None,
         recursive=False,
         onerror=None,
-        config_files: Optional[Set[str]] = None,
     ):
         if onerror is None:
             onerror = onerror_collect
@@ -198,7 +195,6 @@ class Plots:
             recursive,
             onerror=onerror,
             props=props,
-            config_files=config_files,
         ):
             _resolve_data_sources(data)
             result.update(data)
@@ -482,7 +478,6 @@ def _collect_pipeline_files(repo, targets: List[str], props, onerror=None):
 def _collect_definitions(
     repo: "Repo",
     targets=None,
-    config_files: Optional[Set[str]] = None,
     props: Optional[Dict] = None,
     onerror: Optional[Callable] = None,
     **kwargs,
@@ -494,34 +489,15 @@ def _collect_definitions(
 
     fs = DVCFileSystem(repo=repo)
 
-    if not config_files:
-        dpath.merge(
-            result,
-            _collect_pipeline_files(repo, targets, props, onerror=onerror),
-        )
+    dpath.merge(
+        result,
+        _collect_pipeline_files(repo, targets, props, onerror=onerror),
+    )
 
-    if targets or (not targets and not config_files):
-        dpath.merge(
-            result,
-            _collect_output_plots(repo, targets, props, onerror=onerror),
-        )
-
-    if config_files:
-        for path in config_files:
-            definitions = parse(fs, path).get("data", {})
-            if definitions:
-                resolved = _resolve_definitions(
-                    repo.dvcfs,
-                    targets,
-                    props,
-                    path,
-                    definitions,
-                    onerror=onerror,
-                )
-                dpath.merge(
-                    result,
-                    {path: resolved},
-                )
+    dpath.merge(
+        result,
+        _collect_output_plots(repo, targets, props, onerror=onerror),
+    )
 
     for target in targets:
         if not result or fs.exists(target):

--- a/tests/func/plots/test_show.py
+++ b/tests/func/plots/test_show.py
@@ -9,7 +9,7 @@ from dvc.repo import Repo
 from dvc.repo.plots import PlotMetricTypeError
 from dvc.utils import onerror_collect
 from dvc.utils.fs import remove
-from dvc.utils.serialize import EncodingError, YAMLFileCorruptedError
+from dvc.utils.serialize import EncodingError, YAMLFileCorruptedError, modify_yaml
 from tests.utils.plots import get_plot
 
 
@@ -351,14 +351,11 @@ def test_collect_non_existing_dir(tmp_dir, dvc, run_copy_metrics):
         ),
     ],
 )
-@pytest.mark.parametrize("separate_config", [True, False])
-def test_load_from_config(
+def test_top_level_plots(
     tmp_dir,
     dvc,
     plot_config,
     expected_datafiles,
-    separate_config,
-    run_copy_metrics,
 ):
     data = {
         "data1.json": [
@@ -377,23 +374,11 @@ def test_load_from_config(
             os.makedirs(dirname)
         (tmp_dir / filename).dump_json(content, sort_keys=True)
 
-    config_files = None
-    if separate_config:
-        (tmp_dir / "plot_config.json").dump_json(plot_config, sort_keys=True)
-        config_file = "plot_config.json"
-        config_files = {config_file}
-    else:
-        # TODO we need that to create any stage, as dvc.yaml plots
-        #     collections bases on existing stages - fix collection
-        run_copy_metrics("data1.json", "copy.json", name="train")
+    config_file = "dvc.yaml"
+    with modify_yaml(config_file) as dvcfile_content:
+        dvcfile_content["plots"] = plot_config
 
-        from dvc.utils.serialize import modify_yaml
-
-        config_file = "dvc.yaml"
-        with modify_yaml(config_file) as dvcfile_content:
-            dvcfile_content["plots"] = plot_config
-
-    result = dvc.plots.show(config_files=config_files)
+    result = dvc.plots.show()
 
     assert plot_config == get_plot(
         result, "workspace", typ="definitions", file=config_file

--- a/tests/unit/command/test_plots.py
+++ b/tests/unit/command/test_plots.py
@@ -53,8 +53,6 @@ def test_plots_diff(dvc, mocker, plots_data):
             "HEAD",
             "tag1",
             "tag2",
-            "--from-config",
-            "path_to_config",
         ]
     )
     assert cli_args.func == CmdPlotsDiff
@@ -78,7 +76,6 @@ def test_plots_diff(dvc, mocker, plots_data):
             "y_label": "y_title",
         },
         experiment=True,
-        config_files={"path_to_config"},
     )
     render_mock.assert_not_called()
 
@@ -104,7 +101,6 @@ def test_plots_show_vega(dvc, mocker, plots_data):
     m = mocker.patch(
         "dvc.repo.plots.Plots.show",
         return_value=plots_data,
-        config_files=None,
     )
     render_mock = mocker.patch("dvc_render.render_html", return_value="html_path")
 
@@ -113,7 +109,6 @@ def test_plots_show_vega(dvc, mocker, plots_data):
     m.assert_called_once_with(
         targets=["datafile"],
         props={"template": "template", "header": False},
-        config_files=None,
     )
     render_mock.assert_not_called()
 


### PR DESCRIPTION
- [plots: Remove unnecessary OrderedDict usage in load_sv.](https://github.com/iterative/dvc/pull/9072/commits/621b67778296ab8bb2824545c8d6c0d2a0089ef4)
- [plots: Remove --from-config](https://github.com/iterative/dvc/pull/9072/commits/0b146c3bee8c981f992e82438b336b3fdd68837c)
- [plots: Fix match_defs_renderers when plots are defined in nt format.](https://github.com/iterative/dvc/pull/9072/commits/9da193dddd06c99f176db21ff053bc6db42be7f7)

`plots.show` returned `definitions` in native `nt` format but sources in `posixpath` format so the matching was failing.

Closes https://github.com/iterative/dvc/issues/8689

- Add `test_show_plots_defined_with_native_os_path`.