### PR TITLE
experiments: auto push experiments 

### DIFF
--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -336,6 +336,8 @@ SCHEMA = {
         "params": str,
         "plots": str,
         "live": str,
+        "auto_push": Bool,
+        "git_remote": str,
     },
     "parsing": {
         "bool": All(Lower, Choices("store_true", "boolean_optional")),

--- a/tests/func/experiments/test_remote.py
+++ b/tests/func/experiments/test_remote.py
@@ -4,6 +4,7 @@ import pytest
 from funcy import first
 
 from dvc.repo.experiments.utils import exp_refs_by_rev
+from dvc.repo.experiments.exceptions import ExperimentExistsError
 
 
 @pytest.mark.parametrize("use_url", [True, False])
@@ -372,3 +373,39 @@ def test_push_pull_invalid_workspace(
         dvc.experiments.push(git_upstream.remote, push_cache=True)
         dvc.experiments.pull(git_upstream.remote, pull_cache=True)
         assert "failed to collect" not in caplog.text
+
+
+@pytest.mark.parametrize(
+    "auto_push, expected_key", [(True, "up_to_date"), (False, "success")]
+)
+def test_auto_push_on_run(
+    tmp_dir, scm, dvc, git_upstream, local_remote, exp_stage, auto_push, expected_key
+):
+    remote = git_upstream.remote
+
+    with dvc.config.edit() as conf:
+        conf["exp"]["auto_push"] = auto_push
+        conf["exp"]["git_remote"] = remote
+
+    exp_name = "foo"
+    dvc.experiments.run(exp_stage.addressing, params=["foo=2"], name=exp_name)
+
+    assert first(dvc.experiments.push(name=exp_name, git_remote=remote)) == expected_key
+
+@pytest.mark.parametrize(
+    "auto_push, expected_key", [(True, "up_to_date"), (False, "success")]
+)
+def test_auto_push_on_save(
+    tmp_dir, scm, dvc, git_upstream, local_remote, exp_stage, auto_push, expected_key
+):
+    remote = git_upstream.remote
+    exp_name = "foo"
+    dvc.experiments.run(exp_stage.addressing, params=["foo=2"], name=exp_name)
+
+    with dvc.config.edit() as conf:
+        conf["exp"]["auto_push"] = auto_push
+        conf["exp"]["git_remote"] = remote
+
+    dvc.experiments.save(name=exp_name, force=True)
+
+    assert first(dvc.experiments.push(name=exp_name, git_remote=remote)) == expected_key

--- a/tests/func/experiments/test_remote.py
+++ b/tests/func/experiments/test_remote.py
@@ -4,7 +4,6 @@ import pytest
 from funcy import first
 
 from dvc.repo.experiments.utils import exp_refs_by_rev
-from dvc.repo.experiments.exceptions import ExperimentExistsError
 
 
 @pytest.mark.parametrize("use_url", [True, False])
@@ -391,6 +390,7 @@ def test_auto_push_on_run(
     dvc.experiments.run(exp_stage.addressing, params=["foo=2"], name=exp_name)
 
     assert first(dvc.experiments.push(name=exp_name, git_remote=remote)) == expected_key
+
 
 @pytest.mark.parametrize(
     "auto_push, expected_key", [(True, "up_to_date"), (False, "success")]


### PR DESCRIPTION
As requested by https://github.com/iterative/dvc/issues/10137, we want a configuration parameter to auto-push the experiments once they are run. Auto-push means the experiments and artifacts will be sent to git and the DVC remote after each experiment succeeds.

This PR also introduces a default for the `git_remote` to `origin`

:warning: @mattseddon  In this PR I changed the DVC config (`.dvc/config`) to add the new field `exp.auto_push`. When I'm testing to run a demo project locally and look at my studio dashboard (from the web, not a branch), I have a warning
![image](https://github.com/iterative/dvc/assets/14785566/6809a12d-530f-41f2-b0e7-7d704008c6f4). Do you know If the warning would disappear if I build the studio dashboard with the DVC code from this PR? Or should I change code on the studio backend repo to update the new config with the new field `exp.auto_push`? 


* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here: https://github.com/iterative/dvc.org/pull/5165

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
