### PR TITLE
ci: build: split publishing and building into separate jobs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,20 +1,22 @@
-name: Build package
+name: Build and upload package
 on:
   push:
     branches:
     - main
   release:
-    types: [released, prereleased]
+    types:
+    - published
   workflow_dispatch:
+
+env:
+  FORCE_COLOR: 1
 
 permissions:
   contents: read
 
 jobs:
-  pip:
-    permissions:
-      contents: read
-      id-token: write
+  build:
+    name: Build & Verify package
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -26,24 +28,65 @@ jobs:
         python-version: 3.8
 
     - run: python -m pip install --upgrade pip setuptools_scm build twine
+
     - name: Force version for Test PyPI upload
       if: ${{ !startsWith(github.ref, 'refs/tags') }}
       run: echo version=$(python -m setuptools_scm | awk -F+ '{print $1}' | tail -1) >> $GITHUB_ENV
 
-    - run: |
-        echo 'PKG = "pip"'>dvc/_build.py
-        python -m build
+    - run: echo 'PKG = "pip"'>dvc/_build.py
+    - run: python -m build
       env:
-        SETUPTOOLS_SCM_PRETEND_VERSION: ${{ env.version }}
+        SETUPTOOLS_SCM_PRETEND_VERSION_FOR_DVC: ${{ env.version }}
     - run: twine check --strict dist/*
 
-    - name: Publish to PyPI
-      if: github.event_name == 'release'
-      uses: pypa/gh-action-pypi-publish@release/v1
+    - uses: actions/upload-artifact@v3
+      with:
+        name: Packages
+        path: dist/
 
-    - name: Publish to Test PyPI
-      if: ${{ github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+  test-pypi-publish:
+    name: Publish dev package to test.pypi.org
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.event.action == 'published' || (github.repository == 'iterative/dvc' && github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+
+    environment:
+      name: test-pypi
+      url: https://test.pypi.org/p/dvc
+
+    permissions:
+      id-token: write
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: Packages
+        path: dist
+
+    - name: Upload package to Test PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://test.pypi.org/legacy/
         skip-existing: true
+
+  pypi-publish:
+    name: Publish released package to pypi.org
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event.action == 'published'
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/dvc
+
+    permissions:
+      id-token: write
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: Packages
+        path: dist
+
+    - name: Upload package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
https://github.com/pypa/gh-action-pypi-publish suggests separating building from publishing for security reasons.

>  try to separate building from publishing — this makes sure that any scripts maliciously injected into the build or test environment won't be able to elevate privileges while flying under the radar.

