### PR TITLE
checkout: tweak messages and don't clear pbars

### DIFF
--- a/dvc/repo/checkout.py
+++ b/dvc/repo/checkout.py
@@ -140,7 +140,8 @@ def checkout(  # noqa: C901
 
     with ui.progress(
         unit="entry",
-        desc="Building data index",
+        desc="Building workspace index",
+        leave=True,
     ) as pb:
         old = build_data_index(
             view,
@@ -155,6 +156,7 @@ def checkout(  # noqa: C901
     with ui.progress(
         desc="Comparing indexes",
         unit="entry",
+        leave=True,
     ) as pb:
         diff = compare(old, new, relink=relink, delete=True, callback=pb.as_callback())
 
@@ -175,7 +177,8 @@ def checkout(  # noqa: C901
 
     with ui.progress(
         unit="file",
-        desc="Checkout",
+        desc="Applying changes",
+        leave=True,
     ) as pb:
         apply(
             diff,


### PR DESCRIPTION
No reason to clear those, as they are informative for both us and our users.
<img width="932" alt="Screenshot 2023-09-25 at 23 04 21" src="https://github.com/iterative/dvc/assets/5367102/1c154818-28d6-4977-8e4e-e233f4864243">
