### PR TITLE
status: add option to skip imports

### DIFF
--- a/dvc/commands/data_sync.py
+++ b/dvc/commands/data_sync.py
@@ -429,5 +429,11 @@ def add_parser(subparsers, _parent_parser):
         default=False,
         help="Show status in JSON format.",
     )
+    status_parser.add_argument(
+        "--no-updates",
+        dest="check_updates",
+        action="store_false",
+        help="Ignore updates to imported data.",
+    )
 
     status_parser.set_defaults(func=CmdDataStatus)

--- a/dvc/commands/status.py
+++ b/dvc/commands/status.py
@@ -60,6 +60,7 @@ class CmdDataStatus(CmdDataBase):
                     all_commits=self.args.all_commits,
                     with_deps=self.args.with_deps,
                     recursive=self.args.recursive,
+                    check_updates=self.args.check_updates,
                 )
             except DvcException:
                 logger.exception("")

--- a/tests/unit/command/test_status.py
+++ b/tests/unit/command/test_status.py
@@ -41,6 +41,7 @@ def test_cloud_status(tmp_dir, dvc, mocker):
         all_commits=True,
         with_deps=True,
         recursive=True,
+        check_updates=True,
     )
 
 
@@ -117,3 +118,26 @@ def test_status_up_to_date(dvc, mocker, capsys, cloud_opts, expected_message):
     assert cmd.run() == 0
     captured = capsys.readouterr()
     assert expected_message in captured.out
+
+
+def test_status_check_updates(dvc, mocker, capsys):
+    cli_args = parse_args(["status", "--no-updates"])
+    assert cli_args.func == CmdDataStatus
+
+    cmd = cli_args.func(cli_args)
+    m = mocker.patch.object(cmd.repo, "status", autospec=True, return_value={})
+
+    assert cmd.run() == 0
+
+    m.assert_called_once_with(
+        cloud=False,
+        targets=[],
+        jobs=None,
+        remote=None,
+        all_branches=False,
+        all_tags=False,
+        all_commits=False,
+        with_deps=False,
+        recursive=False,
+        check_updates=False,
+    )


### PR DESCRIPTION
Closes #10038. Adds `dvc status --no-updates`:

```
$ dvc status
data/data.xml.dvc:
        changed deps:
                update available:   get-started/data.xml (https://github.com/iterative/dataset-registry)

$ dvc status --no-updates
Data and pipelines are up to date.
```