### PR TITLE
save import hash info to state

### DIFF
--- a/dvc/dependency/base.py
+++ b/dvc/dependency/base.py
@@ -45,7 +45,7 @@ class Dependency(Output):
             self.fs_path = self.fs.version_path(self.fs_path, self.meta.version_id)
 
     def download(self, to, jobs=None):
-        fs_download(self.fs, self.fs_path, to.fs_path, jobs=jobs)
+        return fs_download(self.fs, self.fs_path, to.fs_path, jobs=jobs)
 
     def save(self):
         super().save()

--- a/dvc/fs/__init__.py
+++ b/dvc/fs/__init__.py
@@ -47,7 +47,7 @@ known_implementations.update(
 
 def download(
     fs: "FileSystem", fs_path: str, to: str, jobs: Optional[int] = None
-) -> int:
+) -> list[tuple[str, str]]:
     from dvc.scm import lfs_prefetch
 
     from .callbacks import TqdmCallback
@@ -61,7 +61,7 @@ def download(
             ]
             if not from_infos:
                 localfs.makedirs(to, exist_ok=True)
-                return 0
+                return []
             to_infos = [
                 localfs.join(to, *fs.relparts(info, fs_path)) for info in from_infos
             ]
@@ -81,7 +81,7 @@ def download(
         cb.set_size(len(from_infos))
         jobs = jobs or fs.jobs
         generic.copy(fs, from_infos, localfs, to_infos, callback=cb, batch_size=jobs)
-        return len(to_infos)
+        return list(zip(from_infos, to_infos))
 
 
 def parse_external_url(url, fs_config=None, config=None):

--- a/dvc/repo/artifacts.py
+++ b/dvc/repo/artifacts.py
@@ -220,7 +220,7 @@ class Artifacts:
 
             out = resolve_output(path, out, force=force)
             fs = self.repo.dvcfs
-            count = fs_download(fs, path, os.path.abspath(out), jobs=jobs)
+            count = len(fs_download(fs, path, os.path.abspath(out), jobs=jobs))
         return count, out
 
     @staticmethod

--- a/tests/func/test_import.py
+++ b/tests/func/test_import.py
@@ -6,13 +6,13 @@ from funcy import first
 
 from dvc.cachemgr import CacheManager
 from dvc.config import NoRemoteError
-from dvc.dependency import base
 from dvc.dvcfile import load_file
 from dvc.fs import system
 from dvc.scm import Git
 from dvc.stage.exceptions import StagePathNotFoundError
 from dvc.testing.tmp_dir import make_subrepo
 from dvc.utils.fs import remove
+from dvc_data.hashfile import hash
 from dvc_data.index.index import DataIndexDirError
 
 
@@ -725,14 +725,12 @@ def test_import_invalid_configs(tmp_dir, scm, dvc, erepo_dir):
         )
 
 
-def test_reimport(tmp_dir, scm, dvc, erepo_dir, mocker):
+def test_import_no_hash(tmp_dir, scm, dvc, erepo_dir, mocker):
     with erepo_dir.chdir():
         erepo_dir.dvc_gen("foo", "foo content", commit="create foo")
 
-    spy = mocker.spy(base, "fs_download")
+    spy = mocker.spy(hash, "file_md5")
     dvc.imp(os.fspath(erepo_dir), "foo", "foo_imported")
-    assert spy.called
-
-    spy.reset_mock()
-    dvc.imp(os.fspath(erepo_dir), "foo", "foo_imported", force=True)
-    assert not spy.called
+    out_path = (tmp_dir / "foo_imported").as_posix()
+    for call in spy.call_args_list:
+        assert out_path != call.args[0]

--- a/tests/func/test_import.py
+++ b/tests/func/test_import.py
@@ -732,5 +732,6 @@ def test_import_no_hash(tmp_dir, scm, dvc, erepo_dir, mocker):
     spy = mocker.spy(hash, "file_md5")
     dvc.imp(os.fspath(erepo_dir), "foo", "foo_imported")
     out_path = (tmp_dir / "foo_imported").as_posix()
+    assert spy.call_count == 1
     for call in spy.call_args_list:
         assert out_path != call.args[0]

--- a/tests/func/test_import.py
+++ b/tests/func/test_import.py
@@ -730,8 +730,7 @@ def test_import_no_hash(tmp_dir, scm, dvc, erepo_dir, mocker):
         erepo_dir.dvc_gen("foo", "foo content", commit="create foo")
 
     spy = mocker.spy(hash, "file_md5")
-    dvc.imp(os.fspath(erepo_dir), "foo", "foo_imported")
-    out_path = (tmp_dir / "foo_imported").as_posix()
+    stage = dvc.imp(os.fspath(erepo_dir), "foo", "foo_imported")
     assert spy.call_count == 1
     for call in spy.call_args_list:
-        assert out_path != call.args[0]
+        assert stage.outs[0].fs_path != call.args[0]


### PR DESCRIPTION
This saves the hash info from imports to the output state db so that we don't rehash imports. Without this PR, imported files were always hashed when the output was saved. Existing imported files were even hashed again when doing operations like `dvc import -f`.

This should improve the speed of all imports, and it also reverts the changes in #10388 that caused slowdowns in some scenarios. That previous PR wrongly assumed the slowdown occurred during download, when it actually slowed during `output.save()`. That PR happened to work in some scenarios because the workaround updated the state db.