### PR TITLE
cli: utils: DictAction: limit split to 2 elements

### DIFF
--- a/dvc/cli/utils.py
+++ b/dvc/cli/utils.py
@@ -11,7 +11,7 @@ class DictAction(argparse.Action):
             kvs = [values]
 
         for kv in kvs:
-            key, value = kv.split("=")
+            key, value = kv.split("=", 1)
             if not value:
                 raise argparse.ArgumentError(
                     self,


### PR DESCRIPTION
If value contains more `=`, this will currently error out with too many values to unpack.

Related #9886