### PR TITLE
plots: support x-dict in nested dvc.yaml

### DIFF
--- a/dvc/repo/plots/__init__.py
+++ b/dvc/repo/plots/__init__.py
@@ -423,11 +423,17 @@ def _id_is_path(plot_props=None):
 
 def _adjust_sources(fs, plot_props, config_dir):
     new_plot_props = deepcopy(plot_props)
-    old_y = new_plot_props.pop("y", {})
-    new_y = {}
-    for filepath, val in old_y.items():
-        new_y[_normpath(fs.join(config_dir, filepath))] = val
-    new_plot_props["y"] = new_y
+    for axis in ["x", "y"]:
+        x_is_inferred = axis == "x" and (
+            axis not in new_plot_props or isinstance(new_plot_props[axis], str)
+        )
+        if x_is_inferred:
+            continue
+        old = new_plot_props.pop(axis, {})
+        new = {}
+        for filepath, val in old.items():
+            new[_normpath(fs.join(config_dir, filepath))] = val
+        new_plot_props[axis] = new
     return new_plot_props
 
 


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

-----

This PR fixes a bug in the collection of plots definitions. The bug exists when there is a plot collected from a nested dvc.yaml that uses separate files for the x and y values.

e.g. 

```
- Error vs max_leaf_nodes:
    template: simple
    x: 
      dvclive/plots/metrics/Max_Leaf_Nodes.tsv: Max_Leaf_Nodes
    y:
      dvclive/plots/metrics/Error.tsv: Error
```
in `{root}/pipelines/data-increment/dvc.yaml`

Previously the path to the x file was not updated to take into account the path to the dvc.yaml that it exists in.

For more context see [this thread](https://iterativeai.slack.com/archives/C01APS0FHDM/p1708601001649999).