### PR TITLE
utils.studio: allow any base url to be set, not just the hostname

### DIFF
--- a/dvc/utils/studio.py
+++ b/dvc/utils/studio.py
@@ -57,7 +57,7 @@ def notify_refs(
     data = {"repo_url": repo_url, "client": "dvc", "refs": refs}
 
     try:
-        r = post("/webhook/dvc", token, data, base_url=base_url)
+        r = post("webhook/dvc", token, data, base_url=base_url)
     except requests.RequestException as e:
         logger.trace("", exc_info=True)  # type: ignore[attr-defined]
 


### PR DESCRIPTION
This keeps it in symmetry with
https://github.com/iterative/dvc-studio-client/pull/28, and allows setting the base url with path, not just limited to netloc.

This was always intended to work, urljoin with the added slash was causing this bug.
