### PR TITLE
move: Alias mv to move

### DIFF
--- a/dvc/commands/experiments/ls.py
+++ b/dvc/commands/experiments/ls.py
@@ -59,6 +59,7 @@ def add_parser(experiments_subparsers, parent_parser):
     EXPERIMENTS_LIST_HELP = "List local and remote experiments."
     experiments_list_parser = experiments_subparsers.add_parser(
         "list",
+        aliases=["ls"],
         parents=[parent_parser],
         description=append_doc_link(EXPERIMENTS_LIST_HELP, "exp/list"),
         help=EXPERIMENTS_LIST_HELP,

--- a/dvc/commands/experiments/remove.py
+++ b/dvc/commands/experiments/remove.py
@@ -50,6 +50,7 @@ def add_parser(experiments_subparsers, parent_parser):
     EXPERIMENTS_REMOVE_HELP = "Remove experiments."
     experiments_remove_parser = experiments_subparsers.add_parser(
         "remove",
+        aliases=["rm"],
         parents=[parent_parser],
         description=append_doc_link(EXPERIMENTS_REMOVE_HELP, "exp/remove"),
         help=EXPERIMENTS_REMOVE_HELP,

--- a/dvc/commands/move.py
+++ b/dvc/commands/move.py
@@ -40,3 +40,17 @@ def add_parser(subparsers, parent_parser):
     ).complete = completion.FILE
     move_parser.add_argument("dst", help="Destination path.").complete = completion.FILE
     move_parser.set_defaults(func=CmdMove)
+
+    mv_parser = subparsers.add_parser(
+        "mv",
+        parents=[parent_parser],
+        description=append_doc_link(MOVE_DESCRIPTION, "move"),
+        help=MOVE_HELP,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    mv_parser.add_argument(
+        "src", help="Source path to a data file or directory."
+    ).complete = completion.FILE
+    mv_parser.add_argument("dst", help="Destination path.").complete = completion.FILE
+    mv_parser.set_defaults(func=CmdMove)

--- a/dvc/commands/move.py
+++ b/dvc/commands/move.py
@@ -30,6 +30,7 @@ def add_parser(subparsers, parent_parser):
 
     move_parser = subparsers.add_parser(
         "move",
+        aliases=["mv"],
         parents=[parent_parser],
         description=append_doc_link(MOVE_DESCRIPTION, "move"),
         help=MOVE_HELP,
@@ -40,17 +41,3 @@ def add_parser(subparsers, parent_parser):
     ).complete = completion.FILE
     move_parser.add_argument("dst", help="Destination path.").complete = completion.FILE
     move_parser.set_defaults(func=CmdMove)
-
-    mv_parser = subparsers.add_parser(
-        "mv",
-        parents=[parent_parser],
-        description=append_doc_link(MOVE_DESCRIPTION, "move"),
-        help=MOVE_HELP,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
-
-    mv_parser.add_argument(
-        "src", help="Source path to a data file or directory."
-    ).complete = completion.FILE
-    mv_parser.add_argument("dst", help="Destination path.").complete = completion.FILE
-    mv_parser.set_defaults(func=CmdMove)

--- a/dvc/commands/remove.py
+++ b/dvc/commands/remove.py
@@ -26,6 +26,7 @@ def add_parser(subparsers, parent_parser):
     )
     remove_parser = subparsers.add_parser(
         "remove",
+        aliases=["rm"],
         parents=[parent_parser],
         description=append_doc_link(REMOVE_HELP, "remove"),
         help=REMOVE_HELP,


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Docs Issue: https://github.com/iterative/dvc.org/issues/4825

Fixes: #9901 

Alias `dvc mv` to have same functionality as `dvc move`
Alias `dvc rm` = `dvc remove`
Alias `dvc exp ls` = `dvc exp list`
Alias `dvc exp rm` = `dvc exp remove`
