### PR TITLE
logger: type-safe logger.trace

### DIFF
--- a/dvc/analytics.py
+++ b/dvc/analytics.py
@@ -1,10 +1,11 @@
 import json
-import logging
 import os
+
+from dvc.log import logger
 
 from .env import DVC_ANALYTICS_ENDPOINT, DVC_NO_ANALYTICS
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 def collect_and_send_report(args=None, return_code=None):
@@ -35,9 +36,7 @@ def collect_and_send_report(args=None, return_code=None):
     with tempfile.NamedTemporaryFile(delete=False, mode="w") as fobj:
         json.dump(report, fobj)
 
-    logger.trace(  # type: ignore[attr-defined]
-        "Saving analytics report to %s", fobj.name
-    )
+    logger.trace("Saving analytics report to %s", fobj.name)
     daemon(["analytics", fobj.name])
 
 
@@ -78,15 +77,15 @@ def send(path):
     report.update(_runtime_info())
 
     logger.debug("uploading report to %s", url)
-    logger.trace("Sending %s to %s", report, url)  # type: ignore[attr-defined]
+    logger.trace("Sending %s to %s", report, url)
 
     try:
         requests.post(url, json=report, headers=headers, timeout=5)
     except requests.exceptions.RequestException as e:
-        logger.trace("", exc_info=True)  # type: ignore[attr-defined]
+        logger.trace("", exc_info=True)
         logger.debug("failed to send analytics report %s", str(e))
 
-    logger.trace("removing report %s", path)  # type: ignore[attr-defined]
+    logger.trace("removing report %s", path)
     os.remove(path)
 
 

--- a/dvc/cli/__init__.py
+++ b/dvc/cli/__init__.py
@@ -2,15 +2,14 @@
 
 import logging
 import sys
+from typing import Optional
+
+from dvc.log import logger
 
 # Workaround for CPython bug. See [1] and [2] for more info.
 # [1] https://github.com/aws/aws-cli/blob/1.16.277/awscli/clidriver.py#L55
 # [2] https://bugs.python.org/issue29288
-from typing import Optional
-
 "".encode("idna")
-
-logger = logging.getLogger("dvc")
 
 
 class DvcParserError(Exception):
@@ -197,7 +196,7 @@ def main(argv=None):  # noqa: C901, PLR0912, PLR0915
             logger.debug("v%s%s, %s on %s", __version__, pkg, pyv, platform())
             logger.debug("command: %s", " ".join(argv or sys.argv))
 
-        logger.trace(args)  # type: ignore[attr-defined]
+        logger.trace(args)
 
         if sys.stdout and not sys.stdout.closed and not args.quiet:
             from dvc.ui import ui
@@ -241,9 +240,7 @@ def main(argv=None):  # noqa: C901, PLR0912, PLR0915
         if analytics.is_enabled():
             analytics.collect_and_send_report(args, ret)
 
-        logger.trace(  # type: ignore[attr-defined]
-            "Process %s exiting with %s", os.getpid(), ret
-        )
+        logger.trace("Process %s exiting with %s", os.getpid(), ret)
 
         return ret
     finally:

--- a/dvc/cli/command.py
+++ b/dvc/cli/command.py
@@ -1,12 +1,13 @@
-import logging
 import os
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
+from dvc.log import logger
+
 if TYPE_CHECKING:
     from dvc.config import Config
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdBase(ABC):

--- a/dvc/cli/parser.py
+++ b/dvc/cli/parser.py
@@ -1,6 +1,5 @@
 """Main parser for the dvc cli."""
 import argparse
-import logging
 import os
 from functools import lru_cache
 
@@ -46,10 +45,11 @@ from dvc.commands import (
     update,
     version,
 )
+from dvc.log import logger
 
 from . import DvcParserError
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 COMMANDS = [
     init,

--- a/dvc/commands/add.py
+++ b/dvc/commands/add.py
@@ -1,11 +1,11 @@
 import argparse
-import logging
 
 from dvc.cli import completion
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
+from dvc.log import logger
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdAdd(CmdBase):

--- a/dvc/commands/artifacts.py
+++ b/dvc/commands/artifacts.py
@@ -1,12 +1,12 @@
 import argparse
-import logging
 
 from dvc.cli import completion
 from dvc.cli.command import CmdBaseNoRepo
 from dvc.cli.utils import DictAction, append_doc_link, fix_subparsers
 from dvc.exceptions import DvcException
+from dvc.log import logger
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdArtifactsGet(CmdBaseNoRepo):

--- a/dvc/commands/commit.py
+++ b/dvc/commands/commit.py
@@ -1,11 +1,11 @@
 import argparse
-import logging
 
 from dvc.cli import completion
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
+from dvc.log import logger
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdCommit(CmdBase):

--- a/dvc/commands/completion.py
+++ b/dvc/commands/completion.py
@@ -1,12 +1,12 @@
 import argparse
-import logging
 
 from dvc.cli.command import CmdBaseNoRepo
 from dvc.cli.completion import PREAMBLE
 from dvc.cli.utils import append_doc_link
+from dvc.log import logger
 from dvc.ui import ui
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 SUPPORTED_SHELLS = ["bash", "zsh"]

--- a/dvc/commands/config.py
+++ b/dvc/commands/config.py
@@ -1,12 +1,12 @@
 import argparse
-import logging
 import os
 
 from dvc.cli.command import CmdBaseNoRepo
 from dvc.cli.utils import append_doc_link
+from dvc.log import logger
 from dvc.ui import ui
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 NAME_REGEX = r"^(?P<remote>remote\.)?(?P<section>[^\.]*)\.(?P<option>[^\.]*)$"
 

--- a/dvc/commands/daemon.py
+++ b/dvc/commands/daemon.py
@@ -1,10 +1,9 @@
-import logging
-
 from dvc.cli import completion
 from dvc.cli.command import CmdBaseNoRepo
 from dvc.cli.utils import fix_subparsers
+from dvc.log import logger
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdDaemonBase(CmdBaseNoRepo):

--- a/dvc/commands/data.py
+++ b/dvc/commands/data.py
@@ -1,11 +1,11 @@
 import argparse
-import logging
 from typing import TYPE_CHECKING
 
 from funcy import chunks, compact, log_durations
 
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link, fix_subparsers
+from dvc.log import logger
 from dvc.ui import ui
 from dvc.utils import colorize
 
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from dvc.repo.data import Status as DataStatus
 
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdDataStatus(CmdBase):
@@ -106,7 +106,7 @@ class CmdDataStatus(CmdBase):
         return 0
 
     def run(self) -> int:
-        with log_durations(logger.trace, "in data_status"):  # type: ignore[attr-defined]
+        with log_durations(logger.trace, "in data_status"):
             status = self.repo.data_status(
                 granular=self.args.granular,
                 untracked_files=self.args.untracked_files,

--- a/dvc/commands/data_sync.py
+++ b/dvc/commands/data_sync.py
@@ -1,11 +1,11 @@
 import argparse
-import logging
 
 from dvc.cli import completion
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
+from dvc.log import logger
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdDataBase(CmdBase):

--- a/dvc/commands/destroy.py
+++ b/dvc/commands/destroy.py
@@ -1,10 +1,10 @@
 import argparse
-import logging
 
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
+from dvc.log import logger
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdDestroy(CmdBase):

--- a/dvc/commands/diff.py
+++ b/dvc/commands/diff.py
@@ -1,13 +1,13 @@
 import argparse
-import logging
 import os
 
 from dvc.cli import completion
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
+from dvc.log import logger
 from dvc.ui import ui
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 def _digest(checksum):

--- a/dvc/commands/experiments/apply.py
+++ b/dvc/commands/experiments/apply.py
@@ -1,12 +1,12 @@
 import argparse
-import logging
 
 from dvc.cli import completion
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
+from dvc.log import logger
 from dvc.ui import ui
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdExperimentsApply(CmdBase):

--- a/dvc/commands/experiments/branch.py
+++ b/dvc/commands/experiments/branch.py
@@ -1,10 +1,10 @@
 import argparse
-import logging
 
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
+from dvc.log import logger
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdExperimentsBranch(CmdBase):

--- a/dvc/commands/experiments/clean.py
+++ b/dvc/commands/experiments/clean.py
@@ -1,10 +1,10 @@
 import argparse
-import logging
 
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
+from dvc.log import logger
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdExperimentsClean(CmdBase):

--- a/dvc/commands/experiments/diff.py
+++ b/dvc/commands/experiments/diff.py
@@ -1,14 +1,14 @@
 import argparse
-import logging
 
 from dvc.cli import completion
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
 from dvc.commands.metrics import DEFAULT_PRECISION
 from dvc.exceptions import DvcException
+from dvc.log import logger
 from dvc.ui import ui
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdExperimentsDiff(CmdBase):

--- a/dvc/commands/experiments/exec_run.py
+++ b/dvc/commands/experiments/exec_run.py
@@ -1,8 +1,7 @@
-import logging
-
 from dvc.cli.command import CmdBaseNoRepo
+from dvc.log import logger
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdExecutorRun(CmdBaseNoRepo):

--- a/dvc/commands/experiments/ls.py
+++ b/dvc/commands/experiments/ls.py
@@ -1,12 +1,12 @@
 import argparse
-import logging
 
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
 from dvc.exceptions import InvalidArgumentError
+from dvc.log import logger
 from dvc.ui import ui
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdExperimentsList(CmdBase):

--- a/dvc/commands/experiments/pull.py
+++ b/dvc/commands/experiments/pull.py
@@ -1,11 +1,11 @@
 import argparse
-import logging
 
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
+from dvc.log import logger
 from dvc.ui import ui
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdExperimentsPull(CmdBase):

--- a/dvc/commands/experiments/push.py
+++ b/dvc/commands/experiments/push.py
@@ -1,13 +1,13 @@
 import argparse
-import logging
 from typing import Any, Dict
 
 from dvc.cli import completion
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
+from dvc.log import logger
 from dvc.ui import ui
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdExperimentsPush(CmdBase):

--- a/dvc/commands/experiments/queue_worker.py
+++ b/dvc/commands/experiments/queue_worker.py
@@ -1,8 +1,7 @@
-import logging
-
 from dvc.cli.command import CmdBase
+from dvc.log import logger
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdQueueWorker(CmdBase):

--- a/dvc/commands/experiments/remove.py
+++ b/dvc/commands/experiments/remove.py
@@ -1,12 +1,12 @@
 import argparse
-import logging
 
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
 from dvc.exceptions import InvalidArgumentError
+from dvc.log import logger
 from dvc.ui import ui
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdExperimentsRemove(CmdBase):

--- a/dvc/commands/experiments/rename.py
+++ b/dvc/commands/experiments/rename.py
@@ -1,12 +1,12 @@
 import argparse
-import logging
 
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
 from dvc.exceptions import InvalidArgumentError
+from dvc.log import logger
 from dvc.ui import ui
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdExperimentsRename(CmdBase):

--- a/dvc/commands/experiments/run.py
+++ b/dvc/commands/experiments/run.py
@@ -1,11 +1,11 @@
 import argparse
-import logging
 
 from dvc.cli.utils import append_doc_link
 from dvc.commands.repro import CmdRepro
 from dvc.commands.repro import add_arguments as add_repro_arguments
+from dvc.log import logger
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdExperimentsRun(CmdRepro):

--- a/dvc/commands/experiments/save.py
+++ b/dvc/commands/experiments/save.py
@@ -1,12 +1,12 @@
 import argparse
-import logging
 
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
 from dvc.exceptions import DvcException
+from dvc.log import logger
 from dvc.ui import ui
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdExperimentsSave(CmdBase):

--- a/dvc/commands/experiments/show.py
+++ b/dvc/commands/experiments/show.py
@@ -1,5 +1,4 @@
 import argparse
-import logging
 import re
 from datetime import date, datetime
 from typing import TYPE_CHECKING, Dict, Iterable
@@ -10,6 +9,7 @@ from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
 from dvc.commands.metrics import DEFAULT_PRECISION
 from dvc.exceptions import DvcException
+from dvc.log import logger
 from dvc.ui import ui
 from dvc.utils.serialize import encode_exception
 
@@ -21,7 +21,7 @@ FILL_VALUE = "-"
 FILL_VALUE_ERRORED = "!"
 
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 experiment_types = {

--- a/dvc/commands/freeze.py
+++ b/dvc/commands/freeze.py
@@ -1,12 +1,12 @@
 import argparse
-import logging
 
 from dvc.cli import completion
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
 from dvc.exceptions import DvcException
+from dvc.log import logger
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdFreezeBase(CmdBase):

--- a/dvc/commands/gc.py
+++ b/dvc/commands/gc.py
@@ -1,12 +1,12 @@
 import argparse
-import logging
 import os
 
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
+from dvc.log import logger
 from dvc.ui import ui
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdGC(CmdBase):

--- a/dvc/commands/get.py
+++ b/dvc/commands/get.py
@@ -1,12 +1,12 @@
 import argparse
-import logging
 
 from dvc.cli import completion
 from dvc.cli.command import CmdBaseNoRepo
 from dvc.cli.utils import DictAction, append_doc_link
 from dvc.exceptions import DvcException
+from dvc.log import logger
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdGet(CmdBaseNoRepo):

--- a/dvc/commands/get_url.py
+++ b/dvc/commands/get_url.py
@@ -1,12 +1,12 @@
 import argparse
-import logging
 
 from dvc.cli import completion
 from dvc.cli.command import CmdBaseNoRepo
 from dvc.cli.utils import DictAction, append_doc_link
 from dvc.exceptions import DvcException
+from dvc.log import logger
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdGetUrl(CmdBaseNoRepo):

--- a/dvc/commands/git_hook.py
+++ b/dvc/commands/git_hook.py
@@ -1,11 +1,11 @@
-import logging
 import os
 
 from dvc.cli.command import CmdBaseNoRepo
 from dvc.cli.utils import fix_subparsers
 from dvc.exceptions import NotDvcRepoError
+from dvc.log import logger
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdHookBase(CmdBaseNoRepo):

--- a/dvc/commands/imp.py
+++ b/dvc/commands/imp.py
@@ -1,12 +1,12 @@
 import argparse
-import logging
 
 from dvc.cli import completion
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import DictAction, append_doc_link
 from dvc.exceptions import DvcException
+from dvc.log import logger
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdImport(CmdBase):

--- a/dvc/commands/imp_url.py
+++ b/dvc/commands/imp_url.py
@@ -1,12 +1,12 @@
 import argparse
-import logging
 
 from dvc.cli import completion
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import DictAction, append_doc_link
 from dvc.exceptions import DvcException
+from dvc.log import logger
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdImportUrl(CmdBase):

--- a/dvc/commands/init.py
+++ b/dvc/commands/init.py
@@ -1,15 +1,15 @@
 import argparse
-import logging
 
 import colorama
 
 from dvc import analytics
 from dvc.cli.command import CmdBaseNoRepo
 from dvc.cli.utils import append_doc_link
+from dvc.log import logger
 from dvc.utils import boxify
 from dvc.utils import format_link as fmt_link
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 def _welcome_message():

--- a/dvc/commands/install.py
+++ b/dvc/commands/install.py
@@ -1,11 +1,11 @@
 import argparse
-import logging
 
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
 from dvc.exceptions import DvcException
+from dvc.log import logger
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdInstall(CmdBase):

--- a/dvc/commands/ls/__init__.py
+++ b/dvc/commands/ls/__init__.py
@@ -1,14 +1,14 @@
 import argparse
-import logging
 
 from dvc.cli import completion
 from dvc.cli.command import CmdBaseNoRepo
 from dvc.cli.utils import DictAction, append_doc_link
 from dvc.commands.ls.ls_colors import LsColors
 from dvc.exceptions import DvcException
+from dvc.log import logger
 from dvc.ui import ui
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 def _format_entry(entry, fmt):

--- a/dvc/commands/ls_url.py
+++ b/dvc/commands/ls_url.py
@@ -1,12 +1,12 @@
 import argparse
-import logging
 
 from dvc.cli.command import CmdBaseNoRepo
 from dvc.cli.utils import DictAction, append_doc_link
+from dvc.log import logger
 
 from .ls import show_entries
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdListUrl(CmdBaseNoRepo):

--- a/dvc/commands/metrics.py
+++ b/dvc/commands/metrics.py
@@ -1,13 +1,13 @@
 import argparse
-import logging
 
 from dvc.cli import completion
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link, fix_subparsers
+from dvc.log import logger
 from dvc.ui import ui
 from dvc.utils.serialize import encode_exception
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 DEFAULT_PRECISION = 5

--- a/dvc/commands/move.py
+++ b/dvc/commands/move.py
@@ -1,12 +1,12 @@
 import argparse
-import logging
 
 from dvc.cli import completion
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
 from dvc.exceptions import DvcException
+from dvc.log import logger
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdMove(CmdBase):

--- a/dvc/commands/params.py
+++ b/dvc/commands/params.py
@@ -1,12 +1,12 @@
 import argparse
-import logging
 
 from dvc.cli import completion
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link, fix_subparsers
+from dvc.log import logger
 from dvc.ui import ui
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdParamsDiff(CmdBase):

--- a/dvc/commands/plots.py
+++ b/dvc/commands/plots.py
@@ -1,5 +1,4 @@
 import argparse
-import logging
 import os
 from typing import TYPE_CHECKING, Dict, List, Optional
 
@@ -9,6 +8,7 @@ from dvc.cli import completion
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link, fix_subparsers
 from dvc.exceptions import DvcException
+from dvc.log import logger
 from dvc.ui import ui
 from dvc.utils import format_link
 
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from dvc.render.match import RendererWithErrors
 
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 def _show_json(

--- a/dvc/commands/queue/kill.py
+++ b/dvc/commands/queue/kill.py
@@ -1,10 +1,10 @@
 import argparse
-import logging
 
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
+from dvc.log import logger
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdQueueKill(CmdBase):

--- a/dvc/commands/queue/logs.py
+++ b/dvc/commands/queue/logs.py
@@ -1,10 +1,10 @@
 import argparse
-import logging
 
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
+from dvc.log import logger
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdQueueLogs(CmdBase):

--- a/dvc/commands/queue/remove.py
+++ b/dvc/commands/queue/remove.py
@@ -1,12 +1,12 @@
 import argparse
-import logging
 
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
 from dvc.exceptions import InvalidArgumentError
+from dvc.log import logger
 from dvc.ui import ui
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdQueueRemove(CmdBase):

--- a/dvc/commands/queue/start.py
+++ b/dvc/commands/queue/start.py
@@ -1,11 +1,11 @@
 import argparse
-import logging
 
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
+from dvc.log import logger
 from dvc.ui import ui
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdQueueStart(CmdBase):

--- a/dvc/commands/queue/status.py
+++ b/dvc/commands/queue/status.py
@@ -1,12 +1,12 @@
 import argparse
-import logging
 
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
 from dvc.compare import TabularData
+from dvc.log import logger
 from dvc.ui import ui
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdQueueStatus(CmdBase):

--- a/dvc/commands/queue/stop.py
+++ b/dvc/commands/queue/stop.py
@@ -1,11 +1,11 @@
 import argparse
-import logging
 
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
+from dvc.log import logger
 from dvc.ui import ui
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdQueueStop(CmdBase):

--- a/dvc/commands/remove.py
+++ b/dvc/commands/remove.py
@@ -1,12 +1,12 @@
 import argparse
-import logging
 
 from dvc.cli import completion
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
 from dvc.exceptions import DvcException
+from dvc.log import logger
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdRemove(CmdBase):

--- a/dvc/commands/root.py
+++ b/dvc/commands/root.py
@@ -1,11 +1,11 @@
 import argparse
-import logging
 
 from dvc.cli.command import CmdBaseNoRepo
 from dvc.cli.utils import append_doc_link
+from dvc.log import logger
 from dvc.utils import relpath
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdRoot(CmdBaseNoRepo):

--- a/dvc/commands/stage.py
+++ b/dvc/commands/stage.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Dict, Iterable, List
 from dvc.cli import completion
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link, fix_subparsers
+from dvc.log import logger
 from dvc.utils.cli_parse import parse_params
 from dvc.utils.humanize import truncate_text
 
@@ -14,7 +15,7 @@ if TYPE_CHECKING:
     from dvc.output import Output
     from dvc.stage import Stage
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 MAX_TEXT_LENGTH = 80
 
@@ -67,9 +68,7 @@ class CmdStageList(CmdBase):
     def _get_stages(self) -> Iterable["Stage"]:
         if self.args.all:
             stages: List["Stage"] = self.repo.index.stages
-            logger.trace(  # type: ignore[attr-defined]
-                "%d no. of stages found", len(stages)
-            )
+            logger.trace("%d no. of stages found", len(stages))
             return stages
 
         # removing duplicates while maintaining order

--- a/dvc/commands/status.py
+++ b/dvc/commands/status.py
@@ -1,11 +1,10 @@
-import logging
-
 from dvc.commands.data_sync import CmdDataBase
 from dvc.exceptions import DvcException
+from dvc.log import logger
 from dvc.ui import ui
 from dvc.utils import format_link
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdDataStatus(CmdDataBase):

--- a/dvc/commands/unprotect.py
+++ b/dvc/commands/unprotect.py
@@ -1,12 +1,12 @@
 import argparse
-import logging
 
 from dvc.cli import completion
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
 from dvc.exceptions import DvcException
+from dvc.log import logger
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdUnprotect(CmdBase):

--- a/dvc/commands/update.py
+++ b/dvc/commands/update.py
@@ -1,12 +1,12 @@
 import argparse
-import logging
 
 from dvc.cli import completion
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
 from dvc.exceptions import DvcException
+from dvc.log import logger
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdUpdate(CmdBase):

--- a/dvc/commands/version.py
+++ b/dvc/commands/version.py
@@ -1,11 +1,11 @@
 import argparse
-import logging
 
 from dvc.cli.command import CmdBaseNoRepo
 from dvc.cli.utils import append_doc_link
+from dvc.log import logger
 from dvc.ui import ui
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class CmdVersion(CmdBaseNoRepo):

--- a/dvc/config.py
+++ b/dvc/config.py
@@ -1,5 +1,4 @@
 """DVC config objects."""
-import logging
 import os
 import re
 from contextlib import contextmanager
@@ -9,6 +8,7 @@ from typing import TYPE_CHECKING, Dict, Optional
 from funcy import compact, memoize, re_find
 
 from dvc.exceptions import DvcException, NotDvcRepoError
+from dvc.log import logger
 
 from .utils.objects import cached_property
 
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from dvc.fs import FileSystem
     from dvc.types import DictStrAny, StrPath
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class ConfigError(DvcException):

--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from urllib.parse import urlparse
 
@@ -16,7 +15,9 @@ from voluptuous import (
     Schema,
 )
 
-logger = logging.getLogger(__name__)
+from dvc.log import logger
+
+logger = logger.getChild(__name__)
 
 Bool = All(
     Lower,

--- a/dvc/daemon.py
+++ b/dvc/daemon.py
@@ -8,6 +8,8 @@ import sys
 from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Sequence, Union
 
+from dvc.log import logger
+
 if TYPE_CHECKING:
     from typing import ContextManager
 
@@ -15,7 +17,7 @@ from dvc.env import DVC_DAEMON, DVC_DAEMON_LOGFILE
 from dvc.utils import fix_env, is_binary
 from dvc.utils.collections import ensure_list
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 def _suppress_resource_warning(popen: subprocess.Popen) -> None:

--- a/dvc/dagascii.py
+++ b/dvc/dagascii.py
@@ -1,6 +1,5 @@
 """Draws DAG in ASCII."""
 
-import logging
 import math
 import os
 
@@ -8,7 +7,9 @@ from grandalf.graphs import Edge, Graph, Vertex
 from grandalf.layouts import SugiyamaLayout
 from grandalf.routing import EdgeViewer, route_with_lines
 
-logger = logging.getLogger(__name__)
+from dvc.log import logger
+
+logger = logger.getChild(__name__)
 
 
 class VertexViewer:

--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -1,10 +1,10 @@
 """Manages dvc remotes that user can use with push/pull/status commands."""
 
-import logging
 from typing import TYPE_CHECKING, Iterable, Optional, Set, Tuple
 
 from dvc.config import NoRemoteError, RemoteConfigError
 from dvc.fs.callbacks import Callback
+from dvc.log import logger
 from dvc.utils.objects import cached_property
 from dvc_data.hashfile.db import get_index
 from dvc_data.hashfile.transfer import TransferResult
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from dvc_data.hashfile.hash_info import HashInfo
     from dvc_data.hashfile.status import CompareStatusResult
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class Remote:

--- a/dvc/dependency/param.py
+++ b/dvc/dependency/param.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import typing
 from collections import defaultdict
@@ -7,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 import dpath
 
 from dvc.exceptions import DvcException
+from dvc.log import logger
 from dvc.utils.serialize import ParseError, load_path
 from dvc_data.hashfile.hash_info import HashInfo
 
@@ -15,7 +15,7 @@ from .base import Dependency
 if TYPE_CHECKING:
     from dvc.fs import FileSystem
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class MissingParamsError(DvcException):

--- a/dvc/dvcfile.py
+++ b/dvc/dvcfile.py
@@ -1,5 +1,4 @@
 import contextlib
-import logging
 import os
 from typing import (
     TYPE_CHECKING,
@@ -14,6 +13,7 @@ from typing import (
 )
 
 from dvc.exceptions import DvcException
+from dvc.log import logger
 from dvc.stage import serialize
 from dvc.stage.exceptions import (
     StageFileBadNameError,
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from .parsing import DataResolver
     from .stage import Stage
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 _T = TypeVar("_T")
 
 DVC_FILE_SUFFIX = ".dvc"

--- a/dvc/fs/data.py
+++ b/dvc/fs/data.py
@@ -1,8 +1,8 @@
 import functools
-import logging
 import os
 from typing import TYPE_CHECKING
 
+from dvc.log import logger
 from dvc.utils import as_posix
 from dvc_objects.fs.base import FileSystem
 
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from dvc_data.fs import DataFileSystem as _DataFileSystem
 
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class DataFileSystem(FileSystem):

--- a/dvc/fs/dvc.py
+++ b/dvc/fs/dvc.py
@@ -1,6 +1,5 @@
 import errno
 import functools
-import logging
 import ntpath
 import os
 import posixpath
@@ -11,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, Type, Un
 from fsspec.spec import AbstractFileSystem
 from funcy import wrap_with
 
+from dvc.log import logger
 from dvc_objects.fs.base import FileSystem
 from dvc_objects.fs.path import Path
 
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from dvc.repo import Repo
     from dvc.types import DictStrAny, StrPath
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 RepoFactory = Union[Callable[..., "Repo"], Type["Repo"]]
 Key = Tuple[str, ...]

--- a/dvc/ignore.py
+++ b/dvc/ignore.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import re
 from collections import namedtuple
@@ -10,12 +9,13 @@ from pathspec.util import normalize_file
 from pygtrie import Trie
 
 from dvc.fs import Schemes, localfs
+from dvc.log import logger
 from dvc.pathspec_math import PatternInfo, merge_patterns
 
 if TYPE_CHECKING:
     from dvc.fs import AnyFSPath, FileSystem
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class DvcIgnore:

--- a/dvc/log.py
+++ b/dvc/log.py
@@ -1,0 +1,10 @@
+# using a separate module instead of using `dvc.logger` to not create an import-cycle.
+import logging
+
+
+class LoggerWithTrace(logging.Logger):
+    # only for type checking
+    trace = logging.debug
+
+
+logger: "LoggerWithTrace" = logging.getLogger("dvc")  # type: ignore[assignment]

--- a/dvc/logger.py
+++ b/dvc/logger.py
@@ -7,9 +7,7 @@ import os
 import sys
 
 import colorama
-
-from dvc.env import DVC_SHOW_TRACEBACK
-from dvc.progress import Tqdm
+from tqdm import tqdm
 
 
 def add_logging_level(level_name, level_num, method_name=None):
@@ -155,7 +153,7 @@ class LoggerHandler(logging.StreamHandler):
                         pass
 
             msg = self.format(record)
-            Tqdm.write(msg, file=self.stream, end=getattr(self, "terminator", "\n"))
+            tqdm.write(msg, file=self.stream, end=getattr(self, "terminator", "\n"))
             self.flush()
         except (BrokenPipeError, RecursionError):
             raise
@@ -204,7 +202,7 @@ def setup(level: int = logging.INFO, log_colors: bool = True) -> None:
     console_trace.setFormatter(formatter)
     console_trace.addFilter(exclude_filter(logging.DEBUG))
 
-    show_traceback = bool(os.environ.get(DVC_SHOW_TRACEBACK))
+    show_traceback = bool(os.environ.get("DVC_SHOW_TRACEBACK"))
     err_formatter = ColorFormatter(
         log_colors=log_colors and isatty(sys.stderr), show_traceback=show_traceback
     )

--- a/dvc/logger.py
+++ b/dvc/logger.py
@@ -179,11 +179,12 @@ def set_loggers_level(level: int = logging.INFO) -> None:
 
 
 def setup(level: int = logging.INFO, log_colors: bool = True) -> None:
-    from dvc.utils import isatty
-
     colorama.init()
 
-    formatter = ColorFormatter(log_colors=log_colors and isatty(sys.stdout))
+    color_out = log_colors and bool(sys.stdout) and sys.stdout.isatty()
+    color_err = log_colors and bool(sys.stderr) and sys.stderr.isatty()
+
+    formatter = ColorFormatter(log_colors=color_out)
 
     console_info = LoggerHandler(sys.stdout)
     console_info.setLevel(logging.INFO)
@@ -203,9 +204,7 @@ def setup(level: int = logging.INFO, log_colors: bool = True) -> None:
     console_trace.addFilter(exclude_filter(logging.DEBUG))
 
     show_traceback = bool(os.environ.get("DVC_SHOW_TRACEBACK"))
-    err_formatter = ColorFormatter(
-        log_colors=log_colors and isatty(sys.stderr), show_traceback=show_traceback
-    )
+    err_formatter = ColorFormatter(log_colors=color_err, show_traceback=show_traceback)
     console_errors = LoggerHandler(sys.stderr)
     console_errors.setLevel(logging.WARNING)
     console_errors.setFormatter(err_formatter)

--- a/dvc/logger.py
+++ b/dvc/logger.py
@@ -7,7 +7,8 @@ import os
 import sys
 
 import colorama
-from tqdm import tqdm
+
+from dvc.progress import Tqdm
 
 
 def add_logging_level(level_name, level_num, method_name=None):
@@ -153,7 +154,7 @@ class LoggerHandler(logging.StreamHandler):
                         pass
 
             msg = self.format(record)
-            tqdm.write(msg, file=self.stream, end=getattr(self, "terminator", "\n"))
+            Tqdm.write(msg, file=self.stream, end=getattr(self, "terminator", "\n"))
             self.flush()
         except (BrokenPipeError, RecursionError):
             raise

--- a/dvc/output.py
+++ b/dvc/output.py
@@ -1,5 +1,4 @@
 import errno
-import logging
 import os
 import posixpath
 from collections import defaultdict
@@ -20,6 +19,7 @@ from dvc.exceptions import (
     DvcException,
     MergeError,
 )
+from dvc.log import logger
 from dvc.utils import format_link
 from dvc.utils.objects import cached_property
 from dvc_data.hashfile import check as ocheck
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
 
     from .ignore import DvcIgnoreFilter
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 CHECKSUM_SCHEMA = Any(

--- a/dvc/parsing/__init__.py
+++ b/dvc/parsing/__init__.py
@@ -18,6 +18,7 @@ from typing import (
 from funcy import collecting, first, isa, join, reraise
 
 from dvc.exceptions import DvcException
+from dvc.log import logger
 from dvc.parsing.interpolate import ParseError
 from dvc.utils.objects import cached_property
 
@@ -45,7 +46,7 @@ if TYPE_CHECKING:
     from .context import SeqOrMap
 
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 STAGES_KWD = "stages"
 VARS_KWD = "vars"
@@ -192,7 +193,7 @@ class DataResolver:
     def resolve(self):
         """Used for testing purposes, otherwise use resolve_one()."""
         data = join(map(self.resolve_one, self.get_keys()))
-        logger.trace("Resolved dvc.yaml:\n%s", data)  # type: ignore[attr-defined]
+        logger.trace("Resolved dvc.yaml:\n%s", data)
         return {STAGES_KWD: data}
 
     def has_key(self, key: str):
@@ -283,9 +284,7 @@ class EntryDefinition:
         except VarsAlreadyLoaded as exc:
             format_and_raise(exc, f"'{self.where}.{name}.vars'", self.relpath)
 
-        logger.trace(  # type: ignore[attr-defined]
-            "Context during resolution of stage %s:\n%s", name, context
-        )
+        logger.trace("Context during resolution of stage %s:\n%s", name, context)
 
         with context.track() as tracked_data:
             # NOTE: we do not pop "wdir", and resolve it again

--- a/dvc/parsing/context.py
+++ b/dvc/parsing/context.py
@@ -1,4 +1,3 @@
-import logging
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Mapping, MutableMapping, MutableSequence, Sequence
@@ -10,6 +9,7 @@ from typing import Any, Dict, List, Optional, Union
 from funcy import identity, lfilter, nullcontext, select
 
 from dvc.exceptions import DvcException
+from dvc.log import logger
 from dvc.parsing.interpolate import (
     get_expression,
     get_matches,
@@ -20,7 +20,7 @@ from dvc.parsing.interpolate import (
     validate_value,
 )
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 SeqOrMap = Union[Sequence, Mapping]
 DictStr = Dict[str, Any]
 
@@ -434,7 +434,7 @@ class Context(CtxDict):
                 self.merge_from(fs, default, wdir)
             else:
                 msg = "%s does not exist, it won't be used in parametrization"
-                logger.trace(msg, to_import)  # type: ignore[attr-defined]
+                logger.trace(msg, to_import)
 
         stage_name = stage_name or ""
         for index, item in enumerate(vars_):

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -7,13 +7,12 @@ from typing import TYPE_CHECKING
 from tqdm import tqdm
 
 from dvc.env import DVC_IGNORE_ISATTY
-from dvc.log import logger
 from dvc.utils import env2bool
 
 if TYPE_CHECKING:
     from dvc.fs.callbacks import TqdmCallback
 
-logger = logger.getChild(__name__)
+logger = logging.getLogger(__name__)
 tqdm.set_lock(RLock())
 
 

--- a/dvc/progress.py
+++ b/dvc/progress.py
@@ -7,12 +7,13 @@ from typing import TYPE_CHECKING
 from tqdm import tqdm
 
 from dvc.env import DVC_IGNORE_ISATTY
+from dvc.log import logger
 from dvc.utils import env2bool
 
 if TYPE_CHECKING:
     from dvc.fs.callbacks import TqdmCallback
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 tqdm.set_lock(RLock())
 
 

--- a/dvc/prompt.py
+++ b/dvc/prompt.py
@@ -1,10 +1,11 @@
 """Manages user prompts."""
 
-import logging
 from getpass import getpass
 from typing import Collection, Optional
 
-logger = logging.getLogger(__name__)
+from dvc.log import logger
+
+logger = logger.getChild(__name__)
 
 
 def ask(prompt: str, limited_to: Optional[Collection[str]] = None):

--- a/dvc/render/match.py
+++ b/dvc/render/match.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from collections import defaultdict
 from typing import TYPE_CHECKING, DefaultDict, Dict, List, NamedTuple, Optional
@@ -7,6 +6,7 @@ import dpath
 import dpath.options
 from funcy import get_in, last
 
+from dvc.log import logger
 from dvc.repo.plots import _normpath, infer_data_sources
 from dvc.utils.plots import group_definitions_by_id
 
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 
 dpath.options.ALLOW_EMPTY_STRING_KEYS = True
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 def _squash_plots_properties(data: List) -> Dict:

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from collections import defaultdict
 from contextlib import contextmanager
@@ -15,6 +14,7 @@ from typing import (
 
 from dvc.exceptions import NotDvcRepoError, OutputNotFoundError
 from dvc.ignore import DvcIgnoreFilter
+from dvc.log import logger
 from dvc.utils.objects import cached_property
 
 if TYPE_CHECKING:
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from .index import Index
     from .scm_context import SCMContext
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 @contextmanager

--- a/dvc/repo/artifacts.py
+++ b/dvc/repo/artifacts.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import posixpath
 from pathlib import Path
@@ -12,6 +11,7 @@ from dvc.exceptions import (
     FileExistsLocallyError,
     InvalidArgumentError,
 )
+from dvc.log import logger
 from dvc.utils import relpath, resolve_output
 from dvc.utils.objects import cached_property
 from dvc.utils.serialize import modify_yaml
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from dvc.repo import Repo
     from dvc.scm import Git
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 def check_name_format(name: str) -> None:
@@ -286,7 +286,7 @@ class Artifacts:
         name = _reformat_name(name)
         saved_exc: Optional[Exception] = None
         try:
-            logger.trace("Trying studio-only config")  # type: ignore[attr-defined]
+            logger.trace("Trying studio-only config")
             return cls._download_studio(
                 url,
                 name,
@@ -311,7 +311,7 @@ class Artifacts:
             remote=remote,
             remote_config=remote_config,
         ) as repo:
-            logger.trace("Trying repo [studio] config")  # type: ignore[attr-defined]
+            logger.trace("Trying repo [studio] config")
             dvc_studio_config = dict(repo.config.get("studio"))
             try:
                 return cls._download_studio(

--- a/dvc/repo/brancher.py
+++ b/dvc/repo/brancher.py
@@ -1,16 +1,16 @@
-import logging
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Iterator, Optional, Tuple
 
 from scmrepo.git import Git
 
 from dvc.exceptions import NotDvcRepoError
+from dvc.log import logger
 from dvc.scm import iter_revs
 
 if TYPE_CHECKING:
     from dvc.repo import Repo
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 def brancher(
@@ -71,7 +71,7 @@ def brancher(
 
     scm = self.scm
 
-    logger.trace("switching fs to workspace")  # type: ignore[attr-defined]
+    logger.trace("switching fs to workspace")
     self.fs = LocalFileSystem(url=self.root_dir)
     yield "workspace"
 
@@ -115,11 +115,11 @@ def _switch_fs(
     from dvc.fs import GitFileSystem, LocalFileSystem
 
     if rev == "workspace":
-        logger.trace("switching fs to workspace")  # type: ignore[attr-defined]
+        logger.trace("switching fs to workspace")
         repo.fs = LocalFileSystem(url=repo.root_dir)
         return
 
-    logger.trace("switching fs to revision %s", rev[:7])  # type: ignore[attr-defined]
+    logger.trace("switching fs to revision %s", rev[:7])
     assert isinstance(repo.scm, Git)
     fs = GitFileSystem(scm=repo.scm, rev=rev)
     root_dir = repo.fs.path.join("/", *repo_root_parts)

--- a/dvc/repo/checkout.py
+++ b/dvc/repo/checkout.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from typing import TYPE_CHECKING, Dict, List
 
@@ -8,6 +7,7 @@ from dvc.exceptions import (
     DvcException,
     NoOutputOrStageError,
 )
+from dvc.log import logger
 from dvc.ui import ui
 from dvc.utils import relpath
 
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from dvc_data.index import BaseDataIndex, DataIndexEntry
     from dvc_objects.fs.base import FileSystem
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 def _fspath_dir(path):

--- a/dvc/repo/collect.py
+++ b/dvc/repo/collect.py
@@ -1,11 +1,12 @@
-import logging
 from typing import TYPE_CHECKING, Callable, Iterable, List, Optional, Tuple
+
+from dvc.log import logger
 
 if TYPE_CHECKING:
     from dvc.output import Output
     from dvc.repo import Repo
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 FilterFn = Callable[["Output"], bool]

--- a/dvc/repo/diff.py
+++ b/dvc/repo/diff.py
@@ -1,13 +1,13 @@
 import errno
-import logging
 import os
 from collections import defaultdict
 from typing import Dict, List, Optional
 
+from dvc.log import logger
 from dvc.repo import locked
 from dvc.ui import ui
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 def _path(entry):

--- a/dvc/repo/experiments/__init__.py
+++ b/dvc/repo/experiments/__init__.py
@@ -1,10 +1,10 @@
-import logging
 import os
 import re
 from typing import TYPE_CHECKING, Dict, Iterable, List, Optional
 
 from funcy import chain, first
 
+from dvc.log import logger
 from dvc.ui import ui
 from dvc.utils import relpath
 from dvc.utils.objects import cached_property
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     from .queue.workspace import WorkspaceQueue
     from .stash import ExpStashEntry
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class Experiments:

--- a/dvc/repo/experiments/apply.py
+++ b/dvc/repo/experiments/apply.py
@@ -1,7 +1,7 @@
-import logging
 import os
 from typing import TYPE_CHECKING, Optional
 
+from dvc.log import logger
 from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
 from dvc.scm import Git
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from dvc.repo import Repo
     from dvc.repo.experiments import Experiments
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 @locked

--- a/dvc/repo/experiments/branch.py
+++ b/dvc/repo/experiments/branch.py
@@ -1,6 +1,5 @@
-import logging
-
 from dvc.exceptions import InvalidArgumentError
+from dvc.log import logger
 from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
 from dvc.scm import RevError
@@ -8,7 +7,7 @@ from dvc.scm import RevError
 from .exceptions import InvalidExpRevError
 from .utils import exp_refs_by_rev
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 @locked

--- a/dvc/repo/experiments/collect.py
+++ b/dvc/repo/experiments/collect.py
@@ -1,5 +1,4 @@
 import itertools
-import logging
 import os
 from dataclasses import fields
 from datetime import datetime
@@ -18,6 +17,7 @@ from typing import (
 from funcy import first
 from scmrepo.exceptions import SCMError as InnerSCMError
 
+from dvc.log import logger
 from dvc.scm import Git, SCMError, iter_revs
 
 from .exceptions import InvalidExpRefError
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 
     from .cache import ExpCache
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 def collect_rev(

--- a/dvc/repo/experiments/diff.py
+++ b/dvc/repo/experiments/diff.py
@@ -1,9 +1,8 @@
-import logging
-
+from dvc.log import logger
 from dvc.utils.diff import diff as _diff
 from dvc.utils.diff import format_dict
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 def diff(repo, *args, a_rev=None, b_rev=None, param_deps=False, **kwargs):

--- a/dvc/repo/experiments/executor/base.py
+++ b/dvc/repo/experiments/executor/base.py
@@ -27,6 +27,7 @@ from scmrepo.exceptions import SCMError
 
 from dvc.env import DVC_EXP_AUTO_PUSH, DVC_EXP_GIT_REMOTE
 from dvc.exceptions import DvcException
+from dvc.log import logger
 from dvc.repo.experiments.exceptions import ExperimentExistsError
 from dvc.repo.experiments.refs import EXEC_BASELINE, EXEC_BRANCH, ExpRefInfo
 from dvc.repo.experiments.utils import to_studio_params
@@ -45,7 +46,7 @@ if TYPE_CHECKING:
     from dvc.scm import Git
     from dvc.stage import PipelineStage, Stage
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class ExecutorResult(NamedTuple):
@@ -492,9 +493,7 @@ class BaseExecutor(ABC):
                 targets = kwargs.get("targets")
 
             repro_force = kwargs.get("force", False)
-            logger.trace(  # type: ignore[attr-defined]
-                "Executor repro with force = '%s'", str(repro_force)
-            )
+            logger.trace("Executor repro with force = '%s'", str(repro_force))
 
             repro_dry = kwargs.get("dry")
 

--- a/dvc/repo/experiments/executor/local.py
+++ b/dvc/repo/experiments/executor/local.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from contextlib import ExitStack
 from tempfile import mkdtemp
@@ -9,6 +8,7 @@ from funcy import retry
 from shortuuid import uuid
 
 from dvc.lock import LockError
+from dvc.log import logger
 from dvc.repo.experiments.refs import (
     EXEC_BASELINE,
     EXEC_BRANCH,
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from dvc.repo.experiments.stash import ExpStashEntry
     from dvc.scm import NoSCM
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class BaseLocalExecutor(BaseExecutor):

--- a/dvc/repo/experiments/ls.py
+++ b/dvc/repo/experiments/ls.py
@@ -1,14 +1,14 @@
-import logging
 from collections import defaultdict
 from typing import Dict, List, Optional, Tuple, Union
 
+from dvc.log import logger
 from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
 from dvc.scm import iter_revs
 
 from .utils import exp_refs_by_baseline
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 @locked

--- a/dvc/repo/experiments/pull.py
+++ b/dvc/repo/experiments/pull.py
@@ -1,9 +1,9 @@
-import logging
 from typing import Iterable, List, Mapping, Optional, Set, Union
 
 from funcy import group_by
 from scmrepo.git.backend.base import SyncStatus
 
+from dvc.log import logger
 from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
 from dvc.scm import TqdmGit, iter_revs
@@ -13,7 +13,7 @@ from .exceptions import UnresolvedExpNamesError
 from .refs import ExpRefInfo
 from .utils import exp_commits, exp_refs, exp_refs_by_baseline, resolve_name
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 @locked

--- a/dvc/repo/experiments/push.py
+++ b/dvc/repo/experiments/push.py
@@ -1,4 +1,3 @@
-import logging
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -16,6 +15,7 @@ from scmrepo.git.backend.base import SyncStatus
 
 from dvc.env import DVC_STUDIO_TOKEN, DVC_STUDIO_URL
 from dvc.exceptions import DvcException
+from dvc.log import logger
 from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
 from dvc.scm import Git, TqdmGit, iter_revs
@@ -29,7 +29,7 @@ from .utils import exp_commits, exp_refs, exp_refs_by_baseline, resolve_name
 if TYPE_CHECKING:
     from dvc.repo import Repo
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class UploadError(DvcException):

--- a/dvc/repo/experiments/queue/base.py
+++ b/dvc/repo/experiments/queue/base.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
@@ -23,6 +22,7 @@ from funcy import retry
 from dvc.dependency import ParamsDependency
 from dvc.env import DVC_EXP_BASELINE_REV, DVC_EXP_NAME, DVC_ROOT
 from dvc.lock import LockError
+from dvc.log import logger
 from dvc.repo.experiments.exceptions import ExperimentExistsError
 from dvc.repo.experiments.executor.base import BaseExecutor
 from dvc.repo.experiments.executor.local import WorkspaceExecutor
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     from dvc.repo.experiments.serialize import ExpRange
     from dvc.scm import Git
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 @dataclass(frozen=True)

--- a/dvc/repo/experiments/queue/tempdir.py
+++ b/dvc/repo/experiments/queue/tempdir.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from collections import defaultdict
 from typing import TYPE_CHECKING, Collection, Dict, Generator, List, Optional
@@ -6,6 +5,7 @@ from typing import TYPE_CHECKING, Collection, Dict, Generator, List, Optional
 from funcy import first
 
 from dvc.exceptions import DvcException
+from dvc.log import logger
 from dvc.repo.experiments.exceptions import ExpQueueEmptyError
 from dvc.repo.experiments.executor.base import ExecutorInfo, TaskStatus
 from dvc.repo.experiments.executor.local import TempDirExecutor
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from dvc.repo.experiments.serialize import ExpRange
     from dvc_task.proc.manager import ProcessManager
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 _STANDALONE_TMP_DIR = os.path.join(EXEC_TMP_DIR, "standalone")

--- a/dvc/repo/experiments/queue/utils.py
+++ b/dvc/repo/experiments/queue/utils.py
@@ -1,13 +1,13 @@
-import logging
 from typing import TYPE_CHECKING, Dict, List
 
 from scmrepo.exceptions import SCMError
 
+from dvc.log import logger
 from dvc.repo.experiments.executor.base import ExecutorInfo, TaskStatus
 from dvc.repo.experiments.refs import EXEC_NAMESPACE, EXPS_NAMESPACE, EXPS_STASH
 from dvc.repo.experiments.utils import get_exp_rwlock, iter_remote_refs
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 if TYPE_CHECKING:

--- a/dvc/repo/experiments/queue/workspace.py
+++ b/dvc/repo/experiments/queue/workspace.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import os
 from collections import defaultdict
 from typing import TYPE_CHECKING, Collection, Dict, Generator, List, Optional
@@ -8,6 +7,7 @@ import psutil
 from funcy import first
 
 from dvc.exceptions import DvcException
+from dvc.log import logger
 from dvc.repo.experiments.exceptions import ExpQueueEmptyError
 from dvc.repo.experiments.executor.base import ExecutorInfo, TaskStatus
 from dvc.repo.experiments.executor.local import WorkspaceExecutor
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
     from .base import QueueDoneResult
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class WorkspaceQueue(BaseStashQueue):

--- a/dvc/repo/experiments/remove.py
+++ b/dvc/repo/experiments/remove.py
@@ -1,6 +1,6 @@
-import logging
 from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Union
 
+from dvc.log import logger
 from dvc.repo import locked
 from dvc.repo.scm_context import scm_context
 from dvc.scm import Git, iter_revs
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from .refs import ExpRefInfo
 
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 @locked

--- a/dvc/repo/experiments/rename.py
+++ b/dvc/repo/experiments/rename.py
@@ -1,6 +1,6 @@
-import logging
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
+from dvc.log import logger
 from dvc.repo.experiments.exceptions import (
     ExperimentExistsError,
     UnresolvedExpNamesError,
@@ -13,7 +13,7 @@ from .refs import ExpRefInfo
 if TYPE_CHECKING:
     from dvc.repo import Repo
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 def rename(

--- a/dvc/repo/experiments/run.py
+++ b/dvc/repo/experiments/run.py
@@ -1,13 +1,13 @@
-import logging
 from typing import Dict, Iterable, Optional
 
 from dvc.dependency.param import ParamsDependency
 from dvc.exceptions import InvalidArgumentError
+from dvc.log import logger
 from dvc.repo import locked
 from dvc.ui import ui
 from dvc.utils.cli_parse import to_path_overrides
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 @locked

--- a/dvc/repo/experiments/save.py
+++ b/dvc/repo/experiments/save.py
@@ -1,14 +1,15 @@
-import logging
 import os
 from typing import TYPE_CHECKING, List, Optional
 
 from funcy import first
 
+from dvc.log import logger
+
 if TYPE_CHECKING:
     from dvc.repo import Repo
 
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 def save(

--- a/dvc/repo/experiments/show.py
+++ b/dvc/repo/experiments/show.py
@@ -1,4 +1,3 @@
-import logging
 from collections import Counter, defaultdict
 from datetime import date, datetime
 from typing import (
@@ -18,6 +17,7 @@ from typing import (
 )
 
 from dvc.exceptions import InvalidArgumentError
+from dvc.log import logger
 from dvc.scm import Git
 from dvc.ui import ui
 from dvc.utils.flatten import flatten
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
     from .serialize import ExpRange, ExpState
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 def show(

--- a/dvc/repo/experiments/stash.py
+++ b/dvc/repo/experiments/stash.py
@@ -1,4 +1,3 @@
-import logging
 import re
 from contextlib import contextmanager
 from typing import Dict, Iterable, Iterator, NamedTuple, Optional
@@ -6,12 +5,13 @@ from typing import Dict, Iterable, Iterator, NamedTuple, Optional
 from scmrepo.git import Stash
 
 from dvc.exceptions import DvcException
+from dvc.log import logger
 from dvc_objects.fs.local import localfs
 from dvc_objects.fs.utils import as_atomic
 
 from .refs import APPLY_HEAD, APPLY_STASH
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class ExpStashEntry(NamedTuple):

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -1,13 +1,13 @@
-import logging
 from typing import List, Tuple
 
 from dvc.exceptions import DownloadError
+from dvc.log import logger
 from dvc.ui import ui
 from dvc_data.index import DataIndex, FileStorage
 
 from . import locked
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 def _make_index_onerror(onerror, rev):

--- a/dvc/repo/gc.py
+++ b/dvc/repo/gc.py
@@ -1,7 +1,7 @@
-import logging
 from typing import TYPE_CHECKING, List, Optional
 
 from dvc.exceptions import InvalidArgumentError
+from dvc.log import logger
 
 from . import locked
 
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from dvc.repo import Repo
     from dvc.repo.index import ObjectContainer
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 def _validate_args(**kwargs):

--- a/dvc/repo/get.py
+++ b/dvc/repo/get.py
@@ -1,15 +1,15 @@
-import logging
 import os
 from typing import TYPE_CHECKING, Union
 
 from dvc.exceptions import DvcException
+from dvc.log import logger
 from dvc.utils import resolve_output
 
 if TYPE_CHECKING:
     from dvc.fs.dvc import DVCFileSystem
 
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class GetDVCFileError(DvcException):

--- a/dvc/repo/imports.py
+++ b/dvc/repo/imports.py
@@ -1,8 +1,9 @@
-import logging
 import os
 from functools import partial
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, List, Set, Tuple, Union
+
+from dvc.log import logger
 
 if TYPE_CHECKING:
     from dvc.dependency.base import Dependency
@@ -13,7 +14,7 @@ if TYPE_CHECKING:
     from dvc_data.hashfile.hash_info import HashInfo
 
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 def unfetched_view(

--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -21,6 +21,7 @@ from funcy.debug import format_time
 
 from dvc.fs import LocalFileSystem
 from dvc.fs.callbacks import DEFAULT_CALLBACK
+from dvc.log import logger
 from dvc.utils.objects import cached_property
 
 if TYPE_CHECKING:
@@ -40,7 +41,7 @@ if TYPE_CHECKING:
     from dvc_objects.fs.base import FileSystem
 
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 ObjectContainer = Dict[Optional["HashFileDB"], Set["HashInfo"]]
 
 
@@ -49,9 +50,7 @@ def log_walk(seq):
         start = time.perf_counter()
         yield root, dirs, files
         duration = format_time(time.perf_counter() - start)
-        logger.trace(  # type: ignore[attr-defined]
-            "%s in collecting stages from %s", duration, root
-        )
+        logger.trace("%s in collecting stages from %s", duration, root)
 
 
 def collect_files(

--- a/dvc/repo/init.py
+++ b/dvc/repo/init.py
@@ -1,15 +1,15 @@
-import logging
 import os
 
 from dvc.config import Config
 from dvc.exceptions import InitError, InvalidArgumentError
 from dvc.ignore import init as init_dvcignore
+from dvc.log import logger
 from dvc.repo import Repo
 from dvc.scm import SCM, SCMError
 from dvc.utils import relpath
 from dvc.utils.fs import remove
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 def init(root_dir=os.curdir, no_scm=False, force=False, subdir=False):  # noqa: C901

--- a/dvc/repo/metrics/show.py
+++ b/dvc/repo/metrics/show.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from itertools import chain
 from typing import (
@@ -17,6 +16,7 @@ from typing import (
 from funcy import ldistinct
 from scmrepo.exceptions import SCMError
 
+from dvc.log import logger
 from dvc.repo import locked
 from dvc.scm import NoSCMError
 from dvc.utils import as_posix, expand_paths
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from dvc.repo import Repo
     from dvc.scm import Git, NoSCM
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 def _collect_top_level_metrics(repo: "Repo") -> Iterator[str]:

--- a/dvc/repo/open_repo.py
+++ b/dvc/repo/open_repo.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import tempfile
 import threading
@@ -7,6 +6,7 @@ from typing import TYPE_CHECKING, Dict, Optional, Tuple
 from funcy import retry, wrap_with
 
 from dvc.exceptions import NotDvcRepoError
+from dvc.log import logger
 from dvc.repo import Repo
 from dvc.scm import CloneError, map_scm_exception
 from dvc.utils import relpath
@@ -14,7 +14,7 @@ from dvc.utils import relpath
 if TYPE_CHECKING:
     from dvc.scm import Git
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 @map_scm_exception()

--- a/dvc/repo/params/show.py
+++ b/dvc/repo/params/show.py
@@ -1,10 +1,10 @@
-import logging
 import os
 from collections import defaultdict
 from itertools import chain
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple, Union
 
 from dvc.dependency.param import ParamsDependency, read_param_file
+from dvc.log import logger
 from dvc.repo import locked
 from dvc.repo.metrics.show import FileResult, Result
 from dvc.stage import PipelineStage
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from dvc.fs import FileSystem
     from dvc.repo import Repo
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 def _collect_top_level_params(repo: "Repo") -> Iterator[str]:

--- a/dvc/repo/plots/__init__.py
+++ b/dvc/repo/plots/__init__.py
@@ -1,6 +1,5 @@
 import csv
 import io
-import logging
 import os
 from collections import defaultdict
 from copy import deepcopy
@@ -23,7 +22,8 @@ import dpath.options
 from funcy import first, ldistinct, project, reraise
 
 from dvc.exceptions import DvcException
-from dvc.utils import error_handler, errored_revisions, onerror_collect
+from dvc.log import logger
+from dvc.utils import error_handler, errored_revisions
 from dvc.utils.objects import cached_property
 from dvc.utils.serialize import PARSERS, EncodingError
 from dvc.utils.threadpool import ThreadPoolExecutor
@@ -37,7 +37,12 @@ if TYPE_CHECKING:
 
 dpath.options.ALLOW_EMPTY_STRING_KEYS = True
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
+
+
+def onerror_collect(result: Dict, exception: Exception, *args, **kwargs):
+    logger.debug("", exc_info=True)
+    result["error"] = exception
 
 
 SUPPORTED_IMAGE_EXTENSIONS = ImageRenderer.EXTENSIONS

--- a/dvc/repo/pull.py
+++ b/dvc/repo/pull.py
@@ -1,10 +1,9 @@
-import logging
-
 from dvc.exceptions import CheckoutError
+from dvc.log import logger
 from dvc.repo import locked
 from dvc.utils import glob_targets
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 @locked

--- a/dvc/repo/remove.py
+++ b/dvc/repo/remove.py
@@ -1,7 +1,7 @@
-import logging
 import typing
 
 from dvc.dvcfile import DVC_FILE_SUFFIX
+from dvc.log import logger
 from dvc.stage.exceptions import (
     StageFileDoesNotExistError,
     StageFileIsNotDvcFileError,
@@ -13,7 +13,7 @@ from . import locked
 if typing.TYPE_CHECKING:
     from dvc.repo import Repo
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 @locked

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -1,4 +1,3 @@
-import logging
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -17,6 +16,7 @@ from typing import (
 from funcy import ldistinct
 
 from dvc.exceptions import ReproductionError
+from dvc.log import logger
 from dvc.repo.scm_context import scm_context
 from dvc.stage.cache import RunCacheNotSupported
 from dvc.utils import humanize
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
     from . import Repo
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 T = TypeVar("T")
 
 

--- a/dvc/repo/scm_context.py
+++ b/dvc/repo/scm_context.py
@@ -14,6 +14,7 @@ from typing import (
     Union,
 )
 
+from dvc.log import logger
 from dvc.utils import relpath
 from dvc.utils.collections import ensure_list
 
@@ -22,7 +23,7 @@ if TYPE_CHECKING:
     from dvc.scm import Base
 
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class SCMContext:

--- a/dvc/repo/stage.py
+++ b/dvc/repo/stage.py
@@ -1,5 +1,4 @@
 import fnmatch
-import logging
 import typing
 from contextlib import suppress
 from functools import wraps
@@ -10,11 +9,12 @@ from dvc.exceptions import (
     OutputDuplicationError,
     OutputNotFoundError,
 )
+from dvc.log import logger
 from dvc.repo import lock_repo
 from dvc.ui import ui
 from dvc.utils import as_posix, parse_target
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 if typing.TYPE_CHECKING:
     from networkx import DiGraph

--- a/dvc/repo/status.py
+++ b/dvc/repo/status.py
@@ -1,11 +1,11 @@
-import logging
 from itertools import chain, compress
 
 from dvc.exceptions import InvalidArgumentError
+from dvc.log import logger
 
 from . import locked
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 def _joint_status(pairs):

--- a/dvc/repo/worktree.py
+++ b/dvc/repo/worktree.py
@@ -1,10 +1,10 @@
-import logging
 from functools import partial
 from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Tuple, Union
 
 from funcy import first
 
 from dvc.fs.callbacks import Callback
+from dvc.log import logger
 from dvc.stage.exceptions import StageUpdateError
 
 if TYPE_CHECKING:
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from dvc_data.index import DataIndex, DataIndexView
     from dvc_objects.fs.base import FileSystem
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 # for files, if our version's checksum (etag) matches the latest remote

--- a/dvc/rwlock.py
+++ b/dvc/rwlock.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import os
 from collections import defaultdict
 from contextlib import contextmanager
@@ -7,12 +6,14 @@ from contextlib import contextmanager
 import psutil
 from voluptuous import Invalid, Optional, Required, Schema
 
+from dvc.log import logger
+
 from .exceptions import DvcException
 from .fs import localfs
 from .lock import make_lock
 from .utils import relpath
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 INFO_SCHEMA = {Required("pid"): int, Required("cmd"): str}

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import string
 from collections import defaultdict
@@ -22,6 +21,7 @@ from funcy import project
 
 from dvc import prompt
 from dvc.exceptions import CacheLinkError, CheckoutError, DvcException, MergeError
+from dvc.log import logger
 from dvc.utils import relpath
 from dvc.utils.objects import cached_property
 
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
     from dvc_data.hashfile.hash_info import HashInfo
     from dvc_objects.db import ObjectDB
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 # Disallow all punctuation characters except hyphen and underscore
 INVALID_STAGENAME_CHARS = set(string.punctuation) - {"_", "-"}
 Env = Dict[str, str]

--- a/dvc/stage/cache.py
+++ b/dvc/stage/cache.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, List, Optional, Tuple
@@ -8,12 +7,13 @@ from funcy import first
 from dvc import fs
 from dvc.config import RemoteConfigError
 from dvc.exceptions import CollectCacheError, DvcException
+from dvc.log import logger
 from dvc.utils import dict_sha256, relpath
 
 if TYPE_CHECKING:
     from dvc_objects.db import ObjectDB
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class RunCacheNotFoundError(DvcException):

--- a/dvc/stage/imports.py
+++ b/dvc/stage/imports.py
@@ -1,8 +1,7 @@
-import logging
-
 from dvc.exceptions import InvalidArgumentError
+from dvc.log import logger
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 def _update_import_on_remote(stage, remote, jobs):

--- a/dvc/stage/loader.py
+++ b/dvc/stage/loader.py
@@ -1,4 +1,3 @@
-import logging
 from collections.abc import Mapping
 from copy import deepcopy
 from itertools import chain
@@ -7,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Tuple
 from funcy import get_in, lcat, once, project
 
 from dvc import dependency, output
+from dvc.log import logger
 from dvc.parsing import FOREACH_KWD, JOIN, MATRIX_KWD, EntryNotFound
 from dvc.utils.objects import cached_property
 from dvc_data.hashfile.meta import Meta
@@ -19,7 +19,7 @@ from .utils import fill_stage_dependencies, resolve_paths
 if TYPE_CHECKING:
     from dvc.dvcfile import ProjectFile, SingleStageFile
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class StageLoader(Mapping):
@@ -138,9 +138,7 @@ class StageLoader(Mapping):
 
         if self.lockfile_data and name not in self.lockfile_data:
             self.lockfile_needs_update()
-            logger.trace(  # type: ignore[attr-defined]
-                "No lock entry found for '%s:%s'", self.dvcfile.relpath, name
-            )
+            logger.trace("No lock entry found for '%s:%s'", self.dvcfile.relpath, name)
 
         resolved_stage = resolved_data[name]
         stage = self.load_stage(

--- a/dvc/stage/run.py
+++ b/dvc/stage/run.py
@@ -1,15 +1,15 @@
-import logging
 import os
 import signal
 import subprocess
 import threading
 
+from dvc.log import logger
 from dvc.utils import fix_env
 
 from .decorators import unlocked_repo
 from .exceptions import StageCmdFailedError
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 def _make_cmd(executable, cmd):

--- a/dvc/ui/pager.py
+++ b/dvc/ui/pager.py
@@ -1,15 +1,15 @@
 """Draws DAG in ASCII."""
 
-import logging
 import os
 import pydoc
 
 from rich.pager import Pager
 
 from dvc.env import DVC_PAGER
+from dvc.log import logger
 from dvc.utils import format_link
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 DEFAULT_PAGER = "less"
@@ -85,7 +85,7 @@ def find_pager():
 
 def pager(text: str) -> None:
     _pager = find_pager()
-    logger.trace("Using pager: '%s'", _pager)  # type: ignore[attr-defined]
+    logger.trace("Using pager: '%s'", _pager)
     make_pager(_pager)(text)
 
 

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -2,7 +2,6 @@
 
 import hashlib
 import json
-import logging
 import os
 import re
 import sys
@@ -15,7 +14,6 @@ if TYPE_CHECKING:
 
     from dvc.fs import FileSystem
 
-logger = logging.getLogger(__name__)
 
 LARGE_DIR_SIZE = 100
 TARGET_REGEX = re.compile(r"(?P<path>.*?)(:(?P<name>[^\\/:]*))??$")
@@ -360,10 +358,6 @@ def parse_target(
         if not name:
             ret = (target, None)
             return ret if is_valid_filename(target) else ret[::-1]
-
-    if not path:
-        logger.trace("Assuming file to be '%s'", default)  # type: ignore[attr-defined]
-
     return path or default, name
 
 
@@ -403,11 +397,6 @@ def error_handler(func):
         return result
 
     return wrapper
-
-
-def onerror_collect(result: Dict, exception: Exception, *args, **kwargs):
-    logger.debug("", exc_info=True)
-    result["error"] = exception
 
 
 def errored_revisions(rev_data: Dict) -> List:

--- a/dvc/utils/fs.py
+++ b/dvc/utils/fs.py
@@ -1,5 +1,4 @@
 import errno
-import logging
 import os
 import shutil
 import stat
@@ -7,11 +6,12 @@ import sys
 from typing import TYPE_CHECKING
 
 from dvc.exceptions import DvcException
+from dvc.log import logger
 
 if TYPE_CHECKING:
     from dvc.types import StrPath
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 class BasePathNotInCheckedPathException(DvcException):

--- a/dvc/utils/hydra.py
+++ b/dvc/utils/hydra.py
@@ -1,8 +1,8 @@
-import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional
 
 from dvc.exceptions import InvalidArgumentError
+from dvc.log import logger
 
 from .collections import merge_dicts, remove_missing_keys, to_omegaconf
 
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from dvc.types import StrPath
 
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 
 def compose_and_dump(
@@ -60,7 +60,7 @@ def compose_and_dump(
         dumper(output_file, OmegaConf.to_object(cfg))
     else:
         Path(output_file).write_text(OmegaConf.to_yaml(cfg), encoding="utf-8")
-    logger.trace(  # type: ignore[attr-defined]
+    logger.trace(
         "Hydra composition enabled. Contents dumped to %s:\n %s", output_file, cfg
     )
 

--- a/dvc/utils/studio.py
+++ b/dvc/utils/studio.py
@@ -1,4 +1,3 @@
-import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from urllib.parse import urljoin
 
@@ -12,11 +11,12 @@ from dvc.env import (
     DVC_STUDIO_TOKEN,
     DVC_STUDIO_URL,
 )
+from dvc.log import logger
 
 if TYPE_CHECKING:
     from requests import Response
 
-logger = logging.getLogger(__name__)
+logger = logger.getChild(__name__)
 
 STUDIO_URL = "https://studio.iterative.ai"
 
@@ -33,7 +33,7 @@ def post(
     session = requests.Session()
     session.mount(url, HTTPAdapter(max_retries=max_retries))
 
-    logger.trace("Sending %s to %s", data, url)  # type: ignore[attr-defined]
+    logger.trace("Sending %s to %s", data, url)
 
     headers = {"Authorization": f"token {token}"}
     r = session.post(
@@ -66,7 +66,7 @@ def notify_refs(
     try:
         r = post("webhook/dvc", token, data, base_url=base_url)
     except requests.RequestException as e:
-        logger.trace("", exc_info=True)  # type: ignore[attr-defined]
+        logger.trace("", exc_info=True)
 
         msg = str(e)
         if e.response is None:
@@ -83,9 +83,7 @@ def notify_refs(
         d = r.json()
 
     if d:
-        logger.trace(  # type: ignore[attr-defined]
-            "received response: %s (status=%r)", d, r.status_code
-        )
+        logger.trace("received response: %s (status=%r)", d, r.status_code)
     return d
 
 

--- a/tests/func/plots/test_show.py
+++ b/tests/func/plots/test_show.py
@@ -7,8 +7,7 @@ from dvc.cli import main
 from dvc.dvcfile import PROJECT_FILE
 from dvc.exceptions import OverlappingOutputPathsError
 from dvc.repo import Repo
-from dvc.repo.plots import PlotMetricTypeError
-from dvc.utils import onerror_collect
+from dvc.repo.plots import PlotMetricTypeError, onerror_collect
 from dvc.utils.fs import remove
 from dvc.utils.serialize import EncodingError, YAMLFileCorruptedError, modify_yaml
 from tests.utils.plots import get_plot

--- a/tests/func/test_daemon.py
+++ b/tests/func/test_daemon.py
@@ -4,7 +4,7 @@ import re
 import subprocess
 import sys
 from collections import defaultdict
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path
 from threading import Thread
@@ -108,7 +108,8 @@ def test_analytics(tmp_path, server):
     assert match, "no match for the pid"
     pid = int(match.group(1).strip())
 
-    psutil.Process(pid).wait(timeout=10)
+    with suppress(psutil.NoSuchProcess):
+        psutil.Process(pid).wait(timeout=10)
     assert not os.path.exists(report_file)
     assert f"Process {pid} exiting with 0" in logfile.read_text(encoding="utf8")
     assert server.RequestHandlerClass.hits == {"POST": 1}
@@ -138,7 +139,8 @@ def test_updater(tmp_dir, dvc, server):
     assert match, "no match for the pid"
     pid = int(match.group(1).strip())
 
-    psutil.Process(pid).wait(timeout=10)
+    with suppress(psutil.NoSuchProcess):
+        psutil.Process(pid).wait(timeout=10)
     assert f"Process {pid} exiting with 0" in logfile.read_text(encoding="utf8")
     assert server.RequestHandlerClass.hits == {"GET": 1}
     # check that the file is saved correctly


### PR DESCRIPTION
I got tired of adding `# type: ignore[attr-defined]` while using `logger.trace`.
So, now you need to import logger from `from dvc.log import logger` and
create a child logger using `logger.getChild(__name__)`. `logger.getChild`
will return a logger type-hinted as a logger having a `trace` method.

So, from now on, instead of:
```python
import logging

logger = logging.getogger(__name__)
```

you'll have to do following:
```python
from dvc.log import logger

logger = logger.getChild(__name__)
```

To me, the need for adding type-ignore made me less likely to use it.

