### PR TITLE
remove `dvc.main.main` alias

### DIFF
--- a/dvc/main.py
+++ b/dvc/main.py
@@ -1,2 +1,0 @@
-# TODO: remove in 3.0, kept for backward compatibility
-from .cli import main  # noqa: F401, pylint: disable=unused-import


### PR DESCRIPTION
You can import it using:
```python
from dvc.cli import main

main(...)
```

