### PR TITLE
exp run: allow running in empty git repo

### DIFF
--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -256,7 +256,17 @@ class Experiments:
             )
 
         name = kwargs.get("name", None)
-        baseline_sha = kwargs.get("baseline_rev") or self.repo.scm.get_rev()
+        if self.repo.scm.no_commits:
+            from dulwich.index import commit_tree as _commit_tree
+            from dulwich.porcelain import commit_tree
+
+            dulwich_repo = self.repo.scm.dulwich.repo
+            logger.warning("Creating an initial commit in an empty git repository")
+            tree = _commit_tree(dulwich_repo.object_store, [])
+            message = b"initial empty commit - dvc"
+            baseline_sha = commit_tree(dulwich_repo, tree, message=message)
+        else:
+            baseline_sha = kwargs.get("baseline_rev") or self.repo.scm.get_rev()
 
         if name:
             exp_ref = ExpRefInfo(baseline_sha=baseline_sha, name=name)


### PR DESCRIPTION
Opened only for discussion about the approach.

This PR creates an initial empty commit (without touching the git index) in the user's default branch (or, wherever the `symbolic-ref HEAD` points to). So this does not make any changes to the workspace or include it to index or in a commit.

Since it's an orphan commit without a parent, there is no good way to undo this commit.
That's the disadvantage of this approach.
There is `git update-ref -d HEAD` which removes `.git/HEAD`, or you can amend (`git commit --amend`) or rebase (`git rebase -i --root`) later though. But that's more of a modification than undo. 