### PR TITLE
repo: open: handle bare git repos

### DIFF
--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -125,6 +125,8 @@ class Repo:
             if not scm:
                 try:
                     scm = SCM(root_dir or os.curdir)
+                    if scm.dulwich.repo.bare:
+                        raise NotDvcRepoError(f"{scm.root_dir} is a bare git repo")
                 except SCMError:
                     scm = SCM(os.curdir, no_scm=True)
 


### PR DESCRIPTION
If we are asked to open a potentially unitialized repo, we need to make sure it is not a bare git repo, so that we don't accidentally start putting dvc files inside git control dir.

Discovered while working on #8789

