### PR TITLE
testing.benchmarks: sanitize venv names containing slashes

### DIFF
--- a/dvc/testing/benchmarks/fixtures.py
+++ b/dvc/testing/benchmarks/fixtures.py
@@ -20,10 +20,15 @@ def bench_config(request):
 @pytest.fixture(scope="session")
 def make_dvc_venv(tmp_path_factory):
     def _make_dvc_venv(name):
+        name = _sanitize_venv_name(name)
         venv_dir = tmp_path_factory.mktemp(f"dvc-venv-{name}")
         return VirtualEnv(workspace=venv_dir)
 
     return _make_dvc_venv
+
+
+def _sanitize_venv_name(name):
+    return name.replace("/", "-").replace("\\", "-")
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Allows git `refs/...` ref names containing slashes to be used in `--dvc-revs` (useful for testing PR refs)