### PR TITLE
cli: data_sync: show warning about missing default remote

### DIFF
--- a/dvc/commands/data_sync.py
+++ b/dvc/commands/data_sync.py
@@ -14,6 +14,10 @@ class CmdDataBase(CmdBase):
         from dvc.utils.humanize import get_summary
 
         default_msg = "Everything is up to date."
+
+        if not self.args.remote and not self.repo.config["core"].get("remote"):
+            ui.warn("No remote provided and no default remote set.")
+
         ui.write(get_summary(stats.items()) or default_msg)
 
 


### PR DESCRIPTION
Currently only really affects `dvc pull` and `dvc fetch`, since they've migrated to using index, but `dvc status -c` and `dvc push` will error out (like they used to) about missing remote before they reach this new check.

<img width="977" alt="Screenshot 2023-09-26 at 19 53 00" src="https://github.com/iterative/dvc/assets/5367102/f52a58d7-a818-41bf-bcc7-b90fb0917869">

Fixes #9733 