### PR TITLE
add attrs explicit dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
+    "attrs>=22.2.0",
     "colorama>=0.3.9",
     "configobj>=5.0.6",
     "distro>=1.3",


### PR DESCRIPTION
fixes `AttrsInstance` import failing on older versions of attrs, fixed by https://github.com/python-attrs/attrs/issues/987

## TODO:

- [ ] Update conda package.
- [ ] Do we update other places (other packages in some way)?

