### PR TITLE
close streams

### DIFF
--- a/dvc/daemon.py
+++ b/dvc/daemon.py
@@ -82,6 +82,7 @@ def _spawn_posix(cmd, env):
     sys.stdin.close()
     sys.stdout.close()
     sys.stderr.close()
+    os.closerange(0, 3)
 
     if platform.system() == "Darwin":
         # workaround for MacOS bug


### PR DESCRIPTION
I have been seeing weird perf issue when the output was being redirected:
```console
$ time dvc plots show --json | less
{}
dvc plots show --json  0.38s user 0.06s system 96% cpu 0.452 total
less  0.00s user 0.00s system 0% cpu 1.731 total

$ time DVC_NO_ANALYTICS=true dvc plots show --json | less
{}
DVC_NO_ANALYTICS=true dvc plots show --json  0.33s user 0.04s system 96% cpu 0.393 total
less  0.00s user 0.00s system 0% cpu 0.393 total
```

I could not find an issue why it would take so long, but my suspicion was that the stdin to the `less` was not being closed for some reason. So I tried adding `os.close()` and it was fast again. 

I was not able to find an issue regarding this on Cpython, and I would love if I could get confirmation of the bug from other team members as well.


The `dvc doctor` output is:
```console
dvc doctor
DVC version: 2.48.1.dev1+g82fbbb33c.d20230314
---------------------------------------------
Platform: Python 3.11.0 on Linux-6.2.5-arch1-1-x86_64-with-glibc2.37
Subprojects:
        dvc_data = 0.44.1
        dvc_objects = 0.21.1
        dvc_render = 0.2.1.dev4+g31002b2
        dvc_task = 0.2.0
        scmrepo = 0.1.15
Supports:
        azure (adlfs = 2023.1.0, knack = 0.10.1, azure-identity = 1.12.0),
        gdrive (pydrive2 = 1.15.1),
        gs (gcsfs = 2023.3.0),
        hdfs (fsspec = 2023.3.0, pyarrow = 11.0.0),
        http (aiohttp = 3.8.4, aiohttp-retry = 2.8.3),
        https (aiohttp = 3.8.4, aiohttp-retry = 2.8.3),
        oss (ossfs = 2021.8.0),
        s3 (s3fs = 2023.3.0, boto3 = 1.24.59),
        ssh (sshfs = 2023.1.0),
        webdav (webdav4 = 0.9.8),
        webdavs (webdav4 = 0.9.8),
        webhdfs (fsspec = 2023.3.0)
Cache types: reflink, hardlink, symlink
Cache directory: btrfs on /dev/mapper/luks-32904e1a-5815-412d-855b-a16aaae40528
Caches: local
Remotes: https
Workspace directory: btrfs on /dev/mapper/luks-32904e1a-5815-412d-855b-a16aaae40528
Repo: dvc, git
Repo.site_cache_dir: /var/tmp/dvc/repo/217568916d1a48a014e29707a1b2dbb9
```
