### PR TITLE
dvc.utils.pkg: move PKG to top-level dvc

### DIFF
--- a/dvc/__init__.py
+++ b/dvc/__init__.py
@@ -3,7 +3,11 @@ DVC
 ----
 Make your data science projects reproducible and shareable.
 """
+from typing import Optional
+
 import dvc.logger
+from dvc import _build
 from dvc.version import __version__, version_tuple  # noqa: F401
 
+PKG: "Optional[str]" = _build.PKG
 dvc.logger.setup()

--- a/dvc/_build.py
+++ b/dvc/_build.py
@@ -1,0 +1,1 @@
+PKG = None

--- a/dvc/cli/__init__.py
+++ b/dvc/cli/__init__.py
@@ -75,7 +75,7 @@ def _log_exceptions(exc: Exception) -> Optional[int]:
     from dvc.fs import AuthError, ConfigError, RemoteMissingDepsError
 
     if isinstance(exc, RemoteMissingDepsError):
-        from dvc.utils.pkg import PKG
+        from dvc import PKG
 
         proto = exc.protocol
         by_pkg = {
@@ -83,9 +83,9 @@ def _log_exceptions(exc: Exception) -> Optional[int]:
             "conda": f"conda install -c conda-forge dvc-{proto}",
         }
 
-        cmd = by_pkg.get(PKG)
-        if cmd:
+        if PKG in by_pkg:
             link = format_link("https://dvc.org/doc/install")
+            cmd = by_pkg.get(PKG)
             hint = (
                 "To install dvc with those dependencies, run:\n"
                 "\n"
@@ -190,8 +190,7 @@ def main(argv=None):  # noqa: C901, PLR0912, PLR0915
         if level and level <= logging.DEBUG:
             from platform import platform, python_implementation, python_version
 
-            from dvc import __version__
-            from dvc.utils.pkg import PKG
+            from dvc import PKG, __version__
 
             pyv = " ".join([python_implementation(), python_version()])
             pkg = f" ({PKG})" if PKG else ""

--- a/dvc/info.py
+++ b/dvc/info.py
@@ -6,13 +6,12 @@ import platform
 
 import psutil
 
-from dvc import __version__
+from dvc import PKG, __version__
 from dvc.exceptions import NotDvcRepoError
 from dvc.fs import Schemes, generic, get_fs_cls, get_fs_config, registry
 from dvc.repo import Repo
 from dvc.scm import SCMError
 from dvc.utils import error_link
-from dvc.utils.pkg import PKG
 
 SUBPROJECTS = (
     "dvc_data",

--- a/dvc/updater.py
+++ b/dvc/updater.py
@@ -6,8 +6,7 @@ from typing import TYPE_CHECKING, Optional
 
 from packaging import version
 
-from dvc import __version__
-from dvc.utils.pkg import PKG
+from dvc import PKG, __version__
 
 if TYPE_CHECKING:
     from dvc.ui import RichText

--- a/dvc/utils/pkg.py
+++ b/dvc/utils/pkg.py
@@ -1,6 +1,0 @@
-try:
-    # file is created during dvc build
-    # pylint:disable=unused-import
-    from .build import PKG  # type: ignore[import]
-except ImportError:
-    PKG = None  # type: ignore[assignment]

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -20,7 +20,7 @@ parser.add_argument("--apple-id-username")
 parser.add_argument("--apple-id-password")
 args = parser.parse_args()
 
-(dvc / "utils" / "build.py").write_text(f'PKG = "{args.pkg}"')
+(dvc / "_build.py").write_text(f'PKG = "{args.pkg}"')
 
 if not (dvc / "_dvc_version.py").exists():
     raise Exception("no version info found")

--- a/scripts/build_package.sh
+++ b/scripts/build_package.sh
@@ -8,7 +8,7 @@ if [ ! -d "dvc" ]; then
   exit 1
 fi
 
-echo 'PKG = "pip"' >dvc/utils/build.py
+echo 'PKG = "pip"' >dvc/_build.py
 
 python -m pip install build twine
 python -m build

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -39,7 +39,7 @@ def test_state_pickle_errors_are_correctly_raised(tmp_dir, caplog, mocker):
 )
 def test_remote_missing_deps_are_correctly_reported(tmp_dir, caplog, mocker, pkg, msg):
     error = RemoteMissingDepsError(FileSystem(), "proto", "proto://", ["deps"])
-    mocker.patch("dvc.utils.pkg.PKG", pkg)
+    mocker.patch("dvc.PKG", pkg)
     mocker.patch(
         "dvc.cli.parse_args",
         return_value=Namespace(


### PR DESCRIPTION
PKG has to be specified in dvc/_build.py now, and can be imported using:

```python
    from dvc import PKG
```

This is done to avoid importing from dvc/utils pkg which can be expensive, since we started logging PKG info in CLI main.
Also it's not an utility, so it is better that it remains at the top-level namespace. It's also a static information that never changes.

Note that we may have to fix the path for a few packages that we build, like conda/snap/chocolatey.