### PR TITLE
exp save: Don't relink during commit

### DIFF
--- a/dvc/repo/experiments/save.py
+++ b/dvc/repo/experiments/save.py
@@ -24,7 +24,7 @@ def _save_experiment(
     name: Optional[str],
     include_untracked: Optional[List[str]],
 ) -> str:
-    repo.commit([], force=True)
+    repo.commit([], force=True, relink=False)
 
     name = name or get_random_exp_name(repo.scm, baseline_rev)
     ref_info = ExpRefInfo(baseline_rev, name)


### PR DESCRIPTION
Same change as in https://github.com/iterative/dvc/pull/9076 but for `exp save`
