### PR TITLE
exp: push/pull --rev help text shows default val

### DIFF
--- a/dvc/commands/experiments/pull.py
+++ b/dvc/commands/experiments/pull.py
@@ -51,7 +51,7 @@ def add_parser(experiments_subparsers, parent_parser):
         help=EXPERIMENTS_PULL_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    add_rev_selection_flags(experiments_pull_parser, "Pull", False)
+    add_rev_selection_flags(experiments_pull_parser, "Pull", True)
     experiments_pull_parser.add_argument(
         "-f",
         "--force",

--- a/dvc/commands/experiments/push.py
+++ b/dvc/commands/experiments/push.py
@@ -92,7 +92,7 @@ def add_parser(experiments_subparsers, parent_parser):
         help=EXPERIMENTS_PUSH_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    add_rev_selection_flags(experiments_push_parser, "Push", False)
+    add_rev_selection_flags(experiments_push_parser, "Push", True)
     experiments_push_parser.add_argument(
         "-f",
         "--force",


### PR DESCRIPTION
Follow up to #9361. Updates help text to show `(HEAD by default)` in `--rev`:

```
  --rev <commit>        Pull experiments derived from the specified `<commit>` as
                        baseline (HEAD by default).
```