### PR TITLE
config: use local config from local_dvc_dir

### DIFF
--- a/dvc/config.py
+++ b/dvc/config.py
@@ -90,6 +90,7 @@ class Config(dict):
     def __init__(
         self,
         dvc_dir: Optional["StrPath"] = None,
+        local_dvc_dir: Optional["StrPath"] = None,
         validate: bool = True,
         fs: Optional["FileSystem"] = None,
         config: Optional["DictStrAny"] = None,
@@ -104,6 +105,10 @@ class Config(dict):
 
         if dvc_dir:
             self.dvc_dir = self.fs.path.abspath(dvc_dir)
+
+        self.local_dvc_dir = local_dvc_dir
+        if not fs and not local_dvc_dir:
+            self.local_dvc_dir = dvc_dir
 
         self.load(
             validate=validate, config=config, remote=remote, remote_config=remote_config
@@ -140,7 +145,9 @@ class Config(dict):
 
         if self.dvc_dir is not None:
             files["repo"] = self.fs.path.join(self.dvc_dir, self.CONFIG)
-            files["local"] = self.fs.path.join(self.dvc_dir, self.CONFIG_LOCAL)
+
+        if self.local_dvc_dir is not None:
+            files["local"] = self.wfs.path.join(self.local_dvc_dir, self.CONFIG_LOCAL)
 
         return files
 

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -244,6 +244,7 @@ class Repo:
 
         return Config(
             self.dvc_dir,
+            local_dvc_dir=self.local_dvc_dir,
             fs=self.fs,
             config=self._config,
             remote=self._remote,


### PR DESCRIPTION
This used to work like so but by accident, when we didn't reload config at all when collecting other revisions.

Regression from https://github.com/iterative/dvc/pull/9758

Testing is a bit tricky, but easy to run into when using (e.g. `dvc fetch --all-commits` when you have an azure remote that you need to set credentials for).

