### PR TITLE
Add doctest for dagascii.draw

### DIFF
--- a/dvc/dagascii.py
+++ b/dvc/dagascii.py
@@ -209,6 +209,30 @@ def draw(vertices, edges):
     Args:
         vertices (list): list of graph vertices.
         edges (list): list of graph edges.
+
+    Returns:
+        str: ASCII representation
+
+    Example:
+        >>> from dvc.dagascii import draw
+        >>> vertices = [1, 2, 3, 4]
+        >>> edges = [(1, 2), (2, 3), (2, 4), (1, 4)]
+        >>> print(draw(vertices, edges))
+        +---+     +---+
+        | 3 |     | 4 |
+        +---+    *+---+
+          *    **   *
+          *  **     *
+          * *       *
+        +---+       *
+        | 2 |      *
+        +---+     *
+             *    *
+              *  *
+               **
+             +---+
+             | 1 |
+             +---+
     """
     # pylint: disable=too-many-locals
     # NOTE: coordinates might me negative, so we need to shift


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

This PR is just additional docs for the dagascii.draw function. Specifically documents the return value type and it adds a doctest to illustrate what the function does.

I'm a big fan of text representations of graphs. So when I was browsing the code and saw this I got excited. But while reading the code I wondered: what does this graph look like? I went through the effort of constructing a small example and printed it for myself. Certainly a nifty way to visualize a DAG. I think it would be nice if the code was able to provide a gist of that output without requireing the user to construct an example, and I think adding  a doctest here provides that.

Not sure how maintainers feel about doctests -- I see the repo has some of them, but not too many. As I learn codebases I often need to construct mwe to illustrate what a piece does for myself, so if the maintainers are interested, I'll continue submitting small PRs that add doctests like these as I generate them for myself. 