### PR TITLE
repo: add `brancher.switch`

### DIFF
--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -3,7 +3,16 @@ import os
 from collections import defaultdict
 from contextlib import contextmanager
 from functools import wraps
-from typing import TYPE_CHECKING, Callable, Iterable, List, Optional, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    ContextManager,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
 from dvc.exceptions import FileMissingError
 from dvc.exceptions import IsADirectoryError as DvcIsADirectoryError
@@ -462,6 +471,11 @@ class Repo:
         from dvc.repo.brancher import brancher
 
         return brancher(self, *args, **kwargs)
+
+    def switch(self, rev: str) -> ContextManager[str]:
+        from dvc.repo.brancher import switch
+
+        return switch(self, rev)
 
     def used_objs(  # noqa: PLR0913
         self,

--- a/dvc/repo/data.py
+++ b/dvc/repo/data.py
@@ -182,10 +182,7 @@ def _diff_head_to_index(
 ) -> Dict[str, List[str]]:
     index = repo.index.data["repo"]
 
-    for rev in repo.brancher(revs=[head]):
-        if rev == "workspace":
-            continue
-
+    with repo.switch(head):
         head_index = repo.index.data["repo"]
 
     with ui.status("Calculating diff between head/index"):

--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -19,7 +19,7 @@ from typing import (
 from scmrepo.exceptions import SCMError as InnerScmError
 
 from dvc.exceptions import DvcException
-from dvc.scm import Git, RevError, SCMError, iter_revs, resolve_rev
+from dvc.scm import Git, SCMError, iter_revs, resolve_rev
 
 from .refs import ExpRefInfo
 from .serialize import SerializableError, SerializableExp
@@ -122,10 +122,8 @@ def _collect_from_repo(
     **kwargs,
 ) -> "SerializableExp":
     running = running or {}
-    for rev in repo.brancher(revs=[exp_rev]):
+    with repo.switch(exp_rev) as rev:
         if rev == "workspace":
-            if exp_rev != "workspace":
-                continue
             timestamp: Optional[datetime] = None
         else:
             commit = repo.scm.resolve_commit(rev)
@@ -151,7 +149,6 @@ def _collect_from_repo(
             executor=executor,
             error=error,
         )
-    raise RevError(f"nonexistent exp rev: '{exp_rev}'")
 
 
 def _collect_complete_experiment(

--- a/dvc/repo/experiments/utils.py
+++ b/dvc/repo/experiments/utils.py
@@ -35,6 +35,7 @@ from .refs import (
 
 if TYPE_CHECKING:
     from dvc.repo import Repo
+    from dvc.scm import NoSCM
 
 
 EXEC_TMP_DIR = "exps"
@@ -108,7 +109,9 @@ def exp_refs_by_rev(scm: "Git", rev: str) -> Generator[ExpRefInfo, None, None]:
 
 
 def exp_refs_by_baseline(
-    scm: "Git", revs: Optional[Set[str]] = None, url: Optional[str] = None
+    scm: "Git",
+    revs: Optional[Set[str]] = None,
+    url: Optional[str] = None,
 ) -> Mapping[str, List[ExpRefInfo]]:
     """Iterate over all experiment refs with the specified baseline."""
     all_exp_refs = exp_refs(scm, url)
@@ -233,7 +236,7 @@ def remove_exp_refs(scm: "Git", ref_infos: Iterable[ExpRefInfo]):
         scm.remove_ref(str(ref_info))
 
 
-def fix_exp_head(scm: "Git", ref: Optional[str]) -> Optional[str]:
+def fix_exp_head(scm: Union["Git", "NoSCM"], ref: Optional[str]) -> Optional[str]:
     if ref:
         name, tail = Git.split_ref_pattern(ref)
         if name == "HEAD" and scm.get_ref(EXEC_BASELINE):

--- a/dvc/scm.py
+++ b/dvc/scm.py
@@ -165,7 +165,7 @@ def clone(url: str, to_path: str, **kwargs):
             raise CloneError("SCM error") from exc
 
 
-def resolve_rev(scm: "Git", rev: str) -> str:
+def resolve_rev(scm: Union["Git", "NoSCM"], rev: str) -> str:
     from scmrepo.exceptions import RevError as InternalRevError
 
     from dvc.repo.experiments.utils import fix_exp_head
@@ -173,6 +173,7 @@ def resolve_rev(scm: "Git", rev: str) -> str:
     try:
         return scm.resolve_rev(fix_exp_head(scm, rev))
     except InternalRevError as exc:
+        assert isinstance(scm, Git)
         # `scm` will only resolve git branch and tag names,
         # if rev is not a sha it may be an abbreviated experiment name
         if not (rev == "HEAD" or rev.startswith("refs/")):

--- a/tests/func/experiments/test_checkpoints.py
+++ b/tests/func/experiments/test_checkpoints.py
@@ -25,9 +25,7 @@ def test_new_checkpoint(tmp_dir, scm, dvc, checkpoint_stage, mocker, workspace, 
     exp = first(results)
 
     new_mock.assert_called_once()
-    for rev in dvc.brancher([exp]):
-        if rev == "workspace":
-            continue
+    with dvc.switch(exp):
         fs = dvc.dvcfs
         with fs.open("foo") as fobj:
             assert fobj.read().strip() == str(checkpoint_stage.iterations)
@@ -69,9 +67,7 @@ def test_resume_checkpoint(
     )
     exp = first(results)
 
-    for rev in dvc.brancher([exp]):
-        if rev == "workspace":
-            continue
+    with dvc.switch(exp):
         fs = dvc.dvcfs
         with fs.open("foo") as fobj:
             assert fobj.read().strip() == str(2 * checkpoint_stage.iterations)
@@ -94,9 +90,7 @@ def test_reset_checkpoint(tmp_dir, scm, dvc, checkpoint_stage, caplog, workspace
     )
     exp = first(results)
 
-    for rev in dvc.brancher([exp]):
-        if rev == "workspace":
-            continue
+    with dvc.switch(exp):
         fs = dvc.dvcfs
         with fs.open("foo") as fobj:
             assert fobj.read().strip() == str(checkpoint_stage.iterations)
@@ -132,18 +126,14 @@ def test_resume_branch(tmp_dir, scm, dvc, checkpoint_stage, workspace):
     )
     checkpoint_b = first(results)
 
-    for rev in dvc.brancher([checkpoint_a]):
-        if rev == "workspace":
-            continue
+    with dvc.switch(checkpoint_a):
         fs = dvc.dvcfs
         with fs.open("foo") as fobj:
             assert fobj.read().strip() == str(2 * checkpoint_stage.iterations)
         with fs.open("metrics.yaml") as fobj:
             assert fobj.read().strip() == "foo: 2"
 
-    for rev in dvc.brancher([checkpoint_b]):
-        if rev == "workspace":
-            continue
+    with dvc.switch(checkpoint_b):
         fs = dvc.dvcfs
         with fs.open("foo") as fobj:
             assert fobj.read().strip() == str(2 * checkpoint_stage.iterations)

--- a/tests/unit/fs/test_data.py
+++ b/tests/unit/fs/test_data.py
@@ -89,10 +89,7 @@ def test_open_in_history(tmp_dir, scm, dvc):
     dvc.scm.add(["foo.dvc", ".gitignore"])
     dvc.scm.commit("foofoo")
 
-    for rev in dvc.brancher(revs=["HEAD~1"]):
-        if rev == "workspace":
-            continue
-
+    with dvc.switch("HEAD~1"):
         fs = DataFileSystem(index=dvc.index.data["repo"])
         with fs.open("foo", "r") as fobj:
             assert fobj.read() == "foo"

--- a/tests/unit/fs/test_dvc.py
+++ b/tests/unit/fs/test_dvc.py
@@ -59,10 +59,7 @@ def test_open_in_history(tmp_dir, scm, dvc):
     dvc.scm.add(["foo.dvc", ".gitignore"])
     dvc.scm.commit("foofoo")
 
-    for rev in dvc.brancher(revs=["HEAD~1"]):
-        if rev == "workspace":
-            continue
-
+    with dvc.switch("HEAD~1"):
         fs = DVCFileSystem(repo=dvc)
         with fs.open("foo", "r") as fobj:
             assert fobj.read() == "foo"


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

There's several places that we use brancher to switch the repo context to a specific git rev (especially in experiments), but brancher includes a lot of unnecessary overhead since it is designed to iterate over multiple revs and do git branch/tag lookups, etc.

- Adds `brancher.switch`/`repo.switch` (equivalent to `git switch`) to switch repo fs context to a specific revision (as opposed to iterating over all contexts for a range of revs in `brancher.brancher`). Note that this is not equivalent to `brancher([rev], sha_only=True)` because brancher always adds `workspace` to the list of revisions.