### PR TITLE
tests: remove unnecessary variable interpolation

### DIFF
--- a/tests/func/experiments/test_save.py
+++ b/tests/func/experiments/test_save.py
@@ -8,7 +8,7 @@ from dvc.scm import resolve_rev
 
 def setup_stage(tmp_dir, dvc, scm):
     tmp_dir.gen("params.yaml", "foo: 1")
-    dvc.run(name="echo-foo", outs=["bar"], cmd="echo ${foo} > bar")
+    dvc.run(name="echo-foo", outs=["bar"], cmd="echo foo > bar")
     scm.add(["dvc.yaml", "dvc.lock", ".gitignore", "params.yaml"])
     scm.commit("init")
 


### PR DESCRIPTION
dvc.run does not expand variables. It is only done when it's actually read from dvc.yaml file. So during dvc run, the shell will try to expand the variable, which does not exist.

I don't think that the intention was to use shell variables. But I don't think we should ever use them, as they will fail on some shells (eg: fish) and should keep the scripts as simple as possible.

