### PR TITLE
fix name of the loggers used

### DIFF
--- a/dvc/cli/__init__.py
+++ b/dvc/cli/__init__.py
@@ -12,6 +12,9 @@ from dvc.log import logger
 "".encode("idna")
 
 
+logger = logger.getChild(__name__)
+
+
 class DvcParserError(Exception):
     """Base class for CLI parser errors."""
 

--- a/dvc/log.py
+++ b/dvc/log.py
@@ -7,4 +7,4 @@ class LoggerWithTrace(logging.Logger):
     trace = logging.debug
 
 
-logger: "LoggerWithTrace" = logging.getLogger("dvc")  # type: ignore[assignment]
+logger: "LoggerWithTrace" = logging.getLogger()  # type: ignore[assignment]


### PR DESCRIPTION
`__name__` looks something like `dvc.commands.diff`, but if we are already instantiating root logger with `dvc`, it adds up to create something like `dvc.dvc.commands.diff`.

We should be using a root logger here instead.

