### PR TITLE
deps: install tzdata for testing with celery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ tests = [
     "pytest-timeout>=2",
     "pytest-xdist>=3.2",
     'pywin32>=225; sys_platform == "win32"', # optional test dependency
+    'tzdata; sys_platform == "win32"',  # for testing with celery
 ]
 webdav = ["dvc-webdav==2.19.1"]
 webhdfs = ["dvc-webhdfs==2.19"]


### PR DESCRIPTION
Temporary(?) fix for CI on windows with py >=3.9. 

```
2023-06-04T17:07:33.7789701Z tests\unit\repo\experiments\conftest.py:94: in session_worker
2023-06-04T17:07:33.7789796Z     with _thread_worker(
2023-06-04T17:07:33.7790012Z tests\unit\repo\experiments\conftest.py:61: in _thread_worker
2023-06-04T17:07:33.7790251Z     from celery.contrib.testing import worker
2023-06-04T17:07:33.7790893Z C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\celery\contrib\testing\worker.py:7: in <module>
2023-06-04T17:07:33.7791072Z     import celery.worker.consumer
2023-06-04T17:07:33.7791785Z C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\celery\worker\consumer\__init__.py:4: in <module>
2023-06-04T17:07:33.7792052Z     from .consumer import Consumer
2023-06-04T17:07:33.7792817Z C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\celery\worker\consumer\consumer.py:16: in <module>
2023-06-04T17:07:33.7793135Z     from kombu.asynchronous.semaphore import DummyLock
2023-06-04T17:07:33.7793645Z C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\kombu\asynchronous\__init__.py:7: in <module>
2023-06-04T17:07:33.7793791Z     from .hub import Hub, get_event_loop, set_event_loop
2023-06-04T17:07:33.7794386Z C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\kombu\asynchronous\hub.py:19: in <module>
2023-06-04T17:07:33.7794610Z     from .timer import Timer
2023-06-04T17:07:33.7795249Z C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\kombu\asynchronous\timer.py:32: in <module>
2023-06-04T17:07:33.7795703Z     EPOCH = datetime.utcfromtimestamp(0).replace(tzinfo=ZoneInfo("UTC"))
2023-06-04T17:07:33.7795925Z _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
2023-06-04T17:07:33.7795936Z 
2023-06-04T17:07:33.7796106Z key = 'UTC'
2023-06-04T17:07:33.7796115Z 
2023-06-04T17:07:33.7796312Z     def load_tzdata(key):
2023-06-04T17:07:33.7796481Z         import importlib.resources
2023-06-04T17:07:33.7796605Z     
2023-06-04T17:07:33.7796825Z         components = key.split("/")
2023-06-04T17:07:33.7797372Z         package_name = ".".join(["tzdata.zoneinfo"] + components[:-1])
2023-06-04T17:07:33.7797748Z         resource_name = components[-1]
2023-06-04T17:07:33.7797870Z     
2023-06-04T17:07:33.7797999Z         try:
2023-06-04T17:07:33.7798294Z             return importlib.resources.open_binary(package_name, resource_name)
2023-06-04T17:07:33.7798627Z         except (ImportError, FileNotFoundError, UnicodeEncodeError):
2023-06-04T17:07:33.7798978Z             # There are three types of exception that can be raised that all amount
2023-06-04T17:07:33.7799143Z             # to "we cannot find this key":
2023-06-04T17:07:33.7799269Z             #
2023-06-04T17:07:33.7799779Z             # ImportError: If package_name doesn't exist (e.g. if tzdata is not
2023-06-04T17:07:33.7800164Z             #   installed, or if there's an error in the folder name like
2023-06-04T17:07:33.7800312Z             #   Amrica/New_York)
2023-06-04T17:07:33.7800677Z             # FileNotFoundError: If resource_name doesn't exist in the package
2023-06-04T17:07:33.7800832Z             #   (e.g. Europe/Krasnoy)
2023-06-04T17:07:33.7801207Z             # UnicodeEncodeError: If package_name or resource_name are not UTF-8,
2023-06-04T17:07:33.7801562Z             #   such as keys containing a surrogate character.
2023-06-04T17:07:33.7801941Z >           raise ZoneInfoNotFoundError(f"No time zone found with key {key}")
2023-06-04T17:07:33.7802527Z E           zoneinfo._common.ZoneInfoNotFoundError: 'No time zone found with key UTC'
2023-06-04T17:07:33.7802537Z 
2023-06-04T17:07:33.7803084Z C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\zoneinfo\_common.py:24: ZoneInfoNotFoundError
```