### PR TITLE
improve error message for 1.0 lockfile format

### DIFF
--- a/dvc/schema.py
+++ b/dvc/schema.py
@@ -42,9 +42,10 @@ LOCK_FILE_STAGE_SCHEMA = {
     StageParams.PARAM_OUTS: [DATA_SCHEMA],
 }
 
+NO_SCHEMA_MSG = "This is a 1.0 lockfile format which is unsupported in dvc>=3.0"
 LOCKFILE_STAGES_SCHEMA = {str: LOCK_FILE_STAGE_SCHEMA}
 LOCKFILE_SCHEMA = {
-    Required("schema"): Equal("2.0", "invalid schema version"),
+    Required("schema", NO_SCHEMA_MSG): Equal("2.0", "invalid schema version"),
     STAGES: LOCKFILE_STAGES_SCHEMA,
 }
 


### PR DESCRIPTION
```console
'./dvc.lock' validation failed: 5 errors.                             

extra keys not allowed, in prepare, line 2, column 3
   1 prepare:                                                                   
   2   cmd: python src/prepare.py data/data.xml                                 

extra keys not allowed, in featurize, line 16, column 3
  15 featurize:                                                                 
  16   cmd: python src/featurization.py data/prepared data/features             

extra keys not allowed, in train, line 30, column 3
  29 train:                                                                     
  30   cmd: python src/train.py data/features model.pkl                         

extra keys not allowed, in evaluate, line 44, column 3
  43 evaluate:                                                                  
  44   cmd: python src/evaluate.py model.pkl data/features scores.json prc.json 

This is a 1.0 lockfile format which is unsupported in dvc>=3.0, in schema
```

It'll look something like above. We cannot stop early in voluptuous without specifically handling it, so dvc will still report other errors. Studio will still get `ValidationError` which it will have to parse if it needs this information.


