### PR TITLE
exp: show active experiments first

### DIFF
--- a/dvc/repo/experiments/collect.py
+++ b/dvc/repo/experiments/collect.py
@@ -304,7 +304,7 @@ def collect(
         experiments = list(
             itertools.chain.from_iterable(
                 _sorted_ranges(collected.get(baseline_rev, []))
-                for collected in (successful, active, queued, failed)
+                for collected in (active, successful, queued, failed)
             )
         )
         result.append(


### PR DESCRIPTION
In #9348, I missed that there was a workspace row for the running experiment in the workspace because it wasn't shown until after all the completed experiments. In general, I think it's better to prioritize all `Running` experiments first, even if it separates them from other experiments with non-empty states.

Before:

```
$ dvc exp show
 ───────────────────────────────────────────────────────────────────────────────────────>
  Experiment                   Created        State     Executor    train.step.loss   tr>
 ───────────────────────────────────────────────────────────────────────────────────────>
  workspace                    -              -         -                         -     >
  small                        Apr 11, 2023   -         -                   0.25993     >
  ├── 492d213 [peaky-fore]     08:55 AM       -         -                   0.27985     >
  ├── 1105023 [riant-morn]     08:39 AM       -         -                    0.2986     >
  ├── 7def4d2 [tarot-trio]     08:37 AM       -         -                         -     >
  ├── 9bf407c [toned-scow]     08:37 AM       -         -                   0.22034     >
  ├── eacc645 [mucky-cwms]     Apr 19, 2023   -         -                   0.22034     >
  ├── add0876 [swell-dirk]     Apr 19, 2023   -         -                   0.21999     >
  ├── cdb7d30 [flash-cuss]     Apr 19, 2023   -         -                   0.21671     >
  ├── workspace [naggy-jeer]   -              Running   Workspace                 -     >
  ├── 12cf403 [strip-scab]     -              Running   Dvc-task                  -     >
  ├── ce032ce [splay-purl]     -              Running   Dvc-task                  -     >
  ├── 3d180e7 [wider-puds]     08:55 AM       Queued    Dvc-task            0.27985     >
  ├── 25e70bd [group-jura]     08:55 AM       Queued    Dvc-task            0.27985     >
  ├── 620dff2 [reeky-bate]     Apr 19, 2023   Queued    Dvc-task            0.25993     >
  ├── 1b65e87 [gross-yate]     Apr 19, 2023   Failed    -                   0.25993     >
  └── a2bb770 [optic-mold]     Apr 19, 2023   Failed    -                   0.25993     >
```

After:

```
$ dvc exp show
 ───────────────────────────────────────────────────────────────────────────────────────>
  Experiment                   Created        State     Executor    train.step.loss   tr>
 ───────────────────────────────────────────────────────────────────────────────────────>
  workspace                    -              -         -                   0.27985     >
  small                        Apr 11, 2023   -         -                   0.25993     >
  ├── workspace [naggy-jeer]   -              Running   Workspace           0.27985     >
  ├── 12cf403 [strip-scab]     -              Running   Dvc-task            0.25993     >
  ├── ce032ce [splay-purl]     -              Running   Dvc-task            0.25993     >
  ├── 492d213 [peaky-fore]     08:55 AM       -         -                   0.27985     >
  ├── 1105023 [riant-morn]     08:39 AM       -         -                    0.2986     >
  ├── 7def4d2 [tarot-trio]     08:37 AM       -         -                         -     >
  ├── 9bf407c [toned-scow]     08:37 AM       -         -                   0.22034     >
  ├── eacc645 [mucky-cwms]     Apr 19, 2023   -         -                   0.22034     >
  ├── add0876 [swell-dirk]     Apr 19, 2023   -         -                   0.21999     >
  ├── cdb7d30 [flash-cuss]     Apr 19, 2023   -         -                   0.21671     >
  ├── 3d180e7 [wider-puds]     08:55 AM       Queued    Dvc-task            0.27985     >
  ├── 25e70bd [group-jura]     08:55 AM       Queued    Dvc-task            0.27985     >
  ├── 620dff2 [reeky-bate]     Apr 19, 2023   Queued    Dvc-task            0.25993     >
  ├── 1b65e87 [gross-yate]     Apr 19, 2023   Failed    -                   0.25993     >
  └── a2bb770 [optic-mold]     Apr 19, 2023   Failed    -                   0.25993     >
```
