### PR TITLE
tests: remove pytest-lazy-fixture

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,6 @@ tests = [
     "pytest<8,>=7",
     "pytest-cov>=4.1.0",
     "pytest-docker>=1,<4",
-    "pytest-lazy-fixture",
     "pytest-mock",
     "pytest-test-utils",
     "pytest-timeout>=2",

--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -208,10 +208,9 @@ def test_verify_hashes(tmp_dir, scm, dvc, mocker, tmp_path_factory, local_remote
 
 
 @flaky(max_runs=3, min_passes=1)
-@pytest.mark.parametrize(
-    "erepo", [pytest.lazy_fixture("git_dir"), pytest.lazy_fixture("erepo_dir")]
-)
-def test_pull_git_imports(tmp_dir, dvc, scm, erepo):
+@pytest.mark.parametrize("erepo_type", ["git_dir", "erepo_dir"])
+def test_pull_git_imports(request, tmp_dir, dvc, scm, erepo_type):
+    erepo = request.getfixturevalue(erepo_type)
     with erepo.chdir():
         erepo.scm_gen({"dir": {"bar": "bar"}}, commit="second")
         erepo.scm_gen("foo", "foo", commit="first")

--- a/tests/func/test_get.py
+++ b/tests/func/test_get.py
@@ -80,13 +80,12 @@ def test_get_repo_broken_dir(tmp_dir, erepo_dir):
     assert not (tmp_dir / "out").exists()
 
 
-@pytest.mark.parametrize(
-    "erepo", [pytest.lazy_fixture("git_dir"), pytest.lazy_fixture("erepo_dir")]
-)
-def test_get_git_file(tmp_dir, erepo):
+@pytest.mark.parametrize("erepo_type", ["git_dir", "erepo_dir"])
+def test_get_git_file(request, tmp_dir, erepo_type):
     src = "some_file"
     dst = "some_file_imported"
 
+    erepo = request.getfixturevalue(erepo_type)
     erepo.scm_gen({src: "hello"}, commit="add a regular file")
 
     Repo.get(os.fspath(erepo), src, dst)
@@ -94,13 +93,12 @@ def test_get_git_file(tmp_dir, erepo):
     assert (tmp_dir / dst).read_text() == "hello"
 
 
-@pytest.mark.parametrize(
-    "erepo", [pytest.lazy_fixture("git_dir"), pytest.lazy_fixture("erepo_dir")]
-)
-def test_get_git_dir(tmp_dir, erepo):
+@pytest.mark.parametrize("erepo_type", ["git_dir", "erepo_dir"])
+def test_get_git_dir(request, tmp_dir, erepo_type):
     src = "some_directory"
     dst = "some_directory_imported"
 
+    erepo = request.getfixturevalue(erepo_type)
     erepo.scm_gen({src: {"dir": {"file.txt": "hello"}}}, commit="add a regular dir")
 
     Repo.get(os.fspath(erepo), src, dst)

--- a/tests/func/test_ls.py
+++ b/tests/func/test_ls.py
@@ -518,17 +518,19 @@ def test_ls_target(erepo_dir, use_scm):
 
 
 @pytest.mark.parametrize(
-    "dvc_top_level, erepo",
+    "dvc_top_level, erepo_type",
     [
-        (True, pytest.lazy_fixture("erepo_dir")),
-        (False, pytest.lazy_fixture("git_dir")),
+        (True, "erepo_dir"),
+        (False, "git_dir"),
     ],
 )
-def test_subrepo(dvc_top_level, erepo):
+def test_subrepo(request, dvc_top_level, erepo_type):
     from tests.func.test_get import make_subrepo
 
     dvc_files = {"foo.txt": "foo.txt", "dvc_dir": {"lorem": "lorem"}}
     scm_files = {"bar.txt": "bar.txt", "scm_dir": {"ipsum": "ipsum"}}
+
+    erepo = request.getfixturevalue(erepo_type)
     subrepo = erepo / "subrepo"
     make_subrepo(subrepo, erepo.scm)
 


### PR DESCRIPTION
Since it's no longer being maintained. See https://github.com/TvoroG/pytest-lazy-fixture/issues/65.

