### PR TITLE
gc: add --skip-failed

### DIFF
--- a/dvc/commands/gc.py
+++ b/dvc/commands/gc.py
@@ -86,6 +86,7 @@ class CmdGC(CmdBase):
             num=self.args.num,
             not_in_remote=self.args.not_in_remote,
             dry=self.args.dry,
+            skip_failed=self.args.skip_failed,
         )
         return 0
 
@@ -187,6 +188,12 @@ def add_parser(subparsers, parent_parser):
         "--remote",
         help="Remote storage to collect garbage in",
         metavar="<name>",
+    )
+    gc_parser.add_argument(
+        "--skip-failed",
+        action="store_true",
+        default=False,
+        help="Skip revisions that fail when collected.",
     )
     gc_parser.add_argument(
         "-f",

--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -357,3 +357,15 @@ class ArtifactNotFoundError(DvcException):
 
         desc = f" @ {stage or version}" if (stage or version) else ""
         super().__init__(f"Unable to find artifact '{name}{desc}'")
+
+
+class RevCollectionError(DvcException):
+    """Thrown if a revision failed to be collected.
+
+    Args:
+        rev (str): revision that failed (or "workspace").
+    """
+
+    def __init__(self, rev):
+        self.rev = rev
+        super().__init__(f"Failed to collect '{rev}'")

--- a/dvc/repo/gc.py
+++ b/dvc/repo/gc.py
@@ -68,6 +68,7 @@ def gc(  # noqa: PLR0913, C901
     num: Optional[int] = None,
     not_in_remote: bool = False,
     dry: bool = False,
+    skip_failed: bool = False,
 ):
     # require `workspace` to be true to come into effect.
     # assume `workspace` to be enabled if any of `all_tags`, `all_commits`,
@@ -113,6 +114,7 @@ def gc(  # noqa: PLR0913, C901
                 jobs=jobs,
                 revs=[rev] if rev else None,
                 num=num or 1,
+                skip_failed=skip_failed,
             ).items():
                 if odb not in odb_to_obj_ids:
                     odb_to_obj_ids[odb] = set()

--- a/tests/func/test_gc.py
+++ b/tests/func/test_gc.py
@@ -7,7 +7,7 @@ import textwrap
 import pytest
 
 from dvc.cli import main
-from dvc.exceptions import CollectCacheError, InvalidArgumentError
+from dvc.exceptions import CollectCacheError, InvalidArgumentError, RevCollectionError
 from dvc.fs import LocalFileSystem
 from dvc.utils.fs import remove
 from dvc_data.hashfile.db.local import LocalHashFileDB
@@ -439,3 +439,13 @@ def test_gc_logging(caplog, dvc, good_and_bad_cache):
     assert "Removed 3 objects from repo cache." in caplog.text
     assert "No unused 'local' cache to remove." in caplog.text
     assert "No unused 'legacy' cache to remove." in caplog.text
+
+
+def test_gc_skip_failed(tmp_dir, dvc):
+    with open("dvc.yaml", mode="w") as f:
+        f.write("\ninvalid")
+
+    with pytest.raises(RevCollectionError):
+        dvc.gc(force=True, workspace=True)
+
+    dvc.gc(force=True, workspace=True, skip_failed=True)

--- a/tests/func/test_gc.py
+++ b/tests/func/test_gc.py
@@ -111,8 +111,9 @@ def test_gc_no_dir_cache(tmp_dir, dvc):
 
     remove(dir_stage.outs[0].cache_path)
 
-    with pytest.raises(CollectCacheError):
+    with pytest.raises(RevCollectionError) as exc:
         dvc.gc(workspace=True)
+    assert type(exc.value.__cause__) == CollectCacheError
 
     assert _count_files(dvc.cache.local.path) == 4
     dvc.gc(force=True, workspace=True)

--- a/tests/unit/command/test_gc.py
+++ b/tests/unit/command/test_gc.py
@@ -26,6 +26,7 @@ def test_(dvc, scm, mocker):
             "--projects",
             "project1",
             "project2",
+            "--skip-failed",
         ]
     )
     assert cli_args.func == CmdGC
@@ -51,6 +52,7 @@ def test_(dvc, scm, mocker):
         num=None,
         not_in_remote=False,
         dry=True,
+        skip_failed=True,
     )
 
     cli_args = parse_args(["gc"])


### PR DESCRIPTION
Closes https://github.com/iterative/dvc/issues/5037. Follows up on the great work started by @courentin in https://github.com/iterative/dvc/pull/5038. Also related to https://github.com/iterative/dvc/issues/9768#issuecomment-1845895172.

Example:

```sh
$ dvc gc -A --skip-failed
WARNING: This will remove all cache except items used in the workspace and all git commits of the current repo.
Are you sure you want to proceed? [y/n]: y
WARNING: Failed to collect 'workspace', skipping
WARNING: Failed to collect '964799719df645d5104c541410549f702d2a9b5d', skipping
WARNING: Failed to collect '9c24c7652c3eb28adaa2caafdff7dfdc21f1e449', skipping
WARNING: Failed to collect '616500724541bcd2f7f89584187b00f838ecf9a9', skipping
No unused 'repo' cache to remove.
No unused 'local' cache to remove.
No unused 'legacy' cache to remove.
```