### PR TITLE
Fix Repo instantiation error when using fsspec chaining API

### DIFF
--- a/dvc/fs/dvc.py
+++ b/dvc/fs/dvc.py
@@ -83,6 +83,11 @@ class _DVCFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
         repo: Optional["Repo"] = None,
         subrepos: bool = False,
         repo_factory: Optional[RepoFactory] = None,
+        fo: Optional[str] = None,
+        # pylint:disable-next=unused-argument
+        target_options: Optional[Dict[str, Any]] = None,  # noqa: ARG002
+        # pylint:disable-next=unused-argument
+        target_protocol: Optional[str] = None,  # noqa: ARG002
         **repo_kwargs: Any,
     ) -> None:
         """DVC + git-tracked files fs.
@@ -125,6 +130,7 @@ class _DVCFileSystem(AbstractFileSystem):  # pylint:disable=abstract-method
         super().__init__()
         self._repo_stack = ExitStack()
         if repo is None:
+            url = url if url is not None else fo
             repo = self._make_repo(url=url, rev=rev, subrepos=subrepos, **repo_kwargs)
             assert repo is not None
             # pylint: disable=protected-access


### PR DESCRIPTION
Fixes #9896

`DVCFileSystem` can now be instantiated using a `fsspec`-compliant URL. 

Example:

```python
from fsspec.core import url_to_fs

fs, _ = url_to_fs("dvc::https://gitlab.com/repository/group/my-repo")
```

Not sure how to test this, feel free to give feedback on that.

PS: It unfortunately does not solve my original use case of loading a file using HuggingFace datasets, it seems that `datasets` expects the URL to be fully qualified like so: `dvc::https://gitlab.com/repository/group/my-repo/my-folder/my-file.json` but this fails because `DVCFileSystem` expects the URL to point to the root of an SCM repo. Not sure how to continue from here, according to you is it an issue with DVC or HuggingFace datasets?
