### PR TITLE
deps: put lower bound on dvc-http

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "distro>=1.3",
     "dpath<3,>=2.1.0",
     "dvc-data>=0.47.1,<0.48",
-    "dvc-http",
+    "dvc-http>=2.29.0",
     "dvc-render>=0.3.1,<0.4.0",
     "dvc-studio-client>=0.6.1,<1",
     "dvc-task>=0.2.0,<1",


### PR DESCRIPTION
People are still running into `ImportError: cannot import name 'fsspec_loop' from 'fsspec.asyn' ` because of it.

Fixes #9244

