### PR TITLE
Add params collection to index

### DIFF
--- a/tests/func/test_repo_index.py
+++ b/tests/func/test_repo_index.py
@@ -315,3 +315,26 @@ def test_ignored_dir_unignored_pattern(tmp_dir, dvc, scm):
     (stage,) = tmp_dir.dvc_gen({"data/raw/tracked.csv": "5,6,7,8"})
     index = Index.from_repo(dvc)
     assert index.stages == [stage]
+
+
+def test_param_keys_returns_default_file(tmp_dir, dvc):
+    tmp_dir.gen({"params.yaml": "param: 100\n"})
+    index = Index.from_repo(dvc)
+    assert index.param_keys == {"repo": {("params.yaml",)}}
+
+
+def test_param_keys_no_params(dvc):
+    index = Index.from_repo(dvc)
+    assert index.param_keys == {"repo": set()}
+
+
+def test_param_keys_top_level_params(tmp_dir, dvc):
+    params_file_path = "classifier/custom_params_file.yaml"
+    top_level_params = f"""
+params:
+  - {params_file_path}
+    """
+    tmp_dir.gen(params_file_path, "param: 100\n")
+    tmp_dir.gen("dvc.yaml", top_level_params)
+    index = Index.from_repo(dvc)
+    assert index.param_keys == {"repo": {("classifier", "custom_params_file.yaml")}}


### PR DESCRIPTION
Add `param` files collection to index to implement:

```python
downloaded_cnt = repo.fetch(
           ...
            types=["metrics", "plots", "params"],
            ...
        )
```

It's not used anywhere atm and needed to potentially migrate Studio code to use Index.

## TODO

- [x] Add tests. ~Do we have any tests for index at all @skshetry @efiop? I don't see anything, and plan to add `unit/test_index` or something like that.~ Found the `repo_index` one.
