### PR TITLE
stage.run: always set DVC_ROOT env var

### DIFF
--- a/dvc/repo/experiments/queue/base.py
+++ b/dvc/repo/experiments/queue/base.py
@@ -348,6 +348,8 @@ class BaseStashQueue(ABC):
                     if not name:
                         name = get_random_exp_name(self.scm, baseline_rev)
                     run_env[DVC_EXP_NAME] = name
+                    # Override DVC_ROOT env var to point to the parent DVC repo
+                    # root (and not an executor tempdir root)
                     run_env[DVC_ROOT] = self.repo.root_dir
 
                     # save studio config to read later by dvc and dvclive

--- a/dvc/stage/run.py
+++ b/dvc/stage/run.py
@@ -39,10 +39,14 @@ def _enforce_cmd_list(cmd):
 
 
 def prepare_kwargs(stage, run_env=None):
+    from dvc.env import DVC_ROOT
+
     kwargs = {"cwd": stage.wdir, "env": fix_env(None), "close_fds": True}
 
     if run_env:
         kwargs["env"].update(run_env)
+    if DVC_ROOT not in kwargs["env"]:
+        kwargs["env"][DVC_ROOT] = stage.repo.root_dir
 
     # NOTE: when you specify `shell=True`, `Popen` [1] will default to
     # `/bin/sh` on *nix and will add ["/bin/sh", "-c"] to your command.


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Related https://github.com/iterative/dvclive/issues/670

- Sets `DVC_ROOT` env var during stage execution regardless of whether pipeline is run with `dvc repro` or `dvc exp run` 
- `DVC_ROOT` always points to the main/parent DVC repo root. (For `dvc exp run`, it will not point to temp/queue executor tempdirs)