### PR TITLE
[WIP] pre-commit: use system dvc

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,8 +3,7 @@
   - pre-commit
   entry: dvc
   id: dvc-pre-commit
-  language: python
-  language_version: python3
+  language: system
   name: DVC pre-commit
   require_serial: true
   stages:
@@ -15,8 +14,7 @@
   - pre-push
   entry: dvc
   id: dvc-pre-push
-  language: python
-  language_version: python3
+  language: system
   name: DVC pre-push
   require_serial: true
   stages:
@@ -27,8 +25,7 @@
   - post-checkout
   entry: dvc
   id: dvc-post-checkout
-  language: python
-  language_version: python3
+  language: system
   minimum_pre_commit_version: 2.2.0
   name: DVC post-checkout
   require_serial: true


### PR DESCRIPTION
We ourselves use system's dvc in our hooks https://github.com/iterative/dvc/blob/e9c7cd63a2df6ab84d0b7343e944ff2d45634558/.pre-commit-config.yaml#L80 , which makes sense since if you use dvc you obviously have one installed in your environment and using an isolated dvc in your pre-commit hooks could be creating more trouble because of potential version mismatches.
