### PR TITLE
build: temporarily pin setuptools-scm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=61", "setuptools_scm[toml]>=7"]
+requires = ["setuptools>=61", "setuptools_scm[toml]>=7,<8"]
 
 [project]
 name = "dvc"


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

see: https://github.com/pypa/setuptools_scm/issues/912

setuptools_scm 8.0.1 generates type hints that are only valid on python>=3.9, pinning this until the fix is released