### PR TITLE
add/commit: use hardlink to transfer files to the cache when `cache.type` is hardlink and on relink mode

### DIFF
--- a/dvc/output.py
+++ b/dvc/output.py
@@ -752,8 +752,9 @@ class Output:
             granular = (
                 self.is_dir_checksum and filter_info and filter_info != self.fs_path
             )
+            hardlink = relink and next(iter(self.cache.cache_types), None) == "hardlink"
             if granular:
-                obj = self._commit_granular_dir(filter_info, hardlink=False)
+                obj = self._commit_granular_dir(filter_info, hardlink=hardlink)
             else:
                 staging, _, obj = self._build(
                     self.cache,
@@ -771,7 +772,7 @@ class Output:
                         self.cache,
                         {obj.hash_info},
                         shallow=False,
-                        hardlink=False,
+                        hardlink=hardlink,
                         callback=cb,
                     )
             if relink:
@@ -1399,12 +1400,14 @@ class Output:
 
         assert staging
         assert obj.hash_info
+
+        hardlink = relink and next(iter(self.cache.cache_types), None) == "hardlink"
         with TqdmCallback(desc=f"Adding {self} to cache", unit="file") as cb:
             otransfer(
                 staging,
                 self.cache,
                 {obj.hash_info},
-                hardlink=False,
+                hardlink=hardlink,
                 shallow=False,
                 callback=cb,
             )


### PR DESCRIPTION
When the `cache_type` is `hardlink`, we can simply hardlink the file from the workspace to the cache, and we don't need to relink back from the cache to the workspace.

| Name                                   | Time (in s)       |
|----------------------------------------|-------------------|
| test_add_hardlink-add[hardlink-relink] |    17.5393 (1.0)  |
| test_add_hardlink-add[main]            |    32.9904 (1.88) |


Note that this is a bit unsafe, because a failure in the middle of `dvc add` may end up in a situation where the file has been hardlinked to the cache, but we have not protected them yet to make it read-only. Modification of these files in the workspace might corrupt cache (since they are hardlinked). But this is what we were doing before #10513, and there is always a chance of corruption for hardlink anyway.

Also note that before #10513, on relink mode, we were hardlinking on all link types, but in this PR, I have limited it to just `hardlink` cache types.
