### PR TITLE
repro: make stages run in order of the graph

### DIFF
--- a/dvc/repo/graph.py
+++ b/dvc/repo/graph.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Iterator, List, Set
+from typing import TYPE_CHECKING, Any, Iterator, List, Set, TypeVar
 
 from dvc.fs import localfs
 from dvc.utils.fs import path_isin
@@ -7,6 +7,8 @@ if TYPE_CHECKING:
     from networkx import DiGraph
 
     from dvc.stage import Stage
+
+T = TypeVar("T")
 
 
 def check_acyclic(graph: "DiGraph") -> None:
@@ -37,6 +39,26 @@ def get_pipelines(graph: "DiGraph"):
     import networkx as nx
 
     return [graph.subgraph(c).copy() for c in nx.weakly_connected_components(graph)]
+
+
+def get_subgraph_of_nodes(
+    graph: "DiGraph", sources: List[Any], downstream: bool = False
+) -> "DiGraph":
+    from networkx import dfs_postorder_nodes, reverse_view
+
+    assert sources
+    g = reverse_view(graph) if downstream else graph
+    nodes = []
+    for source in sources:
+        nodes.extend(dfs_postorder_nodes(g, source))
+    return graph.subgraph(nodes)
+
+
+def get_steps(graph: "DiGraph", sources: List[T], downstream: bool = False) -> List[T]:
+    from networkx import dfs_postorder_nodes
+
+    sub = get_subgraph_of_nodes(graph, sources, downstream=downstream)
+    return list(dfs_postorder_nodes(sub))
 
 
 def collect_pipeline(stage: "Stage", graph: "DiGraph") -> Iterator["Stage"]:

--- a/dvc/repo/graph.py
+++ b/dvc/repo/graph.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Iterator, List, Set, TypeVar
+from typing import TYPE_CHECKING, Any, Iterator, List, Optional, Set, TypeVar
 
 from dvc.fs import localfs
 from dvc.utils.fs import path_isin
@@ -42,11 +42,13 @@ def get_pipelines(graph: "DiGraph"):
 
 
 def get_subgraph_of_nodes(
-    graph: "DiGraph", sources: List[Any], downstream: bool = False
+    graph: "DiGraph", sources: Optional[List[Any]] = None, downstream: bool = False
 ) -> "DiGraph":
     from networkx import dfs_postorder_nodes, reverse_view
 
-    assert sources
+    if not sources:
+        return graph
+
     g = reverse_view(graph) if downstream else graph
     nodes = []
     for source in sources:
@@ -54,7 +56,9 @@ def get_subgraph_of_nodes(
     return graph.subgraph(nodes)
 
 
-def get_steps(graph: "DiGraph", sources: List[T], downstream: bool = False) -> List[T]:
+def get_steps(
+    graph: "DiGraph", sources: Optional[List[T]] = None, downstream: bool = False
+) -> List[T]:
     from networkx import dfs_postorder_nodes
 
     sub = get_subgraph_of_nodes(graph, sources, downstream=downstream)

--- a/tests/func/repro/test_repro.py
+++ b/tests/func/repro/test_repro.py
@@ -1282,3 +1282,17 @@ def test_repro_rm_recursive(tmp_dir, dvc):
     dvc.reproduce()
     assert (tmp_dir / "dir").exists()
     assert not (tmp_dir / "dir" / "foo").exists()
+
+
+def test_repro_single_item_with_multiple_targets(tmp_dir, dvc, copy_script):
+    stage1 = dvc.stage.add(cmd="echo foo > foo", outs=["foo"], name="gen-foo")
+    with dvc.lock:
+        stage1.run()
+
+    stage2 = dvc.stage.add(
+        cmd="python copy.py foo bar", deps=["foo"], outs=["bar"], name="copy-foo-bar"
+    )
+    assert dvc.reproduce(["copy-foo-bar", "gen-foo"], single_item=True) == [
+        stage2,
+        stage1,
+    ]

--- a/tests/unit/repo/test_graph.py
+++ b/tests/unit/repo/test_graph.py
@@ -8,12 +8,14 @@ from dvc.repo.graph import get_steps, get_subgraph_of_nodes
 @pytest.mark.parametrize(
     "nodes,downstream,expected_edges",
     [
+        ([], False, {1: [2, 3], 2: [4, 5], 3: [6, 7], 8: [9]}),
         ([1], False, {1: [2, 3], 2: [4, 5], 3: [6, 7]}),
         ([2], False, {2: [4, 5]}),
         ([3], False, {3: [6, 7]}),
         ([8], False, [(8, 9)]),
         ([2, 3, 8], False, {2: [4, 5], 3: [6, 7], 8: [9]}),
         ([4], False, {4: []}),
+        ([], True, {1: [2, 3], 2: [4, 5], 3: [6, 7], 8: [9]}),
         ([1], True, {1: []}),
         ([9], True, [(8, 9)]),
         ([2], True, [(1, 2)]),
@@ -39,12 +41,14 @@ def test_subgraph_of_nodes(nodes, downstream, expected_edges):
 @pytest.mark.parametrize(
     "nodes,downstream,expected_steps",
     [
+        ([], False, [4, 5, 2, 6, 7, 3, 1, 9, 8]),
         ([1], False, [4, 5, 2, 6, 7, 3, 1]),
         ([2], False, [4, 5, 2]),
         ([3], False, [6, 7, 3]),
         ([8], False, [9, 8]),
         ([2, 3, 8], False, [4, 5, 2, 6, 7, 3, 9, 8]),
         ([4], False, [4]),
+        ([], True, [4, 5, 2, 6, 7, 3, 1, 9, 8]),
         ([1], True, [1]),
         ([9], True, [9, 8]),
         ([2], True, [2, 1]),

--- a/tests/unit/repo/test_graph.py
+++ b/tests/unit/repo/test_graph.py
@@ -1,0 +1,65 @@
+import pytest
+from networkx import DiGraph
+from networkx.utils import graphs_equal
+
+from dvc.repo.graph import get_steps, get_subgraph_of_nodes
+
+
+@pytest.mark.parametrize(
+    "nodes,downstream,expected_edges",
+    [
+        ([1], False, {1: [2, 3], 2: [4, 5], 3: [6, 7]}),
+        ([2], False, {2: [4, 5]}),
+        ([3], False, {3: [6, 7]}),
+        ([8], False, [(8, 9)]),
+        ([2, 3, 8], False, {2: [4, 5], 3: [6, 7], 8: [9]}),
+        ([4], False, {4: []}),
+        ([1], True, {1: []}),
+        ([9], True, [(8, 9)]),
+        ([2], True, [(1, 2)]),
+        ([6], True, [(1, 3), (3, 6)]),
+        ([2, 3, 8], True, {1: [2, 3], 8: []}),
+        ([4, 7], True, {1: [2, 3], 2: [4], 3: [7]}),
+    ],
+)
+def test_subgraph_of_nodes(nodes, downstream, expected_edges):
+    r"""
+             1
+           /   \
+          2     3      8
+         / \   / \     |
+        4   5 6   7    9
+    """
+    graph = DiGraph({1: [2, 3], 2: [4, 5], 3: [6, 7], 8: [9]})
+    subgraph = get_subgraph_of_nodes(graph, nodes, downstream=downstream)
+    expected = DiGraph(expected_edges)
+    assert graphs_equal(expected, subgraph)
+
+
+@pytest.mark.parametrize(
+    "nodes,downstream,expected_steps",
+    [
+        ([1], False, [4, 5, 2, 6, 7, 3, 1]),
+        ([2], False, [4, 5, 2]),
+        ([3], False, [6, 7, 3]),
+        ([8], False, [9, 8]),
+        ([2, 3, 8], False, [4, 5, 2, 6, 7, 3, 9, 8]),
+        ([4], False, [4]),
+        ([1], True, [1]),
+        ([9], True, [9, 8]),
+        ([2], True, [2, 1]),
+        ([6], True, [6, 3, 1]),
+        ([2, 3, 8], True, [8, 2, 3, 1]),
+        ([4, 7], True, [4, 2, 7, 3, 1]),
+    ],
+)
+def test_steps(nodes, downstream, expected_steps):
+    r"""
+             1
+           /   \
+          2     3      8
+         / \   / \     |
+        4   5 6   7    9
+    """
+    graph = DiGraph({1: [2, 3], 2: [4, 5], 3: [6, 7], 8: [9]})
+    assert get_steps(graph, nodes, downstream=downstream) == expected_steps


### PR DESCRIPTION
This PR closes https://github.com/iterative/dvc/issues/9367, and makes a few other changes:

- `--single-item` now runs in the order the target is provided, instead of the position in it's dag. So, if you provide `dvc repro stage1 stage2 --single-item`, `stage1` will run before `stage2` even if `stage2` comes before `stage1`. Because that's what you want most of the time.
(And I did not want to complicate the code too much.)
- `--downstream` stages will run in the order of the graph instead of running stages of each target with post-order traversal.

The order is also enforced in normal cases, not just in `--downstream` by traversing the graph in post order. Previously, we were removing duplicates manually. 

https://github.com/iterative/dvc/blob/36ec25ffd78a23bb718036419eb28062edee6177/dvc/repo/reproduce.py#L222-L228