### PR TITLE
erepo: set subrepos/uninitialized explicitly

### DIFF
--- a/dvc/dependency/repo.py
+++ b/dvc/dependency/repo.py
@@ -222,7 +222,13 @@ class RepoDependency(Dependency):
 
         d = self.def_repo
         rev = self._get_rev(locked=locked)
-        return external_repo(d[self.PARAM_URL], rev=rev, **kwargs)
+        return external_repo(
+            d[self.PARAM_URL],
+            rev=rev,
+            subrepos=True,
+            uninitialized=True,
+            **kwargs,
+        )
 
     def _get_rev(self, locked: bool = True):
         d = self.def_repo

--- a/dvc/external_repo.py
+++ b/dvc/external_repo.py
@@ -68,12 +68,6 @@ def external_repo(
         **kwargs,
     )
 
-    if "subrepos" not in repo_kwargs:
-        repo_kwargs["subrepos"] = True
-
-    if "uninitialized" not in repo_kwargs:
-        repo_kwargs["uninitialized"] = True
-
     repo = Repo(**repo_kwargs)
 
     try:

--- a/dvc/repo/get.py
+++ b/dvc/repo/get.py
@@ -52,7 +52,12 @@ def get(url, path, out=None, rev=None, jobs=None):
     cache_types = ["reflink", "hardlink", "copy"]
     try:
         with external_repo(
-            url=url, rev=rev, cache_dir=tmp_dir, cache_types=cache_types
+            url=url,
+            rev=rev,
+            subrepos=True,
+            uninitialized=True,
+            cache_dir=tmp_dir,
+            cache_types=cache_types,
         ) as repo:
             from dvc.fs.data import DataFileSystem
 

--- a/tests/unit/test_external_repo.py
+++ b/tests/unit/test_external_repo.py
@@ -25,7 +25,7 @@ def test_hook_is_called(tmp_dir, erepo_dir, mocker):
             repo.scm_gen("foo", "foo", commit=f"git add {repo}/foo")
             repo.dvc_gen("bar", "bar", commit=f"dvc add {repo}/bar")
 
-    with external_repo(str(erepo_dir)) as repo:
+    with external_repo(str(erepo_dir), subrepos=True, uninitialized=True) as repo:
         spy = mocker.spy(repo.dvcfs.fs, "repo_factory")
 
         list(repo.dvcfs.walk("", ignore_subrepos=False))  # drain
@@ -62,7 +62,11 @@ def test_subrepo_is_constructed_properly(
 
     cache_dir = make_tmp_dir("temp-cache")
     with external_repo(
-        str(tmp_dir), cache_dir=str(cache_dir), cache_types=["symlink"]
+        str(tmp_dir),
+        subrepos=True,
+        uninitialized=True,
+        cache_dir=str(cache_dir),
+        cache_types=["symlink"],
     ) as repo:
         spy = mocker.spy(repo.dvcfs.fs, "repo_factory")
 


### PR DESCRIPTION
Towards unifying `Repo.open` and `external_repo` behaviour to get rid
of the latter.

Related #8789