### PR TITLE
dvc dependency repo: Catch FileNotFoundError

### DIFF
--- a/dvc/dependency/repo.py
+++ b/dvc/dependency/repo.py
@@ -115,7 +115,7 @@ class RepoDependency(Dependency):
                 state=self.repo.state,
                 prompt=confirm,
             )
-        except CheckoutError:
+        except (CheckoutError, FileNotFoundError):
             super().download(to=to, jobs=jobs)
 
     def update(self, rev: Optional[str] = None):


### PR DESCRIPTION
This should fix https://github.com/iterative/dvc/issues/10500

- When checkouting non-existent file the _checkout_file recursively calls os.stat on a symlinked file which destination doesn't exist. This causes a FileNotFoundError but it is not catched and it causes an unexpected error instead.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
