### PR TITLE
fetch: warn if cloud-versioned file has no version ID

### DIFF
--- a/dvc/repo/pull.py
+++ b/dvc/repo/pull.py
@@ -1,5 +1,6 @@
 import logging
 
+from dvc.exceptions import CheckoutError
 from dvc.repo import locked
 from dvc.utils import glob_targets
 
@@ -38,13 +39,17 @@ def pull(  # noqa: PLR0913
         recursive=recursive,
         run_cache=run_cache,
     )
-    stats = self.checkout(
-        targets=expanded_targets,
-        with_deps=with_deps,
-        force=force,
-        recursive=recursive,
-        allow_missing=allow_missing,
-    )
+    try:
+        stats = self.checkout(
+            targets=expanded_targets,
+            with_deps=with_deps,
+            force=force,
+            recursive=recursive,
+            allow_missing=allow_missing,
+        )
+    except CheckoutError as exc:
+        exc.stats["fetched"] = processed_files_count
+        raise
 
     stats["fetched"] = processed_files_count
     return stats


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Closes #9226

- fetch/pull will now warn and subsequently fail when trying to fetch a file with no version ID from a cloud-versioned remote (i.e. when the file was not previously pushed to the versioned remote)

```
$ dvc pull                                    ⏎
WARNING: Some files are missing cloud version information and will not be fetched from the remote:
azure://test-versioned/cats-dogs/data/train/cats/cat.1.jpg
azure://test-versioned/cats-dogs/data/train/cats/cat.10.jpg
ERROR: failed to pull data from the cloud - 2 files failed to download
```