### PR TITLE
exp remove: fix ui for removing from git remotes

### DIFF
--- a/dvc/repo/experiments/remove.py
+++ b/dvc/repo/experiments/remove.py
@@ -58,7 +58,7 @@ def remove(  # noqa: C901, PLR0912
                 queue_entry_list.append(result.queue_entry)
 
         if remained:
-            raise UnresolvedExpNamesError(remained)
+            raise UnresolvedExpNamesError(remained, git_remote=git_remote)
     elif rev:
         exp_ref_dict = _resolve_exp_by_baseline(repo, rev, num, git_remote)
         removed.extend(exp_ref_dict.keys())

--- a/tests/func/experiments/test_remove.py
+++ b/tests/func/experiments/test_remove.py
@@ -2,6 +2,7 @@ import pytest
 from funcy import first
 
 from dvc.exceptions import InvalidArgumentError
+from dvc.repo.experiments.exceptions import UnresolvedExpNamesError
 from dvc.repo.experiments.utils import exp_refs_by_rev
 
 
@@ -120,6 +121,11 @@ def test_remove_remote(tmp_dir, scm, dvc, exp_stage, git_upstream, use_url):
     assert git_upstream.tmp_dir.scm.get_ref(str(ref_info_list[0])) is None
     assert git_upstream.tmp_dir.scm.get_ref(str(ref_info_list[1])) is None
     assert git_upstream.tmp_dir.scm.get_ref(str(ref_info_list[2])) == exp_list[2]
+
+    with pytest.raises(
+        UnresolvedExpNamesError, match=f"Experiment 'foo' does not exist in '{remote}'"
+    ):
+        dvc.experiments.remove(git_remote=remote, exp_names=["foo"])
 
 
 def test_remove_experiments_by_rev(tmp_dir, scm, dvc, exp_stage):


### PR DESCRIPTION
Before:

```
$ dvc exp remove -g upstream bijou-rues
ERROR: 'bijou-rues' is not a valid experiment name
```

After:

```
$ dvc exp remove -g upstream bijou-rues
ERROR: Experiment 'bijou-rues' does not exist in 'upstream'
```