### PR TITLE
plots: log failures during datapoint conversions

### DIFF
--- a/dvc/render/match.py
+++ b/dvc/render/match.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from collections import defaultdict
 from typing import TYPE_CHECKING, DefaultDict, Dict, List, NamedTuple, Optional
@@ -17,6 +18,7 @@ if TYPE_CHECKING:
 
 
 dpath.options.ALLOW_EMPTY_STRING_KEYS = True
+logger = logging.getLogger(__name__)
 
 
 def _squash_plots_properties(data: List) -> Dict:
@@ -113,6 +115,7 @@ def match_defs_renderers(  # noqa: C901, PLR0912
             try:
                 dps, rev_props = converter.flat_datapoints(rev)
             except Exception as e:  # noqa: BLE001, pylint: disable=broad-except
+                logger.warning("In %r, %s", rev, str(e).lower())
                 def_errors[rev] = e
                 continue
 


### PR DESCRIPTION
Fixes #9441.

Note that we do merge props, and use that for all revision. So you may see a warning for each revisions.

Example output:
```console
$ dvc plots diff
WARNING: In 'workspace', could not find provided field ('accss') in data fields ('step, acc').                                                                                                                       
WARNING: In 'HEAD', could not find provided field ('accss') in data fields ('step, acc').
file:///home/saugat/projects/iterative/vscode-dvc-demo/dvc_plots/index.html
```