### PR TITLE
bench: mark test_get/import as flaky

### DIFF
--- a/dvc/testing/benchmarks/cli/commands/test_get.py
+++ b/dvc/testing/benchmarks/cli/commands/test_get.py
@@ -1,3 +1,7 @@
+import pytest
+
+
+@pytest.mark.flaky(max_runs=3, min_passes=1)
 def test_get(bench_dvc, tmp_dir, scm, dvc, make_dataset, remote):
     dataset = make_dataset(
         cache=False, files=False, dvcfile=True, commit=True, remote=True

--- a/dvc/testing/benchmarks/cli/commands/test_import.py
+++ b/dvc/testing/benchmarks/cli/commands/test_import.py
@@ -1,3 +1,7 @@
+import pytest
+
+
+@pytest.mark.flaky(max_runs=3, min_passes=1)
 def test_import(bench_dvc, tmp_dir, scm, dvc, make_dataset, remote):
     dataset = make_dataset(
         cache=False, files=False, dvcfile=True, commit=True, remote=True


### PR DESCRIPTION
Sometimes seeing those error out in 2.x and early 3.x with:

```
ERROR: unexpected error - [Errno 95] no more link types left to try out: [Errno 95] Operation not supported
```

It seems like we've fixed it at some point, but I was not able to quickly find a link. Will update this if I do.
