### PR TITLE
exp push: soft wrap link so that the URL does not break

### DIFF
--- a/dvc/commands/experiments/push.py
+++ b/dvc/commands/experiments/push.py
@@ -52,7 +52,9 @@ class CmdExperimentsPush(CmdBase):
             ui.write(humanize.get_summary(stats.items()))
 
         if project_url := result.get("url"):
-            ui.write("[yellow]View your experiments at", project_url, styled=True)
+            ui.rich_print(
+                "View your experiments at", project_url, style="yellow", soft_wrap=True
+            )
 
     def run(self):
         from dvc.repo.experiments.push import UploadError


### PR DESCRIPTION
Rich by default uses linebreaks rather than soft-wrap like `builtins.print()` which breaks link in some terminals (like VSCode).