### PR TITLE
limit pytest version to <8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ tests = [
     "dvc-ssh",
     "filelock",
     "flaky",
-    "pytest>=7,<9",
+    "pytest>=7,<8.1",
     "pytest-cov>=4.1.0",
     "pytest-docker>=1,<4",
     "pytest-mock",


### PR DESCRIPTION
Changes in pytest==8.1.0 breaks `flaky` plugin.

See https://github.com/box/flaky/issues/198.

It's breaking the CI.

