### PR TITLE
`dvc studio login` automatically push experiments by default

### DIFF
--- a/dvc/commands/studio.py
+++ b/dvc/commands/studio.py
@@ -46,20 +46,25 @@ class CmdStudioLogin(CmdConfig):
 
         self.save_config(hostname, access_token)
 
+        if not self.config["exp"].get("auto_push", True):
+            from dvc.ui import ui
+
+            ui.warn(
+                "exp.auto_push is disabled. \n"
+                "Enable with 'dvc config exp.auto_push true' "
+                "to automatically push experiments to Studio."
+            )
+
         config_path = self.config.files["global"]
         ui.write(f"Authentication complete. Saved token to {config_path}.")
-        ui.write("Experiments are now being pushed automatically as git commits.")
-        ui.write(
-            "To avoid this behavior and keep the results of your experiments locally, "
-            "you should run `dvc config --global exp.auto_push false`."
-        )
         return 0
 
     def save_config(self, hostname, token):
         with self.config.edit("global") as conf:
             conf["studio"]["token"] = token
             conf["studio"]["url"] = hostname
-            conf["exp"]["auto_push"] = True
+            if "auto_push" not in conf["exp"]:
+                conf["exp"]["auto_push"] = True
 
 
 class CmdStudioLogout(CmdConfig):

--- a/dvc/commands/studio.py
+++ b/dvc/commands/studio.py
@@ -48,12 +48,18 @@ class CmdStudioLogin(CmdConfig):
 
         config_path = self.config.files["global"]
         ui.write(f"Authentication complete. Saved token to {config_path}.")
+        ui.write("Experiments are now being pushed automatically as git commits.")
+        ui.write(
+            "To avoid this behavior and keep the results of your experiments locally, "
+            "you should run `dvc config --global exp.auto_push false`."
+        )
         return 0
 
     def save_config(self, hostname, token):
         with self.config.edit("global") as conf:
             conf["studio"]["token"] = token
             conf["studio"]["url"] = hostname
+            conf["exp"]["auto_push"] = True
 
 
 class CmdStudioLogout(CmdConfig):

--- a/dvc/repo/experiments/executor/base.py
+++ b/dvc/repo/experiments/executor/base.py
@@ -688,8 +688,15 @@ class BaseExecutor(ABC):
         push_cache=True,
         run_cache=True,
     ):
+        from dvc.ui import ui
+
         branch = dvc.scm.get_ref(EXEC_BRANCH, follow=False)
         try:
+            ui.write(
+                f"Auto pushing experiment to '{git_remote}'. You can cancel the push "
+                "with CTRL+C. If you need to push your experiment again, you can "
+                f"retry later using `dvc exp push`",
+            )
             dvc.experiments.push(
                 git_remote,
                 branch,

--- a/tests/unit/command/test_studio.py
+++ b/tests/unit/command/test_studio.py
@@ -1,7 +1,16 @@
+import pytest
 from dvc_studio_client.auth import AuthorizationExpiredError
 
+from dvc import env
 from dvc.cli import main
 from dvc.utils.studio import STUDIO_URL
+
+
+@pytest.fixture(autouse=True)
+def global_config_dir(monkeypatch, tmp_dir_factory):
+    monkeypatch.setenv(
+        env.DVC_GLOBAL_CONFIG_DIR, str(tmp_dir_factory.mktemp("studio-login"))
+    )
 
 
 def test_studio_login_token_check_failed(mocker):


### PR DESCRIPTION
Context: https://github.com/iterative/dvc/issues/10137

The `dvc studio login` command now sets the config so that every experiment is automatically pushed on `dvc exp run` and `dvc exp save`. 
I also added a few helping tips for the users to say that if the push is too long, they can cancel and launch it back later on. 



* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
