### PR TITLE
dvc.testing: fix lockfile in docker_services fixture

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ tests = [
     "flaky",
     "pytest<8,>=7",
     "pytest-cov",
-    "pytest-docker",
+    "pytest-docker>=1,<2",
     "pytest-lazy-fixture",
     "pytest-mock",
     "pytest-test-utils",


### PR DESCRIPTION
I wanted to depend on internals of `pytest_docker` as much as possible, but the lifecycle of it makes it very difficult to do so. (and considering we use `pytest-xdist` this makes it much harder).