### PR TITLE
checkout: use ui.progress

### DIFF
--- a/dvc/fs/callbacks.py
+++ b/dvc/fs/callbacks.py
@@ -2,17 +2,67 @@
 from contextlib import ExitStack
 from typing import TYPE_CHECKING, Any, BinaryIO, Dict, Optional, Union
 
+from dvc.progress import Tqdm
 from dvc.utils.objects import cached_property
-from dvc_objects.fs.callbacks import (  # noqa: F401
-    DEFAULT_CALLBACK,
-    Callback,
-    TqdmCallback,
-)
+from dvc_objects.fs.callbacks import DEFAULT_CALLBACK, Callback  # noqa: F401
 
 if TYPE_CHECKING:
     from rich.progress import TaskID
 
     from dvc.ui._rich_progress import RichTransferProgress
+
+
+# NOTE: this is very similar to dvc-objects.fs.callbacks.TqdmCallback,
+# but it works with out own Tqdm instance.
+class TqdmCallback(Callback):
+    def __init__(
+        self,
+        size: Optional[int] = None,
+        value: int = 0,
+        progress_bar: Optional["Tqdm"] = None,
+        **tqdm_kwargs,
+    ):
+        tqdm_kwargs["total"] = size or -1
+        self._tqdm_kwargs = tqdm_kwargs
+        self._progress_bar = progress_bar
+        self._stack = ExitStack()
+        super().__init__(size=size, value=value)
+
+    @cached_property
+    def progress_bar(self):
+        progress_bar = (
+            self._progress_bar
+            if self._progress_bar is not None
+            else Tqdm(**self._tqdm_kwargs)
+        )
+        return self._stack.enter_context(progress_bar)
+
+    def __enter__(self):
+        return self
+
+    def close(self):
+        self._stack.close()
+
+    def set_size(self, size):
+        # Tqdm tries to be smart when to refresh,
+        # so we try to force it to re-render.
+        super().set_size(size)
+        self.progress_bar.refresh()
+
+    def call(self, hook_name=None, **kwargs):  # noqa: ARG002
+        self.progress_bar.update_to(self.value, total=self.size)
+
+    def branch(
+        self,
+        path_1: "Union[str, BinaryIO]",
+        path_2: str,
+        kwargs: Dict[str, Any],
+        child: Optional[Callback] = None,
+    ):
+        child = child or TqdmCallback(
+            bytes=True, desc=path_1 if isinstance(path_1, str) else path_2
+        )
+        return super().branch(path_1, path_2, kwargs, child=child)
 
 
 class RichCallback(Callback):

--- a/dvc/fs/callbacks.py
+++ b/dvc/fs/callbacks.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 
 # NOTE: this is very similar to dvc-objects.fs.callbacks.TqdmCallback,
-# but it works with out own Tqdm instance.
+# but it works with our own Tqdm instance.
 class TqdmCallback(Callback):
     def __init__(
         self,

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -2,11 +2,15 @@
 import logging
 import sys
 from threading import RLock
+from typing import TYPE_CHECKING
 
 from tqdm import tqdm
 
 from dvc.env import DVC_IGNORE_ISATTY
 from dvc.utils import env2bool
+
+if TYPE_CHECKING:
+    from dvc.fs.callbacks import TqdmCallback
 
 logger = logging.getLogger(__name__)
 tqdm.set_lock(RLock())
@@ -158,3 +162,8 @@ class Tqdm(tqdm):
             d["ncols_desc"] = d["ncols_info"] = 1
             d["prefix"] = ""
         return d
+
+    def as_callback(self) -> "TqdmCallback":
+        from dvc.fs.callbacks import TqdmCallback
+
+        return TqdmCallback(progress_bar=self)


### PR DESCRIPTION
Makes for a better ui, as users will no longer see `0%` for operations that don't have pre-determined total.

This is also more correct from arch perspective to use dvc's ui and dvc's `TqdmCallback` in dvc.
