### PR TITLE
remove pytest-virtualenv

### DIFF
--- a/dvc/testing/benchmarks/fixtures.py
+++ b/dvc/testing/benchmarks/fixtures.py
@@ -9,7 +9,6 @@ import virtualenv
 from dulwich.porcelain import clone
 from funcy import first
 from packaging import version
-from pytest_benchmark.utils import subprocess
 
 from dvc.types import StrPath
 
@@ -20,17 +19,16 @@ def bench_config(request):
 
 
 class VirtualEnv:
-    def __init__(self, path: StrPath = os.curdir) -> None:
+    def __init__(self, path: StrPath) -> None:
         self.path = Path(path)
         self.bin = self.path / ("Scripts" if os.name == "nt" else "bin")
 
     def create(self) -> None:
-        assert not self.path.exists()
         virtualenv.cli_run([os.fspath(self.path)])
 
     def run(self, cmd: str, *args: str, env: Optional[Dict[str, str]] = None) -> None:
         exe = self.which(cmd)
-        subprocess.check_output([exe, *args], env=env)
+        check_output([exe, *args], env=env) # noqa: S603
 
     def which(self, cmd: str) -> str:
         assert self.bin.exists()

--- a/dvc/testing/benchmarks/fixtures.py
+++ b/dvc/testing/benchmarks/fixtures.py
@@ -2,11 +2,16 @@ import os
 import shutil
 from pathlib import Path
 from subprocess import check_output
+from typing import Dict, Optional
 
 import pytest
+import virtualenv
 from dulwich.porcelain import clone
 from funcy import first
 from packaging import version
+from pytest_benchmark.utils import subprocess
+
+from dvc.types import StrPath
 
 
 @pytest.fixture(scope="session")
@@ -14,14 +19,32 @@ def bench_config(request):
     return request.config.bench_config
 
 
+class VirtualEnv:
+    def __init__(self, path: StrPath = os.curdir) -> None:
+        self.path = Path(path)
+        self.bin = self.path / ("Scripts" if os.name == "nt" else "bin")
+
+    def create(self) -> None:
+        assert not self.path.exists()
+        virtualenv.cli_run([os.fspath(self.path)])
+
+    def run(self, cmd: str, *args: str, env: Optional[Dict[str, str]] = None) -> None:
+        exe = self.which(cmd)
+        subprocess.check_output([exe, *args], env=env)
+
+    def which(self, cmd: str) -> str:
+        assert self.bin.exists()
+        return shutil.which(cmd, path=self.bin) or cmd
+
+
 @pytest.fixture(scope="session")
 def make_dvc_venv(tmp_path_factory):
     def _make_dvc_venv(name):
-        from pytest_virtualenv import VirtualEnv
-
         name = _sanitize_venv_name(name)
         venv_dir = tmp_path_factory.mktemp(f"dvc-venv-{name}")
-        return VirtualEnv(workspace=venv_dir)
+        venv = VirtualEnv(venv_dir)
+        venv.create()
+        return venv
 
     return _make_dvc_venv
 
@@ -74,16 +97,16 @@ def make_dvc_bin(
         venv = dvc_venvs.get(dvc_rev)
         if not venv:
             venv = make_dvc_venv(dvc_rev)
-            venv.run("pip install -U pip")
+            venv.run("pip", "install", "-U", "pip")
             if bench_config.dvc_install_deps:
                 egg = f"dvc[{bench_config.dvc_install_deps}]"
             else:
                 egg = "dvc"
-            venv.run(f"pip install git+file://{dvc_git_repo}@{dvc_rev}#egg={egg}")
+            venv.run("pip", "install", f"git+file://{dvc_git_repo}@{dvc_rev}#egg={egg}")
             if dvc_rev in ["2.18.1", "2.11.0", "2.6.3"]:
-                venv.run("pip install fsspec==2022.11.0")
+                venv.run("pip", "install", "fsspec==2022.11.0")
             dvc_venvs[dvc_rev] = venv
-        dvc_bin = venv.virtualenv / "bin" / "dvc"
+        dvc_bin = venv.which("dvc")
     else:
         dvc_bin = bench_config.dvc_bin
 

--- a/dvc/testing/benchmarks/fixtures.py
+++ b/dvc/testing/benchmarks/fixtures.py
@@ -28,7 +28,7 @@ class VirtualEnv:
 
     def run(self, cmd: str, *args: str, env: Optional[Dict[str, str]] = None) -> None:
         exe = self.which(cmd)
-        check_output([exe, *args], env=env) # noqa: S603
+        check_output([exe, *args], env=env)  # noqa: S603
 
     def which(self, cmd: str) -> str:
         assert self.bin.exists()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,9 +90,9 @@ s3 = ["dvc-s3==2.23.0"]
 ssh = ["dvc-ssh>=2.22.1,<3"]
 ssh_gssapi = ["dvc-ssh[gssapi]>=2.22.1,<3"]
 testing = [
-  "pytest-test-utils",
   "pytest-benchmark[histogram]",
-  "pytest-virtualenv",
+  "pytest-test-utils",
+  "virtualenv",
 ]
 tests = [
     "dvc[testing]",
@@ -156,8 +156,6 @@ filterwarnings = [
     # google.logging: https://github.com/googleapis/python-logging/issues/730
     # Also happens with `zc.lockfile`.
     "ignore:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning",
-    # tpi imports pkg_resources
-    "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
     # see https://github.com/networkx/networkx/issues/5723.
     "ignore:nx.nx_pydot.* depends on the pydot package, which has.*known issues and is not actively maintained:DeprecationWarning",
 ]
@@ -230,12 +228,11 @@ module = [
     "pyparsing",
     "pytest_benchmark.*",
     "pytest_docker.plugin",
-    "pytest_virtualenv.*",
     "ruamel.*",
     "ruamel.yaml.*",
     "shortuuid",
     "shtab",
-    "tpi.*",
+    "virtualenv",
     "viztracer",
     "voluptuous",
     "yappi",


### PR DESCRIPTION
It does not look like it's being actively maintained. It is also failing on Python 3.12 due to `imp` module which has been removed in the latest version.

- https://github.com/man-group/pytest-plugins/pull/219
- https://github.com/man-group/pytest-plugins/issues/220