### PR TITLE
ls/ls-url: use humanize.naturalsize instead of tqdm

### DIFF
--- a/dvc/commands/ls/__init__.py
+++ b/dvc/commands/ls/__init__.py
@@ -1,8 +1,6 @@
 import argparse
 import logging
 
-from tqdm import tqdm
-
 from dvc.cli import completion
 from dvc.cli.command import CmdBaseNoRepo
 from dvc.cli.utils import DictAction, append_doc_link
@@ -14,11 +12,13 @@ logger = logging.getLogger(__name__)
 
 
 def _format_entry(entry, fmt):
+    from humanize import naturalsize
+
     size = entry.get("size")
     if size is None:
         size = ""
     else:
-        size = tqdm.format_sizeof(size, divisor=1024)
+        size = naturalsize(size, gnu=True)
     return size, fmt(entry)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dependencies = [
     "tqdm<5,>=4.63.1",
     "voluptuous>=0.11.7",
     "zc.lockfile>=1.2.1",
+    "humanize",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Currently we get odd formatting like

```
456    .devcontainer.json
139    .dvcignore
61.0   .gitattributes
96.0   .github
7.00   .gitignore
5.76k  README.md
160    data
1.84k  dvc.lock
519    dvc.yaml
4.00   foo
96.0   models
96.0   notebooks
225    params.yaml
46.0   requirements.txt
128    results
160    src
```

(notice stuff like 46.0)

and there doesn't seem to be a simple way to fix that in tqdm, in addition to the general feeling that we are abusing tqdm's util for this.

So let's just use `humanize`, which gets us a more pleasing result:

```
456B  .devcontainer.json
139B  .dvcignore
61B   .gitattributes
96B   .github
7B    .gitignore
5.8K  README.md
160B  data
1.8K  dvc.lock
519B  dvc.yaml
4B    foo
96B   models
96B   notebooks
225B  params.yaml
46B   requirements.txt
128B  results
160B  src
```

Followup for https://github.com/iterative/dvc/pull/9854
