### PR TITLE
dvc-10427 Always Clean the Workers on Shutdown.

### DIFF
--- a/dvc/repo/experiments/queue/celery.py
+++ b/dvc/repo/experiments/queue/celery.py
@@ -129,9 +129,11 @@ class LocalCeleryQueue(BaseStashQueue):
         wdir_hash = hashlib.sha256(self.wdir.encode("utf-8")).hexdigest()[:6]
         node_name = f"dvc-exp-{wdir_hash}-{num}@localhost"
         cmd = ["exp", "queue-worker", node_name]
-        if num == 1:
-            # automatically run celery cleanup when primary worker shuts down
-            cmd.append("--clean")
+
+        # Always clean the queues as non expired messages will be excluded by dvc_task
+        # effectively skipping the cleaning.
+        cmd.append("--clean")
+
         if logger.getEffectiveLevel() <= logging.DEBUG:
             cmd.append("-v")
         name = f"dvc-exp-worker-{num}"

--- a/tests/func/experiments/test_experiments.py
+++ b/tests/func/experiments/test_experiments.py
@@ -484,7 +484,6 @@ def test_run_celery(tmp_dir, scm, dvc, exp_stage, mocker):
 def test_run_celery_queues_two_jobs_each_one_with_cleaning_flag(
     tmp_dir, scm, dvc, exp_stage, mocker
 ):
-    # This is one of the tests we need to update
     dvc.experiments.run(exp_stage.addressing, params=["foo=2"], queue=True)
     dvc.experiments.run(exp_stage.addressing, params=["foo=3"], queue=True)
     assert len(dvc.experiments.stash_revs) == 2

--- a/tests/unit/command/test_queue.py
+++ b/tests/unit/command/test_queue.py
@@ -96,6 +96,10 @@ def test_experiments_start(dvc, scm, mocker):
     assert cmd.run() == 0
     assert m.call_count == 3
 
+    # Ensure each call to _spawn_worker will be for the nth worker
+    for n, call_arg in enumerate(m.call_args_list, start=1):
+        assert call_arg[0][0] == n
+
 
 def test_experiments_stop(dvc, scm, mocker):
     cli_args = parse_args(["queue", "stop", "--kill"])


### PR DESCRIPTION
Related to:

- https://github.com/iterative/dvc/issues/10427

In order to effectively remove the obsolete files in `FSApp.data_folder_in` ([source](https://github.com/nablabits/dvc-task/blob/f15acd796b9721e52cb012fb7fc4e706e06ae8f0/src/dvc_task/app/filesystem.py#L44)) we need to call `clean` for each worker. This should be a fairly safe operation as `_gc` ([source](https://github.com/nablabits/dvc-task/blob/f15acd796b9721e52cb012fb7fc4e706e06ae8f0/src/dvc_task/app/filesystem.py#L44)) will exclude from cleaning non expired messages.

## How to Test this
It's somewhat tricky to set up everything to verify the solution, so I have created a PR here to ease the process:

- https://github.com/nablabits/example-get-started-experiments/pull/1


---

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
