### PR TITLE
repro: skip building pipelines for `--all-pipelines`

### DIFF
--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -59,7 +59,6 @@ def plan_repro(
     stages: Optional[List["Stage"]] = None,
     pipeline: bool = False,
     downstream: bool = False,
-    all_pipelines: bool = False,
 ) -> List["Stage"]:
     r"""Derive the evaluation of the given node for the given graph.
 
@@ -98,23 +97,20 @@ def plan_repro(
     """
     from .graph import get_pipeline, get_pipelines, get_steps
 
-    if pipeline or all_pipelines:
-        pipelines = get_pipelines(graph)
-        if stages and pipeline:
-            pipelines = [get_pipeline(pipelines, stage) for stage in stages]
-
+    active = _remove_frozen_stages(graph)
+    if stages and pipeline:
         leaves: List["Stage"] = []
+        pipelines = get_pipelines(active)
+        pipelines = [get_pipeline(pipelines, stage) for stage in stages]
         for pline in pipelines:
             leaves.extend(node for node in pline if pline.in_degree(node) == 0)
         stages = ldistinct(leaves)
-
-    active = _remove_frozen_stages(graph)
     return get_steps(active, stages, downstream=downstream)
 
 
 @locked
 @scm_context
-def reproduce(  # noqa: C901
+def reproduce(
     self: "Repo",
     targets: Union[Iterable[str], str, None] = None,
     recursive: bool = False,
@@ -145,13 +141,7 @@ def reproduce(  # noqa: C901
     steps = stages
     if pipeline or all_pipelines or not single_item:
         graph = self.index.graph
-        steps = plan_repro(
-            graph,
-            stages,
-            pipeline=pipeline,
-            downstream=downstream,
-            all_pipelines=all_pipelines,
-        )
+        steps = plan_repro(graph, stages, pipeline=pipeline, downstream=downstream)
     return _reproduce_stages(steps, **kwargs)
 
 


### PR DESCRIPTION
We don't need to build pipelines for `--all-pipelines`. We simply can run everything off of a graph, in dfs order.

Also fixes a bug where `--all-pipelines --downstream` would only run the leaves (i.e. output that no other stage depends on). `--downstream` should not be considered when using `--all-pipelines`, and should just run everything.
