### PR TITLE
studio: handle revision errors when posting

### DIFF
--- a/dvc/repo/experiments/utils.py
+++ b/dvc/repo/experiments/utils.py
@@ -337,7 +337,7 @@ def to_studio_params(dvc_params):
     if not dvc_params:
         return result
     for rev_data in dvc_params.values():
-        for file_name, file_data in rev_data["data"].items():
+        for file_name, file_data in rev_data.get("data", {}).items():
             result[file_name] = file_data["data"]
 
     return result

--- a/tests/unit/repo/experiments/test_utils.py
+++ b/tests/unit/repo/experiments/test_utils.py
@@ -2,7 +2,7 @@ import pytest
 
 from dvc.exceptions import InvalidArgumentError
 from dvc.repo.experiments.refs import EXPS_NAMESPACE, ExpRefInfo
-from dvc.repo.experiments.utils import check_ref_format, resolve_name
+from dvc.repo.experiments.utils import check_ref_format, resolve_name, to_studio_params
 
 
 def commit_exp_ref(tmp_dir, scm, file="foo", contents="foo", name="foo"):
@@ -53,3 +53,20 @@ def test_run_check_ref_format(scm, name, result):
     else:
         with pytest.raises(InvalidArgumentError):
             check_ref_format(scm, ref)
+
+
+@pytest.mark.parametrize(
+    "params,expected",
+    [
+        (
+            {"workspace": {"data": {"params.yaml": {"data": {"foo": 1}}}}},
+            {"params.yaml": {"foo": 1}},
+        ),
+        (
+            {"workspace": {"error": "something went wrong"}},
+            {},
+        ),
+    ],
+)
+def test_to_studio_params(params, expected):
+    assert to_studio_params(params) == expected


### PR DESCRIPTION
Context: I found this when testing out a https://github.com/iterative/dvclive/pull/464 in a repo with overlapping outputs (tracking the model as both a stage output and in a .dvc file).

Before this PR:

```
$ dvc exp run -f
DVC failed to load some parameters for following revisions: ''.
DVC failed to load some metrics for following revisions: ''.
ERROR: Failed to reproduce experiment '9dc4c70': 'data'
```

After this PR:

```
$ dvc exp run -f
DVC failed to load some parameters for following revisions: ''.
DVC failed to load some metrics for following revisions: ''.
ERROR: output 'model' is already specified in stages:
        - train
        - model.dvc
```

This still isn't a good UX, but at least now I can see a somewhat more useful error.