### PR TITLE
api.get_url: use index storage for getting remote URL

### DIFF
--- a/dvc/fs/dvc.py
+++ b/dvc/fs/dvc.py
@@ -54,6 +54,8 @@ def _merge_info(repo, key, fs_info, dvc_info):
         ret["size"] = dvc_info["size"]
         if not fs_info and "md5" in dvc_info:
             ret["md5"] = dvc_info["md5"]
+        if not fs_info and "md5-dos2unix" in dvc_info:
+            ret["md5-dos2unix"] = dvc_info["md5-dos2unix"]
 
     if fs_info:
         ret["type"] = fs_info["type"]

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -586,12 +586,16 @@ class Repo:
     def close(self):
         self.scm.close()
         self.state.close()
+        if "dvcfs" in self.__dict__:
+            self.dvcfs.close()
         if self._data_index is not None:
             self._data_index.close()
 
     def _reset(self):
         self.scm._reset()  # pylint: disable=protected-access
         self.state.close()
+        if "dvcfs" in self.__dict__:
+            self.dvcfs.close()
         self.__dict__.pop("index", None)
         self.__dict__.pop("dvcignore", None)
         self.__dict__.pop("dvcfs", None)

--- a/dvc/repo/open_repo.py
+++ b/dvc/repo/open_repo.py
@@ -67,6 +67,7 @@ def open_repo(url, *args, **kwargs):
         url = os.getcwd()
 
     if os.path.exists(url):
+        url = os.path.abspath(url)
         try:
             config = _get_remote_config(url)
             config.update(kwargs.get("config") or {})

--- a/tests/func/api/test_data.py
+++ b/tests/func/api/test_data.py
@@ -198,11 +198,13 @@ def test_get_url_subrepos(tmp_dir, scm, local_cloud):
         local_cloud / "files" / "md5" / "ac" / "bd18db4cc2f85cedef654fccc4a4d8"
     )
     assert api.get_url(os.path.join("subrepo", "dir", "foo")) == expected_url
+    assert api.get_url(os.path.join("subrepo", "dir", "foo"), repo=".") == expected_url
 
     expected_url = os.fspath(
         local_cloud / "files" / "md5" / "37" / "b51d194a7513e45b56f6524f2d51f2"
     )
     assert api.get_url("subrepo/bar") == expected_url
+    assert api.get_url("subrepo/bar", repo=".") == expected_url
 
 
 def test_open_from_remote(tmp_dir, erepo_dir, cloud, local_cloud):


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Fixes #9176

Previously, `dvc.api.get_url` just tried to get the default or specified remote and then manually generated a URL based on hard-coded `'md5'` dict lookup. As a result, it did not support per-output `remote:` settings and did not support cases where a legacy 2.x output would return `md5-dos2unix` info instead of `md5`.

- `DVCFileSystem.info()` now returns a properly generated `dvc_info['remote_url']` field for DVC outs that gets populated using the actual remote storage for the given data index entry (meaning per-output `remote:` is used when set, and default or `--remote` flag otherwise)
- `api.get_url` and `dvc get --show-url` now use the `remote_url` field from `dvcfs.info()`

cli:
```shell
$ dvc get --show-url . test.txt                      ⏎
s3://peter-test-unversioned-ap/legacy-test/files/md5/a2/ead3516dd1be4a3c7f45716c0a0eb7
$ dvc get --show-url . test-legacy.txt
s3://peter-test-unversioned-ap/legacy-test/26/8a5059001855fef30b4f95f82044ed
```

api:
```python
>>> from dvc.api import DVCFileSystem, get_url
>>> get_url("test-legacy.txt", repo=".")
's3://peter-test-unversioned-ap/legacy-test/26/8a5059001855fef30b4f95f82044ed'
>>> fs = DVCFileSystem(".")
>>> fs.info("test-legacy.txt")["dvc_info"]["remote_url"]
's3://peter-test-unversioned-ap/legacy-test/26/8a5059001855fef30b4f95f82044ed'
```