### PR TITLE
params/metrics: do not fail during dir expansion

### DIFF
--- a/dvc/repo/params/show.py
+++ b/dvc/repo/params/show.py
@@ -6,9 +6,9 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 
 from dvc.dependency.param import ParamsDependency, read_param_file
 from dvc.log import logger
-from dvc.repo.metrics.show import FileResult, Result
+from dvc.repo.metrics.show import FileResult, Result, try_expand_paths
 from dvc.stage import PipelineStage
-from dvc.utils import as_posix, expand_paths
+from dvc.utils import as_posix
 from dvc.utils.collections import ensure_list
 
 if TYPE_CHECKING:
@@ -77,7 +77,7 @@ def _collect_params(
         path = fs.from_os_path(param)
         # make paths absolute for DVCFileSystem
         repo_path = f"{fs.root_marker}{path}"
-        ret.update(dict.fromkeys(expand_paths(fs, [repo_path]), _params))
+        ret.update(dict.fromkeys(try_expand_paths(fs, [repo_path]), _params))
     return ret
 
 

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -5,15 +5,12 @@ import json
 import os
 import re
 import sys
-from collections.abc import Iterable, Iterator
 from typing import TYPE_CHECKING, Optional
 
 import colorama
 
 if TYPE_CHECKING:
     from typing import TextIO
-
-    from dvc.fs import FileSystem
 
 
 LARGE_DIR_SIZE = 100
@@ -408,14 +405,6 @@ def errored_revisions(rev_data: dict) -> list:
         if nested_contains(data, "error"):
             result.append(revision)
     return result
-
-
-def expand_paths(fs: "FileSystem", paths: Iterable[str]) -> Iterator[str]:
-    for path in paths:
-        if fs.isdir(path):
-            yield from fs.find(path)
-        else:
-            yield path
 
 
 def isatty(stream: "Optional[TextIO]") -> bool:


### PR DESCRIPTION
Closes https://github.com/iterative/dvc/issues/10018.

We have to be careful when expanding paths. This PR fall backs to assume it
as a file when either of `isdir` and `find` raises error due to some mishaps.
The consequence of this assumption happens when we try to read the file.
In that case, if the directory exists, and we happen to try to open it
as a file, dvc will raise `IsADirectoryError`, but that is handled correctly
and won't fail catastrophically like this did.

This is what I get now:
```console
$ dvc metrics show --json
DVC failed to load some metrics for following revisions: ''.
{
  "": {
    "data": {
      "results/train/metrics.json": {
        "error": {
          "type": "DataIndexDirError",
          "msg": "failed to load directory ('results', 'train')"
        }
      },
      "results/evaluate/metrics.json": {
        "data": {
          "dice_multi": 0.8789161007343483
        }
      }
    }
  }
}
```

The error message is not great, but at least it won't fail.