### PR TITLE
stage add: introduce --run option

### DIFF
--- a/dvc/repo/stage.py
+++ b/dvc/repo/stage.py
@@ -122,16 +122,15 @@ class StageLoad:
             force=force,
             **stage_data,
         )
-        with self.repo.scm_context:
-            stage.dump(update_lock=update_lock)
-            try:
-                stage.ignore_outs()
-            except FileNotFoundError as exc:
-                ui.warn(
-                    f"Could not create .gitignore entry in {exc.filename}."
-                    " DVC will attempt to create .gitignore entry again when"
-                    " the stage is run."
-                )
+        stage.dump(update_lock=update_lock)
+        try:
+            stage.ignore_outs()
+        except FileNotFoundError as exc:
+            ui.warn(
+                f"Could not create .gitignore entry in {exc.filename}."
+                " DVC will attempt to create .gitignore entry again when"
+                " the stage is run."
+            )
 
         return stage
 

--- a/tests/unit/command/test_stage.py
+++ b/tests/unit/command/test_stage.py
@@ -86,3 +86,15 @@ def test_stage_add(mocker, dvc, command, parsed_command):
         cmd=parsed_command,
         force=True,
     )
+
+
+def test_stage_add_and_run(mocker, dvc):
+    cli_args = parse_args(["stage", "add", "--run", "-n", "foo", "-o", "foo", "cmd"])
+    cmd = cli_args.func(cli_args)
+    add_mock = mocker.patch.object(cmd.repo.stage, "add")
+
+    assert cmd.run() == 0
+
+    assert called_once_with_subset(add_mock, name="foo", outs=["foo"], cmd="cmd")
+    add_mock.return_value.run.assert_called_once()
+    add_mock.return_value.dump.assert_called_once_with(update_pipeline=False)


### PR DESCRIPTION
Part of #5846.

Will backport and document this for 2.0, will deprecate `dvc run` separately.