### PR TITLE
Fix: Prettifying unexpected error on FileExists for get/get-url/imp-url/add and introducing --force

### DIFF
--- a/dvc/commands/add.py
+++ b/dvc/commands/add.py
@@ -62,6 +62,7 @@ class CmdAdd(CmdBase):
                 remote=self.args.remote,
                 to_remote=self.args.to_remote,
                 jobs=self.args.jobs,
+                force=self.args.force,
             )
 
         except DvcException:
@@ -139,6 +140,14 @@ def add_parser(subparsers, parent_parser):
             "The default value is 4 * cpu_count(). "
         ),
         metavar="<number>",
+    )
+    parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        default=False,
+        help="Ignores overwrites to dvc.yaml file and allows overwriting local stage"
+        " output (file or folder) if exists.",
     )
 
     _add_annotating_args(parser)

--- a/dvc/commands/add.py
+++ b/dvc/commands/add.py
@@ -146,8 +146,7 @@ def add_parser(subparsers, parent_parser):
         "--force",
         action="store_true",
         default=False,
-        help="Ignores overwrites to dvc.yaml file and allows overwriting local stage"
-        " output (file or folder) if exists.",
+        help="Override local file or folder if exists.",
     )
 
     _add_annotating_args(parser)

--- a/dvc/commands/get.py
+++ b/dvc/commands/get.py
@@ -36,6 +36,7 @@ class CmdGet(CmdBaseNoRepo):
                 out=self.args.out,
                 rev=self.args.rev,
                 jobs=self.args.jobs,
+                force=self.args.force,
             )
             return 0
         except CloneError:
@@ -93,5 +94,12 @@ def add_parser(subparsers, parent_parser):
             "The default value is 4 * cpu_count(). "
         ),
         metavar="<number>",
+    )
+    get_parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        default=False,
+        help="Override local file or folder if exists.",
     )
     get_parser.set_defaults(func=CmdGet)

--- a/dvc/commands/get_url.py
+++ b/dvc/commands/get_url.py
@@ -14,7 +14,12 @@ class CmdGetUrl(CmdBaseNoRepo):
         from dvc.repo import Repo
 
         try:
-            Repo.get_url(self.args.url, out=self.args.out, jobs=self.args.jobs)
+            Repo.get_url(
+                self.args.url,
+                out=self.args.out,
+                jobs=self.args.jobs,
+                force=self.args.force,
+            )
             return 0
         except DvcException:
             logger.exception("failed to get '%s'", self.args.url)
@@ -45,5 +50,12 @@ def add_parser(subparsers, parent_parser):
             "The default value is 4 * cpu_count(). "
         ),
         metavar="<number>",
+    )
+    get_parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        default=False,
+        help="Override local file or folder if exists.",
     )
     get_parser.set_defaults(func=CmdGetUrl)

--- a/dvc/commands/imp_url.py
+++ b/dvc/commands/imp_url.py
@@ -25,6 +25,7 @@ class CmdImportUrl(CmdBase):
                 labels=self.args.labels,
                 meta=self.args.meta,
                 jobs=self.args.jobs,
+                force=self.args.force,
                 version_aware=self.args.version_aware,
             )
         except DvcException:
@@ -111,6 +112,13 @@ def add_parser(subparsers, parent_parser):
             "The default value is 4 * cpu_count(). "
         ),
         metavar="<number>",
+    )
+    import_parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        default=False,
+        help="Override local file or folder if exists.",
     )
     import_parser.add_argument(
         "--version-aware",

--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -1,4 +1,5 @@
 """Exceptions raised by the dvc."""
+import errno
 from typing import Dict, List
 
 from dvc.utils import format_link
@@ -204,6 +205,18 @@ class ETagMismatchError(DvcException):
             "ETag mismatch detected when copying file to cache! "
             "(expected: '{}', actual: '{}')".format(etag, cached_etag)
         )
+
+
+class FileExistsLocallyError(FileExistsError, DvcException):
+    def __init__(self, path, hint=None):
+        import os.path
+
+        self.path = path
+        hint = "" if hint is None else f". {hint}"
+        path_typ = "directory" if os.path.isdir(path) else "file"
+        msg = f"The {path_typ} '{path}' already exists locally{hint}"
+        super().__init__(msg)
+        self.errno = errno.EEXIST
 
 
 class FileMissingError(DvcException):

--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -247,11 +247,12 @@ def create_stages(
     fname: Optional[str] = None,
     transfer: bool = False,
     external: bool = False,
+    force: bool = False,
     **kwargs: Any,
 ) -> Iterator["Stage"]:
     for target in targets:
         if kwargs.get("out"):
-            target = resolve_output(target, kwargs["out"])
+            target = resolve_output(target, kwargs["out"], force=force)
         path, wdir, out = resolve_paths(
             repo, target, always_local=transfer and not kwargs.get("out")
         )
@@ -263,6 +264,7 @@ def create_stages(
             wdir=wdir,
             outs=[out],
             external=external,
+            force=force,
         )
 
         out_obj = stage.outs[0]

--- a/dvc/repo/get.py
+++ b/dvc/repo/get.py
@@ -27,7 +27,7 @@ def get(url, path, out=None, rev=None, jobs=None, force=False):
     from dvc.external_repo import external_repo
     from dvc.fs.callbacks import Callback
 
-    out = resolve_output(path, out, override=force, override_hint=True)
+    out = resolve_output(path, out, force=force)
 
     if is_valid_filename(out):
         raise GetDVCFileError()

--- a/dvc/repo/get.py
+++ b/dvc/repo/get.py
@@ -20,14 +20,14 @@ class GetDVCFileError(DvcException):
         )
 
 
-def get(url, path, out=None, rev=None, jobs=None):
+def get(url, path, out=None, rev=None, jobs=None, force=False):
     import shortuuid
 
     from dvc.dvcfile import is_valid_filename
     from dvc.external_repo import external_repo
     from dvc.fs.callbacks import Callback
 
-    out = resolve_output(path, out)
+    out = resolve_output(path, out, override=force, override_hint=True)
 
     if is_valid_filename(out):
         raise GetDVCFileError()

--- a/dvc/repo/get_url.py
+++ b/dvc/repo/get_url.py
@@ -7,7 +7,7 @@ from dvc.utils import resolve_output
 
 
 def get_url(url, out=None, *, config=None, jobs=None, force=False):
-    out = resolve_output(url, out, override=force, override_hint=True)
+    out = resolve_output(url, out, force=force)
     out = os.path.abspath(out)
     (out,) = output.loads_from(None, [out], use_cache=False)
 

--- a/dvc/repo/get_url.py
+++ b/dvc/repo/get_url.py
@@ -6,8 +6,8 @@ from dvc.fs import download, parse_external_url
 from dvc.utils import resolve_output
 
 
-def get_url(url, out=None, *, config=None, jobs=None):
-    out = resolve_output(url, out)
+def get_url(url, out=None, *, config=None, jobs=None, force=False):
+    out = resolve_output(url, out, override=force, override_hint=True)
     out = os.path.abspath(out)
     (out,) = output.loads_from(None, [out], use_cache=False)
 

--- a/dvc/repo/imp_url.py
+++ b/dvc/repo/imp_url.py
@@ -34,7 +34,7 @@ def imp_url(  # noqa: C901, PLR0913
     fs_config=None,
     version_aware: bool = False,
 ):
-    out = resolve_output(url, out, override=force, override_hint=True)
+    out = resolve_output(url, out, force=force)
     path, wdir, out = resolve_paths(self, out, always_local=to_remote and not out)
 
     if to_remote and (no_exec or no_download or version_aware):

--- a/dvc/repo/imp_url.py
+++ b/dvc/repo/imp_url.py
@@ -30,10 +30,11 @@ def imp_url(  # noqa: C901, PLR0913
     labels=None,
     meta=None,
     jobs=None,
+    force=False,
     fs_config=None,
     version_aware: bool = False,
 ):
-    out = resolve_output(url, out)
+    out = resolve_output(url, out, override=force, override_hint=True)
     path, wdir, out = resolve_paths(self, out, always_local=to_remote and not out)
 
     if to_remote and (no_exec or no_download or version_aware):

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -416,7 +416,7 @@ class Stage(params.StageParams):
         (out,) = self.outs
         out.transfer(source, odb=odb, jobs=kwargs.get("jobs"))
         if not to_remote:
-            out.checkout()
+            out.checkout(force=kwargs.get("force"))
             out.ignore()
 
     @rwlocked(read=["deps"], write=["outs"])

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -255,9 +255,10 @@ def env2bool(var, undefined=False):
     return bool(re.search("1|y|yes|true", var, flags=re.I))
 
 
-def resolve_output(inp, out):
-    import errno
+def resolve_output(inp, out, override=False, override_hint=False):
     from urllib.parse import urlparse
+
+    from dvc.exceptions import FileExistsLocallyError
 
     name = os.path.basename(os.path.normpath(urlparse(inp).path))
     if not out:
@@ -267,8 +268,9 @@ def resolve_output(inp, out):
     else:
         ret = out
 
-    if os.path.exists(ret):
-        raise FileExistsError(errno.EEXIST, os.strerror(errno.EEXIST), ret)
+    if os.path.exists(ret) and not override:
+        hint = "\nTo override it, re-run with '--force'." if override_hint else ""
+        raise FileExistsLocallyError(ret, hint=hint)
 
     return ret
 

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -255,7 +255,7 @@ def env2bool(var, undefined=False):
     return bool(re.search("1|y|yes|true", var, flags=re.I))
 
 
-def resolve_output(inp, out, override=False, override_hint=False):
+def resolve_output(inp, out, force=False):
     from urllib.parse import urlparse
 
     from dvc.exceptions import FileExistsLocallyError
@@ -268,8 +268,8 @@ def resolve_output(inp, out, override=False, override_hint=False):
     else:
         ret = out
 
-    if os.path.exists(ret) and not override:
-        hint = "\nTo override it, re-run with '--force'." if override_hint else ""
+    if os.path.exists(ret) and not force:
+        hint = "\nTo override it, re-run with '--force'."
         raise FileExistsLocallyError(ret, hint=hint)
 
     return ret

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -468,6 +468,28 @@ def test_should_throw_proper_exception_on_corrupted_stage_file(caplog, tmp_dir, 
     assert expected_error in caplog.text
 
 
+def test_should_throw_proper_exception_on_existing_out(caplog, tmp_dir, dvc):
+    tmp_dir.gen({"foo": "foo"})
+    (tmp_dir / "out").write_text("old contents")
+
+    assert main(["add", "foo", "--out", "out"]) == 1
+
+    assert (tmp_dir / "out").read_text() == "old contents"
+    expected_error_lines = [
+        "Error: The file 'out' already exists locally.",
+        "To override it, re-run with '--force'.",
+    ]
+    assert all(line in caplog.text for line in expected_error_lines)
+
+
+def test_add_force_overwrite_out(caplog, tmp_dir, dvc):
+    tmp_dir.gen({"foo": "foo"})
+    (tmp_dir / "out").write_text("old contents")
+
+    assert main(["add", "foo", "--out", "out", "--force"]) == 0
+    assert (tmp_dir / "foo").read_text() == "foo"
+
+
 def test_add_filename(tmp_dir, dvc):
     tmp_dir.gen({"foo": "foo", "bar": "bar", "data": {"file": "file"}})
     ret = main(["add", "foo", "bar", "--file", "error.dvc"])

--- a/tests/func/test_import_url.py
+++ b/tests/func/test_import_url.py
@@ -49,6 +49,21 @@ def test_should_remove_outs_before_import(tmp_dir, dvc, mocker, erepo_dir):
     assert remove_outs_call_counter.mock.call_count == 1
 
 
+def test_import_conflict_and_override(tmp_dir, dvc):
+    tmp_dir.gen("foo", "foo")
+    tmp_dir.gen("bar", "bar")
+
+    # bar exists, fail
+    ret = main(["import-url", "foo", "bar"])
+    assert ret != 0
+    assert not os.path.exists("bar.dvc")
+
+    # force override
+    ret = main(["import-url", "foo", "bar", "--force"])
+    assert ret == 0
+    assert os.path.exists("bar.dvc")
+
+
 def test_import_filename(tmp_dir, dvc, cloud):
     external_source = cloud / "file"
     (cloud / "file").write_text("content", encoding="utf-8")

--- a/tests/unit/command/test_add.py
+++ b/tests/unit/command/test_add.py
@@ -41,6 +41,7 @@ def test_add(mocker, dvc):
         labels=None,
         meta=None,
         jobs=None,
+        force=False,
     )
 
 
@@ -78,6 +79,7 @@ def test_add_to_remote(mocker):
         labels=None,
         meta=None,
         jobs=None,
+        force=False,
     )
 
 

--- a/tests/unit/command/test_get.py
+++ b/tests/unit/command/test_get.py
@@ -23,7 +23,9 @@ def test_get(mocker):
 
     assert cmd.run() == 0
 
-    m.assert_called_once_with("repo_url", path="src", out="out", rev="version", jobs=4)
+    m.assert_called_once_with(
+        "repo_url", path="src", out="out", rev="version", jobs=4, force=False
+    )
 
 
 def test_get_url(mocker, capsys):

--- a/tests/unit/command/test_get_url.py
+++ b/tests/unit/command/test_get_url.py
@@ -11,4 +11,4 @@ def test_get_url(mocker):
 
     assert cmd.run() == 0
 
-    m.assert_called_once_with("src", out="out", jobs=5)
+    m.assert_called_once_with("src", out="out", jobs=5, force=False)

--- a/tests/unit/command/test_imp_url.py
+++ b/tests/unit/command/test_imp_url.py
@@ -41,6 +41,7 @@ def test_import_url(mocker):
         labels=None,
         meta=None,
         jobs=4,
+        force=False,
         version_aware=False,
     )
 
@@ -94,10 +95,11 @@ def test_import_url_no_exec_download_flags(mocker, flag, expected):
         remote=None,
         to_remote=False,
         desc="description",
-        jobs=None,
         type=None,
         labels=None,
         meta=None,
+        jobs=None,
+        force=False,
         version_aware=False,
         **expected,
     )
@@ -136,6 +138,7 @@ def test_import_url_to_remote(mocker):
         labels=None,
         meta=None,
         jobs=None,
+        force=False,
         version_aware=False,
     )
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Closes #5387

### Changes:
- [x]  Fixing error output on dvc get/get-url/import-url/add upon conflict with a local file

  Example:
  ```sh
  ❯ python -m dvc get https://github.com/iterative/dvc README.rst -o test.rst
  ❯ python -m dvc get https://github.com/iterative/dvc README.rst -o test.rst
  ERROR: failed to get 'README.rst' from 'https://github.com/iterative/dvc' - The file 'test.rst' already exists locally. 
  To override it, re-run with '--force'.
  ❯ python -m dvc get https://github.com/iterative/dvc README.rst -o test.rst --force
  ```
- [x] Adding `--force` flag to override
- [x] tests
- [ ] updating docs with `--force` <- not done yet