### PR TITLE
batch dump and batch update of old stages

### DIFF
--- a/dvc/repo/commit.py
+++ b/dvc/repo/commit.py
@@ -78,10 +78,10 @@ def commit(
             dvcfile._reset()
             old_stages = dict(dvcfile.stages)
         else:
-            old_stages = {}
+            old_stages = None
 
         for stage in val["stages"]:
-            old_stage = old_stages.get(stage.name, None)
+            old_stage = old_stages[stage.name] if old_stages else None
 
             if force:
                 stage.save(allow_missing=allow_missing, old_stage=old_stage)

--- a/dvc/repo/commit.py
+++ b/dvc/repo/commit.py
@@ -74,21 +74,22 @@ def commit(
 
     for val in stages_by_dvcfile.values():
         dvcfile = val["stages"][0].dvcfile
-        dvcfile._reset()
-        old_stages = dict(dvcfile.stages)
+        if isinstance(dvcfile, ProjectFile):
+            dvcfile._reset()
+            old_stages = dict(dvcfile.stages)
+        else:
+            old_stages = {}
 
         for stage in val["stages"]:
+            old_stage = old_stages.get(stage.name, None)
+
             if force:
-                stage.save(
-                    allow_missing=allow_missing, old_stage=old_stages[stage.name]
-                )
+                stage.save(allow_missing=allow_missing, old_stage=old_stage)
             else:
                 changes = stage.changed_entries()
                 if any(changes):
                     prompt_to_commit(stage, changes, force=force)
-                    stage.save(
-                        allow_missing=allow_missing, old_stage=old_stages[stage.name]
-                    )
+                    stage.save(allow_missing=allow_missing, old_stage=old_stage)
             stage.commit(
                 filter_info=stage_info.filter_info,
                 allow_missing=allow_missing,


### PR DESCRIPTION
## Description

Rather than running stage.dump separately for each stage, which involves loading the dvc.lock file many times, this proposed code groups stages together by their dvcfiles and does a `dvcfile.batch_dump` (see the `stages_by_dvcfile` object).

Also, rather than getting the old version of each stage within `get_versioned_outs`, this proposed code gets all old versions in one step, stores them in a `old_stages` object, and then passes each old stage to stage.save. This similarly removes a step where the lock file is reloaded once per stage.

My understanding is that these changes improve the speed of dvc commit when the dvc.lock file is very large and slow to load, without causing any changes or problems regarding the function's behavior. That said, I am not 100%, especially when it comes to the get_versioned_outs part which I have less context for. I would appreciate feedback about what this could be missing!

## Related issues

Fixes https://github.com/iterative/dvc/issues/10629, although it seems like it would be even better to have separate lock files.

## Checklist

* [x] ❗❗ **(WITH CAVEAT BELOW!!!)**  ❗❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.
  - I am not a python expert so I apologize if I missed something! I did not add a test for this change because I did not see an obvious unit test to update. However, I did run this version with the reproducible example in https://github.com/iterative/dvc/issues/10629 and saw that it reduced commit time as described there. 
  - I ran pytest in the the development environment and there were 6 tests that failed that seem to be related to some kind of API. These tests also failed when I ran pytest while on the main branch without any changes. So it seems like there was something about the developer environment that I did not set up correctly, rather than these being caused by the changes I made. I'm not sure though. Might you have any insight as to why these fail?

```
FAILED tests/func/test_daemon.py::test_analytics - subprocess.CalledProcessError: Command '['/home/fishea10/dvc/venv/bin/python3', '/home/fishea10/dvc/dvc/__main__.py', 'config', '-l', '-vv']' returned non-zero exit status 1.

FAILED tests/func/test_daemon.py::test_updater - subprocess.CalledProcessError: Command '['/home/fishea10/dvc/venv/bin/python3', '/home/fishea10/dvc/dvc/__main__.py', 'version', '-vv']' returned non-zero exit status 1.

FAILED tests/integration/test_studio_live_experiments.py::test_post_to_studio[None-False-True] - AssertionError: assert 'mytoken' == 'STUDIO_TOKEN'

FAILED tests/integration/test_studio_live_experiments.py::test_post_to_studio[None-False-False] - AssertionError: assert 'mytoken' == 'STUDIO_TOKEN'

FAILED tests/integration/test_studio_live_experiments.py::test_post_to_studio[DVC_EXP_GIT_REMOTE-False-True] - AssertionError: assert 'mytoken' == 'STUDIO_TOKEN'

FAILED tests/integration/test_studio_live_experiments.py::test_post_to_studio[DVC_EXP_GIT_REMOTE-False-False] - AssertionError: assert 'mytoken' == 'STUDIO_TOKEN'
```

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.
  - NA. There is no change from the user's perspective.


