### PR TITLE
collect files from subrepos

### DIFF
--- a/dvc/dvcfile.py
+++ b/dvc/dvcfile.py
@@ -104,7 +104,9 @@ class FileMixin:
         return relpath(self.path)
 
     def exists(self):
-        is_ignored = self.repo.dvcignore.is_ignored_file(self.path)
+        is_ignored = self.repo.dvcignore.is_ignored_file(
+            self.path, ignore_subrepos=(not self.repo.subrepos)
+        )
         return self.repo.fs.exists(self.path) and not is_ignored
 
     def _is_git_ignored(self):

--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -78,7 +78,9 @@ def collect_files(
         # trailing slash needed to check if a directory is gitignored
         return dir_path in outs or is_ignored(f"{dir_path}{sep}")
 
-    walk_iter = repo.dvcignore.walk(fs, repo.root_dir, followlinks=False)
+    walk_iter = repo.dvcignore.walk(
+        fs, repo.root_dir, followlinks=False, ignore_subrepos=(not repo.subrepos)
+    )
     if logger.isEnabledFor(logging.TRACE):  # type: ignore[attr-defined]
         walk_iter = log_walk(walk_iter)
 

--- a/tests/func/artifacts/test_artifacts.py
+++ b/tests/func/artifacts/test_artifacts.py
@@ -6,6 +6,7 @@ import pytest
 
 from dvc.annotations import Artifact
 from dvc.exceptions import ArtifactNotFoundError, InvalidArgumentError
+from dvc.repo import Repo
 from dvc.repo.artifacts import check_name_format
 from dvc.utils.strictyaml import YAMLSyntaxError, YAMLValidationError
 
@@ -205,4 +206,17 @@ def test_parametrized(tmp_dir, dvc):
     )
     assert tmp_dir.dvc.artifacts.read() == {
         "dvc.yaml": {"myart": Artifact(path="myart.pkl", type="model")}
+    }
+
+
+def test_artifacts_read_on_dvc_subrepo(tmp_dir, dvc):
+    subdir = tmp_dir / "subdir"
+    (subdir / ".dvc").mkdir(parents=True)
+    (subdir / "dvc.yaml").dump(dvcyaml)
+
+    artifacts = {
+        name: Artifact(**values) for name, values in dvcyaml["artifacts"].items()
+    }
+    assert Repo(subrepos=True).artifacts.read() == {
+        f"subdir{os.path.sep}dvc.yaml": artifacts,
     }


### PR DESCRIPTION
See https://iterativeai.slack.com/archives/C05L7S1TWAW/p1712247647559389. Fixes issue where `dvc.api.artifacts_show()` and other methods that collect from the repo index skip subrepos.

TODO:
- [x] tests