### PR TITLE
param: optimize fix for exponential memory allocation

### DIFF
--- a/dvc/dependency/param.py
+++ b/dvc/dependency/param.py
@@ -54,14 +54,12 @@ def read_param_file(
                 continue
         return ret
 
-    from copy import deepcopy
-
     from dpath import merge
 
-    for key_path in key_paths:
+    for key_path in set(key_paths):
         merge(
             ret,
-            deepcopy(dpath.search(config, key_path, separator=".")),
+            dpath.search(config, key_path, separator="."),
             separator=".",
         )
     return ret

--- a/dvc/dependency/param.py
+++ b/dvc/dependency/param.py
@@ -54,13 +54,15 @@ def read_param_file(
                 continue
         return ret
 
+    from copy import deepcopy
+        
     from dpath import merge
     from funcy import distinct
 
     for key_path in distinct(key_paths):
         merge(
             ret,
-            dpath.search(config, key_path, separator="."),
+            deepcopy(dpath.search(config, key_path, separator=".")),
             separator=".",
         )
     return ret

--- a/dvc/dependency/param.py
+++ b/dvc/dependency/param.py
@@ -54,15 +54,13 @@ def read_param_file(
                 continue
         return ret
 
-    from copy import deepcopy
-
     from dpath import merge
     from funcy import distinct
 
     for key_path in distinct(key_paths):
         merge(
             ret,
-            deepcopy(dpath.search(config, key_path, separator=".")),
+            dpath.search(config, key_path, separator="."),
             separator=".",
         )
     return ret

--- a/dvc/dependency/param.py
+++ b/dvc/dependency/param.py
@@ -55,7 +55,7 @@ def read_param_file(
         return ret
 
     from copy import deepcopy
-        
+
     from dpath import merge
     from funcy import distinct
 

--- a/dvc/dependency/param.py
+++ b/dvc/dependency/param.py
@@ -54,12 +54,15 @@ def read_param_file(
                 continue
         return ret
 
+    from copy import deepcopy
+    
     from dpath import merge
-
-    for key_path in set(key_paths):
+    from funcy import distinct
+    
+    for key_path in distinct(key_paths):
         merge(
             ret,
-            dpath.search(config, key_path, separator="."),
+            deepcopy(dpath.search(config, key_path, separator=".")),
             separator=".",
         )
     return ret

--- a/dvc/dependency/param.py
+++ b/dvc/dependency/param.py
@@ -55,10 +55,10 @@ def read_param_file(
         return ret
 
     from copy import deepcopy
-    
+
     from dpath import merge
     from funcy import distinct
-    
+
     for key_path in distinct(key_paths):
         merge(
             ret,


### PR DESCRIPTION
As @skshetry proposed on https://github.com/iterative/dvc/pull/10178#issuecomment-1858747531, deduplicating `key_paths` would be enough, because `dpath.search` with distinct keys will never output the same object twice.

> [!IMPORTANT]
> This patch seems to fix #10177 and some other creative variants I wrote, but I'm still afraid of unforeseen edge cases; not sure if this is a good idea.