### PR TITLE
repro --pull implies --allow-missing

### DIFF
--- a/dvc/commands/repro.py
+++ b/dvc/commands/repro.py
@@ -118,8 +118,8 @@ and then the stage name name.
         action="store_true",
         default=False,
         help=(
-            "Try automatically pulling missing cache for outputs restored "
-            "from the run-cache."
+            "Try automatically pulling missing dependencies and outputs. "
+            "Implies --allow-missing."
         ),
     )
     repro_parser.add_argument(

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -233,12 +233,14 @@ def reproduce(
         targets_list = ensure_list(targets or PROJECT_FILE)
         stages = collect_stages(self, targets_list, recursive=recursive, glob=glob)
 
-    if kwargs.get("pull", False) and kwargs.get("run_cache", True):
-        logger.debug("Pulling run cache")
-        try:
-            self.stage_cache.pull(None)
-        except RunCacheNotSupported as e:
-            logger.warning("Failed to pull run cache: %s", e)
+    if kwargs.get("pull", False):
+        kwargs["allow_missing"] = True
+        if kwargs.get("run_cache", True):
+            logger.debug("Pulling run cache")
+            try:
+                self.stage_cache.pull(None)
+            except RunCacheNotSupported as e:
+                logger.warning("Failed to pull run cache: %s", e)
 
     graph = None
     steps = stages


### PR DESCRIPTION
See https://github.com/iterative/dvc/issues/10412#issuecomment-2103410493. When we introduced `--allow-missing`, we also updated the behavior of `--pull`, but kept them as separate flags for a couple reasons (see discussion [here](https://github.com/iterative/dvc/pull/9375#issuecomment-1529825295)):

- didn't want to change behavior of `--pull` too much
- worried about too much complexity in one flag
- wanted to wait and see how it was used

Since then, every user I have encountered expects the behavior to be what `--pull --allow-missing` does. I don't see any valid case where someone using `--pull` would not want `--allow-missing` (we are basically already implying this by treating missing data as needing to be pulled).

