### PR TITLE
Migrate from PyPI tokens to Trusted Publishers

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   pip:
+    environment: pypi
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,9 @@ on:
     types: [released, prereleased]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   pip:
     permissions:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   pip:
-    environment: pypi
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,13 +7,12 @@ on:
     types: [released, prereleased]
   workflow_dispatch:
 
-permissions:
-  contents: read
-  id-token: write
-
 jobs:
   pip:
     environment: pypi
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers#using-trusted-publishing-with-github-actions