### PR TITLE
repo: site_cache_dir: separate subdir from root_dir

### DIFF
--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -637,7 +637,9 @@ class Repo:
         btime = self._btime or getattr(os.stat(root_dir), "st_birthtime", None)
 
         md5 = hashlib.md5(  # noqa: S324
-            str((root_dir, subdir, btime, getpass.getuser(), version_tuple[0], salt)).encode()
+            str(
+                (root_dir, subdir, btime, getpass.getuser(), version_tuple[0], salt)
+            ).encode()
         )
         repo_token = md5.hexdigest()
         return os.path.join(repos_dir, repo_token)

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -610,7 +610,6 @@ class Repo:
 
         subdir = None
         if isinstance(self.fs, GitFileSystem):
-            relparts: tuple[str, ...] = ()
             if self.root_dir != "/":
                 # subrepo
                 subdir = self.root_dir

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -608,12 +608,13 @@ class Repo:
 
         cache_dir = self.config["core"].get("site_cache_dir") or site_cache_dir()
 
+        subdir = None
         if isinstance(self.fs, GitFileSystem):
             relparts: tuple[str, ...] = ()
             if self.root_dir != "/":
                 # subrepo
-                relparts = self.fs.relparts(self.root_dir, "/")
-            root_dir = os.path.join(self.scm.root_dir, *relparts)
+                subdir = self.root_dir
+            root_dir = self.scm.root_dir
         else:
             root_dir = self.root_dir
 
@@ -629,14 +630,14 @@ class Repo:
         # components were changed (useful to prevent newer dvc versions from
         # using older broken cache). Please reset this back to 0 if other parts
         # of the token components are changed.
-        salt = 2
+        salt = 0
 
         # NOTE: This helps us avoid accidentally reusing cache for repositories
         # that just happened to be at the same path as old deleted ones.
         btime = self._btime or getattr(os.stat(root_dir), "st_birthtime", None)
 
         md5 = hashlib.md5(  # noqa: S324
-            str((root_dir, btime, getpass.getuser(), version_tuple[0], salt)).encode()
+            str((root_dir, subdir, btime, getpass.getuser(), version_tuple[0], salt)).encode()
         )
         repo_token = md5.hexdigest()
         return os.path.join(repos_dir, repo_token)


### PR DESCRIPTION
Currently we join scm root_dir with subrepo root dir to have something that would represent that subrepo, but that directory might not exist in reality as we might be using a bare git repo and get such error:

```
  File "/Users/.../.venv/lib/python3.11/site-packages/dvc/repo/__init__.py", line 653, in site_cache_dir
    btime = self._btime or getattr(os.stat(root_dir), "st_birthtime", None)
                                   ^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/q1/fqyfkpr52qv8r43qn53xpxh40000gq/T/tmpcus9rcv7dvc-clone/pipelines/pdb_processing'
```

So we should just treat those as separate things.

Unfortunately adding a test for the error described above turned out to be rather not trivial, as we rarely end up with a bare repo these days, so I'll postpone that till https://github.com/iterative/dvc/issues/9296 is resolved, as using bare repos will trigger more bugs everywhere.
