### PR TITLE
gha: try setting PYTHONUTF8

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,6 +42,8 @@ jobs:
     - uses: pre-commit/action@v3.0.0
     - name: run tests
       timeout-minutes: 40
+      env:
+        PYTHONUTF8: 1
       run: >
         pytest -n=logical --timeout=300 --durations=100
         --cov --cov-report=xml --cov-report=term


### PR DESCRIPTION
Trying to see if that will help with encoding error on windows with python 3.11

Temp workaround for #9413