### PR TITLE
import/get: optimize LFS prefetching

### DIFF
--- a/dvc/fs/__init__.py
+++ b/dvc/fs/__init__.py
@@ -69,7 +69,9 @@ def download(
             to_infos = [to]
 
         if isinstance(fs, DVCFileSystem):
-            lfs_prefetch(fs, from_infos)
+            lfs_prefetch(
+                fs, [f"{fs.normpath(fs_path)}/**" if fs.isdir(fs_path) else fs_path]
+            )
         cb.set_size(len(from_infos))
         jobs = jobs or fs.jobs
         generic.copy(fs, from_infos, localfs, to_infos, callback=cb, batch_size=jobs)


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] ~~📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.~~

I've significantly optimized LFS prefetching performance. With this change, `include` in `scmrepo.git.lfs.fetch()` is now a single-item list with either a Unix filename pattern like `<subdir>/**` or a file path. `scmrepo.git.lfs.fetch._collect_objects()` still enumerates all files in the repo with `fs.find("/")` (that's quite fast even with many files) but `scmrepo.git.lfs.fetch._filter_paths()` only matches those files against a single pattern.

Partially fixes https://github.com/iterative/scmrepo/issues/338.

/cc @shcheklein