### PR TITLE
fix(config): respect global config env variable

### DIFF
--- a/dvc/dirs.py
+++ b/dvc/dirs.py
@@ -15,7 +15,7 @@ def system_config_dir():
 
 
 def global_config_dir():
-    return os.getenv(env.DVC_SYSTEM_CONFIG_DIR) or platformdirs.user_config_dir(
+    return os.getenv(env.DVC_GLOBAL_CONFIG_DIR) or platformdirs.user_config_dir(
         APPNAME, APPAUTHOR
     )
 

--- a/tests/unit/test_dirs.py
+++ b/tests/unit/test_dirs.py
@@ -1,0 +1,8 @@
+from dvc.dirs import global_config_dir
+from dvc.env import DVC_GLOBAL_CONFIG_DIR
+
+
+def test_global_config_dir_respects_env_var(monkeypatch):
+    path = "/some/random/path"
+    monkeypatch.setenv(DVC_GLOBAL_CONFIG_DIR, path)
+    assert global_config_dir() == path


### PR DESCRIPTION
Minor fix in the way we handle config dirs. I think it's not documented and primarily used for test. We plan to start using it to isolate tests in Studio and isolate repos on workers.

------------

* [X] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [X] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
