### PR TITLE
tests: do not setup pytest plugin entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,9 +127,6 @@ dvc = "dvc.cli:main"
 [project.entry-points."fsspec.specs"]
 dvc = "dvc.api:DVCFileSystem"
 
-[project.entry-points."pytest11"]
-dvc-testing = "dvc.testing.plugin"
-
 [project.entry-points."pyinstaller40"]
 hook-dirs = "dvc.__pyinstaller:get_hook_dirs"
 tests = "dvc.__pyinstaller:get_PyInstaller_tests"


### PR DESCRIPTION
We should not register a pytest plugin automatically, as we may have fixtures that might override user's fixtures. Also, it might raise import errors as in https://github.com/iterative/dvc/issues/10118.

We can still use this as a plugin ourselves by setting the following in `conftest.py` file.
```python
pytest_plugins = ['dvc.testing.plugin']
```
