### PR TITLE
tests: use mocker instead of unittest.mock where possible

### DIFF
--- a/tests/func/test_add.py
+++ b/tests/func/test_add.py
@@ -4,7 +4,6 @@ import os
 import shutil
 import stat
 import textwrap
-from unittest.mock import call
 
 import pytest
 
@@ -631,8 +630,8 @@ def test_add_optimization_for_hardlink_on_empty_files(tmp_dir, dvc, mocker):
     stages = dvc.add(["foo", "bar", "lorem", "ipsum"])
 
     assert m.call_count == 8
-    assert m.call_args != call(tmp_dir / "foo")
-    assert m.call_args != call(tmp_dir / "bar")
+    assert m.call_args != mocker.call(tmp_dir / "foo")
+    assert m.call_args != mocker.call(tmp_dir / "bar")
 
     for stage in stages[:2]:
         # hardlinks are not created for empty files

--- a/tests/func/test_analytics.py
+++ b/tests/func/test_analytics.py
@@ -1,5 +1,4 @@
 import os
-from unittest.mock import call
 
 import pytest
 
@@ -40,7 +39,7 @@ def test_collect_and_send_report(mocker, dvc, mock_daemon):
 
     assert mock_daemon.call_count == 1
     assert mock_post.call_count == 1
-    assert mock_post.call_args == call(
+    assert mock_post.call_args == mocker.call(
         "https://analytics.dvc.org",
         json=ANY(dict),
         headers={"content-type": "application/json"},

--- a/tests/func/test_external_repo.py
+++ b/tests/func/test_external_repo.py
@@ -1,5 +1,4 @@
 import os
-from unittest.mock import ANY
 
 from dvc.repo.open_repo import CLONES
 from dvc.repo.open_repo import _external_repo as external_repo
@@ -140,7 +139,9 @@ def test_shallow_clone_branch(erepo_dir, mocker):
         with repo.dvcfs.open("file") as fd:
             assert fd.read() == "branch"
 
-    clone_spy.assert_called_with(url, ANY, shallow_branch="branch", progress=ANY)
+    clone_spy.assert_called_with(
+        url, mocker.ANY, shallow_branch="branch", progress=mocker.ANY
+    )
 
     path, _ = CLONES[url]
     CLONES[url] = (path, True)
@@ -165,7 +166,9 @@ def test_shallow_clone_tag(erepo_dir, mocker):
         with repo.dvcfs.open("file") as fd:
             assert fd.read() == "foo"
 
-    clone_spy.assert_called_with(url, ANY, shallow_branch="v1", progress=ANY)
+    clone_spy.assert_called_with(
+        url, mocker.ANY, shallow_branch="v1", progress=mocker.ANY
+    )
 
     path, _ = CLONES[url]
     CLONES[url] = (path, True)

--- a/tests/unit/command/test_machine.py
+++ b/tests/unit/command/test_machine.py
@@ -1,5 +1,4 @@
 import os
-from unittest.mock import call
 
 import configobj
 import pytest
@@ -77,7 +76,7 @@ def test_status(tmp_dir, scm, dvc, mocker):
     m = mocker.patch.object(cmd.repo.machine, "status", autospec=True, return_value=[])
     assert cmd.run() == 0
     assert m.call_count == 2
-    m.assert_has_calls([call("foo"), call("myaws")])
+    m.assert_has_calls([mocker.call("foo"), mocker.call("myaws")])
 
 
 def test_destroy(tmp_dir, dvc, mocker):

--- a/tests/unit/fs/test_dvc.py
+++ b/tests/unit/fs/test_dvc.py
@@ -1,7 +1,6 @@
 import os
 import posixpath
 import shutil
-from unittest import mock
 
 import pytest
 
@@ -346,33 +345,35 @@ def test_subrepos(tmp_dir, scm, dvc, mocker):
 
         return f
 
-    with mock.patch.object(
+    mock_subrepo1 = mocker.patch.object(
         fs.fs, "_get_repo", side_effect=assert_fs_belongs_to_repo(subrepo1.dvc)
-    ):
-        assert fs.exists("dir/repo/foo") is True
-        assert fs.exists("dir/repo/bar") is False
+    )
+    assert fs.exists("dir/repo/foo") is True
+    assert fs.exists("dir/repo/bar") is False
 
-        assert fs.isfile("dir/repo/foo") is True
-        assert fs.isfile("dir/repo/dir1/bar") is True
-        assert fs.isfile("dir/repo/dir1") is False
+    assert fs.isfile("dir/repo/foo") is True
+    assert fs.isfile("dir/repo/dir1/bar") is True
+    assert fs.isfile("dir/repo/dir1") is False
 
-        assert fs.isdir("dir/repo/dir1") is True
-        assert fs.isdir("dir/repo/dir1/bar") is False
-        assert fs.isdvc("dir/repo/foo") is True
+    assert fs.isdir("dir/repo/dir1") is True
+    assert fs.isdir("dir/repo/dir1/bar") is False
+    assert fs.isdvc("dir/repo/foo") is True
+    mocker.stop(mock_subrepo1)
 
-    with mock.patch.object(
+    mock_subrepo2 = mocker.patch.object(
         fs.fs, "_get_repo", side_effect=assert_fs_belongs_to_repo(subrepo2.dvc)
-    ):
-        assert fs.exists("dir/repo2/lorem") is True
-        assert fs.exists("dir/repo2/ipsum") is False
+    )
+    assert fs.exists("dir/repo2/lorem") is True
+    assert fs.exists("dir/repo2/ipsum") is False
 
-        assert fs.isfile("dir/repo2/lorem") is True
-        assert fs.isfile("dir/repo2/dir2/ipsum") is True
-        assert fs.isfile("dir/repo2/dir2") is False
+    assert fs.isfile("dir/repo2/lorem") is True
+    assert fs.isfile("dir/repo2/dir2/ipsum") is True
+    assert fs.isfile("dir/repo2/dir2") is False
 
-        assert fs.isdir("dir/repo2/dir2") is True
-        assert fs.isdir("dir/repo2/dir2/ipsum") is False
-        assert fs.isdvc("dir/repo2/lorem") is True
+    assert fs.isdir("dir/repo2/dir2") is True
+    assert fs.isdir("dir/repo2/dir2/ipsum") is False
+    assert fs.isdvc("dir/repo2/lorem") is True
+    mocker.stop(mock_subrepo2)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/repo/experiments/queue/test_remove.py
+++ b/tests/unit/repo/experiments/queue/test_remove.py
@@ -1,5 +1,3 @@
-from unittest.mock import call
-
 from dvc.repo.experiments.queue.base import QueueDoneResult
 
 
@@ -37,7 +35,11 @@ def test_remove_queued(test_queue, mocker):
     assert test_queue.clear(queued=True) == queued_test
     remove_revs_mocker.assert_called_once_with(list(stash_dict.values()))
     reject_mocker.assert_has_calls(
-        [call("msg_queue1"), call("msg_queue2"), call("msg_queue3")]
+        [
+            mocker.call("msg_queue1"),
+            mocker.call("msg_queue2"),
+            mocker.call("msg_queue3"),
+        ]
     )
 
 
@@ -84,7 +86,9 @@ def test_remove_done(test_queue, mocker):
         "success2",
     ]
     remove_revs_mocker.assert_called_once_with([stash_dict["failed3"]])
-    purge_mocker.assert_has_calls([call("msg_failed3"), call("msg_success2")])
+    purge_mocker.assert_has_calls(
+        [mocker.call("msg_failed3"), mocker.call("msg_success2")]
+    )
 
     remove_revs_mocker.reset_mock()
     purge_mocker.reset_mock()
@@ -94,12 +98,12 @@ def test_remove_done(test_queue, mocker):
     )
     purge_mocker.assert_has_calls(
         [
-            call("msg_failed1"),
-            call("msg_failed2"),
-            call("msg_failed3"),
-            call("msg_success1"),
-            call("msg_success2"),
-            call("msg_success3"),
+            mocker.call("msg_failed1"),
+            mocker.call("msg_failed2"),
+            mocker.call("msg_failed3"),
+            mocker.call("msg_success1"),
+            mocker.call("msg_success2"),
+            mocker.call("msg_success3"),
         ],
         any_order=True,
     )

--- a/tests/unit/repo/test_open_repo.py
+++ b/tests/unit/repo/test_open_repo.py
@@ -1,5 +1,4 @@
 import os
-from unittest.mock import call
 
 import pytest
 
@@ -34,7 +33,7 @@ def test_hook_is_called(tmp_dir, erepo_dir, mocker):
         paths = ["/" + path.replace("\\", "/") for path in subrepo_paths]
         spy.assert_has_calls(
             [
-                call(
+                mocker.call(
                     path,
                     fs=repo.fs,
                     scm=repo.scm,


### PR DESCRIPTION
Had the "pleasure" of finding a mocker.patch leak into other tests and one of the suspicions is that mixing unittest.mock and mocker might be somehow related.

In any case, we should use mocker where possible anyway.
