### PR TITLE
repo: don't try to gitignore custom cache locations

### DIFF
--- a/dvc/cachemgr.py
+++ b/dvc/cachemgr.py
@@ -42,11 +42,8 @@ class CacheManager:
         self.config = config = repo.config["cache"]
         self._odb = {}
 
-        default = None
-        if repo and repo.local_dvc_dir:
-            default = os.path.join(repo.local_dvc_dir, self.CACHE_DIR)
-
         local = config.get("local")
+        default = self.default_local_cache_dir
 
         if local:
             settings = {"name": local}
@@ -102,6 +99,13 @@ class CacheManager:
         (i.e. `dvc cache dir`).
         """
         return self.legacy.path
+
+    @property
+    def default_local_cache_dir(self) -> Optional[str]:
+        repo = self._repo
+        if repo and repo.local_dvc_dir:
+            return os.path.join(repo.local_dvc_dir, self.CACHE_DIR)
+        return None
 
 
 def migrate_2_to_3(repo: "Repo", dry: bool = False):

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -15,7 +15,6 @@ from typing import (
 
 from dvc.exceptions import NotDvcRepoError, OutputNotFoundError
 from dvc.ignore import DvcIgnoreFilter
-from dvc.utils.fs import path_isin
 from dvc.utils.objects import cached_property
 
 if TYPE_CHECKING:
@@ -455,8 +454,9 @@ class Repo:
         flist = [self.config.files["local"]]
         if tmp_dir := self.tmp_dir:
             flist.append(tmp_dir)
-        if path_isin(self.cache.legacy.path, self.root_dir):
-            flist.append(self.cache.legacy.path)
+
+        if cache_dir := self.cache.default_local_cache_dir:
+            flist.append(cache_dir)
 
         for file in flist:
             self.scm_context.ignore(file)


### PR DESCRIPTION
If user uses some custom cache location, there is really no reason for us to try to gitignore it, as we have no idea what he is planning to do with that and overall it often might be sign of this being misused. Maybe we could also have some warnings/errors, but that's out of scope for this PR.

Fixes https://github.com/iterative/studio/issues/7405

