### PR TITLE
out: str: don't try to relpath paths outside of the repo

### DIFF
--- a/dvc/output.py
+++ b/dvc/output.py
@@ -488,6 +488,9 @@ class Output:
         ):
             return str(self.def_path)
 
+        if not self.fs.path.isin(self.fs_path, self.repo.root_dir):
+            return self.fs_path
+
         cur_dir = self.fs.path.getcwd()
         if self.fs.path.isin(cur_dir, self.repo.root_dir):
             return self.fs.path.relpath(self.fs_path, cur_dir)

--- a/tests/unit/output/test_local.py
+++ b/tests/unit/output/test_local.py
@@ -2,7 +2,6 @@ import os
 
 from dvc.output import Output
 from dvc.stage import Stage
-from dvc.utils import relpath
 from dvc_data.hashfile.hash_info import HashInfo
 from dvc_data.hashfile.meta import Meta
 
@@ -11,7 +10,7 @@ def test_str_workdir_outside_repo(tmp_dir, erepo_dir):
     stage = Stage(erepo_dir.dvc)
     output = Output(stage, "path", cache=False)
 
-    assert relpath("path", erepo_dir.dvc.root_dir) == str(output)
+    assert os.path.abspath("path") == str(output)
 
 
 def test_str_workdir_inside_repo(dvc):


### PR DESCRIPTION
This is not very useful overall, but also results in a ValueError from relpath on windows if your repo and output are on different drives.

