### PR TITLE
exp show: show metrics that include separator

### DIFF
--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -177,7 +177,7 @@ def _build_rows(
                 )
 
 
-def _sort_column(
+def _sort_column(  # noqa: C901
     sort_by: str,
     metric_names: Mapping[str, Iterable[str]],
     param_names: Mapping[str, Iterable[str]],
@@ -190,13 +190,13 @@ def _sort_column(
             matches.add((path, sort_name, "metrics"))
         if path in param_names and sort_name in param_names[path]:
             matches.add((path, sort_name, "params"))
-    else:
+    if not matches:
         for path in metric_names:
-            if sort_name in metric_names[path]:
-                matches.add((path, sort_name, "metrics"))
+            if sort_by in metric_names[path]:
+                matches.add((path, sort_by, "metrics"))
         for path in param_names:
-            if sort_name in param_names[path]:
-                matches.add((path, sort_name, "params"))
+            if sort_by in param_names[path]:
+                matches.add((path, sort_by, "params"))
 
     if len(matches) == 1:
         return matches.pop()

--- a/tests/func/experiments/test_show.py
+++ b/tests/func/experiments/test_show.py
@@ -352,6 +352,15 @@ def test_show_sort(tmp_dir, scm, dvc, exp_stage, caplog):
     assert main(["exp", "show", "--no-pager", "--sort-by=metrics.yaml:foo"]) == 0
 
 
+def test_show_sort_metric_sep(tmp_dir, scm, dvc, caplog):
+    metrics_path = tmp_dir / "metrics.json"
+    metrics_path.write_text('{"my::metric": 1}')
+    dvcyaml_path = tmp_dir / "dvc.yaml"
+    dvcyaml_path.write_text("metrics: [metrics.json]")
+    dvc.experiments.save()
+    assert main(["exp", "show", "--no-pager", "--sort-by=my::metric"]) == 0
+
+
 @pytest.mark.vscode
 @pytest.mark.parametrize(
     "status, pid_exists",


### PR DESCRIPTION
Fixes `dvc exp show --sort-by` when `:` separator is included in metric name (see https://iterativeai.slack.com/archives/C03JS2V4MQU/p1691415243711839). Not sure if we should explicitly allow this, but I don't see any harm with this fix.