### PR TITLE
ls: implement --tree to show as a tree and --level to limit depth for recursion

### DIFF
--- a/dvc/commands/ls/ls_colors.py
+++ b/dvc/commands/ls/ls_colors.py
@@ -32,7 +32,9 @@ class LsColors:
         if entry.get("isexec", False):
             return self._format(text, code="ex")
 
-        _, ext = os.path.splitext(text)
+        stem, ext = os.path.splitext(text)
+        if not ext and stem.startswith("."):
+            ext = stem
         return self._format(text, ext=ext)
 
     def _format(self, text, code=None, ext=None):

--- a/dvc/repo/ls.py
+++ b/dvc/repo/ls.py
@@ -4,7 +4,43 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 if TYPE_CHECKING:
     from dvc.fs.dvc import DVCFileSystem
 
+
+def _open_repo(
+    url: str,
+    rev: Optional[str] = None,
+    config: Union[None, dict[str, Any], str] = None,
+    remote: Optional[str] = None,
+    remote_config: Optional[dict] = None,
+):
+    from dvc.config import Config
+
     from . import Repo
+
+    if config and not isinstance(config, dict):
+        config_dict = Config.load_file(config)
+    else:
+        config_dict = None
+
+    return Repo.open(
+        url,
+        rev=rev,
+        subrepos=True,
+        uninitialized=True,
+        config=config_dict,
+        remote=remote,
+        remote_config=remote_config,
+    )
+
+
+def _adapt_info(info: dict[str, Any]) -> dict[str, Any]:
+    dvc_info = info.get("dvc_info", {})
+    return {
+        "isout": dvc_info.get("isout", False),
+        "isdir": info["type"] == "directory",
+        "isexec": info.get("isexec", False),
+        "size": info.get("size"),
+        "md5": dvc_info.get("md5") or dvc_info.get("md5-dos2unix"),
+    }
 
 
 def ls(
@@ -16,6 +52,7 @@ def ls(
     config: Union[None, dict[str, Any], str] = None,
     remote: Optional[str] = None,
     remote_config: Optional[dict] = None,
+    maxdepth: Optional[int] = None,
 ):
     """Methods for getting files and outputs for the repo.
 
@@ -41,60 +78,58 @@ def ls(
             "isexec": bool,
         }
     """
-    from dvc.config import Config
-
-    from . import Repo
-
-    if config and not isinstance(config, dict):
-        config_dict = Config.load_file(config)
-    else:
-        config_dict = None
-
-    with Repo.open(
-        url,
-        rev=rev,
-        subrepos=True,
-        uninitialized=True,
-        config=config_dict,
-        remote=remote,
-        remote_config=remote_config,
-    ) as repo:
+    with _open_repo(url, rev, config, remote, remote_config) as repo:
         path = path or ""
+        fs: DVCFileSystem = repo.dvcfs
+        fs_path = fs.from_os_path(path)
+        return _ls(fs, fs_path, recursive, dvc_only, maxdepth)
 
-        ret = _ls(repo, path, recursive, dvc_only)
 
-        ret_list = []
-        for path, info in ret.items():
-            info["path"] = path
-            ret_list.append(info)
-        ret_list.sort(key=lambda f: f["path"])
-        return ret_list
+def ls_tree(
+    url: str,
+    path: Optional[str] = None,
+    rev: Optional[str] = None,
+    dvc_only: bool = False,
+    config: Union[None, dict[str, Any], str] = None,
+    remote: Optional[str] = None,
+    remote_config: Optional[dict] = None,
+    maxdepth: Optional[int] = None,
+):
+    with _open_repo(url, rev, config, remote, remote_config) as repo:
+        path = path or ""
+        fs: DVCFileSystem = repo.dvcfs
+        fs_path = fs.from_os_path(path)
+        return _ls_tree(fs, fs_path, dvc_only, maxdepth)
 
 
 def _ls(
-    repo: "Repo",
+    fs: "DVCFileSystem",
     path: str,
     recursive: Optional[bool] = None,
     dvc_only: bool = False,
+    maxdepth: Optional[int] = None,
 ):
-    fs: DVCFileSystem = repo.dvcfs
-    fs_path = fs.from_os_path(path)
-
-    fs_path = fs.info(fs_path)["name"]
+    fs_path = fs.info(path)["name"]
 
     infos = {}
-    if fs.isfile(fs_path):
-        infos[os.path.basename(path)] = fs.info(fs_path)
+
+    # ignore maxdepth only if recursive is not set
+    maxdepth = maxdepth if recursive else None
+    if maxdepth == 0 or fs.isfile(fs_path):
+        infos[os.path.basename(path) or os.curdir] = fs.info(fs_path)
     else:
         for root, dirs, files in fs.walk(
-            fs_path, dvcfiles=True, dvc_only=dvc_only, detail=True
+            fs_path,
+            dvcfiles=True,
+            dvc_only=dvc_only,
+            detail=True,
+            maxdepth=maxdepth,
         ):
-            if not recursive:
-                files.update(dirs)
-
             parts = fs.relparts(root, fs_path)
             if parts == (".",):
                 parts = ()
+            if not recursive or (maxdepth and len(parts) >= maxdepth - 1):
+                files.update(dirs)
 
             for name, entry in files.items():
                 infos[os.path.join(*parts, name)] = entry
@@ -102,15 +137,37 @@ def _ls(
             if not recursive:
                 break
 
-    ret = {}
-    for name, info in infos.items():
-        dvc_info = info.get("dvc_info", {})
-        ret[name] = {
-            "isout": dvc_info.get("isout", False),
-            "isdir": info["type"] == "directory",
-            "isexec": info.get("isexec", False),
-            "size": info.get("size"),
-            "md5": dvc_info.get("md5") or dvc_info.get("md5-dos2unix"),
-        }
+    ret_list = []
+    for p, info in sorted(infos.items(), key=lambda x: x[0]):
+        _info = _adapt_info(info)
+        _info["path"] = p
+        ret_list.append(_info)
+    return ret_list
 
+
+def _ls_tree(
+    fs, path, dvc_only: bool = False, maxdepth: Optional[int] = None, _info=None
+):
+    ret = {}
+    info = _info or fs.info(path)
+
+    path = info["name"].rstrip(fs.sep) or os.curdir
+    name = path.rsplit("/", 1)[-1]
+    ls_info = _adapt_info(info)
+    ls_info["path"] = path
+
+    recurse = maxdepth is None or maxdepth > 0
+    if recurse and info["type"] == "directory":
+        infos = fs.ls(path, dvcfiles=True, dvc_only=dvc_only, detail=True)
+        infos.sort(key=lambda f: f["name"])
+        maxdepth = maxdepth - 1 if maxdepth is not None else None
+        contents = {}
+        for info in infos:
+            d = _ls_tree(
+                fs, info["name"], dvc_only=dvc_only, maxdepth=maxdepth, _info=info
+            )
+            contents.update(d)
+        ls_info["contents"] = contents
+
+    ret[name] = ls_info
     return ret

--- a/dvc/ui/__init__.py
+++ b/dvc/ui/__init__.py
@@ -300,6 +300,7 @@ class Console:
         header_styles: Optional[Union[dict[str, "Styles"], Sequence["Styles"]]] = None,
         row_styles: Optional[Sequence["Styles"]] = None,
         borders: Union[bool, str] = False,
+        colalign: Optional[tuple[str, ...]] = None,
     ) -> None:
         from dvc.ui import table as t
 
@@ -321,7 +322,13 @@ class Console:
             return
 
         return t.plain_table(
-            self, data, headers, markdown=markdown, pager=pager, force=force
+            self,
+            data,
+            headers,
+            markdown=markdown,
+            pager=pager,
+            force=force,
+            colalign=colalign,
         )
 
     def status(self, status: str, **kwargs: Any) -> "Status":

--- a/dvc/ui/table.py
+++ b/dvc/ui/table.py
@@ -29,6 +29,7 @@ def plain_table(
     markdown: bool = False,
     pager: bool = False,
     force: bool = True,
+    colalign: Optional[tuple[str, ...]] = None,
 ) -> None:
     from funcy import nullcontext
     from tabulate import tabulate
@@ -40,6 +41,7 @@ def plain_table(
         disable_numparse=True,
         # None will be shown as "" by default, overriding
         missingval="-",
+        colalign=colalign,
     )
     if markdown:
         # NOTE: md table is incomplete without the trailing newline

--- a/tests/unit/command/ls/test_ls.py
+++ b/tests/unit/command/ls/test_ls.py
@@ -1,7 +1,7 @@
 import json
 
 from dvc.cli import parse_args
-from dvc.commands.ls import CmdList
+from dvc.commands.ls import CmdList, show_tree
 
 
 def _test_cli(mocker, *args):
@@ -27,6 +27,7 @@ def test_list(mocker):
         config=None,
         remote=None,
         remote_config=None,
+        maxdepth=None,
     )
 
 
@@ -42,6 +43,7 @@ def test_list_recursive(mocker):
         config=None,
         remote=None,
         remote_config=None,
+        maxdepth=None,
     )
 
 
@@ -57,6 +59,7 @@ def test_list_git_ssh_rev(mocker):
         config=None,
         remote=None,
         remote_config=None,
+        maxdepth=None,
     )
 
 
@@ -73,6 +76,7 @@ def test_list_targets(mocker):
         config=None,
         remote=None,
         remote_config=None,
+        maxdepth=None,
     )
 
 
@@ -88,6 +92,7 @@ def test_list_outputs_only(mocker):
         config=None,
         remote=None,
         remote_config=None,
+        maxdepth=None,
     )
 
 
@@ -114,6 +119,65 @@ def test_list_config(mocker):
         config="myconfig",
         remote="myremote",
         remote_config={"k1": "v1", "k2": "v2"},
+        maxdepth=None,
+    )
+
+
+def test_list_level(mocker):
+    url = "local_dir"
+    m = _test_cli(mocker, url, None, "--level", "1")
+    m.assert_called_once_with(
+        url,
+        None,
+        recursive=False,
+        rev=None,
+        dvc_only=False,
+        config=None,
+        remote=None,
+        remote_config=None,
+        maxdepth=1,
+    )
+
+
+def test_list_tree(mocker):
+    url = "git@github.com:repo"
+    cli_args = parse_args(
+        [
+            "list",
+            url,
+            "local_dir",
+            "--rev",
+            "123",
+            "--tree",
+            "--show-hash",
+            "--size",
+            "--level",
+            "2",
+            "--dvc-only",
+            "--config",
+            "myconfig",
+            "--remote",
+            "myremote",
+            "--remote-config",
+            "k1=v1",
+            "k2=v2",
+        ]
+    )
+    assert cli_args.func == CmdList
+
+    cmd = cli_args.func(cli_args)
+    m = mocker.patch("dvc.repo.ls.ls_tree")
+
+    assert cmd.run() == 0
+    m.assert_called_once_with(
+        url,
+        "local_dir",
+        rev="123",
+        dvc_only=True,
+        config="myconfig",
+        remote="myremote",
+        remote_config={"k1": "v1", "k2": "v2"},
+        maxdepth=2,
     )
 
 
@@ -163,6 +227,268 @@ def test_show_colors(mocker, capsys, monkeypatch):
         "\x1b[01;34msrc\x1b[0m",
         "\x1b[01;32mrun.sh\x1b[0m",
     ]
+
+
+def test_show_size(mocker, capsys):
+    cli_args = parse_args(["list", "local_dir", "--size"])
+    assert cli_args.func == CmdList
+    cmd = cli_args.func(cli_args)
+
+    result = [
+        {
+            "isdir": False,
+            "isexec": 0,
+            "isout": False,
+            "path": ".dvcignore",
+            "size": 100,
+        },
+        {
+            "isdir": False,
+            "isexec": 0,
+            "isout": False,
+            "path": ".gitignore",
+            "size": 200,
+        },
+        {
+            "isdir": False,
+            "isexec": 0,
+            "isout": False,
+            "path": "README.md",
+            "size": 100_000,
+        },
+    ]
+    mocker.patch("dvc.repo.Repo.ls", return_value=result)
+
+    assert cmd.run() == 0
+    out, _ = capsys.readouterr()
+    entries = out.splitlines()
+
+    assert entries == ["  100  .dvcignore", "  200  .gitignore", "97.7k  README.md"]
+
+
+def test_show_hash(mocker, capsys):
+    cli_args = parse_args(["list", "local_dir", "--show-hash"])
+    assert cli_args.func == CmdList
+    cmd = cli_args.func(cli_args)
+
+    result = [
+        {
+            "isdir": False,
+            "isexec": 0,
+            "isout": False,
+            "path": ".dvcignore",
+            "md5": "123",
+        },
+        {
+            "isdir": False,
+            "isexec": 0,
+            "isout": False,
+            "path": ".gitignore",
+            "md5": "456",
+        },
+        {
+            "isdir": False,
+            "isexec": 0,
+            "isout": False,
+            "path": "README.md",
+            "md5": "789",
+        },
+    ]
+    mocker.patch("dvc.repo.Repo.ls", return_value=result)
+
+    assert cmd.run() == 0
+    out, _ = capsys.readouterr()
+    entries = out.splitlines()
+
+    assert entries == ["123  .dvcignore", "456  .gitignore", "789  README.md"]
+
+
+def test_show_size_and_hash(mocker, capsys):
+    cli_args = parse_args(["list", "local_dir", "--size", "--show-hash"])
+    assert cli_args.func == CmdList
+    cmd = cli_args.func(cli_args)
+
+    result = [
+        {
+            "isdir": False,
+            "isexec": 0,
+            "isout": False,
+            "path": ".dvcignore",
+            "size": 100,
+            "md5": "123",
+        },
+        {
+            "isdir": False,
+            "isexec": 0,
+            "isout": False,
+            "path": ".gitignore",
+            "size": 200,
+            "md5": "456",
+        },
+        {
+            "isdir": False,
+            "isexec": 0,
+            "isout": False,
+            "path": "README.md",
+            "size": 100_000,
+            "md5": "789",
+        },
+    ]
+    mocker.patch("dvc.repo.Repo.ls", return_value=result)
+
+    assert cmd.run() == 0
+    out, _ = capsys.readouterr()
+    entries = out.splitlines()
+
+    assert entries == [
+        "  100  123  .dvcignore",
+        "  200  456  .gitignore",
+        "97.7k  789  README.md",
+    ]
+
+
+def test_show_tree(capsys):
+    entries = {
+        "data": {
+            "isout": True,
+            "isdir": True,
+            "isexec": False,
+            "size": 192,
+            "path": "data",
+            "md5": "3fb071066d5d5b282f56a0169340346d.dir",
+            "contents": {
+                "dir": {
+                    "isout": False,
+                    "isdir": True,
+                    "isexec": False,
+                    "size": 96,
+                    "path": "data/dir",
+                    "md5": None,
+                    "contents": {
+                        "subdir": {
+                            "isout": True,
+                            "isdir": True,
+                            "isexec": False,
+                            "size": 96,
+                            "md5": None,
+                            "path": "data/dir/subdir",
+                            "contents": {
+                                "foobar": {
+                                    "isout": True,
+                                    "isdir": False,
+                                    "isexec": False,
+                                    "size": 4,
+                                    "md5": "d3b07384d113edec49eaa6238ad5ff00",
+                                }
+                            },
+                        },
+                        "foo": {
+                            "isout": False,
+                            "isdir": False,
+                            "isexec": False,
+                            "size": 4,
+                            "path": "data/dir/foo",
+                            "md5": None,
+                        },
+                    },
+                },
+                "bar": {
+                    "isout": True,
+                    "isdir": False,
+                    "isexec": False,
+                    "size": 4,
+                    "path": "data/bar",
+                    "md5": "c157a79031e1c40f85931829bc5fc552",
+                },
+                "large-file": {
+                    "isout": False,
+                    "isdir": False,
+                    "isexec": False,
+                    "size": 1073741824,
+                    "path": "data/large-file",
+                    "md5": None,
+                },
+                "dir2": {
+                    "isout": True,
+                    "isdir": True,
+                    "isexec": False,
+                    "size": 96,
+                    "md5": None,
+                    "path": "data/dir2",
+                    "contents": {
+                        "foo": {
+                            "isout": True,
+                            "isdir": False,
+                            "isexec": False,
+                            "size": 4,
+                            "path": "data/dir2/foo",
+                            "md5": "d3b07384d113edec49eaa6238ad5ff00",
+                        }
+                    },
+                },
+            },
+        }
+    }
+
+    show_tree(entries, with_color=False)
+    out, _ = capsys.readouterr()
+    expected = """\
+data
+├── dir
+│   ├── subdir
+│   │   └── foobar
+│   └── foo
+├── bar
+├── large-file
+└── dir2
+    └── foo
+"""
+    assert out == expected
+
+    show_tree(entries, with_color=False, with_size=True)
+    out, _ = capsys.readouterr()
+    expected = """\
+  192  data
+   96  ├── dir
+   96  │   ├── subdir
+    4  │   │   └── foobar
+    4  │   └── foo
+    4  ├── bar
+1.00G  ├── large-file
+   96  └── dir2
+    4      └── foo
+"""
+    assert out == expected
+
+    show_tree(entries, with_color=False, with_hash=True)
+    out, _ = capsys.readouterr()
+    expected = """\
+3fb071066d5d5b282f56a0169340346d.dir  data
+-                                     ├── dir
+-                                     │   ├── subdir
+d3b07384d113edec49eaa6238ad5ff00      │   │   └── foobar
+-                                     │   └── foo
+c157a79031e1c40f85931829bc5fc552      ├── bar
+-                                     ├── large-file
+-                                     └── dir2
+d3b07384d113edec49eaa6238ad5ff00          └── foo
+"""
+    assert out == expected
+
+    show_tree(entries, with_color=False, with_hash=True, with_size=True)
+    out, _ = capsys.readouterr()
+    expected = """\
+  192  3fb071066d5d5b282f56a0169340346d.dir  data
+   96  -                                     ├── dir
+   96  -                                     │   ├── subdir
+    4  d3b07384d113edec49eaa6238ad5ff00      │   │   └── foobar
+    4  -                                     │   └── foo
+    4  c157a79031e1c40f85931829bc5fc552      ├── bar
+1.00G  -                                     ├── large-file
+   96  -                                     └── dir2
+    4  d3b07384d113edec49eaa6238ad5ff00          └── foo
+"""
+    assert out == expected
 
 
 def test_list_alias():


### PR DESCRIPTION
```console
$ dvc ls https://github.com/iterative/dataset-registry -TL2
.
├── README.md
├── blog
│   ├── .gitignore
│   └── cats-dogs
├── dvc-course
│   ├── .gitignore
│   └── hymenoptera_data
├── get-started
│   ├── .gitignore
│   └── data.xml
├── github-issues
│   ├── .gitignore
│   └── dataset.parquet
├── images
│   ├── .gitignore
│   ├── dvc-logo-outlines.png
│   ├── owl_sticker.png
│   └── owl_sticker.svg
├── tutorials
│   ├── nlp
│   └── versioning
├── use-cases
│   ├── .gitignore
│   ├── cats-dogs
│   └── pool_data
└── workshop
    ├── .gitignore
    ├── README.md
    ├── dvc_discord_channel.csv
    └── satellite-data
```

```console
$ dvc ls https://github.com/iterative/dataset-registry -RL2
README.md
blog/.gitignore
blog/cats-dogs
blog/cats-dogs.dvc
dvc-course/.gitignore
dvc-course/hymenoptera_data
dvc-course/hymenoptera_data.dvc
dvc.yaml
get-started/.gitignore
get-started/data.xml
get-started/data.xml.dvc
github-issues/.gitignore
github-issues/dataset.parquet
github-issues/dataset.parquet.dvc
images/.gitignore
images/dvc-logo-outlines.png
images/dvc-logo-outlines.png.dvc
images/owl_sticker.png
images/owl_sticker.png.dvc
images/owl_sticker.svg
images/owl_sticker.svg.dvc
tutorials/nlp
tutorials/versioning
use-cases/.gitignore
use-cases/cats-dogs
use-cases/cats-dogs.dvc
use-cases/pool_data
use-cases/pool_data.dvc
workshop/.gitignore
workshop/README.md
workshop/dvc_discord_channel.csv
workshop/dvc_discord_channel.csv.dvc
workshop/satellite-data
workshop/satellite-data.dvc
```