### PR TITLE
pull: Filter RepoDependency objects when pulling subdir

### DIFF
--- a/dvc/output.py
+++ b/dvc/output.py
@@ -1137,6 +1137,9 @@ class Output:
             return {}
 
         (dep,) = self.stage.deps
+        filter_info = kwargs.get("filter_info", None)
+        if filter_info:
+            kwargs["filter_target"] = relpath(filter_info, self.fspath)
         return dep.get_used_objs(**kwargs)
 
     def _validate_output_path(self, path, stage=None):


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

## Purpose
Let's say you have `dvc import`ed a directory from another repo. Now in the downstream repo, you want to `dvc pull` a subdirectory of that import. E.g.
```
foo.dvc
foo
|-- bar
|-- baz
|-- ...
```

and you just want to pull `foo/bar`. Currently, that information (which is in `filter_info` in the call to `Output.get_used_external()` -> `RepoDependency.get_used_objs()` -> `RepoDependency._get_used_and_objs()`, but it is ignored, meaning that everything in `foo` gets pulled.

## Approach
Check for `filter_info` before calling `RepoDependency.get_used_objs()` and, if set, pass along a `filter_target` which is used to filter the objects in `Repo.used_objs()` so that only the requested objects are returned.

## Pre-Merge TODOs
- [ ] I think it makes more sense to overwrite `filter_info` than to add a new `filter_target` kwarg, but I'm not 100% sure how that kwarg is intended to be used in `RepoDepdency` and therefore the correct format to use for it.
- [ ] I'm completely open to changing the implementation, this is my first time poking around in this particular part of the codebase.
- [ ] Tests