### PR TITLE
repo: support separate `md5raw` and (legacy) `md5` cache

### DIFF
--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -30,11 +30,20 @@ class Remote:
     @cached_property
     def odb(self) -> "HashFileDB":
         from dvc_data.hashfile.db import get_odb
+        from dvc_data.hashfile.hash import DEFAULT_ALGORITHM
 
         path = self.path
         if self.worktree:
             path = self.fs.path.join(path, ".dvc", "cache")
+        else:
+            path = self.fs.path.join(path, DEFAULT_ALGORITHM)
+        return get_odb(self.fs, path, hash_name=DEFAULT_ALGORITHM, **self.config)
 
+    @cached_property
+    def legacy_odb(self) -> "HashFileDB":
+        from dvc_data.hashfile.db import get_odb
+
+        path = self.path
         return get_odb(self.fs, path, hash_name="md5", **self.config)
 
 
@@ -101,12 +110,17 @@ class DataCloud:
         self,
         name: Optional[str] = None,
         command: str = "<command>",
+        hash_name: str = "md5raw",
     ) -> "HashFileDB":
+        from dvc_data.hashfile.hash import LEGACY_HASH_NAMES
+
         remote = self.get_remote(name=name, command=command)
         if remote.fs.version_aware or remote.worktree:
             raise NoRemoteError(
                 f"'{command}' is unsupported for cloud versioned remotes"
             )
+        if hash_name in LEGACY_HASH_NAMES:
+            return remote.legacy_odb
         return remote.odb
 
     def _log_missing(self, status: "CompareStatusResult"):

--- a/dvc/fs/data.py
+++ b/dvc/fs/data.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 class DataFileSystem(FileSystem):
     protocol = "local"
 
-    PARAM_CHECKSUM = "md5"
+    PARAM_CHECKSUM = "md5raw"
 
     def _prepare_credentials(self, **config):
         return config

--- a/dvc/fs/dvc.py
+++ b/dvc/fs/dvc.py
@@ -47,8 +47,9 @@ def _merge_info(repo, fs_info, dvc_info):
         ret["dvc_info"] = dvc_info
         ret["type"] = dvc_info["type"]
         ret["size"] = dvc_info["size"]
-        if not fs_info and "md5" in dvc_info:
-            ret["md5"] = dvc_info["md5"]
+        for name in ("md5", "md5raw"):
+            if not fs_info and name in dvc_info:
+                ret[name] = dvc_info[name]
 
     if fs_info:
         ret["type"] = fs_info["type"]
@@ -390,7 +391,7 @@ class _DVCFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
 
 class DVCFileSystem(FileSystem):
     protocol = "local"
-    PARAM_CHECKSUM = "md5"
+    PARAM_CHECKSUM = "md5raw"
 
     def _prepare_credentials(self, **config) -> Dict[str, Any]:
         return config

--- a/dvc/fs/git.py
+++ b/dvc/fs/git.py
@@ -14,7 +14,7 @@ class GitFileSystem(FileSystem):  # pylint:disable=abstract-method
     """Proxies the repo file access methods to Git objects"""
 
     protocol = "local"
-    PARAM_CHECKSUM = "md5"
+    PARAM_CHECKSUM = "md5raw"
 
     def __init__(
         self,

--- a/dvc/output.py
+++ b/dvc/output.py
@@ -405,9 +405,9 @@ class Output:
             self.meta.version_id = version_id
 
         if self.is_in_repo:
-            name = DEFAULT_ALGORITHM
+            self.hash_name = DEFAULT_ALGORITHM
             for name in algorithms_available:
-                if hasattr(self.meta, name):
+                if getattr(self.meta, name, None):
                     self.hash_name = name
                     break
         else:

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -420,8 +420,8 @@ class Repo:
         flist = [self.config.files["local"]]
         if tmp_dir := self.tmp_dir:
             flist.append(tmp_dir)
-        if path_isin(self.cache.repo.path, self.root_dir):
-            flist.append(self.cache.repo.path)
+        if path_isin(self.cache.legacy.path, self.root_dir):
+            flist.append(self.cache.legacy.path)
 
         for file in flist:
             self.scm_context.ignore(file)


### PR DESCRIPTION
* [ ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Alternative to https://github.com/iterative/dvc/pull/9517 (see https://github.com/iterative/dvc/pull/9517#issuecomment-1567613505)
Needs https://github.com/iterative/dvc-objects/pull/209, https://github.com/iterative/dvc-data/pull/360

- Changes default DVC hash to `md5raw`
- Changes 3.x cache location to `<cache_dir>/md5raw/...`
    - 3.x objects with `md5raw` will be pushed/pulled to `<remote_url>/md5raw`
- Existing DVC objects with `md5` hashes will be handled with legacy 2.x dos2unix behavior
    - Legacy 2.x DVC objects are left in place (in `<cache_dir>/...`)
    - Legacy 2.x DVC objects will continue to be pushed/pulled from existing remotes
    - For the purposes of `dvc status`, legacy 2.x outputs will be hashed with dos2unix `md5` (otherwise `dvc status` will report every existing file as changed upon upgrading to 3.x)
- **Modifications to legacy 2.x outputs will be treated as new 3.x files, all future modifications will be hashed with `md5raw` and stored in 3.x cache.**
  - (i.e. upon making a change to an existing file and doing `dvc add file`, the updated .dvc file will now use 3.x `md5raw`).
  - This also means that doing `dvc add file` to an "unchanged" file will migrate the file to 3.x (and create a new copy of the file in 3.x cache according to `md5raw` hash)
  - Likewise, doing `dvc repro -f` (or `dvc repro` where there is no existing run cache) would generate a new `dvc.lock` with 3.x `md5raw` hashes for "unmodified" stage outputs
- All new objects will be hashed as `md5raw` in 3.x. (dos2unix behavior is dropped for all new 3.x objects)
- If a new output is created in 3.x (via pipeline stage or `dvc add`), a new copy of that file will be stored in the new 3.x cache location regardless of whether or not there was an identical object tracked in 2.x (i.e there is no de-duplication between 2.x and 3.x cache).
    - No `md5 <-> md5raw` mapping is supported.