### PR TITLE
output: ignore missing size from files when calculating total size

### DIFF
--- a/dvc/output.py
+++ b/dvc/output.py
@@ -427,7 +427,7 @@ class Output:
             self.hash_info = tree.hash_info
             self.meta.isdir = True
             self.meta.nfiles = len(self.files)
-            self.meta.size = sum(f.get("size") for f in self.files)
+            self.meta.size = sum(filter(None, (f.get("size") for f in self.files)))
             self.meta.remote = first(f.get("remote") for f in self.files)
         elif self.meta.nfiles or self.hash_info and self.hash_info.isdir:
             self.meta.isdir = True


### PR DESCRIPTION
Prevents https://github.com/iterative/studio/issues/5172 from happening. A filesystem may not always return size information.