### PR TITLE
tests: dvcfs: use fspath while testing

### DIFF
--- a/dvc/testing/api_tests.py
+++ b/dvc/testing/api_tests.py
@@ -117,10 +117,10 @@ class TestAPI:
             assert fobj.read() == b"script1"
 
         tmp = make_tmp_dir("temp-download")
-        fs.get_file("data/foo", tmp / "foo")
+        fs.get_file("data/foo", (tmp / "foo").fs_path)
         assert (tmp / "foo").read_text() == "foo"
 
-        fs.get_file("scripts/script1", tmp / "script1")
+        fs.get_file("scripts/script1", (tmp / "script1").fs_path)
         assert (tmp / "script1").read_text() == "script1"
 
         fs.get("/", (tmp / "all").fs_path, recursive=True)


### PR DESCRIPTION
get_file does not support PathLike objects. fsspec does not support them in get_file.

See https://github.com/fsspec/filesystem_spec/issues/896. Fixes test failures in dvc-webhdfs and dvc-hdfs.

