### PR TITLE
import: Expose `--force` flag

### DIFF
--- a/dvc/commands/imp.py
+++ b/dvc/commands/imp.py
@@ -25,6 +25,7 @@ class CmdImport(CmdBase):
                 config=self.args.config,
                 remote=self.args.remote,
                 remote_config=self.args.remote_config,
+                force=self.args.force,
             )
         except CloneError:
             logger.exception("failed to import '%s'", self.args.path)
@@ -65,6 +66,13 @@ def add_parser(subparsers, parent_parser):
         help="Destination path to download files to",
         metavar="<path>",
     ).complete = completion.DIR
+    import_parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        default=False,
+        help="Override destination file or folder if exists.",
+    )
     import_parser.add_argument(
         "--rev",
         nargs="?",

--- a/tests/unit/command/test_imp.py
+++ b/tests/unit/command/test_imp.py
@@ -41,6 +41,7 @@ def test_import(mocker, dvc):
         config="myconfig",
         remote="myremote",
         remote_config={"k1": "v1", "k2": "v2"},
+        force=False,
     )
 
 
@@ -74,6 +75,7 @@ def test_import_no_exec(mocker, dvc):
         config=None,
         remote=None,
         remote_config=None,
+        force=False,
     )
 
 
@@ -107,4 +109,5 @@ def test_import_no_download(mocker, dvc):
         config=None,
         remote=None,
         remote_config=None,
+        force=False,
     )


### PR DESCRIPTION
I have also manually tested this:

```
$ dvc import https://github.com/iterative/dataset-registry use-cases/pool_data
$ dvc import https://github.com/iterative/dataset-registry use-cases/pool_data
$ dvc import https://github.com/iterative/dataset-registry use-cases/pool_data --force
```