### PR TITLE
output: deprecate dos2unix md5 hashing

### DIFF
--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -152,6 +152,7 @@ SCHEMA = {
         Optional("check_update", default=True): Bool,
         "site_cache_dir": str,
         "machine": Lower,
+        Optional("legacy_md5", default=True): Bool,
     },
     "cache": {
         "local": str,

--- a/dvc/output.py
+++ b/dvc/output.py
@@ -515,6 +515,12 @@ class Output:
             self.cache.oid_to_path(self.hash_info.value)
         )
 
+    @cached_property
+    def _is_text(self) -> Optional[bool]:
+        if self.repo.config["core"].get("legacy_md5", True):
+            return None
+        return False
+
     def get_hash(self):
         _, hash_info = self._get_hash_meta()
         return hash_info
@@ -531,6 +537,7 @@ class Output:
             self.hash_name,
             ignore=self.dvcignore,
             dry_run=not self.use_cache,
+            text=self._is_text,
         )
         return meta, obj.hash_info
 
@@ -671,6 +678,7 @@ class Output:
                 self.fs,
                 self.hash_name,
                 ignore=self.dvcignore,
+                text=self._is_text,
             )
         else:
             _, self.meta, self.obj = build(
@@ -680,6 +688,7 @@ class Output:
                 self.hash_name,
                 ignore=self.dvcignore,
                 dry_run=True,
+                text=self._is_text,
             )
             if not self.IS_DEPENDENCY:
                 logger.debug("Output '%s' doesn't use cache. Skipping saving.", self)
@@ -727,6 +736,7 @@ class Output:
                     self.fs,
                     self.hash_name,
                     ignore=self.dvcignore,
+                    text=self._is_text,
                 )
                 otransfer(
                     staging,
@@ -758,6 +768,7 @@ class Output:
             self.fs,
             self.hash_name,
             ignore=self.dvcignore,
+            text=self._is_text,
         )
         assert isinstance(obj, Tree)
         save_obj = obj.filter(prefix)
@@ -973,6 +984,7 @@ class Output:
             "md5",
             upload=upload,
             no_progress_bar=no_progress_bar,
+            text=self._is_text,
         )
         otransfer(
             staging,
@@ -1305,6 +1317,7 @@ class Output:
                 self.hash_name,
                 ignore=self.dvcignore,
                 dry_run=not self.use_cache,
+                text=self._is_text,
             )
         except FileNotFoundError as exc:
             if self.fs_path == path:

--- a/dvc/repo/imports.py
+++ b/dvc/repo/imports.py
@@ -101,6 +101,7 @@ def save_imports(
         logger.warning(str(DataSourceChanged(f"{dep.stage} ({dep})")))
 
     data_view = unfetched.data["repo"]
+    is_text = None if repo.config["core"].get("legacy_md5", True) else False
     if len(data_view):
         cache = repo.cache.local
         if not cache.fs.exists(cache.path):
@@ -111,7 +112,7 @@ def save_imports(
                 unit="files",
             ) as cb:
                 checkout(data_view, tmpdir, cache.fs, callback=cb, storage="data")
-            md5(data_view)
+            md5(data_view, text=is_text)
             save(data_view, odb=cache, hardlink=True)
 
         downloaded.update(

--- a/dvc/repo/init.py
+++ b/dvc/repo/init.py
@@ -67,8 +67,9 @@ def init(root_dir=os.curdir, no_scm=False, force=False, subdir=False):  # noqa: 
 
     config = Config.init(dvc_dir)
 
-    if no_scm:
-        with config.edit() as conf:
+    with config.edit() as conf:
+        conf["core"]["legacy_md5"] = False
+        if no_scm:
             conf["core"]["no_scm"] = True
 
     dvcignore = init_dvcignore(root_dir)

--- a/tests/func/test_init.py
+++ b/tests/func/test_init.py
@@ -120,3 +120,8 @@ def test_init_when_ignored_by_git(tmp_dir, scm, caplog):
         )
         in caplog.text
     )
+
+
+def test_init_legacy_md5(scm):
+    with DvcRepo.init() as repo:
+        assert repo.config["core"].get("legacy_md5") is False


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Will close https://github.com/iterative/dvc/issues/4658

Requires https://github.com/iterative/dvc-data/pull/359

- Adds config option `core.legacy_md5`. When True, legacy `istextfile+dos2unix` behavior will be used when computing MD5 hashes
- `core.legacy_md5` defaults to `true` (behavior is unchanged for existing 2.x repos where `core.legacy_md5` is unset)
- `core.legacy_md5` is explicitly set to `false` in all new DVC repos upon `Repo.init`/`dvc init` (legacy `dos2unix` behavior is disabled by default in new 3.x repos).