### PR TITLE
add native function to validate exp names

### DIFF
--- a/dvc/repo/experiments/rename.py
+++ b/dvc/repo/experiments/rename.py
@@ -34,8 +34,8 @@ def rename(
     if not is_valid_name_format(new_name):
         raise InvalidArgumentError(
             f"Invalid exp name {new_name}, the exp name cannot contain `/` and"
-            "must follow rules in"
-            "https://git-scm.com/docs/git-check-ref-format"
+            " must follow rules in"
+            " https://git-scm.com/docs/git-check-ref-format"
         )
 
     if exp_name:

--- a/dvc/repo/experiments/rename.py
+++ b/dvc/repo/experiments/rename.py
@@ -3,9 +3,10 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 from dvc.repo.experiments.exceptions import (
     ExperimentExistsError,
+    InvalidArgumentError,
     UnresolvedExpNamesError,
 )
-from dvc.repo.experiments.utils import resolve_name
+from dvc.repo.experiments.utils import is_valid_name_format, resolve_name
 from dvc.scm import Git
 
 from .refs import ExpRefInfo
@@ -29,6 +30,13 @@ def rename(
 
     if exp_name == new_name:
         return None
+
+    if not is_valid_name_format(new_name):
+        raise InvalidArgumentError(
+            f"Invalid exp name {new_name}, the exp name cannot contain `/` and"
+            "must follow rules in"
+            "https://git-scm.com/docs/git-check-ref-format"
+        )
 
     if exp_name:
         results: Dict[str, Union[ExpRefInfo, None]] = resolve_name(

--- a/dvc/repo/experiments/utils.py
+++ b/dvc/repo/experiments/utils.py
@@ -290,7 +290,7 @@ def is_valid_name_format(name: str) -> bool:
 
 def check_ref_format(scm: "Git", ref: ExpRefInfo):
     # "/" forbidden, only in dvc exp as we didn't support it for now.
-    if not scm.check_ref_format(str(ref)) or not is_valid_name_format(ref.name):
+    if not is_valid_name_format(ref.name) or not scm.check_ref_format(str(ref)):
         raise InvalidArgumentError(
             f"Invalid exp name {ref.name}, the exp name must follow rules in "
             "https://git-scm.com/docs/git-check-ref-format"

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -476,13 +476,24 @@ def test_experiments_rename_flag(dvc, scm, mocker, capsys, caplog):
     )
 
 
-def test_experiments_rename_invalid(dvc, scm, mocker, capsys, caplog):
+def test_experiments_rename_invalid_usage(dvc, scm, mocker, capsys, caplog):
     cmd = CmdExperimentsRename(parse_args(["exp", "rename", "exp-1"]))
     with pytest.raises(InvalidArgumentError) as excinfo:
         cmd.run()
     assert (
         str(excinfo.value)
         == "An experiment to rename and a new experiment name are required."
+    )
+
+
+def test_experiments_rename_invalid_name(dvc, scm, mocker, capsys, caplog):
+    cmd = CmdExperimentsRename(parse_args(["exp", "rename", "exp-1", "exp:1"]))
+    with pytest.raises(InvalidArgumentError) as excinfo:
+        cmd.run()
+    assert (
+        str(excinfo.value)
+        == "Invalid exp name exp:1, the exp name cannot contain `/` and must follow "
+        "rules in https://git-scm.com/docs/git-check-ref-format"
     )
 
 

--- a/tests/unit/repo/experiments/test_utils.py
+++ b/tests/unit/repo/experiments/test_utils.py
@@ -7,6 +7,7 @@ from dvc.repo.experiments.refs import EXPS_NAMESPACE, ExpRefInfo
 from dvc.repo.experiments.utils import (
     check_ref_format,
     gen_random_name,
+    is_valid_name_format,
     resolve_name,
     to_studio_params,
 )
@@ -42,10 +43,17 @@ def test_resolve_exp_ref(tmp_dir, scm, git_upstream, name_only, use_url):
     "name,result",
     [
         ("name", True),
+        ("name-group", True),
+        ("name.group", True),
+        ("name.lock", False),
+        ("rev..rev", False),
         ("group/name", False),
         ("na me", False),
+        (f"na{chr(127)}me", False),
+        ("na\nme", False),
+        ("na\rme", False),
         ("invalid/.name", False),
-        ("@", pytest.param(False, marks=pytest.mark.xfail)),
+        ("@", False),
         (":", False),
         ("^", False),
         ("*", False),
@@ -55,6 +63,7 @@ def test_resolve_exp_ref(tmp_dir, scm, git_upstream, name_only, use_url):
 )
 def test_run_check_ref_format(scm, name, result):
     ref = ExpRefInfo("abc123", name)
+    assert is_valid_name_format(name) == result
     if result:
         check_ref_format(scm, ref)
     else:


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Add a native/independent function to validate user-provided experiment names, not reliant on the backend implementation of `scm.check_ref_format`