### PR TITLE
migrate from appdirs to platformdirs

### DIFF
--- a/dvc/config.py
+++ b/dvc/config.py
@@ -117,7 +117,7 @@ class Config(dict):
 
     @classmethod
     def get_dir(cls, level):
-        from appdirs import site_config_dir, user_config_dir
+        from platformdirs import site_config_dir, user_config_dir
 
         assert level in ("global", "system")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "appdirs>=1.4.3",
     "colorama>=0.3.9",
     "configobj>=5.0.6",
     "distro>=1.3",
@@ -49,6 +48,7 @@ dependencies = [
     "networkx>=2.5",
     "packaging>=19",
     "pathspec>=0.10.3",
+    "platformdirs<4,>=3",
     "psutil>=5.8",
     "pydot>=1.2.4",
     "pygtrie>=2.3.2",
@@ -75,7 +75,6 @@ hdfs = ["dvc-hdfs==2.19"]
 lint = [
     "mypy==1.0.1",
     "pylint==2.16.4",
-    "types-appdirs",
     "types-colorama",
     "types-psutil",
     "types-requests",


### PR DESCRIPTION
appdirs has been deprecated/unmaintained, platformdirs is now recommended. Closes #9130.

