### PR TITLE
fix(pipelines): support date values

### DIFF
--- a/dvc/parsing/context.py
+++ b/dvc/parsing/context.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 from abc import ABC, abstractmethod
 from collections import defaultdict
@@ -152,7 +153,7 @@ class Value(Node):
         return self._value
 
 
-PRIMITIVES = (int, float, str, bytes, bool)
+PRIMITIVES = (int, float, str, bytes, bool, datetime.date)
 
 
 class Container(Node, ABC):


### PR DESCRIPTION
Fixes this:


```yaml
stages:
  download-video-data:
    foreach:
      - 2023-05-09
    do:
      desc: |-
        Downloading video data from ${item}
      outs:
        - out.txt
      cmd:
        - echo ${item} >> out.txt
```

If you run `dvc repro` raises: `ERROR: unexpected error - Unsupported value of type 'date' in '<local>:item'`

TODO:

- [ ] Add tests if the fix makes sense
- [ ] Improve the error message (can we do this?)


-----------

* [X] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [X] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
