### PR TITLE
pytest.ini_options: add --benchmark-skip to suppress pytest-benchmark warning with xdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,7 @@ namespaces = false
 write_to = "dvc/_dvc_version.py"
 
 [tool.pytest.ini_options]
-addopts = "-ra --cov-config pyproject.toml --dist worksteal"
+addopts = "-ra --cov-config pyproject.toml --dist worksteal --benchmark-skip"
 filterwarnings = [
     "error::ResourceWarning",
     "error::pytest.PytestUnraisableExceptionWarning",


### PR DESCRIPTION
We don't run benchmarks here, and benchmarking should always be a separate command than regular test run.

```python
/Users/user/Projects/dvc/.venv/lib/python3.12/site-packages/pytest_benchmark/logger.py:46: PytestBenchmarkWarning: Benchmarks are automatically disabled because xdist plugin is active.Benchmarks cannot be performed reliably in a parallelized environment.
  warner(PytestBenchmarkWarning(text))
```

