### PR TITLE
fix(benchmarks): force older pygit2 for older DVC versions

### DIFF
--- a/dvc/testing/benchmarks/fixtures.py
+++ b/dvc/testing/benchmarks/fixtures.py
@@ -104,6 +104,11 @@ def make_dvc_bin(
             venv.run("pip", "install", f"git+file://{dvc_git_repo}@{dvc_rev}#egg={egg}")
             if dvc_rev in ["2.18.1", "2.11.0", "2.6.3"]:
                 venv.run("pip", "install", "fsspec==2022.11.0")
+            try:
+                if version.Version(dvc_rev) < version.Version("3.50.3"):
+                    venv.run("pip", "install", "pygit2==1.14.1")
+            except version.InvalidVersion:
+                pass
             dvc_venvs[dvc_rev] = venv
         dvc_bin = venv.which("dvc")
     else:


### PR DESCRIPTION
Fixes (hopefully) failing benchmarks.

If you run it locally with:

```bash
DVC_TEST=true python -m pytest --benchmark-group-by func --dvc-revs 3.10.0 --pyargs dvc.testing.benchmarks.cli.commands.test_plots::test_plots --dataset mnist
```

and then:

```
(.venv) √ pytest-14/dvc-project0 % /private/var/folders/8f/fbysfztx1mb953_gpwl477p80000gn/T/pytest-of-ivan/pytest-14/dvc-venv-3.10.00/bin/dvc plots diff HEAD
ERROR: unexpected error - cannot import name 'GIT_OBJ_COMMIT' from 'pygit2' (/private/var/folders/8f/fbysfztx1mb953_gpwl477p80000gn/T/pytest-of-ivan/pytest-14/dvc-venv-3.10.00/lib/python3.12/site-packages/pygit2/__init__.py)
```

It's all related to:

https://github.com/iterative/scmrepo/pull/359
