### PR TITLE
analytics: fix mac not sending reports

### DIFF
--- a/dvc/daemon.py
+++ b/dvc/daemon.py
@@ -3,7 +3,6 @@
 import inspect
 import logging
 import os
-import platform
 import sys
 from subprocess import Popen  # nosec B404
 from typing import List
@@ -58,50 +57,45 @@ def _spawn_windows(cmd, env):
 def _spawn_posix(cmd, env):
     from dvc.cli import main
 
-    if platform.system() == "Darwin":
-        # workaround for MacOS bug
-        # https://github.com/iterative/dvc/issues/4294
-        _popen(cmd, env=env)
-    else:
-        # `fork` will copy buffers, so we need to flush them before forking.
-        # Otherwise, we will get duplicated outputs.
-        if sys.stdout and not sys.stdout.closed:
-            sys.stdout.flush()
-        if sys.stderr and not sys.stderr.closed:
-            sys.stderr.flush()
+    # `fork` will copy buffers, so we need to flush them before forking.
+    # Otherwise, we will get duplicated outputs.
+    if sys.stdout and not sys.stdout.closed:
+        sys.stdout.flush()
+    if sys.stderr and not sys.stderr.closed:
+        sys.stderr.flush()
 
-        # NOTE: using os._exit instead of sys.exit, because dvc built
-        # with PyInstaller has trouble with SystemExit exception and throws
-        # errors such as "[26338] Failed to execute script __main__"
-        try:
-            # pylint: disable-next=no-member
-            pid = os.fork()  # type: ignore[attr-defined]
-            if pid > 0:
-                return
-        except OSError:
-            logger.exception("failed at first fork")
-            os._exit(1)  # pylint: disable=protected-access
+    # NOTE: using os._exit instead of sys.exit, because dvc built
+    # with PyInstaller has trouble with SystemExit exception and throws
+    # errors such as "[26338] Failed to execute script __main__"
+    try:
+        # pylint: disable-next=no-member
+        pid = os.fork()  # type: ignore[attr-defined]
+        if pid > 0:
+            return
+    except OSError:
+        logger.exception("failed at first fork")
+        os._exit(1)  # pylint: disable=protected-access
 
-        os.setsid()  # type: ignore[attr-defined]  # pylint: disable=no-member
+    os.setsid()  # type: ignore[attr-defined]  # pylint: disable=no-member
 
-        try:
-            # pylint: disable-next=no-member
-            pid = os.fork()  # type: ignore[attr-defined]
-            if pid > 0:
-                os._exit(0)  # pylint: disable=protected-access
-        except OSError:
-            logger.exception("failed at second fork")
-            os._exit(1)  # pylint: disable=protected-access
+    try:
+        # pylint: disable-next=no-member
+        pid = os.fork()  # type: ignore[attr-defined]
+        if pid > 0:
+            os._exit(0)  # pylint: disable=protected-access
+    except OSError:
+        logger.exception("failed at second fork")
+        os._exit(1)  # pylint: disable=protected-access
 
-        sys.stdin.close()
-        sys.stdout.close()
-        sys.stderr.close()
-        os.closerange(0, 3)
+    sys.stdin.close()
+    sys.stdout.close()
+    sys.stderr.close()
+    os.closerange(0, 3)
 
-        os.environ.update(env)
-        main(cmd)
+    os.environ.update(env)
+    main(cmd)
 
-        os._exit(0)  # pylint: disable=protected-access
+    os._exit(0)  # pylint: disable=protected-access
 
 
 def _spawn(cmd, env):

--- a/dvc/daemon.py
+++ b/dvc/daemon.py
@@ -3,6 +3,7 @@
 import inspect
 import logging
 import os
+import platform
 import sys
 from subprocess import Popen  # nosec B404
 from typing import List
@@ -54,13 +55,62 @@ def _spawn_windows(cmd, env):
         _suppress_resource_warning(popen)
 
 
+def _spawn_posix(cmd, env):
+    from dvc.cli import main
+
+    if platform.system() == "Darwin":
+        # workaround for MacOS bug
+        # https://github.com/iterative/dvc/issues/4294
+        _popen(cmd, env=env)
+    else:
+        # `fork` will copy buffers, so we need to flush them before forking.
+        # Otherwise, we will get duplicated outputs.
+        if sys.stdout and not sys.stdout.closed:
+            sys.stdout.flush()
+        if sys.stderr and not sys.stderr.closed:
+            sys.stderr.flush()
+
+        # NOTE: using os._exit instead of sys.exit, because dvc built
+        # with PyInstaller has trouble with SystemExit exception and throws
+        # errors such as "[26338] Failed to execute script __main__"
+        try:
+            # pylint: disable-next=no-member
+            pid = os.fork()  # type: ignore[attr-defined]
+            if pid > 0:
+                return
+        except OSError:
+            logger.exception("failed at first fork")
+            os._exit(1)  # pylint: disable=protected-access
+
+        os.setsid()  # type: ignore[attr-defined]  # pylint: disable=no-member
+
+        try:
+            # pylint: disable-next=no-member
+            pid = os.fork()  # type: ignore[attr-defined]
+            if pid > 0:
+                os._exit(0)  # pylint: disable=protected-access
+        except OSError:
+            logger.exception("failed at second fork")
+            os._exit(1)  # pylint: disable=protected-access
+
+        sys.stdin.close()
+        sys.stdout.close()
+        sys.stderr.close()
+        os.closerange(0, 3)
+
+        os.environ.update(env)
+        main(cmd)
+
+        os._exit(0)  # pylint: disable=protected-access
+
+
 def _spawn(cmd, env):
     logger.debug("Trying to spawn '%s'", cmd)
 
     if os.name == "nt":
         _spawn_windows(cmd, env)
     elif os.name == "posix":
-        _popen(cmd, env=env)
+        _spawn_posix(cmd, env)
     else:
         raise NotImplementedError
 


### PR DESCRIPTION
Not sure if this is the best approach to fix the issue, but currently we [do not seem to be sending analytics reports for mac since March](https://iterativeai.slack.com/archives/CB41NAL8H/p1697464559356029?thread_ts=1697200360.717249&cid=CB41NAL8H). I have tested and found that it seems to be some combination of forking and the `_popen` method used. Analytics get sent successfully if I either:
1. Drop all the forking logic, OR
2. Call `main` like it does for linux.

Here I dropped all the forking and conditions here and just use `_popen` directly. This successfully sends reports for me, and I'm not sure why we need forking here since it should happen in a separate, non-blocking process when using `_popen` (and dropping `.communicate()`). 

Not sure if I miss some context for why forking or other logic is needed (I took a look back at https://github.com/iterative/dvc/issues/4294 and https://github.com/iterative/dvc/pull/4262 but wasn't clear why this is all needed).