### PR TITLE
tests: unit: explicitly ask for dvc repo

### DIFF
--- a/tests/unit/command/test_add.py
+++ b/tests/unit/command/test_add.py
@@ -32,7 +32,7 @@ def test_add(mocker, dvc):
     )
 
 
-def test_add_to_remote(mocker):
+def test_add_to_remote(mocker, dvc):
     cli_args = parse_args(
         [
             "add",
@@ -63,7 +63,7 @@ def test_add_to_remote(mocker):
     )
 
 
-def test_add_to_remote_invalid_combinations(mocker, caplog):
+def test_add_to_remote_invalid_combinations(mocker, caplog, dvc):
     cli_args = parse_args(["add", "s3://bucket/foo", "s3://bucket/bar", "--to-remote"])
     assert cli_args.func == CmdAdd
 
@@ -83,7 +83,7 @@ def test_add_to_remote_invalid_combinations(mocker, caplog):
             assert expected_msg in caplog.text
 
 
-def test_add_to_cache_invalid_combinations(mocker, caplog):
+def test_add_to_cache_invalid_combinations(mocker, caplog, dvc):
     cli_args = parse_args(["add", "s3://bucket/foo", "s3://bucket/bar", "-o", "foo"])
     assert cli_args.func == CmdAdd
 

--- a/tests/unit/command/test_data_sync.py
+++ b/tests/unit/command/test_data_sync.py
@@ -2,7 +2,7 @@ from dvc.cli import parse_args
 from dvc.commands.data_sync import CmdDataFetch, CmdDataPull, CmdDataPush
 
 
-def test_fetch(mocker):
+def test_fetch(mocker, dvc):
     cli_args = parse_args(
         [
             "fetch",
@@ -40,7 +40,7 @@ def test_fetch(mocker):
     )
 
 
-def test_pull(mocker):
+def test_pull(mocker, dvc):
     cli_args = parse_args(
         [
             "pull",
@@ -84,7 +84,7 @@ def test_pull(mocker):
     )
 
 
-def test_push(mocker):
+def test_push(mocker, dvc):
     cli_args = parse_args(
         [
             "push",

--- a/tests/unit/command/test_diff.py
+++ b/tests/unit/command/test_diff.py
@@ -19,7 +19,7 @@ def test_digest(checksum, expected):
     assert expected == _digest(checksum)
 
 
-def test_default(mocker, capsys):
+def test_default(mocker, capsys, dvc):
     args = parse_args(["diff"])
     cmd = args.func(args)
     diff = {
@@ -51,7 +51,7 @@ def test_default(mocker, capsys):
     ).format(sep=os.path.sep) in capsys.readouterr()[0]
 
 
-def test_show_hash(mocker, capsys):
+def test_show_hash(mocker, capsys, dvc):
     args = parse_args(["diff", "--show-hash"])
     cmd = args.func(args)
     diff = {
@@ -101,7 +101,7 @@ def test_show_hash(mocker, capsys):
     ) in out
 
 
-def test_show_json(mocker, capsys):
+def test_show_json(mocker, capsys, dvc):
     args = parse_args(["diff", "--json"])
     cmd = args.func(args)
     diff = {
@@ -123,7 +123,7 @@ def test_show_json(mocker, capsys):
     assert '"not in cache": []' in out
 
 
-def test_show_json_and_hash(mocker, capsys):
+def test_show_json_and_hash(mocker, capsys, dvc):
     args = parse_args(["diff", "--json", "--show-hash"])
     cmd = args.func(args)
 
@@ -160,7 +160,7 @@ def test_show_json_and_hash(mocker, capsys):
     assert '"not in cache": []' in out
 
 
-def test_show_json_hide_missing(mocker, capsys):
+def test_show_json_hide_missing(mocker, capsys, dvc):
     args = parse_args(["diff", "--json", "--hide-missing"])
     cmd = args.func(args)
     diff = {
@@ -190,7 +190,7 @@ def test_show_json_hide_missing(mocker, capsys):
 
 
 @pytest.mark.parametrize("show_hash", [None, True, False])
-def test_diff_show_markdown_and_hash(mocker, show_hash):
+def test_diff_show_markdown_and_hash(mocker, show_hash, dvc):
     options = ["diff", "--md"] + (["--show-hash"] if show_hash else [])
     args = parse_args(options)
     cmd = args.func(args)
@@ -221,7 +221,7 @@ def test_diff_show_markdown_and_hash(mocker, show_hash):
         (["--md"], "| Status   | Path   |\n|----------|--------|"),
     ),
 )
-def test_no_changes(mocker, capsys, opts, show, expected):
+def test_no_changes(mocker, capsys, opts, show, expected, dvc):
     args = parse_args(["diff", *opts, *show])
     cmd = args.func(args)
     mocker.patch("dvc.repo.Repo.diff", return_value={})
@@ -330,7 +330,7 @@ def test_show_markdown_hide_missing(capsys):
     ).format(sep=os.path.sep)
 
 
-def test_hide_missing(mocker, capsys):
+def test_hide_missing(mocker, capsys, dvc):
     args = parse_args(["diff", "--hide-missing"])
     cmd = args.func(args)
     diff = {

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -56,7 +56,7 @@ def test_experiments_diff(dvc, scm, mocker):
     )
 
 
-def test_experiments_diff_revs(mocker, capsys):
+def test_experiments_diff_revs(mocker, capsys, dvc, scm):
     mocker.patch(
         "dvc.repo.experiments.diff.diff",
         return_value={
@@ -194,7 +194,7 @@ def test_experiments_list(dvc, scm, mocker):
         (["--sha-only"], "sha-a\n"),
     ],
 )
-def test_experiments_list_format(mocker, capsys, args, expected):
+def test_experiments_list_format(mocker, capsys, args, expected, dvc, scm):
     mocker.patch(
         "dvc.repo.experiments.ls.ls",
         return_value={
@@ -214,7 +214,7 @@ def test_experiments_list_format(mocker, capsys, args, expected):
     assert cap.out == expected
 
 
-def test_experiments_list_remote(mocker, capsys):
+def test_experiments_list_remote(mocker, capsys, dvc, scm):
     mocker.patch(
         "dvc.repo.experiments.ls.ls",
         return_value={

--- a/tests/unit/command/test_imp.py
+++ b/tests/unit/command/test_imp.py
@@ -2,7 +2,7 @@ from dvc.cli import parse_args
 from dvc.commands.imp import CmdImport
 
 
-def test_import(mocker):
+def test_import(mocker, dvc):
     cli_args = parse_args(
         [
             "import",
@@ -34,7 +34,7 @@ def test_import(mocker):
     )
 
 
-def test_import_no_exec(mocker):
+def test_import_no_exec(mocker, dvc):
     cli_args = parse_args(
         [
             "import",
@@ -64,7 +64,7 @@ def test_import_no_exec(mocker):
     )
 
 
-def test_import_no_download(mocker):
+def test_import_no_download(mocker, dvc):
     cli_args = parse_args(
         [
             "import",

--- a/tests/unit/command/test_imp_url.py
+++ b/tests/unit/command/test_imp_url.py
@@ -7,7 +7,7 @@ from dvc.commands.imp_url import CmdImportUrl
 from dvc.exceptions import DvcException
 
 
-def test_import_url(mocker):
+def test_import_url(mocker, dvc):
     cli_args = parse_args(
         [
             "import-url",
@@ -37,7 +37,7 @@ def test_import_url(mocker):
     )
 
 
-def test_failed_import_url(mocker, caplog):
+def test_failed_import_url(mocker, caplog, dvc):
     cli_args = parse_args(["import-url", "http://somesite.com/file_name"])
     assert cli_args.func == CmdImportUrl
 
@@ -60,7 +60,7 @@ def test_failed_import_url(mocker, caplog):
         ("--no-download", {"no_download": True, "no_exec": False}),
     ],
 )
-def test_import_url_no_exec_download_flags(mocker, flag, expected):
+def test_import_url_no_exec_download_flags(mocker, flag, expected, dvc):
     cli_args = parse_args(
         [
             "import-url",
@@ -87,7 +87,7 @@ def test_import_url_no_exec_download_flags(mocker, flag, expected):
     )
 
 
-def test_import_url_to_remote(mocker):
+def test_import_url_to_remote(mocker, dvc):
     cli_args = parse_args(
         [
             "import-url",


### PR DESCRIPTION
Currently, these rely on the root of the repo being in the dvc repo.

Leftover from https://github.com/iterative/dvc/pull/9627
