### PR TITLE
ls/ls-url: introduce --size

### DIFF
--- a/dvc/commands/ls_url.py
+++ b/dvc/commands/ls_url.py
@@ -3,9 +3,8 @@ import logging
 
 from dvc.cli.command import CmdBaseNoRepo
 from dvc.cli.utils import append_doc_link
-from dvc.ui import ui
 
-from .ls import _prettify
+from .ls import show_entries
 
 logger = logging.getLogger(__name__)
 
@@ -16,8 +15,7 @@ class CmdListUrl(CmdBaseNoRepo):
 
         entries = Repo.ls_url(self.args.url, recursive=self.args.recursive)
         if entries:
-            entries = _prettify(entries, with_color=True)
-            ui.write("\n".join(entries))
+            show_entries(entries, with_color=True, with_size=self.args.size)
         return 0
 
 
@@ -39,5 +37,10 @@ def add_parser(subparsers, parent_parser):
         "--recursive",
         action="store_true",
         help="Recursively list files.",
+    )
+    lsurl_parser.add_argument(
+        "--size",
+        action="store_true",
+        help="Show sizes.",
     )
     lsurl_parser.set_defaults(func=CmdListUrl)

--- a/dvc/repo/ls.py
+++ b/dvc/repo/ls.py
@@ -109,6 +109,7 @@ def _ls(
             "isout": dvc_info.get("isout", False),
             "isdir": info["type"] == "directory",
             "isexec": info.get("isexec", False),
+            "size": info.get("size"),
         }
 
     return ret

--- a/dvc/repo/ls_url.py
+++ b/dvc/repo/ls_url.py
@@ -20,6 +20,7 @@ def ls_url(url, *, config=None, recursive=False):
             ls_info = {
                 "path": fs.path.relpath(info["name"], fs_path),
                 "isdir": info["type"] == "directory",
+                "size": info.get("size"),
             }
             ret.append(ls_info)
 


### PR DESCRIPTION
I really need it only for studio right now, but this is really nice to have in a daily life as well.

Caveat: we just throw whatever we have in `size` field, which means that for `dvcfs`,  you might get a disk-usage size for a directory instead of its physical size that usually is completely useless (see your ls -la). I think that's acceptable for now, but we will need `dvc du` for `du` purposes in the future.

E.g.

```
$ dvc ls-url . --size
108    Metadata-and-Results.dvc
97     AudioMP3.dvc
97     AudioWAV.dvc
12181  README.md
54     .gitignore
168    .gitattributes
99     VideoFlash.dvc
312    LICENSE.txt
139    .dvcignore
96     AudioMP3
96     Asset
192    .dvc
64     Metadata-and-Results
64     AudioWAV
192    Scripts
64     VideoFlash
384    .git
96     .vscode
```

```
$ dvc list . --size
139    .dvcignore
168    .gitattributes
54     .gitignore
96     .vscode
96     Asset
96     AudioMP3
97     AudioMP3.dvc
64     AudioWAV
97     AudioWAV.dvc
312    LICENSE.txt
64     Metadata-and-Results
108    Metadata-and-Results.dvc
12181  README.md
192    Scripts
64     VideoFlash
99     VideoFlash.dvc
```

Related https://github.com/iterative/studio/pull/6541