### PR TITLE
handle auto push errors

### DIFF
--- a/dvc/repo/experiments/executor/base.py
+++ b/dvc/repo/experiments/executor/base.py
@@ -677,7 +677,13 @@ class BaseExecutor(ABC):
         git_remote = os.getenv(
             DVC_EXP_GIT_REMOTE, exp_config.get("git_remote", "origin")
         )
-        cls._validate_remotes(dvc, git_remote)
+        try:
+            cls._validate_remotes(dvc, git_remote)
+        except DvcException as exc:
+            logger.warning("Failed to validate remotes. Disabling auto push: %s", exc)
+
+            yield
+            return
         yield
         cls._auto_push(dvc, git_remote)
 
@@ -689,21 +695,24 @@ class BaseExecutor(ABC):
         run_cache=True,
     ):
         from dvc.ui import ui
+        from dvc.utils import format_link
 
         branch = dvc.scm.get_ref(EXEC_BRANCH, follow=False)
+        link = format_link(
+            "https://dvc.org/doc/user-guide/experiment-management/sharing-experiments"
+        )
+        ui.write(
+            f"Pushing experiment to '{git_remote}'. Cancel with CTRL+C. "
+            f"See {link} for more info."
+        )
         try:
-            ui.write(
-                f"Auto pushing experiment to '{git_remote}'. You can cancel the push "
-                "with CTRL+C. If you need to push your experiment again, you can "
-                f"retry later using `dvc exp push`",
-            )
             dvc.experiments.push(
                 git_remote,
                 branch,
                 push_cache=push_cache,
                 run_cache=run_cache,
             )
-        except BaseException as exc:  # noqa: BLE001
+        except DvcException as exc:
             logger.warning(
                 (
                     "Something went wrong while auto pushing experiment "

--- a/tests/func/experiments/test_remote.py
+++ b/tests/func/experiments/test_remote.py
@@ -409,3 +409,16 @@ def test_auto_push_on_save(
     dvc.experiments.save(name=exp_name, force=True)
 
     assert first(dvc.experiments.push(name=exp_name, git_remote=remote)) == expected_key
+
+
+def test_auto_push_misconfigured(
+    tmp_dir, scm, dvc, git_upstream, local_remote, exp_stage, caplog
+):
+    with dvc.config.edit() as conf:
+        conf["exp"]["auto_push"] = True
+        conf["exp"]["git_remote"] = "notfound"
+
+    exp_name = "foo"
+    with caplog.at_level(logging.WARNING, logger="dvc"):
+        dvc.experiments.run(exp_stage.addressing, params=["foo=2"], name=exp_name)
+        assert "Failed to validate remotes" in caplog.text


### PR DESCRIPTION
Fixes `Handle case where remote doesn't exist` in #10137.

This raises a warning and disables auto push if remote validation fails. Without this PR, it fails early, which is also reasonable, but I think it's less desirable for this scenario. If I set up a new repo and login to Studio, I won't be able to run any experiments until I have a dvc and git remote configured or I disable auto push.