### PR TITLE
Fix issue with Windows' dvc.api.read not resolving paths correctly

### DIFF
--- a/dvc/fs/dvc.py
+++ b/dvc/fs/dvc.py
@@ -74,7 +74,7 @@ def _get_dvc_path(dvc_fs, subkey):
 
 class _DVCFileSystem(AbstractFileSystem):
     cachable = False
-    root_marker = "/"
+    root_marker = "/" if os.name != "nt" else ""
 
     def __init__(  # noqa: PLR0913
         self,

--- a/dvc/fs/dvc.py
+++ b/dvc/fs/dvc.py
@@ -75,7 +75,7 @@ def _get_dvc_path(dvc_fs, subkey):
 
 class _DVCFileSystem(AbstractFileSystem):
     cachable = False
-    root_marker = "/" if os.name != "nt" else ""
+    root_marker = "/"
 
     def __init__(  # noqa: PLR0913
         self,

--- a/dvc/fs/dvc.py
+++ b/dvc/fs/dvc.py
@@ -2,6 +2,7 @@ import errno
 import functools
 import ntpath
 import os
+import pathlib
 import posixpath
 import threading
 from contextlib import ExitStack, suppress
@@ -199,7 +200,7 @@ class _DVCFileSystem(AbstractFileSystem):
 
     def _get_key_from_relative(self, path) -> Key:
         path = self._strip_protocol(path)
-        parts = self.path.relparts(path, self.root_marker)
+        parts = pathlib.Path(path).parts
         if parts and parts[0] == os.curdir:
             return parts[1:]
         return parts

--- a/dvc/fs/dvc.py
+++ b/dvc/fs/dvc.py
@@ -2,7 +2,6 @@ import errno
 import functools
 import ntpath
 import os
-import pathlib
 import posixpath
 import threading
 from contextlib import ExitStack, suppress
@@ -200,7 +199,7 @@ class _DVCFileSystem(AbstractFileSystem):
 
     def _get_key_from_relative(self, path) -> Key:
         path = self._strip_protocol(path)
-        parts = pathlib.Path(path).parts
+        parts = self.path.relparts(path, self.root_marker)
         if parts and parts[0] == os.curdir:
             return parts[1:]
         return parts


### PR DESCRIPTION
Running a `dvc.api.read` in a Windows system breaks the pathing unexpectedly.

For example:
```py
dvc.api.read(path="rsc/my-file.txt", repo="C://.../my-repo/")
````

Given this file structure:

```
C://.../
- my-repo/
  - rsc/
    - my-file.txt
  - src/
    - script.py
```

will raise:

```
dvc.exceptions.PathMissingError: The path 'C:\...\src\rsc\my-file.txt' does not exist in the target repository 'C:\...\src\rsc\my-file.txt' neither as a DVC output nor as a Git-tracked file.
```

---

**TBC**: why the PR fixes the issue

---

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

