### PR TITLE
deps: test: remove pytest-docker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,6 @@ tests = [
     "flaky",
     "pytest<8,>=7",
     "pytest-cov>=4.1.0",
-    "pytest-docker>=1,<2",
     "pytest-lazy-fixture",
     "pytest-mock",
     "pytest-test-utils",


### PR DESCRIPTION
We don't use it anymore.

Closes #9748
