### PR TITLE
push: allow no default remote

### DIFF
--- a/dvc/repo/push.py
+++ b/dvc/repo/push.py
@@ -1,5 +1,7 @@
+from contextlib import suppress
 from typing import TYPE_CHECKING, Optional, Sequence
 
+from dvc.config import NoRemoteError
 from dvc.exceptions import InvalidArgumentError, UploadError
 from dvc.utils import glob_targets
 
@@ -30,9 +32,10 @@ def push(  # noqa: C901, PLR0913
     include_imports=False,
 ):
     worktree_remote: Optional["Remote"] = None
-    _remote = self.cloud.get_remote(name=remote)
-    if _remote.worktree or _remote.fs.version_aware:
-        worktree_remote = _remote
+    with suppress(NoRemoteError):
+        _remote = self.cloud.get_remote(name=remote)
+        if _remote and (_remote.worktree or _remote.fs.version_aware):
+            worktree_remote = _remote
 
     pushed = 0
     used_run_cache = self.stage_cache.push(remote, odb=odb) if run_cache else []


### PR DESCRIPTION
Allows running `dvc push` in a repo with a config like this (note, no default remote is set):

```
[core]
['remote "production"']
    url = s3://dvc-temp/ivan/test-multiple-remotes
['remote "sandbox"']
    url = s3://dvc-sandbox-temp/ivan/test-multiple-remotes
```

It's a valid scenario in cases like described here https://github.com/iterative/studio-support/issues/50 - where all outputs are explicitly assigned a remote. E.g. this the modification of the `example-get-started` that I was using to reproduce:

<details>
<summary>dvc.yaml</summary>

```yaml
stages:
  prepare:
    cmd: python src/prepare.py data/data.xml
    deps:
    - data/data.xml
    - src/prepare.py
    params:
    - prepare.seed
    - prepare.split
    outs:
    - data/prepared:
        remote: production
  featurize:
    cmd: python src/featurization.py data/prepared data/features
    deps:
    - data/prepared
    - src/featurization.py
    params:
    - featurize.max_features
    - featurize.ngrams
    outs:
    - data/features:
        remote: sandbox
  train:
    cmd: python src/train.py data/features model.pkl
    deps:
    - data/features
    - src/train.py
    params:
    - train.min_split
    - train.n_est
    - train.seed
    outs:
    - model.pkl:
        remote: production
  evaluate:
    cmd: python src/evaluate.py model.pkl data/features
    deps:
    - data/features
    - model.pkl
    - src/evaluate.py
    outs:
    - eval/importance.png:
        remote: production
    - eval/live/plots:
        remote: production
    - eval/prc:
        remote: sandbox
    metrics:
    - eval/live/metrics.json:
        remote: sandbox
plots:
  - ROC:
      template: simple
      x: fpr
      y:
        eval/live/plots/sklearn/roc/train.json: tpr
        eval/live/plots/sklearn/roc/test.json: tpr
  - Confusion-Matrix:
      template: confusion
      x: actual
      y:
        eval/live/plots/sklearn/cm/train.json: predicted
        eval/live/plots/sklearn/cm/test.json: predicted
  - Precision-Recall:
      template: simple
      x: recall
      y:
        eval/prc/train.json: precision
        eval/prc/test.json: precision
  - eval/importance.png
```

</details>

Without this fix, `dvc push` fails with a "no remote specified" error.

-------

* [X] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [X] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

--------

## TODO

- [ ] Add a test if the approach makes sense