### PR TITLE
artifacts: Bring back `name_is_compatible`.

### DIFF
--- a/dvc/repo/artifacts.py
+++ b/dvc/repo/artifacts.py
@@ -38,6 +38,17 @@ def check_name_format(name: str) -> None:
         ) from exc
 
 
+def name_is_compatible(name: str) -> bool:
+    from gto.constants import assert_name_is_valid
+    from gto.exceptions import ValidationError
+
+    try:
+        assert_name_is_valid(name)
+        return True
+    except ValidationError:
+        return False
+
+
 def check_for_nested_dvc_repo(dvcfile: Path):
     from dvc.repo import Repo
 

--- a/dvc/repo/artifacts.py
+++ b/dvc/repo/artifacts.py
@@ -39,6 +39,10 @@ def check_name_format(name: str) -> None:
 
 
 def name_is_compatible(name: str) -> bool:
+    """
+    Only needed by DVCLive per iterative/dvclive#715
+    Will be removed in future release.
+    """
     from gto.constants import assert_name_is_valid
     from gto.exceptions import ValidationError
 


### PR DESCRIPTION
Unfortunately, DVCLive was importing this function so I am bringing back the name for backwards compatibility.

See https://github.com/iterative/dvclive/pull/715
