### PR TITLE
flush streams before fork

### DIFF
--- a/dvc/daemon.py
+++ b/dvc/daemon.py
@@ -56,6 +56,11 @@ def _spawn_windows(cmd, env):
 def _spawn_posix(cmd, env):
     from dvc.cli import main
 
+    if sys.stdout and not sys.stdout.closed:
+        sys.stdout.flush()
+    if sys.stderr and not sys.stderr.closed:
+        sys.stderr.flush()
+
     # NOTE: using os._exit instead of sys.exit, because dvc built
     # with PyInstaller has trouble with SystemExit exception and throws
     # errors such as "[26338] Failed to execute script __main__"


### PR DESCRIPTION
Even though #9202 is not necessary now, I am keeping it to have the same behavior as colorama, as [`colorama` always flushes by default](https://github.com/tartley/colorama/blob/21c4b94fe21ce29c85c896ace828da24b7527641/colorama/ansitowin32.py#L180). Colorama itself does not have any buffers, it just calls wrapped streams.
