### PR TITLE
exp push: add trailing slash to the endpoint url

### DIFF
--- a/dvc/repo/experiments/push.py
+++ b/dvc/repo/experiments/push.py
@@ -121,7 +121,7 @@ def _notify_studio(
     import requests
     from requests.adapters import HTTPAdapter
 
-    endpoint = urljoin(url or STUDIO_URL, "/webhook/dvc")
+    endpoint = urljoin(url or STUDIO_URL, "/webhook/dvc/")
     session = requests.Session()
     session.mount(endpoint, HTTPAdapter(max_retries=3))
 

--- a/tests/unit/repo/experiments/test_push.py
+++ b/tests/unit/repo/experiments/test_push.py
@@ -18,7 +18,7 @@ def test_notify_studio_for_exp_push(mocker):
 
     assert mock_post.called
     assert mock_post.call_args == mocker.call(
-        urljoin(STUDIO_URL, "/webhook/dvc"),
+        urljoin(STUDIO_URL, "/webhook/dvc/"),
         json={
             "repo_url": "git@github.com:iterative/dvc.git",
             "client": "dvc",


### PR DESCRIPTION
`/webhook/dvc` redirects to `/webhook/dvc/` where the payload gets lost. So we should be posting to the canonical url.