### PR TITLE
fetch: don't clear pbars

### DIFF
--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -143,6 +143,7 @@ def fetch(  # noqa: C901, PLR0913
     with ui.progress(
         desc="Collecting",
         unit="entry",
+        leave=True,
     ) as pb:
         data = collect(
             indexes.values(),
@@ -156,7 +157,8 @@ def fetch(  # noqa: C901, PLR0913
 
     with ui.progress(
         desc="Fetching",
-        unit="file",
+        bar_format="{desc}",
+        leave=True,
     ) as pb:
         try:
             fetch_transferred, fetch_failed = ifetch(


### PR DESCRIPTION
There is more we can do during the `Fetching` stage, but it will require additional tweaks, so just keeping it simple here.

Similar to https://github.com/iterative/dvc/pull/9974


<img width="936" alt="Screenshot 2023-09-26 at 01 05 07" src="https://github.com/iterative/dvc/assets/5367102/5ec3f365-8abf-4df7-9ab5-c7701e207ffb">
