### PR TITLE
repo: site_cache_dir improvements

### DIFF
--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -150,6 +150,7 @@ SCHEMA = {
         Optional("autostage", default=False): Bool,
         Optional("experiments"): Bool,  # obsoleted
         Optional("check_update", default=True): Bool,
+        "site_cache_dir": str,
         "machine": Lower,
     },
     "cache": {

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -565,7 +565,8 @@ class Repo:
 
         from dvc.fs import GitFileSystem
 
-        cache_dir = platformdirs.site_cache_dir("dvc", "iterative", opinion=True)
+        default = platformdirs.site_cache_dir("dvc", "iterative", opinion=True)
+        cache_dir = self.config["core"].get("site_cache_dir") or default
 
         if isinstance(self.fs, GitFileSystem):
             relparts = ()

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -558,6 +558,7 @@ class Repo:
 
     @cached_property
     def site_cache_dir(self) -> str:
+        import getpass
         import hashlib
 
         import platformdirs
@@ -583,7 +584,9 @@ class Repo:
         finally:
             os.umask(umask)
 
-        repo_token = hashlib.md5(os.fsencode(root_dir)).hexdigest()  # noqa: S324
+        repo_token = hashlib.md5(  # noqa: S324
+            str((root_dir, getpass.getuser())).encode()
+        ).hexdigest()
 
         return os.path.join(repos_dir, repo_token)
 


### PR DESCRIPTION
Makes repo dirs isolated by user which handles shared server scenarios. But also introduces `core.site_cache_dir` as a last line of defense in case there is some scenario we haven't thought about. Overall we should discourage using this config option as it could be misused (e.g. never put it on NFS/CIFS/etc or other slow filesystems for performance reasons). If you find yourself needing this config option, please let us know about your scenario so we could see if we could make it work out of the box.

Note that `site_cache_dir` name might be confusing in relation to `dvc cache` with which it has absolutely nothing to do with. The name is coming from an internal library platformdirs(former appdirs)'s site_cache_dir.

Fixes #9249 
