### PR TITLE
fetch: introduce --tree-only

### DIFF
--- a/dvc/commands/data_sync.py
+++ b/dvc/commands/data_sync.py
@@ -91,6 +91,7 @@ class CmdDataFetch(CmdDataBase):
                 with_deps=self.args.with_deps,
                 recursive=self.args.recursive,
                 run_cache=self.args.run_cache,
+                tree_only=self.args.tree_only,
             )
             self.log_summary({"fetched": processed_files_count})
         except DvcException:
@@ -321,6 +322,12 @@ def add_parser(subparsers, _parent_parser):
         action="store_true",
         default=False,
         help="Fetch run history for all stages.",
+    )
+    fetch_parser.add_argument(
+        "--tree-only",
+        action="store_true",
+        default=False,
+        help="Only fetch .dir objects.",
     )
     fetch_parser.set_defaults(func=CmdDataFetch)
 

--- a/dvc/dependency/repo.py
+++ b/dvc/dependency/repo.py
@@ -111,7 +111,7 @@ class RepoDependency(Dependency):
         return used
 
     def _get_used_and_obj(
-        self, obj_only: bool = False, **kwargs
+        self, obj_only: bool = False, tree_only: bool = False, **kwargs
     ) -> Tuple[Dict[Optional["ObjectDB"], Set["HashInfo"]], "Meta", "HashFile"]:
         from dvc.config import NoRemoteError
         from dvc.exceptions import NoOutputOrStageError
@@ -134,6 +134,7 @@ class RepoDependency(Dependency):
                         force=True,
                         jobs=kwargs.get("jobs"),
                         recursive=True,
+                        tree_only=tree_only,
                     ).items():
                         if odb is None:
                             odb = repo.cloud.get_remote_odb()
@@ -161,6 +162,11 @@ class RepoDependency(Dependency):
 
             self._objs[rev] = obj
             self._meta[rev] = meta
+
+            if tree_only:
+                if isinstance(obj, Tree):
+                    used_obj_ids[object_store].add(obj.hash_info)
+                return used_obj_ids, meta, obj
 
             used_obj_ids[object_store].add(obj.hash_info)
             if isinstance(obj, Tree):

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -458,6 +458,7 @@ class Repo:
         revs=None,
         num=1,
         push: bool = False,
+        tree_only: bool = False,
     ):
         """Get the stages related to the given target and collect
         the `info` of its outputs.
@@ -493,6 +494,7 @@ class Repo:
                 recursive=recursive,
                 with_deps=with_deps,
                 push=push,
+                tree_only=tree_only,
             ).items():
                 used[odb].update(objs)
 

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -32,6 +32,7 @@ def fetch(  # noqa: C901, PLR0913
     run_cache=False,
     revs=None,
     odb: Optional["HashFileDB"] = None,
+    tree_only: bool = False,
 ) -> int:
     """Download data items from a cloud and imported repositories
 
@@ -96,6 +97,7 @@ def fetch(  # noqa: C901, PLR0913
                 recursive=recursive,
                 revs=revs,
                 odb=odb,
+                tree_only=tree_only,
             )
             result.transferred.update(d)
             result.failed.update(f)

--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -432,6 +432,7 @@ class Index:
         recursive: bool = False,
         jobs: Optional[int] = None,
         push: bool = False,
+        tree_only: bool = False,
     ) -> "ObjectContainer":
         from collections import defaultdict
 
@@ -444,6 +445,7 @@ class Index:
                 jobs=jobs,
                 filter_info=filter_info,
                 push=push,
+                tree_only=tree_only,
             ).items():
                 used[odb].update(objs)
         return used


### PR DESCRIPTION
Very useful plumbing command to be able to restore full data index before actually downloading files.

This should be used as a step in regular `fetch` in the future instead of implicit `cloud.pull()` in `output.get_dir_cache`.