### PR TITLE
checkout: Expose `--allow-missing` arg.

### DIFF
--- a/dvc/commands/checkout.py
+++ b/dvc/commands/checkout.py
@@ -37,6 +37,7 @@ class CmdCheckout(CmdBase):
                 force=self.args.force,
                 relink=self.args.relink,
                 recursive=self.args.recursive,
+                allow_missing=self.args.allow_missing,
             )
         except CheckoutError as _exc:
             exc = _exc
@@ -100,6 +101,12 @@ def add_parser(subparsers, parent_parser):
         action="store_true",
         default=False,
         help="Recreate links or copies from cache to workspace.",
+    )
+    checkout_parser.add_argument(
+        "--allow-missing",
+        action="store_true",
+        default=False,
+        help="Ignore errors if some of the files or directories are missing.",
     )
     checkout_parser.add_argument(
         "targets",

--- a/tests/unit/command/test_checkout.py
+++ b/tests/unit/command/test_checkout.py
@@ -16,6 +16,7 @@ def test_checkout(tmp_dir, dvc, mocker):
         recursive=False,
         relink=True,
         with_deps=True,
+        allow_missing=False,
     )
 
 


### PR DESCRIPTION
```console
$ git clone https://github.com/iterative/example-get-started-experiments
$ cd example-get-started-experiments
$ dvc fetch models/model.pkl
$ dvc checkout
A       models/model.pkl
ERROR: Checkout failed for following targets:
data/pool_data
data/train_data
data/test_data
model.tar.gz
models/model.pth
results/evaluate/plots/images
Is your cache up to date?
<https://error.dvc.org/missing-files>
```

```console
$ git clone https://github.com/iterative/example-get-started-experiments
$ cd example-get-started-experiments
$ dvc fetch models/model.pkl
$ dvc checkout --allow-missing
A       models/model.pkl
```
