### PR TITLE
bench: test fetch instead of pull

### DIFF
--- a/dvc/testing/benchmarks/cli/commands/test_fetch.py
+++ b/dvc/testing/benchmarks/cli/commands/test_fetch.py
@@ -1,0 +1,3 @@
+def test_fetch(bench_dvc, tmp_dir, dvc, make_dataset, remote):
+    make_dataset(cache=False, dvcfile=True, files=False, remote=True)
+    bench_dvc("fetch")

--- a/dvc/testing/benchmarks/cli/commands/test_pull.py
+++ b/dvc/testing/benchmarks/cli/commands/test_pull.py
@@ -1,3 +1,0 @@
-def test_pull(bench_dvc, tmp_dir, dvc, make_dataset, remote):
-    make_dataset(cache=False, dvcfile=True, files=False, remote=True)
-    bench_dvc("pull")

--- a/dvc/testing/benchmarks/cli/stories/use_cases/test_sharing.py
+++ b/dvc/testing/benchmarks/cli/stories/use_cases/test_sharing.py
@@ -11,7 +11,8 @@ def test_sharing(bench_dvc, tmp_dir, dvc, dataset, remote):
     shutil.rmtree(dataset)
     shutil.rmtree(tmp_dir / ".dvc" / "cache")
 
-    bench_dvc("pull")
-    bench_dvc("pull", name="noop")
+    bench_dvc("fetch")
+    bench_dvc("fetch", name="noop")
 
+    bench_dvc("checkout")
     bench_dvc("checkout", name="noop")


### PR DESCRIPTION
`pull` is literally `fetch` + `checkout` and our main interest there is downloading, so let's just test `fetch` instead.
