### PR TITLE
deps: bump dvc-data to 0.44.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "configobj>=5.0.6",
     "distro>=1.3",
     "dpath<3,>=2.1.0",
-    "dvc-data>=0.43.0,<0.44",
+    "dvc-data>=0.44.0,<0.45",
     "dvc-http",
     "dvc-render>=0.1.2",
     "dvc-studio-client>=0.5.0,<1",


### PR DESCRIPTION
Brings support for cloud versioning and imports to dvcfs.