### PR TITLE
Don't reset remote in brancher

### DIFF
--- a/dvc/repo/brancher.py
+++ b/dvc/repo/brancher.py
@@ -130,10 +130,12 @@ def _switch_fs(
     if not fs.exists(root_dir):
         raise NotDvcRepoError(f"Commit '{rev[:7]}' does not contain a DVC repo")
 
+    remote = repo.config.get("remote", {})
     repo.fs = fs
     repo.root_dir = root_dir
     repo.dvc_dir = fs.join(root_dir, repo.DVC_DIR)
     repo._reset()
+    repo.config["remote"] = remote
 
     if cwd_parts:
         cwd = repo.fs.join("/", *cwd_parts)


### PR DESCRIPTION
Fixes https://discuss.dvc.org/t/dvc-exp-push-fails-with-error-unexpected-error-interactivesshclient-object-has-no-attribute-passphrases/2187/6
