### PR TITLE
repro --pull: always pull deps

### DIFF
--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -613,7 +613,7 @@ class Stage(params.StageParams):
         ) or self.is_partial_import:
             self._sync_import(dry, force, kwargs.get("jobs", None), no_download)
         elif not self.frozen and self.cmd:
-            self._run_stage(dry, force, allow_missing=allow_missing, **kwargs)
+            self._run_stage(dry, force, **kwargs)
         elif kwargs.get("pull"):
             logger.info("Pulling data for %s", self)
             self.repo.pull(self.addressing, jobs=kwargs.get("jobs", None))

--- a/dvc/stage/run.py
+++ b/dvc/stage/run.py
@@ -128,7 +128,7 @@ def run_stage(
     **kwargs,
 ):
     if not force:
-        if allow_missing and kwargs.get("pull") and not dry:
+        if kwargs.get("pull") and not dry:
             _pull_missing_deps(stage)
 
         from .cache import RunCacheNotFoundError

--- a/dvc/stage/run.py
+++ b/dvc/stage/run.py
@@ -124,7 +124,6 @@ def run_stage(
     dry=False,
     force=False,
     run_env=None,
-    allow_missing: bool = False,
     **kwargs,
 ):
     if not force:

--- a/tests/func/repro/test_repro_pull.py
+++ b/tests/func/repro/test_repro_pull.py
@@ -56,3 +56,15 @@ def test_repro_skip_pull_if_no_run_cache_is_passed(tmp_dir, dvc, mocker, local_r
 
     assert dvc.reproduce(pull=True, run_cache=False)
     assert not spy_pull.called
+
+
+def test_repro_skip_pull_if_single_item_is_passed(tmp_dir, dvc, mocker, local_remote):
+    (foo,) = tmp_dir.dvc_gen("foo", "foo")
+
+    dvc.push()
+
+    dvc.stage.add(name="copy-foo", cmd="cp foo bar", deps=["foo"], outs=["bar"])
+    remove("foo")
+    remove(foo.outs[0].cache_path)
+
+    assert dvc.reproduce(pull=True, single_item=True)


### PR DESCRIPTION
Fix for https://iterativeai.slack.com/archives/C03JS2V4MQU/p1702982308956539. 

`repro --pull` was pulling outputs but not dependencies (unless `--allow-missing` was also passed). This normally is enough, but in cases like `repro --pull --single-item`, the output from the previous stage is never pulled, causing the command to fail. This PR pulls dependencies whenever `--pull` is included.
