### PR TITLE
bandit: add exclusion for dvc/repo/experiments/utils.py back

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -303,5 +303,5 @@ ignore-names = ["M", "SCM"]
 max-args = 10
 
 [tool.bandit]
-exclude_dirs = ["tests"]
+exclude_dirs = ["tests", "dvc/repo/experiments/utils.py"]
 skips = ["B101"]


### PR DESCRIPTION
See https://github.com/PyCQA/bandit/pull/940.

Will not be needed when new version of bandit comes.

