### PR TITLE
set DVC_NO_ANALYTICS on lint

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,6 +19,8 @@ jobs:
   lint:
     timeout-minutes: 10
     runs-on: ${{ matrix.os }}
+    env:
+       DVC_NO_ANALYTICS: true
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Hopefully, this will fix windows lint failures. My guess is that dvc daemon is running in the background preventing `uv` to prune cache.

But this is just a guess. Setting this one does not hurt us. We'll know if this was really an issue. :)