### PR TITLE
ruff: enable autofix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ repos:
     rev: 'v0.0.282'
     hooks:
       - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.5
     hooks:


### PR DESCRIPTION
Let's enable autofix in ruff as an experiment.

If it breaks code too often or gets too aggressive, we can rollback or set `unfixable` in the pyproject.toml file as follows:

```toml
[tool.ruff]
unfixable = ["B", "SIM", "TRY", "RUF"]
```