### PR TITLE
repo: consolidate Repo.open logic

### DIFF
--- a/dvc/cli/__init__.py
+++ b/dvc/cli/__init__.py
@@ -245,7 +245,7 @@ def main(argv=None):  # noqa: C901, PLR0912, PLR0915
     finally:
         logger.setLevel(outer_log_level)
 
-        from dvc.external_repo import clean_repos
+        from dvc.repo.open_repo import clean_repos
 
         # Remove cached repos in the end of the call, these are anonymous
         # so won't be reused by any other subsequent run anyway.

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -287,18 +287,9 @@ class Repo:
 
     @staticmethod
     def open(url, *args, **kwargs):  # noqa: A003
-        if url is None:
-            url = os.getcwd()
+        from .open_repo import open_repo
 
-        if os.path.exists(url):
-            try:
-                return Repo(url, *args, **kwargs)
-            except NotDvcRepoError:
-                pass  # fallthrough to external_repo
-
-        from dvc.external_repo import external_repo
-
-        return external_repo(url, *args, **kwargs)
+        return open_repo(url, *args, **kwargs)
 
     @cached_property
     def scm(self) -> Union["Git", "NoSCM"]:

--- a/dvc/repo/get.py
+++ b/dvc/repo/get.py
@@ -24,8 +24,8 @@ def get(url, path, out=None, rev=None, jobs=None, force=False):
     import shortuuid
 
     from dvc.dvcfile import is_valid_filename
-    from dvc.external_repo import external_repo
     from dvc.fs.callbacks import Callback
+    from dvc.repo.open_repo import external_repo
 
     out = resolve_output(path, out, force=force)
 

--- a/dvc/repo/get.py
+++ b/dvc/repo/get.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Union
 
 from dvc.exceptions import DvcException
 from dvc.utils import resolve_output
-from dvc.utils.fs import remove
 
 if TYPE_CHECKING:
     from dvc.fs.dvc import DVCFileSystem
@@ -21,63 +20,38 @@ class GetDVCFileError(DvcException):
 
 
 def get(url, path, out=None, rev=None, jobs=None, force=False):
-    import shortuuid
-
     from dvc.dvcfile import is_valid_filename
     from dvc.fs.callbacks import Callback
-    from dvc.repo.open_repo import external_repo
+    from dvc.repo import Repo
 
     out = resolve_output(path, out, force=force)
 
     if is_valid_filename(out):
         raise GetDVCFileError()
 
-    # Creating a directory right beside the output to make sure that they
-    # are on the same filesystem, so we could take the advantage of
-    # reflink and/or hardlink. Not using tempfile.TemporaryDirectory
-    # because it will create a symlink to tmpfs, which defeats the purpose
-    # and won't work with reflink/hardlink.
-    dpath = os.path.dirname(os.path.abspath(out))
-    tmp_dir = os.path.join(dpath, "." + str(shortuuid.uuid()))
+    with Repo.open(
+        url=url,
+        rev=rev,
+        subrepos=True,
+        uninitialized=True,
+    ) as repo:
+        from dvc.fs.data import DataFileSystem
 
-    # Try any links possible to avoid data duplication.
-    #
-    # Not using symlink, because we need to remove cache after we
-    # are done, and to make that work we would have to copy data
-    # over anyway before removing the cache, so we might just copy
-    # it right away.
-    #
-    # Also, we can't use theoretical "move" link type here, because
-    # the same cache file might be used a few times in a directory.
-    cache_types = ["reflink", "hardlink", "copy"]
-    try:
-        with external_repo(
-            url=url,
-            rev=rev,
-            subrepos=True,
-            uninitialized=True,
-            cache_dir=tmp_dir,
-            cache_types=cache_types,
-        ) as repo:
-            from dvc.fs.data import DataFileSystem
+        fs: Union[DataFileSystem, "DVCFileSystem"]
+        if os.path.isabs(path):
+            fs = DataFileSystem(index=repo.index.data["local"])
+            fs_path = fs.from_os_path(path)
+        else:
+            fs = repo.dvcfs
+            fs_path = fs.from_os_path(path)
 
-            fs: Union[DataFileSystem, "DVCFileSystem"]
-            if os.path.isabs(path):
-                fs = DataFileSystem(index=repo.index.data["local"])
-                fs_path = fs.from_os_path(path)
-            else:
-                fs = repo.dvcfs
-                fs_path = fs.from_os_path(path)
-
-            with Callback.as_tqdm_callback(
-                desc=f"Downloading {fs.path.name(path)}",
-                unit="files",
-            ) as cb:
-                fs.get(
-                    fs_path,
-                    os.path.abspath(out),
-                    batch_size=jobs,
-                    callback=cb,
-                )
-    finally:
-        remove(tmp_dir)
+        with Callback.as_tqdm_callback(
+            desc=f"Downloading {fs.path.name(path)}",
+            unit="files",
+        ) as cb:
+            fs.get(
+                fs_path,
+                os.path.abspath(out),
+                batch_size=jobs,
+                callback=cb,
+            )

--- a/dvc/repo/open_repo.py
+++ b/dvc/repo/open_repo.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 @contextmanager
 @map_scm_exception()
-def external_repo(
+def _external_repo(
     url,
     rev: Optional[str] = None,
     for_write: bool = False,
@@ -70,9 +70,9 @@ def open_repo(url, *args, **kwargs):
         try:
             return Repo(url, *args, **kwargs)
         except NotDvcRepoError:
-            pass  # fallthrough to external_repo
+            pass  # fallthrough to _external_repo
 
-    return external_repo(url, *args, **kwargs)
+    return _external_repo(url, *args, **kwargs)
 
 
 def erepo_factory(url, root_dir, cache_config):

--- a/dvc/repo/open_repo.py
+++ b/dvc/repo/open_repo.py
@@ -13,9 +13,8 @@ from dvc.scm import CloneError, map_scm_exception
 from dvc.utils import relpath
 
 if TYPE_CHECKING:
+    from dvc.scm import Git
     from dvc.types import StrPath
-
-    from .scm import Git
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +67,19 @@ def external_repo(
         repo.close()
         if for_write:
             _remove(path)
+
+
+def open_repo(url, *args, **kwargs):
+    if url is None:
+        url = os.getcwd()
+
+    if os.path.exists(url):
+        try:
+            return Repo(url, *args, **kwargs)
+        except NotDvcRepoError:
+            pass  # fallthrough to external_repo
+
+    return external_repo(url, *args, **kwargs)
 
 
 def erepo_factory(url, root_dir, cache_config):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,7 @@ def enable_ui():
 
 @pytest.fixture(autouse=True)
 def clean_repos():
-    from dvc.external_repo import clean_repos
+    from dvc.repo.open_repo import clean_repos
 
     clean_repos()
 

--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -8,7 +8,7 @@ from flaky.flaky_decorator import flaky
 import dvc_data
 from dvc.cli import main
 from dvc.exceptions import CheckoutError
-from dvc.external_repo import clean_repos
+from dvc.repo.open_repo import clean_repos
 from dvc.stage.exceptions import StageNotFound
 from dvc.testing.remote_tests import TestRemote  # noqa, pylint: disable=unused-import
 from dvc.utils.fs import remove

--- a/tests/func/test_external_repo.py
+++ b/tests/func/test_external_repo.py
@@ -1,7 +1,8 @@
 import os
 from unittest.mock import ANY
 
-from dvc.repo.open_repo import CLONES, external_repo
+from dvc.repo.open_repo import CLONES
+from dvc.repo.open_repo import _external_repo as external_repo
 from dvc.scm import Git
 from dvc.testing.tmp_dir import make_subrepo
 from dvc.utils import relpath

--- a/tests/func/test_external_repo.py
+++ b/tests/func/test_external_repo.py
@@ -1,7 +1,7 @@
 import os
 from unittest.mock import ANY
 
-from dvc.external_repo import CLONES, external_repo
+from dvc.repo.open_repo import CLONES, external_repo
 from dvc.scm import Git
 from dvc.testing.tmp_dir import make_subrepo
 from dvc.utils import relpath

--- a/tests/unit/repo/test_open_repo.py
+++ b/tests/unit/repo/test_open_repo.py
@@ -3,7 +3,7 @@ from unittest.mock import call
 
 import pytest
 
-from dvc.repo.open_repo import external_repo
+from dvc.repo.open_repo import _external_repo as external_repo
 from dvc.testing.tmp_dir import make_subrepo
 
 

--- a/tests/unit/repo/test_open_repo.py
+++ b/tests/unit/repo/test_open_repo.py
@@ -3,7 +3,7 @@ from unittest.mock import call
 
 import pytest
 
-from dvc.external_repo import external_repo
+from dvc.repo.open_repo import external_repo
 from dvc.testing.tmp_dir import make_subrepo
 
 

--- a/tests/unit/repo/test_open_repo.py
+++ b/tests/unit/repo/test_open_repo.py
@@ -65,8 +65,7 @@ def test_subrepo_is_constructed_properly(
         str(tmp_dir),
         subrepos=True,
         uninitialized=True,
-        cache_dir=str(cache_dir),
-        cache_types=["symlink"],
+        config={"cache": {"dir": str(cache_dir), "type": ["symlink"]}},
     ) as repo:
         spy = mocker.spy(repo.dvcfs.fs, "repo_factory")
 


### PR DESCRIPTION
Consolidating all repo-opening in one place, so we can improve it in one place and not have `external_repo` running in the wild.

In general, no one should be using `external_repo` directly.

This change helped identify `dvc get` using `external_repo` directly and so having a different behaviour with local repos from the one in `dvc import`. And also brought attention that `dvc get` doesn't have to set any cache dirs or link types, because `dvcfs` is downloading directly from the cache/remote with no `fetch`ing and so no linking involved anymore.