### PR TITLE
import: error out on import from cloud-versioned remote

### DIFF
--- a/dvc/config.py
+++ b/dvc/config.py
@@ -34,6 +34,11 @@ class NoRemoteError(RemoteConfigError):
     pass
 
 
+class CloudVersioningUnsupportedError(NoRemoteError):
+    def __init__(self, msg):
+        super(ConfigError, self).__init__(msg)
+
+
 class RemoteNotFoundError(RemoteConfigError):
     pass
 

--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -3,7 +3,7 @@
 import logging
 from typing import TYPE_CHECKING, Iterable, Optional
 
-from dvc.config import NoRemoteError, RemoteConfigError
+from dvc.config import CloudVersioningUnsupportedError, NoRemoteError, RemoteConfigError
 from dvc.utils.objects import cached_property
 from dvc_data.hashfile.db import get_index
 
@@ -104,7 +104,7 @@ class DataCloud:
     ) -> "HashFileDB":
         remote = self.get_remote(name=name, command=command)
         if remote.fs.version_aware or remote.worktree:
-            raise NoRemoteError(
+            raise CloudVersioningUnsupportedError(
                 f"'{command}' is unsupported for cloud versioned remotes"
             )
         return remote.odb

--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -261,6 +261,11 @@ class NoOutputInExternalRepoError(DvcException):
         )
 
 
+class CloudVersionedRemoteInExternalRepoError(DvcException):
+    def __init__(self, url):
+        super().__init__(f"Target repository '{url}' uses cloud-versioned remotes.")
+
+
 class HTTPError(DvcException):
     def __init__(self, code, reason):
         super().__init__(f"'{code} {reason}'")

--- a/dvc/output.py
+++ b/dvc/output.py
@@ -1103,7 +1103,7 @@ class Output:
             return {}
 
         obj: Optional["HashFile"]
-        if self.is_dir_checksum:
+        if self.is_dir_checksum and not self.files:
             obj = self._collect_used_dir_cache(**kwargs)
         else:
             obj = self.get_obj(filter_info=kwargs.get("filter_info"))


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Related: #8789

Exception will now be raised when importing a file from a DVC repo that would require cloud-versioned remotes.

```
$ dvc import ../scratch/cloud-versioning cats-dogs
Importing 'cats-dogs (../scratch/cloud-versioning)' -> 'cats-dogs'
ERROR: failed to import 'cats-dogs' from '../scratch/cloud-versioning'. - Target repository '../scratch/cloud-versioning' uses cloud-versioned remotes.: 'dvc import' is unsupported for cloud versioned remotes
```