### PR TITLE
add: raise DoesNotExistError only if the output path does not exist

### DIFF
--- a/dvc/output.py
+++ b/dvc/output.py
@@ -1365,7 +1365,7 @@ class Output:
                 dry_run=not self.use_cache,
             )
         except FileNotFoundError as exc:
-            if self.fs_path == path:
+            if not self.exists:
                 raise self.DoesNotExistError(self) from exc
             if not self.is_dir_checksum:
                 raise


### PR DESCRIPTION
`dvc add` command incorrectly raises a `DoesNotExistError` when a broken symlink exists in an output directory, and the target name is same as the directory's name.

eg: If `data` is an output, and the command is invoked as `dvc add data` (i.e. no virtual directory operations to perform).

The expected behavior is to raise a `FileNotFoundError`.
`DoesNotExistError` should only be raised if the output itself does not exist.

Related: https://github.com/iterative/dvc/issues/3717