### PR TITLE
get/import: use in-memory index for remote repositories

### DIFF
--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -166,7 +166,7 @@ class Repo:
         self._config = config
         self._remote = remote
         self._remote_config = remote_config
-        self._data_index = None
+        self._data_index: Optional[DataIndex] = None
 
         if rev and not fs:
             self._scm = scm = SCM(root_dir or os.curdir)
@@ -232,6 +232,7 @@ class Repo:
             Callable[[str, Exception], None]
         ] = None
         self._lock_depth: int = 0
+        self._is_remote = False
 
     def __str__(self):
         return self.url or self.root_dir
@@ -361,7 +362,9 @@ class Repo:
     def data_index(self) -> "DataIndex":
         from dvc_data.index import DataIndex
 
-        if self._data_index is None:
+        if self._is_remote:
+            self._data_index = DataIndex()
+        elif self._data_index is None:
             index_dir = os.path.join(self.site_cache_dir, "index", "data")
             os.makedirs(index_dir, exist_ok=True)
             self._data_index = DataIndex.open(os.path.join(index_dir, "db.db"))

--- a/dvc/repo/open_repo.py
+++ b/dvc/repo/open_repo.py
@@ -40,7 +40,9 @@ def _external_repo(url, rev: Optional[str] = None, **kwargs) -> "Repo":
         **kwargs,
     )
 
-    return Repo(**repo_kwargs)
+    repo = Repo(**repo_kwargs)
+    repo._is_remote = True
+    return repo
 
 
 def open_repo(url, *args, **kwargs):

--- a/dvc/testing/benchmarks/cli/commands/test_get.py
+++ b/dvc/testing/benchmarks/cli/commands/test_get.py
@@ -6,4 +6,4 @@ def test_get(bench_dvc, tmp_dir, scm, dvc, make_dataset, remote):
     dataset = make_dataset(
         cache=False, files=False, dvcfile=True, commit=True, remote=True
     )
-    bench_dvc("get", tmp_dir, dataset.name, "-o", "new")
+    bench_dvc("get", f"file://{tmp_dir.as_posix()}", dataset.name, "-o", "new")

--- a/dvc/testing/benchmarks/cli/commands/test_import.py
+++ b/dvc/testing/benchmarks/cli/commands/test_import.py
@@ -1,7 +1,6 @@
 import pytest
 
 
-@pytest.mark.flaky(reruns=3)
 @pytest.mark.requires(
     "!=3.53.*,!=3.54.0",
     reason="Takes 10 mins to run. Regression in 3.53.0, fixed in 3.54.1",
@@ -12,4 +11,4 @@ def test_import(bench_dvc, tmp_dir, scm, dvc, make_dataset, remote):
     dataset = make_dataset(
         cache=False, files=False, dvcfile=True, commit=True, remote=True
     )
-    bench_dvc("import", tmp_dir, dataset.name, "-o", "new")
+    bench_dvc("import", f"file://{tmp_dir.as_posix()}", dataset.name, "-o", "new")


### PR DESCRIPTION
Hack to avoid creating index for remote repositories.

More than half of the time is being spent on `SQLtrie.__getitem__`, as they are called individually. But it's unclear to me what things are going to be affected by this, so I am keeping it as a draft for now.






![visualization](https://github.com/user-attachments/assets/2f5743d8-c56d-46de-b079-0dc8956cafbd)
![visualization (1)](https://github.com/user-attachments/assets/66690370-79cd-46d3-9229-0eb76239aeb9)
