### PR TITLE
refactor: dvc.daemon

### DIFF
--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -5,19 +5,11 @@ from dvc import daemon
 
 
 def test_daemon(mocker):
-    mock_windows = mocker.patch("dvc.daemon._spawn_subprocess")
-    mock_posix = mocker.patch("dvc.daemon._spawn_posix")
+    mock = mocker.patch("dvc.daemon._spawn")
     daemon.daemon(["updater"])
 
-    if os.name == "nt":
-        mock_posix.assert_not_called()
-        mock_windows.assert_called()
-        args = mock_windows.call_args[0]
-    else:
-        mock_windows.assert_not_called()
-        mock_posix.assert_called()
-        args = mock_posix.call_args[0]
-
+    mock.assert_called()
+    args = mock.call_args[0]
     env = args[2]
     assert "PYTHONPATH" in env
 


### PR DESCRIPTION
This PR:
1. always uses detached subprocess to run the daemon instead of a subprocess.
2. refactors to be able to run any command in the detached subprocess, not just limited to dvc commands.