### PR TITLE
output: preserve legacy hash_name on save() for unchanged data

### DIFF
--- a/dvc/output.py
+++ b/dvc/output.py
@@ -692,7 +692,7 @@ class Output:
         if self.metric:
             self.verify_metric()
 
-        if self.hash_name == "md5-dos2unix":
+        if self.hash_name == "md5-dos2unix" and self.changed_checksum():
             self.hash_name = "md5"
         if self.use_cache:
             _, self.meta, self.obj = build(

--- a/tests/func/test_commit.py
+++ b/tests/func/test_commit.py
@@ -316,9 +316,12 @@ def test_commit_dos2unix(tmp_dir, dvc):
         }
     )
     legacy_content = (tmp_dir / "foo.dvc").read_text()
+    assert "hash: md5" not in legacy_content
 
-    dvc.commit("foo.dvc")
+    dvc.commit("foo.dvc", force=True)
     assert (tmp_dir / "foo.dvc").read_text() == legacy_content
+
+    tmp_dir.gen("foo", "modified")
     dvc.commit("foo.dvc", force=True)
     content = (tmp_dir / "foo.dvc").read_text()
     assert "hash: md5" in content


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Fixes issue where `exp run` would generate 3.0 `.dvc` and `dvc.lock` files even if legacy 2.x data dependencies were completely unchanged.