### PR TITLE
exp: fix celery run file descriptor leak

### DIFF
--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -629,5 +629,4 @@ class Repo:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self._reset()
-        self.scm.close()
+        self.close()

--- a/dvc/repo/experiments/queue/tasks.py
+++ b/dvc/repo/experiments/queue/tasks.py
@@ -28,17 +28,17 @@ def setup_exp(entry_dict: Dict[str, Any]) -> "BaseExecutor":
     from dvc.repo import Repo
 
     entry = QueueEntry.from_dict(entry_dict)
-    repo = Repo(entry.dvc_root)
-    # TODO: split executor.init_cache into separate subtask - we can release
-    # exp.scm_lock before DVC push
-    executor = BaseStashQueue.init_executor(
-        repo.experiments,
-        entry,
-        TempDirExecutor,
-        location="dvc-task",
-    )
-    infofile = repo.experiments.celery_queue.get_infofile_path(entry.stash_rev)
-    executor.info.dump_json(infofile)
+    with Repo(entry.dvc_root) as repo:
+        # TODO: split executor.init_cache into separate subtask - we can release
+        # exp.scm_lock before DVC push
+        executor = BaseStashQueue.init_executor(
+            repo.experiments,
+            entry,
+            TempDirExecutor,
+            location="dvc-task",
+        )
+        infofile = repo.experiments.celery_queue.get_infofile_path(entry.stash_rev)
+        executor.info.dump_json(infofile)
     return executor
 
 
@@ -59,23 +59,23 @@ def collect_exp(
     from dvc.repo import Repo
 
     entry = QueueEntry.from_dict(entry_dict)
-    repo = Repo(entry.dvc_root)
-    celery_queue = repo.experiments.celery_queue
-    infofile = celery_queue.get_infofile_path(entry.stash_rev)
-    executor_info = ExecutorInfo.load_json(infofile)
-    logger.debug("Collecting experiment info '%s'", str(executor_info))
-    executor = TempDirExecutor.from_info(executor_info)
-    exec_result = executor_info.result
-    try:
-        if exec_result is not None:
-            BaseStashQueue.collect_executor(repo.experiments, executor, exec_result)
-        else:
-            logger.debug("Experiment failed (Exec result was None)")
-            celery_queue.stash_failed(entry)
-    except Exception:  # pylint: disable=broad-except
-        # Log exceptions but do not re-raise so that task chain execution
-        # continues
-        logger.exception("Failed to collect experiment")
+    with Repo(entry.dvc_root) as repo:
+        celery_queue = repo.experiments.celery_queue
+        infofile = celery_queue.get_infofile_path(entry.stash_rev)
+        executor_info = ExecutorInfo.load_json(infofile)
+        logger.debug("Collecting experiment info '%s'", str(executor_info))
+        executor = TempDirExecutor.from_info(executor_info)
+        exec_result = executor_info.result
+        try:
+            if exec_result is not None:
+                BaseStashQueue.collect_executor(repo.experiments, executor, exec_result)
+            else:
+                logger.debug("Experiment failed (Exec result was None)")
+                celery_queue.stash_failed(entry)
+        except Exception:  # pylint: disable=broad-except
+            # Log exceptions but do not re-raise so that task chain execution
+            # continues
+            logger.exception("Failed to collect experiment")
     return executor.root_dir
 
 
@@ -102,9 +102,9 @@ def run_exp(entry_dict: Dict[str, Any]) -> None:
     from dvc.repo import Repo
 
     entry = QueueEntry.from_dict(entry_dict)
-    repo = Repo(entry.dvc_root)
-    queue = repo.experiments.celery_queue
-    infofile = queue.get_infofile_path(entry.stash_rev)
+    with Repo(entry.dvc_root) as repo:
+        queue = repo.experiments.celery_queue
+        infofile = queue.get_infofile_path(entry.stash_rev)
     executor = setup_exp.s(entry_dict)()
     try:
         cmd = ["dvc", "exp", "exec-run", "--infofile", infofile]


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Related: https://github.com/iterative/dvc/issues/8787

Queued (celery) tasks open new `repo.Repo` instances per task (since they are run independently), but repo instances were not being explicitly `close()`ed and any open resources from the repo were leaked. This also meant that each `repo.scm` instance was also leaked (since we never called `repo.scm.close()`) which in turn would lead to dulwich/pygit file handles to git object stores not being closed.

This chain eventually causes us to run out of file descriptors given either a long enough worker run (i.e. lots of experiments being run in a single worker) or large enough concurrency (i.e. lots of parallel worker --jobs), which would then cause the celery worker to exit. (Whether or not users would hit this problem also depends on os/hardware/ulimit configuration/etc)

This would show up as several different queue/concurrency related symptoms:

- queue execution ending prematurely (without the user running `dvc queue stop`)
- explicit "not enough file descriptors" OS errors
- git lockfile errors (if the worker process hard exits while a git backend had an open git lockfile)
- dvc repo lock errors (if worker process hard exits while dvc has open repo lock)
- experiments showing as running in `queue status` even though worker is not running (if worker process hard exits without allowing dvc-task `finally:`/cleanup blocks to run)

Fixes https://github.com/iterative/dvc/issues/8763
Fixes https://github.com/iterative/dvc/issues/8621
Fixes https://github.com/iterative/dvc/issues/8614