### PR TITLE
Update duplicate output error msg

### DIFF
--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -32,12 +32,21 @@ class OutputDuplicationError(DvcException):
         assert isinstance(output, str)
         assert all(hasattr(stage, "relpath") for stage in stages)
         if len(stages) == 1:
-            msg = "output '{}' is already specified in {}.".format(
-                output, first(stages)
+            stage_name = first(stages)
+            msg = (
+                f"output '{output}' is already specified in {stage_name}."
+                f"\nUse `dvc remove {stage_name.addressing}` to stop tracking the "
+                "overlapping output."
             )
         else:
+            stage_names = [s.addressing for s in stages]
             msg = "output '{}' is already specified in stages:\n{}".format(
-                output, "\n".join(f"\t- {s.addressing}" for s in stages)
+                output, "\n".join(f"\t- {s}" for s in stage_names)
+            )
+            msg += "\nUse `dvc remove {}` to stop tracking overlapping outputs.".format(
+                " ".join(
+                    stage_names,
+                )
             )
         super().__init__(msg)
         self.stages = stages

--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -31,23 +31,19 @@ class OutputDuplicationError(DvcException):
 
         assert isinstance(output, str)
         assert all(hasattr(stage, "relpath") for stage in stages)
+        msg = ""
+        stage_names = [s.addressing for s in stages]
+        stages_str = " ".join(stage_names)
         if len(stages) == 1:
             stage_name = first(stages)
-            msg = (
-                f"output '{output}' is already specified in {stage_name}."
-                f"\nUse `dvc remove {stage_name.addressing}` to stop tracking the "
-                "overlapping output."
-            )
+            msg = f"output '{output}' is already specified in {stage_name}."
         else:
-            stage_names = [s.addressing for s in stages]
             msg = "output '{}' is already specified in stages:\n{}".format(
                 output, "\n".join(f"\t- {s}" for s in stage_names)
             )
-            msg += "\nUse `dvc remove {}` to stop tracking overlapping outputs.".format(
-                " ".join(
-                    stage_names,
-                )
-            )
+        msg += (
+            f"\nUse `dvc remove {stages_str}` to stop tracking the overlapping output."
+        )
         super().__init__(msg)
         self.stages = stages
         self.output = output

--- a/tests/func/test_stage.py
+++ b/tests/func/test_stage.py
@@ -4,6 +4,7 @@ import pytest
 
 from dvc.annotations import Annotation
 from dvc.dvcfile import SingleStageFile
+from dvc.exceptions import OutputDuplicationError
 from dvc.fs import LocalFileSystem
 from dvc.output import Output
 from dvc.repo import Repo, lock_repo
@@ -333,3 +334,14 @@ def test_stage_run_checkpoint(tmp_dir, dvc, mocker, checkpoint):
     mock_cmd_run.assert_called_with(
         stage, checkpoint_func=callback, dry=False, run_env=None
     )
+
+
+def test_stage_add_duplicated_output(tmp_dir, dvc):
+    tmp_dir.dvc_gen("foo", "foo")
+    dvc.add("foo")
+
+    with pytest.raises(
+        OutputDuplicationError,
+        match="Use `dvc remove foo.dvc` to stop tracking the overlapping output.",
+    ):
+        dvc.stage.add(name="duplicated", cmd="echo bar > foo", outs=["foo"])


### PR DESCRIPTION
Fixes #8986

Before this PR:

```
$ dvc stage add -f -n train -d train.py -o model python train.py
ERROR: output 'model' is already specified in stages:
        - model.dvc
        - train
```

After this PR:

```
$ dvc stage add -f -n train -d train.py -o model python train.py
ERROR: output 'model' is already specified in stage: 'model.dvc'.
Use `dvc remove model.dvc` to stop tracking the overlapping output.
```