### PR TITLE
repo: index: don't set cache storage if there is no out.cache

### DIFF
--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -215,7 +215,9 @@ def _load_storage_from_out(storage_map, key, out):
     from dvc.config import NoRemoteError
     from dvc_data.index import FileStorage, ObjectStorage
 
-    storage_map.add_cache(ObjectStorage(key, out.cache))
+    if out.cache:
+        storage_map.add_cache(ObjectStorage(key, out.cache))
+
     try:
         remote = out.repo.cloud.get_remote(out.remote)
         if remote.fs.version_aware:


### PR DESCRIPTION
To avoid situations like

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[5], line 1
----> 1 fs.download(cfg["dataset"]["dvc_config"]["path_in_repo"], "d.parquet")

File ~/.../.venv/lib/python3.11/site-packages/fsspec/spec.py:1546, in AbstractFileSystem.download(self, rpath, lpath, recursive, **kwargs)
   1544 def download(self, rpath, lpath, recursive=False, **kwargs):
   1545     """Alias of `AbstractFileSystem.get`."""
-> 1546     return self.get(rpath, lpath, recursive=recursive, **kwargs)

File ~/.../.venv/lib/python3.11/site-packages/fsspec/spec.py:983, in AbstractFileSystem.get(self, rpath, lpath, recursive, callback, maxdepth, **kwargs)
    981 for lpath, rpath in callback.wrap(zip(lpaths, rpaths)):
    982     callback.branch(rpath, lpath, kwargs)
--> 983     self.get_file(rpath, lpath, **kwargs)

File ~/.../.venv/lib/python3.11/site-packages/dvc/fs/dvc.py:479, in _DVCFileSystem.get_file(self, rpath, lpath, **kwargs)
    476         raise
    478 dvc_path = _get_dvc_path(dvc_fs, subkey)
--> 479 return dvc_fs.get_file(dvc_path, lpath, **kwargs)

File ~/.../.venv/lib/python3.11/site-packages/dvc_objects/fs/base.py:653, in FileSystem.get_file(self, from_info, to_info, callback, **kwargs)
    646 def get_file(
    647     self,
    648     from_info: AnyFSPath,
   (...)
    651     **kwargs,
    652 ) -> None:
--> 653     self.fs.get_file(from_info, to_info, callback=callback, **kwargs)

File ~/.../.venv/lib/python3.11/site-packages/dvc_data/fs.py:201, in DataFileSystem.get_file(self, rpath, lpath, callback, **kwargs)
    198 from dvc_data.index import ObjectStorage
    200 try:
--> 201     typ, storage, cache_storage, hi, fs, path = self._get_fs_path(rpath)
    202 except IsADirectoryError:
    203     os.makedirs(lpath, exist_ok=True)

File ~/.../.venv/lib/python3.11/site-packages/dvc_data/fs.py:112, in DataFileSystem._get_fs_path(self, path)
    110     if not storage:
    111         continue
--> 112     data = storage.get(entry)
    113 except (ValueError, StorageKeyError):
    114     continue

File ~/.../.venv/lib/python3.11/site-packages/dvc_data/index/index.py:214, in ObjectStorage.get(self, entry)
    211 if not entry.hash_info:
    212     raise ValueError
--> 214 return self.odb.fs, self.odb.oid_to_path(entry.hash_info.value)

AttributeError: 'NoneType' object has no attribute 'fs'
```

Though similar to https://github.com/iterative/dvc/pull/10273 it is quite challenging to reproduce in a test, so also waiting for https://github.com/iterative/dvc/issues/9296 to use bare repos everywhere and expose similar bugs.