### PR TITLE
deps: bump `dvc-render>=0.3.1<0.4.0`.

### DIFF
--- a/dvc/commands/plots.py
+++ b/dvc/commands/plots.py
@@ -1,5 +1,4 @@
 import argparse
-import json
 import logging
 import os
 
@@ -136,7 +135,7 @@ class CmdPlots(CmdBase):
             if self.args.show_vega:
                 renderer = first(filter(lambda r: r.TYPE == "vega", renderers))
                 if renderer:
-                    ui.write_json(json.loads(renderer.get_filled_template()))
+                    ui.write_json(renderer.get_filled_template(as_string=False))
                 return 0
 
             output_file: Path = (Path.cwd() / out).resolve() / "index.html"

--- a/dvc/render/convert.py
+++ b/dvc/render/convert.py
@@ -1,4 +1,3 @@
-import json
 from collections import defaultdict
 from typing import Dict, List, Union
 
@@ -32,15 +31,17 @@ def to_json(renderer, split: bool = False) -> List[Dict]:
     if renderer.TYPE == "vega":
         grouped = _group_by_rev(renderer.datapoints)
         if split:
-            content = renderer.get_filled_template(skip_anchors=["data"])
+            content = renderer.get_filled_template(
+                skip_anchors=["data"], as_string=False
+            )
         else:
-            content = renderer.get_filled_template()
+            content = renderer.get_filled_template(as_string=False)
         if grouped:
             return [
                 {
                     TYPE_KEY: renderer.TYPE,
                     REVISIONS_KEY: sorted(grouped.keys()),
-                    "content": json.loads(content),
+                    "content": content,
                     "datapoints": grouped,
                 }
             ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "dpath<3,>=2.1.0",
     "dvc-data>=0.44.0,<0.45",
     "dvc-http",
-    "dvc-render>=0.1.2",
+    "dvc-render>=0.3.1,<0.4.0",
     "dvc-studio-client>=0.5.0,<1",
     "dvc-task>=0.2.0,<1",
     "flatten_dict<1,>=0.4.1",

--- a/tests/unit/command/test_plots.py
+++ b/tests/unit/command/test_plots.py
@@ -129,7 +129,7 @@ def test_plots_diff_vega(dvc, mocker, capsys, plots_data):
     mocker.patch("dvc.repo.plots.diff.diff", return_value=plots_data)
     mocker.patch(
         "dvc_render.VegaRenderer.get_filled_template",
-        return_value=json.dumps({"this": "is vega json"}),
+        return_value={"this": "is vega json"},
     )
     render_mock = mocker.patch("dvc_render.render_html")
     assert cmd.run() == 0

--- a/tests/unit/render/test_convert.py
+++ b/tests/unit/render/test_convert.py
@@ -5,7 +5,7 @@ from dvc.render.convert import to_json
 def test_to_json_vega(mocker):
     vega_renderer = mocker.MagicMock()
     vega_renderer.TYPE = "vega"
-    vega_renderer.get_filled_template.return_value = '{"this": "is vega"}'
+    vega_renderer.get_filled_template.return_value = {"this": "is vega"}
     vega_renderer.datapoints = [
         {
             "x": 1,
@@ -50,7 +50,7 @@ def test_to_json_vega(mocker):
 def test_to_json_vega_split(mocker):
     vega_renderer = mocker.MagicMock()
     vega_renderer.TYPE = "vega"
-    vega_renderer.get_filled_template.return_value = '{"this": "is split vega"}'
+    vega_renderer.get_filled_template.return_value = {"this": "is split vega"}
     vega_renderer.datapoints = [
         {
             "x": 1,
@@ -89,7 +89,9 @@ def test_to_json_vega_split(mocker):
             ],
         },
     }
-    vega_renderer.get_filled_template.assert_called_with(skip_anchors=["data"])
+    vega_renderer.get_filled_template.assert_called_with(
+        as_string=False, skip_anchors=["data"]
+    )
 
 
 def test_to_json_image(mocker):


### PR DESCRIPTION
Improve performance by removing unnecessary `json.dumps` calls.
See https://github.com/iterative/dvc-render/pull/124
