### PR TITLE
exp: force add include_untracked paths

### DIFF
--- a/dvc/repo/experiments/executor/base.py
+++ b/dvc/repo/experiments/executor/base.py
@@ -295,7 +295,7 @@ class BaseExecutor(ABC):
             stages = dvc.commit([], force=True, relink=False)
             exp_hash = cls.hash_exp(stages)
             if include_untracked:
-                dvc.scm.add(include_untracked)
+                dvc.scm.add(include_untracked, force=True)  # type: ignore[call-arg]
             cls.commit(
                 dvc.scm,  # type: ignore[arg-type]
                 exp_hash,

--- a/tests/func/experiments/test_save.py
+++ b/tests/func/experiments/test_save.py
@@ -156,6 +156,18 @@ def test_untracked_dvclock_is_included_in_exp(tmp_dir, scm, dvc):
     assert fs.exists("dvc.lock")
 
 
+def test_exp_save_include_untracked_force(tmp_dir, dvc, scm):
+    setup_stage(tmp_dir, dvc, scm)
+
+    new_file = tmp_dir / "new_file"
+    new_file.write_text("new_file")
+    dvc.scm.ignore(new_file)
+    exp = dvc.experiments.save(include_untracked=["new_file"])
+
+    fs = scm.get_fs(exp)
+    assert fs.exists("new_file")
+
+
 def test_exp_save_custom_message(tmp_dir, dvc, scm):
     setup_stage(tmp_dir, dvc, scm)
 


### PR DESCRIPTION
Right now, dvc silently ignores files from `include_untracked` if they are inside `.gitignore`. It would be better to either warn or force add them. Since these are files that are being explicitly included, I thought it would be more helpful to force add them. Some files like `dvc.yaml` are added implicitly by dvc, but in that case we probably want to force add anyway.
