### PR TITLE
data status: exclude remote status by default

### DIFF
--- a/dvc/commands/data.py
+++ b/dvc/commands/data.py
@@ -117,6 +117,7 @@ class CmdDataStatus(CmdBase):
             status = self.repo.data_status(
                 granular=self.args.granular,
                 untracked_files=self.args.untracked_files,
+                not_in_remote=self.args.not_in_remote,
                 remote_refresh=self.args.remote_refresh,
             )
 
@@ -244,10 +245,16 @@ def add_parser(subparsers, parent_parser):
         help="Show untracked files.",
     )
     data_status_parser.add_argument(
-        "--remote-refresh",
+        "--not-in-remote",
         action="store_true",
         default=False,
-        help="Refresh remote index.",
+        help="Show files not in remote.",
+    )
+    data_status_parser.add_argument(
+        "--no-remote-refresh",
+        dest="remote_refresh",
+        action="store_false",
+        help="Use cached remote index (don't check remote).",
     )
     data_status_parser.set_defaults(func=CmdDataStatus)
 

--- a/dvc/repo/data.py
+++ b/dvc/repo/data.py
@@ -172,7 +172,6 @@ def _diff_index_to_wtree(repo: "Repo", **kwargs: Any) -> Dict[str, List[str]]:
             repo.index.data["repo"],
             workspace,
             not_in_cache=True,
-            not_in_remote=True,
             **kwargs,
         )
 

--- a/tests/func/test_data_status.py
+++ b/tests/func/test_data_status.py
@@ -402,7 +402,13 @@ def test_missing_remote_cache(M, tmp_dir, dvc, scm, local_remote):
     tmp_dir.dvc_gen({"dir": {"foo": "foo", "bar": "bar"}})
     tmp_dir.dvc_gen("foobar", "foobar")
 
-    assert dvc.data_status(untracked_files="all") == {
+    assert dvc.data_status() == {
+        **EMPTY_STATUS,
+        "committed": {"added": M.unordered("foobar", join("dir", ""))},
+        "git": M.dict(),
+    }
+
+    assert dvc.data_status(untracked_files="all", not_in_remote=True) == {
         **EMPTY_STATUS,
         "untracked": M.unordered("foobar.dvc", "dir.dvc", ".gitignore"),
         "committed": {"added": M.unordered("foobar", join("dir", ""))},
@@ -410,7 +416,9 @@ def test_missing_remote_cache(M, tmp_dir, dvc, scm, local_remote):
         "git": M.dict(),
     }
 
-    assert dvc.data_status(granular=True, untracked_files="all") == {
+    assert dvc.data_status(
+        granular=True, untracked_files="all", not_in_remote=True
+    ) == {
         **EMPTY_STATUS,
         "untracked": M.unordered("foobar.dvc", "dir.dvc", ".gitignore"),
         "committed": {

--- a/tests/unit/command/test_data_status.py
+++ b/tests/unit/command/test_data_status.py
@@ -51,7 +51,8 @@ def test_cli(dvc, mocker, mocked_status):
     assert cmd.run() == 0
     status.assert_called_once_with(
         untracked_files="all",
-        remote_refresh=False,
+        not_in_remote=False,
+        remote_refresh=True,
         granular=True,
     )
 


### PR DESCRIPTION
Fixes https://github.com/iterative/dvc/issues/9410.

Needs a docs PR.

Before this PR:

```
$ dvc data status --help
usage: dvc data status [-h] [-q | -v] [--json] [--granular] [--unchanged]
                       [--untracked-files [{no,all}]] [--remote-refresh]

...

options:
  ...
  --remote-refresh      Refresh remote index.
```

After this PR:

```
$ dvc data status --help
usage: dvc data status [-h] [-q | -v] [--json] [--granular] [--unchanged]
                       [--untracked-files [{no,all}]] [--not-in-remote]
                       [--no-remote-refresh]

...

options:
  ...
  --not-in-remote       Show files not in remote.
  --no-remote-refresh   Use cached remote index (don't check remote).
```