### PR TITLE
dvcfs: ls: handle empty/missing dirs

### DIFF
--- a/tests/unit/fs/test_dvc.py
+++ b/tests/unit/fs/test_dvc.py
@@ -173,6 +173,23 @@ def test_ls_dirty(tmp_dir, dvc):
     assert set(fs.ls("data")) == {"data/foo", "data/bar"}
 
 
+def test_ls_file_not_found(tmp_dir, dvc):
+    tmp_dir.dvc_gen({"data": "data"})
+
+    fs = DVCFileSystem(repo=dvc)
+    with pytest.raises(FileNotFoundError):
+        fs.ls("missing")
+
+
+def test_ls_dir_empty(tmp_dir, dvc):
+    tmp_dir.dvc_gen({"data": "data"})
+    empty = tmp_dir / "empty"
+    empty.mkdir()
+
+    fs = DVCFileSystem(repo=dvc)
+    assert set(fs.ls("empty")) == set()
+
+
 @pytest.mark.parametrize(
     "dvcfiles,extra_expected",
     [


### PR DESCRIPTION
Related to https://iterativeai.slack.com/archives/C03JS2V4MQU/p1697544594396579.

Assume a repo with an empty directory like:

```
$ tree
.
└── mydir

1 directory, 0 files
```

Before this PR, we get these results:

```python
>>> from dvc.api import DVCFileSystem
>>> fs = DVCFileSystem(".")
>>> fs.ls("mydir")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/dave/Code/dvc/dvc/fs/dvc.py", line 349, in ls
    raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), path)
FileNotFoundError: [Errno 2] No such file or directory: 'mydir'
>>> fs.ls("missing")
[]
```

After this PR, we get these results:

```python
>>> from dvc.api import DVCFileSystem
>>> fs = DVCFileSystem(".")
>>> fs.ls("mydir")
[]
>>> fs.ls("missing")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/dave/Code/dvc/dvc/fs/dvc.py", line 342, in ls
    raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), path)
FileNotFoundError: [Errno 2] No such file or directory: 'missing'
```
