### PR TITLE
exp show: don't cache collection errors

### DIFF
--- a/dvc/repo/experiments/serialize.py
+++ b/dvc/repo/experiments/serialize.py
@@ -117,6 +117,16 @@ class SerializableExp:
         except (TypeError, json.JSONDecodeError) as exc:
             raise DeserializeError("failed to load SerializableExp") from exc
 
+    @property
+    def contains_error(self) -> bool:
+        return (
+            self.error is not None
+            or self.params.get("error")
+            or any(value.get("error") for value in self.params.values())
+            or self.metrics.get("error")
+            or any(value.get("error") for value in self.metrics.values())
+        )
+
 
 @dataclass(frozen=True)
 class _ExpDep:

--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -97,14 +97,12 @@ def collect_experiment_commit(
             force=force,
             **kwargs,
         )
-        if exp_rev != "workspace" and not param_deps:
+        if exp_rev != "workspace" and not param_deps and not exp.contains_error:
             cache.put(exp, force=True)
         return _format_exp(exp)
     except Exception as exc:  # noqa: BLE001, pylint: disable=broad-except
         logger.debug("", exc_info=True)
         error = SerializableError(str(exc), type(exc).__name__)
-        if not (exp_rev == "workspace" or param_deps or status == ExpStatus.Running):
-            cache.put(error, rev=exp_rev, force=True)
         return _format_error(error)
 
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Skip caching revs that contain collection errors for now. When we have better error handling and can differentiate between errors that are cacheable (git-committed invalid files) and those that are not (retry-able network errors) we can re-enable this.

See https://github.com/iterative/dvc.org/pull/4346#discussion_r1123566099