### PR TITLE
fix(add): clarify error message on a pipeline-tracked output

### DIFF
--- a/dvc/repo/add.py
+++ b/dvc/repo/add.py
@@ -74,6 +74,12 @@ def validate_args(targets: List[str], **kwargs: Any) -> None:
         raise InvalidArgumentError(message.format(option=invalid_opt))
 
 
+PIPELINE_TRACKED_UPDATE_FMT = (
+    "Cannot update {out!r}: it is defined and tracked in '{path}'.\n"
+    "Run the pipeline or use 'dvc commit' to force update it."
+)
+
+
 def get_or_create_stage(
     repo: "Repo",
     target: str,
@@ -91,7 +97,8 @@ def get_or_create_stage(
         (out_obj,) = repo.find_outs_by_path(target, strict=False)
         stage = out_obj.stage
         if not stage.is_data_source:
-            raise DvcException(f"cannot update {out!r}: not a data source")
+            msg = PIPELINE_TRACKED_UPDATE_FMT.format(out=out, path=stage.relpath)
+            raise DvcException(msg)
         return StageInfo(stage, output_exists=True)
     except OutputNotFoundError:
         stage = repo.stage.create(

--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -722,7 +722,13 @@ def test_add_optimization_for_hardlink_on_empty_files(tmp_dir, dvc, mocker):
 def test_try_adding_pipeline_tracked_output(tmp_dir, dvc, run_copy):
     tmp_dir.dvc_gen("foo", "foo")
     run_copy("foo", "bar", name="copy-foo-bar")
-    with pytest.raises(DvcException, match="cannot update 'bar': not a data source"):
+    with pytest.raises(
+        DvcException,
+        match=(
+            "Cannot update 'bar': it is defined and tracked in 'dvc.yaml'.\n"
+            "Run the pipeline or use 'dvc commit' to force update it."
+        ),
+    ):
         dvc.add("bar")
 
 


### PR DESCRIPTION
Minor UX improvement. A user was complaining about this message (it was not clear what is going on and how to resolve it).

The error message looked like this: `ERROR: cannot update 'model.pt': not a data source`

Not it looks like: 

```
ERROR: Cannot update 'model.pt': it is defined and tracked in 'dvc.yaml'.
Run the pipeline or use 'dvc commit' to force update it.
```

------------------

* [X] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [X] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
