### PR TITLE
DataCloud: don't set tmp_dir

### DIFF
--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -75,7 +75,6 @@ class DataCloud:
                     config["version_aware"] = True
 
             fs = cls(**config)
-            config["tmp_dir"] = self.repo.index_db_dir
             if self.repo.data_index is not None:
                 index = self.repo.data_index.view(("remote", name))
             else:


### PR DESCRIPTION
This is no longer used anywhere.
