### PR TITLE
Pin funcy dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "dvc-task>=0.2.0,<1",
     "flatten_dict<1,>=0.4.1",
     "flufl.lock>=5",
-    "funcy>=1.14",
+    "funcy>=1.14,<=1.18",
     "grandalf<1,>=0.7",
     "hydra-core>=1.1",
     "iterative-telemetry>=0.0.7",


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

See https://github.com/iterative/dvc/issues/9275

Funcy released version `2.0` yesterday which doesn't work anymore. Version `1.18` still works.
