### PR TITLE
top-level plot collections: fail on empty dict

### DIFF
--- a/dvc/repo/plots/__init__.py
+++ b/dvc/repo/plots/__init__.py
@@ -486,7 +486,8 @@ def _collect_pipeline_files(repo, targets: List[str], props, onerror=None):
         for elem in plots_def:
             if isinstance(elem, str):
                 dvcfile_defs_dict[elem] = None
-            elif elem:
+            else:
+                assert elem
                 k, v = next(iter(elem.items()))
                 dvcfile_defs_dict[k] = v
 

--- a/dvc/repo/plots/__init__.py
+++ b/dvc/repo/plots/__init__.py
@@ -486,7 +486,7 @@ def _collect_pipeline_files(repo, targets: List[str], props, onerror=None):
         for elem in plots_def:
             if isinstance(elem, str):
                 dvcfile_defs_dict[elem] = None
-            else:
+            elif elem:
                 k, v = next(iter(elem.items()))
                 dvcfile_defs_dict[k] = v
 

--- a/dvc/schema.py
+++ b/dvc/schema.py
@@ -112,7 +112,7 @@ PLOT_DEFINITION = {
     Output.PARAM_PLOT_TITLE: str,
     Output.PARAM_PLOT_TEMPLATE: str,
 }
-SINGLE_PLOT_SCHEMA = {str: vol.Any(PLOT_DEFINITION, None)}
+SINGLE_PLOT_SCHEMA = {vol.Required(str): vol.Any(PLOT_DEFINITION, None)}
 ARTIFACTS = "artifacts"
 SINGLE_ARTIFACT_SCHEMA = vol.Schema({str: ARTIFACT_SCHEMA})
 FOREACH_IN = {


### PR DESCRIPTION
If you have a top-level plots with empty dict as follows:

```yaml
# dvc.yaml
plots:
- {}
```

dvc would fail with traceback that looks like:

```python
StopIteration                             Traceback (most recent call last)
Cell In[3], line 1
----> 1 repo.index._plot_sources

File ~/Projects/dvc/.venv/lib/python3.12/site-packages/funcy/objects.py:25, in cached_property.__get__(self, instance, type)
     23 if instance is None:
     24     return self
---> 25 res = instance.__dict__[self.fget.__name__] = self.fget(instance)
     26 return res

File ~/Projects/dvc/dvc/repo/index.py:448, in Index._plot_sources(self)
    445 from dvc.repo.plots import _collect_pipeline_files
    447 sources: List[str] = []
--> 448 for data in _collect_pipeline_files(self.repo, [], {}).values():
    449     for plot_id, props in data.get("data", {}).items():
    450         if isinstance(props.get("y"), dict):

File ~/Projects/dvc/dvc/repo/plots/__init__.py:490, in _collect_pipeline_files(repo, targets, props, onerror)
    488         dvcfile_defs_dict[elem] = None
    489     else:
--> 490         k, v = next(iter(elem.items()))
    491         dvcfile_defs_dict[k] = v
    493 resolved = _resolve_definitions(
    494     repo.dvcfs,
    495     targets,
   (...)
    499     onerror=onerror,
    500 )

StopIteration:
```

The empty dict is not supported by dvc, and we should fail validation in this case.