### PR TITLE
index: don't load external outs

### DIFF
--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -457,6 +457,9 @@ class Index:
             if not out.use_cache:
                 continue
 
+            if not out.is_in_repo:
+                continue
+
             ws, key = out.index_key
             if ws not in by_workspace:
                 by_workspace[ws] = index.view((*prefix, ws))


### PR DESCRIPTION
Will figure out a good (e2e?) test for external outs in a separate PR along with some fixes for `dvc status` and other commands.

This is mostly to fix it for studio, but will also fix it for new index based commands like `dvc diff/data status/etc`.