### PR TITLE
log exit code and pid on verbose-verbose logging

### DIFF
--- a/dvc/cli/__init__.py
+++ b/dvc/cli/__init__.py
@@ -173,10 +173,10 @@ def main(argv=None):  # noqa: C901, PLR0912, PLR0915
     args = None
 
     outer_log_level = logger.level
+    level = None
     try:
         args = parse_args(argv)
 
-        level = None
         if args.quiet:
             level = logging.CRITICAL
         elif args.verbose == 1:
@@ -235,10 +235,16 @@ def main(argv=None):  # noqa: C901, PLR0912, PLR0915
         ret = _log_exceptions(exc) or 255
 
     try:
+        import os
+
         from dvc import analytics
 
         if analytics.is_enabled():
             analytics.collect_and_send_report(args, ret)
+
+        logger.trace(  # type: ignore[attr-defined]
+            "Process %s exiting with %s", os.getpid(), ret
+        )
 
         return ret
     finally:


### PR DESCRIPTION
Is useful for debugging for daemon, for example determining whether a process ran or not, or exited with some code.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
