### PR TITLE
chore(studio): Update Studio URL to new domain

### DIFF
--- a/dvc/utils/studio.py
+++ b/dvc/utils/studio.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 logger = logger.getChild(__name__)
 
-STUDIO_URL = "https://studio.iterative.ai"
+STUDIO_URL = "https://studio.dvc.ai"
 
 
 def post(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "dvc-http>=2.29.0",
     "dvc-objects",
     "dvc-render>=1.0.1,<2",
-    "dvc-studio-client>=0.20,<1",
+    "dvc-studio-client>=0.21,<1",
     "dvc-task>=0.3.0,<1",
     "flatten_dict<1,>=0.4.1",
     "flufl.lock>=5,<8", # https://github.com/iterative/dvc/issues/9654


### PR DESCRIPTION
The https://studio.iterative.ai is deprecated, and we switched to the new domain https://studio.dvc.ai.

The domain change is backwards compatible. The **older versions** of the `dvc` will still work. 🎉 

