### PR TITLE
Rename partial add/remove benchmarks

### DIFF
--- a/dvc/testing/benchmarks/cli/stories/test_modify_data.py
+++ b/dvc/testing/benchmarks/cli/stories/test_modify_data.py
@@ -51,7 +51,7 @@ def test_partial_remove(bench_dvc, tmp_dir, dvc, dataset, remote):
                 shutil.rmtree(dataset / f)
 
     # Benchmark operations for removing files from dataset
-    bench_dvc("add", dataset, name="noop")
-    bench_dvc("push", name="noop")
+    bench_dvc("add", dataset, name="update")
+    bench_dvc("push", name="update")
     bench_dvc("gc", "-f", "-w")
     bench_dvc("gc", "-f", "-w", "-c", name="cloud")

--- a/dvc/testing/benchmarks/cli/stories/test_modify_data.py
+++ b/dvc/testing/benchmarks/cli/stories/test_modify_data.py
@@ -29,8 +29,8 @@ def test_partial_add(bench_dvc, tmp_dir, dvc, dataset, remote):
     shutil.copytree("partial-copy", dataset, dirs_exist_ok=True)
 
     # Benchmark operations for adding files to a dataset
-    bench_dvc("add", dataset, name="partial-add")
-    bench_dvc("push", name="partial-add")
+    bench_dvc("add", dataset, name="partial")
+    bench_dvc("push", name="partial")
     bench_dvc("gc", "-f", "-w", name="noop")
     bench_dvc("gc", "-f", "-w", "-c", name="cloud-noop")
 
@@ -51,7 +51,7 @@ def test_partial_remove(bench_dvc, tmp_dir, dvc, dataset, remote):
                 shutil.rmtree(dataset / f)
 
     # Benchmark operations for removing files from dataset
-    bench_dvc("add", dataset)
-    bench_dvc("push")
+    bench_dvc("add", dataset, name="noop")
+    bench_dvc("push", name="noop")
     bench_dvc("gc", "-f", "-w")
     bench_dvc("gc", "-f", "-w", "-c", name="cloud")


### PR DESCRIPTION
Better naming for some benchmarks and fixes issues due to duplicate naming that cause plots like this:

![visualization(10)](https://github.com/iterative/dvc/assets/2308172/6de80b24-732d-437b-803f-8f245a1b3f42)
