### PR TITLE
Update `pre-commit` to use pinned version of `dvc` and correct stage names

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,7 +8,7 @@
   name: DVC pre-commit
   require_serial: true
   stages:
-  - commit
+  - pre-commit
   verbose: true
 - args:
   - git-hook
@@ -20,7 +20,7 @@
   name: DVC pre-push
   require_serial: true
   stages:
-  - push
+  - pre-push
 - always_run: true
   args:
   - git-hook
@@ -29,7 +29,7 @@
   id: dvc-post-checkout
   language: python
   language_version: python3
-  minimum_pre_commit_version: 2.2.0
+  minimum_pre_commit_version: 3.2.0
   name: DVC post-checkout
   require_serial: true
   stages:

--- a/dvc/repo/install.py
+++ b/dvc/repo/install.py
@@ -16,7 +16,7 @@ def pre_commit_install(scm: "Git") -> None:
     with modify_yaml(config_path) as config:
         entry = {
             "repo": "https://github.com/iterative/dvc",
-            "rev": "3.56.0",
+            "rev": ".".join(map(str, version_tuple[:3])),
             "hooks": [
                 {
                     "id": "dvc-pre-commit",

--- a/dvc/repo/install.py
+++ b/dvc/repo/install.py
@@ -16,7 +16,7 @@ def pre_commit_install(scm: "Git") -> None:
     with modify_yaml(config_path) as config:
         entry = {
             "repo": "https://github.com/iterative/dvc",
-            "rev": "main",
+            "rev": "3.56.0",
             "hooks": [
                 {
                     "id": "dvc-pre-commit",

--- a/dvc/repo/install.py
+++ b/dvc/repo/install.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
-from dvc.exceptions import DvcException
 from dvc import version_tuple
+from dvc.exceptions import DvcException
 
 if TYPE_CHECKING:
     from dvc.repo import Repo

--- a/dvc/repo/install.py
+++ b/dvc/repo/install.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from dvc.exceptions import DvcException
+from dvc import version_tuple
 
 if TYPE_CHECKING:
     from dvc.repo import Repo

--- a/dvc/repo/install.py
+++ b/dvc/repo/install.py
@@ -22,13 +22,13 @@ def pre_commit_install(scm: "Git") -> None:
                     "id": "dvc-pre-commit",
                     "additional_dependencies": [".[all]"],
                     "language_version": "python3",
-                    "stages": ["commit"],
+                    "stages": ["pre-commit"],
                 },
                 {
                     "id": "dvc-pre-push",
                     "additional_dependencies": [".[all]"],
                     "language_version": "python3",
-                    "stages": ["push"],
+                    "stages": ["pre-push"],
                 },
                 {
                     "id": "dvc-post-checkout",


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

## 1. Pin `rev` argument in `pre-commit-config.yaml` writer

The `pre-commit` package recommends against using mutable references such as `main`, as the version of the package pulled in the hook (in this case `dvc`), does not get updated after the first time `pre-commit` installs it. This PR addresses this by instead pinning the hooks to [`dvc` v3.56.0](https://github.com/iterative/dvc/releases/tag/3.56.0). This change is made with the goal of:
- removing the `pre-commit` warning, and
- adding the ability to automatically update the `dvc` version that `pre-commit` refers to when `dvc` receives a new release.

As a reference, [`ruff`](https://github.com/astral-sh/ruff), the python linter and formatter, keeps its pre-commit hooks in a [separate repository](https://github.com/astral-sh/ruff-pre-commit). This repository has its own pre-commit hooks that automatically pull the latest version of `ruff` and updates the version pointer in the `pre-commit-hooks.yaml` file. Maybe `dvc` could do something like this in the future to automate the `pre-commit-hooks.yaml` update process.

## 2. Update `stages` keywords

Additionally, `pre-commit` has [now deprecated](https://github.com/pre-commit/pre-commit/releases/tag/v4.0.0) the acceptable values for the `stages` keyword for `hooks`.  I have updated the `dvc install` command and the `pre-commit-hooks.yaml` file to reflect this change.

As this change was made in `pre-commit` [v3.2.0](https://github.com/pre-commit/pre-commit/releases/tag/v3.2.0), the `dvc` hooks now require `pre-commit` to be updated to at least v3.2.0.

Closes #9897.

Associated documentation PR: https://github.com/iterative/dvc.org/pull/5323.