### PR TITLE
cache migrate: add --dvc-files flag to migrate .dvc and dvc.lock files

### DIFF
--- a/dvc/commands/cache.py
+++ b/dvc/commands/cache.py
@@ -40,8 +40,11 @@ class CmdCacheDir(CmdConfig):
 class CmdCacheMigrate(CmdBase):
     def run(self):
         from dvc.cachemgr import migrate_2_to_3
+        from dvc.repo.commit import commit_2_to_3
 
         migrate_2_to_3(self.repo, dry=self.args.dry)
+        if self.args.dvc_files:
+            commit_2_to_3(self.repo, dry=self.args.dry)
         return 0
 
 
@@ -101,6 +104,14 @@ def add_parser(subparsers, parent_parser):
         description=append_doc_link(CACHE_HELP, "cache/migrate"),
         help=CACHE_MIGRATE_HELP,
         formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    cache_migrate_parser.add_argument(
+        "--dvc-files",
+        help=(
+            "Migrate entries in all existing DVC files in the repository "
+            "to the DVC 3.0 format."
+        ),
+        action="store_true",
     )
     cache_migrate_parser.add_argument(
         "--dry",

--- a/dvc/output.py
+++ b/dvc/output.py
@@ -721,7 +721,7 @@ class Output:
         if self.metric:
             self.verify_metric()
 
-        self._update_legacy_hash_name()
+        self.update_legacy_hash_name()
         if self.use_cache:
             _, self.meta, self.obj = self._build(
                 self.cache,
@@ -745,8 +745,8 @@ class Output:
         self.hash_info = self.obj.hash_info
         self.files = None
 
-    def _update_legacy_hash_name(self):
-        if self.hash_name == "md5-dos2unix" and self.changed_checksum():
+    def update_legacy_hash_name(self, force: bool = False):
+        if self.hash_name == "md5-dos2unix" and (force or self.changed_checksum()):
             self.hash_name = "md5"
 
     def set_exec(self) -> None:
@@ -1391,7 +1391,7 @@ class Output:
             )
 
         assert self.repo
-        self._update_legacy_hash_name()
+        self.update_legacy_hash_name()
         cache = self.cache if self.use_cache else self.local_cache
         assert isinstance(cache, HashFileDB)
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Closes https://github.com/iterative/dvc/issues/9938
Related (workaround for): https://github.com/iterative/dvc/issues/9818

Docs PR https://github.com/iterative/dvc.org/pull/4910

Migration workflow now looks like:
```
$ dvc cache migrate --dvc-files --dry
3 files will be re-hashed and migrated to the DVC 3.0 cache location.
Entries in following DVC files will be migrated to the 3.0 format:
        dir/bar.dvc
        dir/dvc.yaml (dir/dvc.lock)
        foo.dvc

$ dvc cache migrate --dvc-files
Migrated 3 files to DVC 3.0 cache location.
Updating DVC file 'foo.dvc'
Modifying stage 'baz' in 'dir/dvc.yaml'
Updating lock file 'dir/dvc.lock'
Updating DVC file 'dir/bar.dvc'

To track the changes with git, run:

        git add dir/dvc.yaml foo.dvc dir/dvc.lock dir/bar.dvc

To enable auto staging, run:

        dvc config core.autostage true

$ dvc cache migrate --dvc-files
Migrated 0 files to DVC 3.0 cache location.
No DVC files in the repo to migrate to the 3.0 format.
```