### PR TITLE
output: use path instead of relpath

### DIFF
--- a/dvc/output.py
+++ b/dvc/output.py
@@ -1279,7 +1279,7 @@ class Output:
             raise FileNotFoundError(  # noqa: B904
                 errno.ENOENT,
                 os.strerror(errno.ENOENT),
-                self.fs.path.relpath(path),
+                path,
             )
 
         new = tree.from_trie(trie)
@@ -1402,8 +1402,7 @@ class Output:
         otransfer(staging, self.cache, {obj.hash_info}, hardlink=relink, shallow=False)
 
         if relink:
-            rel = self.fs.path.relpath(path)
-            with CheckoutCallback(desc=f"Checking out {rel}", unit="files") as callback:
+            with CheckoutCallback(desc="Checking out {path}", unit="files") as callback:
                 self._checkout(
                     path,
                     self.fs,


### PR DESCRIPTION
Relpath might not exist (e.g. on windows between different drives), we should just use path as is and not get too fancy with the ui, unless we want to constantly keep ValueError in mind when using relpath for ui needs all over the place.

These operations should use index, where we always have current directory and relative paths, so the ui will change accordingly anyway.

