### PR TITLE
[WIP] Set `onerror` in fetch before running transfer

### DIFF
--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -157,6 +157,10 @@ def fetch(  # noqa: PLR0913
     data, unversioned_count = _log_unversioned(data)
     failed_count += unversioned_count
 
+    if onerror:
+        for fs_index in data:
+            fs_index.onerror = _make_index_onerror(onerror, None)
+
     with ui.progress(
         desc="Fetching",
         bar_format="{desc}",


### PR DESCRIPTION
Seems to be need this to fix a test in Studio where we are migrating to the new `fetch` on top of the index.

```python
result = transfer(
                    data.odb,
                    cache.odb,
                    [
                        entry.hash_info
                        for _, entry in fs_index.iteritems(). # Here it is fetching directory again and is raising if it's not found
                        if entry.hash_info
                    ],
                    jobs=jobs,
                    src_index=get_index(data.odb),
                    cache_odb=cache.odb,
                    verify=data.odb.verify,
                    validate_status=_log_missing,
                    callback=cb,
                )
```

## TODO

- [ ] Add tests. First need to check if it makes sense.
