### PR TITLE
`plots`: remove VegaConverter TODO and update misleading comment

### DIFF
--- a/dvc/render/converter/vega.py
+++ b/dvc/render/converter/vega.py
@@ -114,10 +114,6 @@ class VegaConverter(Converter):
         self.plot_id = plot_id
         self.inferred_properties: Dict = {}
 
-        # TODO we should be handling that in `convert`,
-        #      to avoid stateful `self.inferred_properties`
-        self._infer_x_y()
-
     def _infer_y_from_data(self):
         if self.plot_id in self.data:
             for lst in _lists(self.data[self.plot_id]):
@@ -296,16 +292,11 @@ class VegaConverter(Converter):
     ):
         """
         Convert the data. Fill necessary fields ('x', 'y') and return both
-        generated datapoints and updated properties. If `x` is not provided,
-        leave it as None, fronteds should handle it.
-
-        NOTE: Studio uses this method.
-              The only thing studio FE handles is filling `x` and `y`.
-              `x/y_label` should be filled here.
-
-              Datapoints are not stripped according to config, because users
-              might be utilizing other fields in their custom plots.
+        generated datapoints and updated properties. `x`, `y` values and labels
+        are inferred and always provided.
         """
+        self._infer_x_y()
+
         datapoints = self._find_datapoints()
         properties = {**self.properties, **self.inferred_properties}
 

--- a/tests/unit/render/test_vega_converter.py
+++ b/tests/unit/render/test_vega_converter.py
@@ -24,6 +24,7 @@ def test_finding_lists(dictionary, expected_result):
     assert list(result) == expected_result
 
 
+@pytest.mark.studio
 @pytest.mark.parametrize(
     "input_data,properties,expected_datapoints,expected_properties",
     [


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

----

Related to https://github.com/iterative/dvc/issues/9940 / https://github.com/iterative/dvc/pull/9931

This PR removes a TODO + misleading comment from the `VegaConverter` class. The change is already fully tested.

For context:

There is code in Studio that duplicates this logic that I will be removing. I spent a good chunk of time going between the codebases because there is contradictory information lying around.