### PR TITLE
exp: ignore workspace errors during push/pull

### DIFF
--- a/dvc/repo/brancher.py
+++ b/dvc/repo/brancher.py
@@ -20,6 +20,7 @@ def brancher(
     all_tags=False,
     all_commits=False,
     all_experiments=False,
+    workspace=True,
     commit_date: Optional[str] = None,
     sha_only=False,
     num=1,
@@ -31,6 +32,7 @@ def brancher(
         all_branches (bool): iterate over all available branches.
         all_commits (bool): iterate over all commits.
         all_tags (bool): iterate over all available tags.
+        workspace (bool): include workspace.
         commit_date (str): Keep experiments from the commits after(include)
                             a certain date. Date must match the extended
                             ISO 8601 format (YYYY-MM-DD).
@@ -73,7 +75,8 @@ def brancher(
 
     logger.trace("switching fs to workspace")
     self.fs = LocalFileSystem(url=self.root_dir)
-    yield "workspace"
+    if workspace:
+        yield "workspace"
 
     revs = revs.copy() if revs else []
     if "workspace" in revs:

--- a/dvc/repo/experiments/pull.py
+++ b/dvc/repo/experiments/pull.py
@@ -112,4 +112,6 @@ def _pull_cache(
         refs = [refs]
     revs = list(exp_commits(repo.scm, refs))
     logger.debug("dvc fetch experiment '%s'", refs)
-    repo.fetch(jobs=jobs, remote=dvc_remote, run_cache=run_cache, revs=revs)
+    repo.fetch(
+        jobs=jobs, remote=dvc_remote, run_cache=run_cache, revs=revs, workspace=False
+    )

--- a/dvc/repo/experiments/push.py
+++ b/dvc/repo/experiments/push.py
@@ -188,4 +188,6 @@ def _push_cache(
     assert isinstance(repo.scm, Git)
     revs = list(exp_commits(repo.scm, refs))
     logger.debug("dvc push experiment '%s'", refs)
-    return repo.push(jobs=jobs, remote=dvc_remote, run_cache=run_cache, revs=revs)
+    return repo.push(
+        jobs=jobs, remote=dvc_remote, run_cache=run_cache, revs=revs, workspace=False
+    )

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -32,6 +32,7 @@ def _collect_indexes(  # noqa: PLR0913
     recursive=False,
     all_commits=False,
     revs=None,
+    workspace=True,
     max_size=None,
     types=None,
     config=None,
@@ -62,7 +63,7 @@ def _collect_indexes(  # noqa: PLR0913
         all_branches=all_branches,
         all_tags=all_tags,
         all_commits=all_commits,
-        workspace=False,
+        workspace=workspace,
     ):
         try:
             repo.config.merge(config)
@@ -105,6 +106,7 @@ def fetch(  # noqa: PLR0913
     all_commits=False,
     run_cache=False,
     revs=None,
+    workspace=True,
     max_size=None,
     types=None,
     config=None,
@@ -149,6 +151,7 @@ def fetch(  # noqa: PLR0913
         recursive=recursive,
         all_commits=all_commits,
         revs=revs,
+        workspace=workspace,
         max_size=max_size,
         types=types,
         config=config,

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -22,7 +22,7 @@ def _make_index_onerror(onerror, rev):
     return _onerror
 
 
-def _collect_indexes(  # noqa: PLR0913,C901
+def _collect_indexes(  # noqa: PLR0913
     repo,
     targets=None,
     remote=None,
@@ -62,6 +62,7 @@ def _collect_indexes(  # noqa: PLR0913,C901
         all_branches=all_branches,
         all_tags=all_tags,
         all_commits=all_commits,
+        workspace=False,
     ):
         try:
             repo.config.merge(config)
@@ -80,8 +81,6 @@ def _collect_indexes(  # noqa: PLR0913,C901
 
             indexes[rev or "workspace"] = idx
         except Exception as exc:  # noqa: BLE001
-            if revs and rev == "workspace" and rev not in revs:
-                continue
             if onerror:
                 onerror(rev, None, exc)
             collection_exc = exc

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -22,7 +22,7 @@ def _make_index_onerror(onerror, rev):
     return _onerror
 
 
-def _collect_indexes(  # noqa: PLR0913
+def _collect_indexes(  # noqa: PLR0913,C901
     repo,
     targets=None,
     remote=None,
@@ -80,6 +80,8 @@ def _collect_indexes(  # noqa: PLR0913
 
             indexes[rev or "workspace"] = idx
         except Exception as exc:
+            if rev == "workspace" and rev not in revs:
+                continue
             if onerror:
                 onerror(rev, None, exc)
             collection_exc = exc

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -79,13 +79,13 @@ def _collect_indexes(  # noqa: PLR0913,C901
             idx.data["repo"].onerror = _make_index_onerror(onerror, rev)
 
             indexes[rev or "workspace"] = idx
-        except Exception as exc:
-            if rev == "workspace" and rev not in revs:
+        except Exception as exc:  # noqa: BLE001
+            if revs and rev == "workspace" and rev not in revs:
                 continue
             if onerror:
                 onerror(rev, None, exc)
             collection_exc = exc
-            logger.exception("failed to collect '%s'", rev or "workspace")
+            logger.warning("failed to collect '%s'", rev or "workspace")
 
     if not indexes and collection_exc:
         raise collection_exc

--- a/dvc/repo/fetch.py
+++ b/dvc/repo/fetch.py
@@ -85,7 +85,7 @@ def _collect_indexes(  # noqa: PLR0913,C901
             if onerror:
                 onerror(rev, None, exc)
             collection_exc = exc
-            logger.warning("failed to collect '%s'", rev or "workspace")
+            logger.warning("failed to collect '%s', skipping", rev or "workspace")
 
     if not indexes and collection_exc:
         raise collection_exc

--- a/dvc/repo/push.py
+++ b/dvc/repo/push.py
@@ -46,6 +46,7 @@ def push(  # noqa: PLR0913
     all_commits=False,
     run_cache=False,
     revs=None,
+    workspace=True,
     glob=False,
 ):
     from fsspec.utils import tokenize
@@ -87,6 +88,7 @@ def push(  # noqa: PLR0913
         recursive=recursive,
         all_commits=all_commits,
         revs=revs,
+        workspace=workspace,
         push=True,
     )
 

--- a/tests/func/experiments/test_remote.py
+++ b/tests/func/experiments/test_remote.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 from funcy import first
 
@@ -360,3 +362,16 @@ def test_get(tmp_dir, scm, dvc, exp_stage, erepo_dir, use_ref):
             rev=exp_ref.name if use_ref else exp_rev,
         )
         assert (erepo_dir / "params.yaml").read_text().strip() == "foo: 2"
+
+
+def test_push_invalid_workspace(
+    tmp_dir, scm, dvc, git_upstream, exp_stage, local_remote, caplog
+):
+    dvc.experiments.run()
+
+    with open("dvc.yaml", mode="a") as f:
+        f.write("\ninvalid")
+
+    with caplog.at_level(logging.ERROR, logger="dvc"):
+        dvc.experiments.push(git_upstream.remote, push_cache=True)
+        assert "failed to collect" not in caplog.text

--- a/tests/func/experiments/test_remote.py
+++ b/tests/func/experiments/test_remote.py
@@ -372,6 +372,6 @@ def test_push_invalid_workspace(
     with open("dvc.yaml", mode="a") as f:
         f.write("\ninvalid")
 
-    with caplog.at_level(logging.ERROR, logger="dvc"):
+    with caplog.at_level(logging.WARNING, logger="dvc"):
         dvc.experiments.push(git_upstream.remote, push_cache=True)
         assert "failed to collect" not in caplog.text

--- a/tests/func/experiments/test_remote.py
+++ b/tests/func/experiments/test_remote.py
@@ -364,7 +364,7 @@ def test_get(tmp_dir, scm, dvc, exp_stage, erepo_dir, use_ref):
         assert (erepo_dir / "params.yaml").read_text().strip() == "foo: 2"
 
 
-def test_push_invalid_workspace(
+def test_push_pull_invalid_workspace(
     tmp_dir, scm, dvc, git_upstream, exp_stage, local_remote, caplog
 ):
     dvc.experiments.run()
@@ -374,4 +374,5 @@ def test_push_invalid_workspace(
 
     with caplog.at_level(logging.WARNING, logger="dvc"):
         dvc.experiments.push(git_upstream.remote, push_cache=True)
+        dvc.experiments.pull(git_upstream.remote, pull_cache=True)
         assert "failed to collect" not in caplog.text


### PR DESCRIPTION
Fixes https://github.com/iterative/dvc/issues/9768. Even for operations that don't use the workspace, like `dvc exp push`, dvc was logging errors if the workspace state was invalid, making it look like the command failed. This PR suppresses those errors if the workspace was not one of the included revs.