### PR TITLE
deps: bump dvc-oss to >=2.22.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ lint = [
     "types-toml",
     "types-tqdm",
 ]
-oss = ["dvc-oss>=2.20.0"]
+oss = ["dvc-oss>=2.22.0"]
 s3 = ["dvc-s3==2.23.0"]
 ssh = ["dvc-ssh>=2.22.1,<3"]
 ssh_gssapi = ["dvc-ssh[gssapi]>=2.22.1,<3"]


### PR DESCRIPTION
First release with unpinned fsspec version.
