### PR TITLE
repro: introduce --continue-on-error

### DIFF
--- a/dvc/commands/repro.py
+++ b/dvc/commands/repro.py
@@ -33,6 +33,7 @@ class CmdRepro(CmdBase):
             "force_downstream": self.args.force_downstream,
             "pull": self.args.pull,
             "allow_missing": self.args.allow_missing,
+            "on_error": "skip_dependents" if self.args.continue_on_error else "fail",
         }
 
     @property
@@ -135,6 +136,15 @@ and then the stage name name.
         default=False,
         help=(
             "Only print the commands that would be executed without actually executing."
+        ),
+    )
+    repro_parser.add_argument(
+        "--continue-on-error",
+        action="store_true",
+        default=False,
+        help=(
+            "Continue executing, skipping stages having dependencies "
+            "on the failed stages"
         ),
     )
 

--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -167,9 +167,7 @@ class InitError(DvcException):
 
 
 class ReproductionError(DvcException):
-    def __init__(self, name):
-        self.name = name
-        super().__init__(f"failed to reproduce '{name}'")
+    pass
 
 
 class BadMetricError(DvcException):

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -172,7 +172,7 @@ def _reproduce_stages(
             if callable(on_error):
                 on_error(e, stage)
                 continue
-            raise ReproductionError(f"failed to reproduce '{stage.addressing}'") from e
+            raise ReproductionError(f"failed to reproduce {stage.addressing!r}") from e
 
         if not ret:
             stats.unchanged.append(stage)

--- a/tests/unit/command/test_repro.py
+++ b/tests/unit/command/test_repro.py
@@ -14,6 +14,7 @@ common_arguments = {
     "pull": False,
     "allow_missing": False,
     "targets": [],
+    "on_error": "fail",
 }
 repro_arguments = {
     "run_cache": True,


### PR DESCRIPTION
Fixes #8647 and #7292.

TODO:
- [ ] Tests
- [ ] How to get rid of an extra newline at the end?


This PR might change the execution order.
```mermaid
graph TD
6-->2
7-->2
3-->1
4-->3
5-->3
2-->1
```

If you have a graph like this, the execution order would have been: `[4,5,3,6,7,2,1]`.
It's a valid topological ordering.

But with this PR, we'll do order based on degree, so, zero-degree nodes `4,5,6,7` will get processed first, then `3` and `2` will be processed and then `1`. i.e. `[4,5,6,7,3,2,1]`.
Which is still a valid topological ordering.

I think the new logic makes it simpler for implementing `--continue-on-error`, and allows easier parallelization in the future.