### PR TITLE
exp: run: don't relink during commit

### DIFF
--- a/dvc/repo/commit.py
+++ b/dvc/repo/commit.py
@@ -43,6 +43,7 @@ def commit(
     force=False,
     allow_missing=False,
     data_only=False,
+    relink=True,
 ):
     stages_info = [
         info
@@ -60,6 +61,10 @@ def commit(
             if any(changes):
                 prompt_to_commit(stage, changes, force=force)
                 stage.save(allow_missing=allow_missing)
-        stage.commit(filter_info=stage_info.filter_info, allow_missing=allow_missing)
+        stage.commit(
+            filter_info=stage_info.filter_info,
+            allow_missing=allow_missing,
+            relink=relink,
+        )
         stage.dump(update_pipeline=False)
     return [s.stage for s in stages_info]

--- a/dvc/repo/experiments/queue/base.py
+++ b/dvc/repo/experiments/queue/base.py
@@ -472,6 +472,7 @@ class BaseStashQueue(ABC):
                 force=True,
                 allow_missing=True,
                 data_only=True,
+                relink=False,
             )
 
     @staticmethod

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -545,13 +545,13 @@ class Stage(params.StageParams):
         )
 
     @rwlocked(write=["outs"])
-    def commit(self, allow_missing=False, filter_info=None) -> None:
+    def commit(self, allow_missing=False, filter_info=None, **kwargs) -> None:
         from dvc.output import OutputDoesNotExistError
 
         link_failures = []
         for out in self.filter_outs(filter_info):
             try:
-                out.commit(filter_info=filter_info)
+                out.commit(filter_info=filter_info, **kwargs)
             except OutputDoesNotExistError:
                 if not (allow_missing or out.checkpoint):
                     raise


### PR DESCRIPTION
During `exp run` we just want to backup the data to cache to be able to use it in experiments and we don't really need to relink the files in the workspace.

With a dir of 8K files `exp run` goes down from ~20sec to ~10sec for me.

Part of #8809


