### PR TITLE
plots: disable syntax highlighting on plots json output

### DIFF
--- a/dvc/commands/plots.py
+++ b/dvc/commands/plots.py
@@ -19,7 +19,7 @@ def _show_json(renderers, split=False):
     from dvc.render.convert import to_json
 
     result = {renderer.name: to_json(renderer, split) for renderer in renderers}
-    ui.write_json(result)
+    ui.write_json(result, highlight=False)
 
 
 def _adjust_vega_renderers(renderers):


### PR DESCRIPTION
I don't think it's worth it to highlight given the size of json output.

Note that highlighting was/is off when the stdout is redirected.