### PR TITLE
update: preserve `def_path` for version-aware import update

### DIFF
--- a/dvc/dependency/base.py
+++ b/dvc/dependency/base.py
@@ -44,9 +44,6 @@ class Dependency(Output):
         if self.fs.version_aware:
             self.fs_path = self.fs.path.version_path(self.fs_path, rev)
             self.meta = self.get_meta()
-            self.def_path = self.fs.path.version_path(
-                self.def_path, self.meta.version_id
-            )
             self.fs_path = self.fs.path.version_path(self.fs_path, self.meta.version_id)
 
     def download(self, to, jobs=None):

--- a/dvc/testing/workspace_tests.py
+++ b/dvc/testing/workspace_tests.py
@@ -95,6 +95,9 @@ class TestImportURLVersionAware:
         assert (tmp_dir / "file").read_text() == "file"
         assert dvc.status() == {}
 
+        orig_version_id = stage.deps[0].meta.version_id
+        orig_def_path = stage.deps[0].def_path
+
         dvc.cache.local.clear()
         remove(tmp_dir / "file")
         dvc.pull()
@@ -107,6 +110,10 @@ class TestImportURLVersionAware:
         dvc.update(str(tmp_dir / "file.dvc"))
         assert (tmp_dir / "file").read_text() == "modified"
         assert dvc.status() == {}
+
+        stage = first(dvc.index.stages)
+        assert orig_version_id != stage.deps[0].meta.version_id
+        assert orig_def_path == stage.deps[0].def_path
 
         dvc.cache.local.clear()
         remove(tmp_dir / "file")


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Fixes issue noted in slack
```
dvc import-url --version-aware ...
dvc update
```
would result in a modified `path:` for the `deps` entry (after the update, the path would contained a versioned path and no `version_id` field instead of an unversioned path + `version_id` field)