### PR TITLE
pyinstaller: declare dvc_ssh as hidden import

### DIFF
--- a/dvc/__pyinstaller/hook-dvc.py
+++ b/dvc/__pyinstaller/hook-dvc.py
@@ -22,6 +22,7 @@ hiddenimports = [
     "dvc_hdfs",
     "dvc_oss",
     "dvc_s3",
+    "dvc_ssh",
     "dvc_webdav",
     "dvc_webhdfs",
     # https://github.com/pypa/setuptools/issues/1963


### PR DESCRIPTION
Likely with removal of dvc-machine pyinstaller stopped picking up dvc_ssh automatically, so we need to declare it explicitly just like the rest of plugins.

