### PR TITLE
Add parent ctr init call in InvalidArgumentError

### DIFF
--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -17,6 +17,10 @@ class DvcException(Exception):
 class InvalidArgumentError(ValueError, DvcException):
     """Thrown if arguments are invalid."""
 
+    def __init__(self, msg, *args):
+        self.msg = msg
+        super().__init__(msg, *args)
+
 
 class OutputDuplicationError(DvcException):
     """Thrown if a file/directory is specified as an output in more than one


### PR DESCRIPTION
Fix for https://github.com/iterative/studio/issues/6897 (internal ticket).

## Summary:

```python
InvalidArgumentError: Can't use 'bad_name' as artifact name (ID). You can use letters and numbers, and use '-' as separator (but not at the start or end).
  File "dvc/repo/artifacts.py", line 65, in read
    check_name_format(name)
  File "dvc/repo/artifacts.py", line 32, in check_name_format
    raise InvalidArgumentError(

AttributeError: 'InvalidArgumentError' object has no attribute 'msg'
```

Bad name was causing a failure an unexpected `AttributeError` and breaking the parser in Studio.

## Next steps

Separate followup question to discuss is why we allow these names silently. Tbh, I think it's better for us:

- to fail fast here cc @daavoo @dberenbaum @aguschin what was the reason behind this decision? 
- also why don't we allow `_` (it seems as natural as `-`)?

-----------

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [X] ~📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.~

