### PR TITLE
exp show: output executor info for successful exps when available

### DIFF
--- a/dvc/repo/experiments/collect.py
+++ b/dvc/repo/experiments/collect.py
@@ -261,6 +261,7 @@ def _collect_baseline(
         ref_it = (ref for ref in iter(refs) if ref.startswith(str(ref_info)))
     else:
         ref_it = repo.scm.iter_refs(base=str(ref_info))
+    executors = repo.experiments.celery_queue.collect_success_executors([baseline_rev])
     for ref in ref_it:
         try:
             ref_info = ExpRefInfo.from_ref(ref)
@@ -272,7 +273,11 @@ def _collect_baseline(
         exps = list(collect_branch(repo, exp_rev, baseline_rev, **kwargs))
         if exps:
             exps[0].name = ref_info.name
-            yield ExpRange(exps, name=ref_info.name)
+            yield ExpRange(
+                exps,
+                name=ref_info.name,
+                executor=executors.get(str(ref_info)),
+            )
 
 
 def collect(


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Should close #9425
related: https://github.com/iterative/dvc/issues/9442

For sucessfully run queued experiments, `dvc exp show --json` will now include executor info if it's still available (i.e. logs haven't been removed with `dvc queue remove`)

```json
"experiments": [
      {
        "revs": [
          {
            "rev": "cb9a2cbf153a84f29d6c0b811e3b834054931459",
            "name": "timid-pear",
            "data": {
              ...
              },
              "deps": {
                ...
                }
              },
              "outs": {
                ...
              },
              "meta": {}
            },
            "error": null,
            "experiments": null
          }
        ],
        "executor": {
          "state": "success",
          "name": "dvc-task",
          "local": {
            "root": null,
            "log": "/Users/pmrowla/git/example-get-started/.dvc/tmp/exps/run/af02dc1c0758c910a7c643194e5ba3f2687f463f/af02dc1c0758c910a7c643194e5ba3f2687f463f.out",
            "pid": 16615,
            "returncode": 0,
            "task_id": "af02dc1c0758c910a7c643194e5ba3f2687f463f"
          }
        },
        "name": "timid-pear"
      },
...
```

note that:
- `pid` is listed but will no longer be valid since the run finished
- `root` is unavailable since the tempdir used for execution is removed on exp completion (but the logs are available and stored in a separate location)

`executor` will still be null for successful workspace and `--temp` runs since we do not preserve any executor state or logs in those cases (handling logs for these cases will be done separately, but once those are available they will work the same as the dvc-task queued exps here)