### PR TITLE
param: fix exponential memory allocation

### DIFF
--- a/dvc/dependency/param.py
+++ b/dvc/dependency/param.py
@@ -55,6 +55,7 @@ def read_param_file(
         return ret
 
     from copy import deepcopy
+
     from dpath import merge
 
     for key_path in key_paths:

--- a/dvc/dependency/param.py
+++ b/dvc/dependency/param.py
@@ -54,12 +54,13 @@ def read_param_file(
                 continue
         return ret
 
+    from copy import deepcopy
     from dpath import merge
 
     for key_path in key_paths:
         merge(
             ret,
-            dpath.search(config, key_path, separator="."),
+            deepcopy(dpath.search(config, key_path, separator=".")),
             separator=".",
         )
     return ret


### PR DESCRIPTION
Closes https://github.com/iterative/dvc/issues/10177.

### Explanantion

* By default, [`dpath.merge`](https://github.com/dpath-maintainers/dpath-python/blob/e0d412f9d3105623c8ea97159bcdfcc5415b0849/README.rst?plain=1#L279-L291) appends new elements to existing lists.
* Parsing YAML files with [reused anchors](https://yaml.org/spec/1.2.2/#alias-nodes) will create mutable objects (e.g. lists) passed by reference.
* Changes performed to e.g. lists inside `config` will also be applied to e.g. lists inside `ret` sharing the same anchor.

#### Before
```python
from dpath import merge


ret = {}
config = {"list": [1, 2]}

for _ in range(4):
    merge(ret, config)
    print(ret)
```
```console
{'list': [1, 2]}
{'list': [1, 2, 1, 2]}
{'list': [1, 2, 1, 2, 1, 2, 1, 2]}
{'list': [1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2]}
```

#### After
```python
from copy import deepcopy

from dpath import merge


ret = {}
config = {"list": [1, 2]}

for _ in range(4):
    merge(ret, deepcopy(config))
    print(ret)
```
```console
{'list': [1, 2]}
{'list': [1, 2, 1, 2]}
{'list': [1, 2, 1, 2, 1, 2]}
{'list': [1, 2, 1, 2, 1, 2, 1, 2]}
```

> [!WARNING]
> I'm exhausted, please review carefully!