### PR TITLE
output: get rid of out.odb

### DIFF
--- a/dvc/output.py
+++ b/dvc/output.py
@@ -407,7 +407,6 @@ class Output:
         self.fs_path = self._parse_path(self.fs, fs_path)
         self.obj: Optional["HashFile"] = None
 
-        self.odb: Optional["HashFileDB"] = None
         self.remote = remote
 
         if self.fs.version_aware:
@@ -444,8 +443,6 @@ class Output:
         if self.files:
             tree = Tree.from_list(self.files, hash_name=self.hash_name)
             tree.digest(with_meta=True)
-            self.odb = HashFileDB(tree.fs, tree.path + ".odb")
-            self.odb.add(tree.path, tree.fs, tree.hash_info.value)
 
             self.hash_info = tree.hash_info
             self.meta.isdir = True

--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -179,8 +179,6 @@ def _load_storage_from_out(storage_map, key, out):
     from dvc.config import NoRemoteError
     from dvc_data.index import FileStorage, ObjectStorage
 
-    if out.odb:
-        storage_map.add_data(ObjectStorage(key, out.odb))
     storage_map.add_cache(ObjectStorage(key, out.cache))
     try:
         remote = out.repo.cloud.get_remote(out.remote)


### PR DESCRIPTION
We use `out.files` to build index these days, making `out.odb` redundant. This also makes `storage.data` available for use.

Related #10194 