### PR TITLE
exp push: push experiments revs to studio

### DIFF
--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -300,6 +300,7 @@ SCHEMA = {
     "feature": FeatureSchema(
         {
             Optional("machine", default=False): Bool,
+            Optional("push_exp_to_studio", default=False): Bool,
         },
     ),
     "plots": {

--- a/dvc/repo/experiments/push.py
+++ b/dvc/repo/experiments/push.py
@@ -15,10 +15,12 @@ from .utils import exp_commits, exp_refs, exp_refs_by_baseline, resolve_name
 
 logger = logging.getLogger(__name__)
 
+STUDIO_ENDPOINT = ""
+
 
 @locked
 @scm_context
-def push(  # noqa: C901
+def push(  # noqa: C901, PLR0912
     repo,
     git_remote: str,
     exp_names: Union[Iterable[str], str],
@@ -29,6 +31,8 @@ def push(  # noqa: C901
     push_cache: bool = False,
     **kwargs,
 ) -> Iterable[str]:
+    from dvc.utils import env2bool
+
     exp_ref_set: Set["ExpRefInfo"] = set()
     if all_commits:
         exp_ref_set.update(exp_refs(repo.scm))
@@ -69,7 +73,46 @@ def push(  # noqa: C901
             push_result[SyncStatus.UP_TO_DATE] + push_result[SyncStatus.SUCCESS]
         )
         _push_cache(repo, push_cache_ref, **kwargs)
-    return [ref.name for ref in push_result[SyncStatus.SUCCESS]]
+
+    refs = push_result[SyncStatus.SUCCESS]
+    config = repo.config
+    if refs and config["feature"]["push_exp_to_studio"] and not env2bool("DVC_TEST"):
+        from dvc_studio_client.post_live_metrics import get_studio_token_and_repo_url
+
+        token, repo_url = get_studio_token_and_repo_url()
+        if token and repo_url:
+            logger.debug(
+                "pushing experiments %s to Studio",
+                ", ".join(ref.name for ref in refs),
+            )
+            _notify_studio([str(ref) for ref in refs], repo_url, token)
+    return [ref.name for ref in refs]
+
+
+def _notify_studio(
+    refs: List[str],
+    repo_url: str,
+    token: str,
+    endpoint: Optional[str] = None,
+):
+    if not refs:
+        return
+
+    import os
+
+    import requests
+    from requests.adapters import HTTPAdapter
+
+    endpoint = endpoint or os.getenv("STUDIO_ENDPOINT", STUDIO_ENDPOINT)
+    assert endpoint is not None
+
+    session = requests.Session()
+    session.mount(endpoint, HTTPAdapter(max_retries=3))
+
+    json = {"repo_url": repo_url, "client": "dvc", "refs": refs}
+    headers = {"Authorization": f"token {token}"}
+    resp = session.post(endpoint, json=json, headers=headers, timeout=5)
+    resp.raise_for_status()
 
 
 def _push(
@@ -83,7 +126,7 @@ def _push(
     from dvc.scm import GitAuthError
 
     refspec_list = [f"{exp_ref}:{exp_ref}" for exp_ref in refs]
-    logger.debug("git push experiment '%s' -> '%s'", refspec_list, git_remote)
+    logger.debug("git push experiment %s -> '%s'", refspec_list, git_remote)
 
     with TqdmGit(desc="Pushing git refs") as pbar:
         try:

--- a/dvc/repo/experiments/push.py
+++ b/dvc/repo/experiments/push.py
@@ -110,6 +110,8 @@ def _notify_studio(
     session.mount(endpoint, HTTPAdapter(max_retries=3))
 
     json = {"repo_url": repo_url, "client": "dvc", "refs": refs}
+    logger.trace("Sending %s to %s", json, endpoint)  # type: ignore[attr-defined]
+
     headers = {"Authorization": f"token {token}"}
     resp = session.post(endpoint, json=json, headers=headers, timeout=5)
     resp.raise_for_status()

--- a/tests/unit/repo/experiments/test_push.py
+++ b/tests/unit/repo/experiments/test_push.py
@@ -1,0 +1,27 @@
+from requests import Response
+
+from dvc.repo.experiments.push import STUDIO_ENDPOINT, _notify_studio
+
+
+def test_notify_studio_for_exp_push(mocker):
+    valid_response = Response()
+    valid_response.status_code = 200
+    mock_post = mocker.patch("requests.Session.post", return_value=valid_response)
+
+    _notify_studio(
+        ["ref1", "ref2", "ref3"],
+        "git@github.com:iterative/dvc.git",
+        "TOKEN",
+    )
+
+    assert mock_post.called
+    assert mock_post.call_args == mocker.call(
+        STUDIO_ENDPOINT,
+        json={
+            "repo_url": "git@github.com:iterative/dvc.git",
+            "client": "dvc",
+            "refs": ["ref1", "ref2", "ref3"],
+        },
+        headers={"Authorization": "token TOKEN"},
+        timeout=5,
+    )


### PR DESCRIPTION
Currently blocked, as we don't have any endpoints. We have agreed on the payload for now.

This will be behind a feature flag before the endpoint is stable. You can turn this by following ways:
```console
dvc config feature.push_exp_to_studio true
```

To push experiments, it needs a `STUDIO_TOKEN` envvar set.
And just do `dvc exp push`.

I'll merge this on approval, as everything is behind a feature-flag, and requires `STUDIO_TOKEN` to be set.

Closes https://github.com/iterative/dvc/issues/9163.