### PR TITLE
Fix #10638 : makes remove return correct list when used with both `--queue` and `-A` 

### DIFF
--- a/dvc/repo/experiments/remove.py
+++ b/dvc/repo/experiments/remove.py
@@ -75,7 +75,7 @@ def remove(  # noqa: C901, PLR0912
         exp_ref_list.extend(exp_ref_dict.values())
     elif all_commits:
         exp_ref_list.extend(exp_refs(repo.scm, git_remote))
-        removed = [ref.name for ref in exp_ref_list]
+        removed.extend([ref.name for ref in exp_ref_list])
 
     if keep:
         exp_ref_list = list(set(exp_refs(repo.scm, git_remote)) - set(exp_ref_list))

--- a/tests/func/experiments/test_remove.py
+++ b/tests/func/experiments/test_remove.py
@@ -42,6 +42,20 @@ def test_remove_all_queued_experiments(tmp_dir, scm, dvc, exp_stage):
     assert len(dvc.experiments.stash_revs) == 0
     assert scm.get_ref(str(ref_info)) is not None
 
+def test_remove_all_experiments_queued_and_commits(tmp_dir, scm, dvc, exp_stage):
+    queue_length = 3
+    for i in range(queue_length):
+        dvc.experiments.run(exp_stage.addressing, params=[f"foo={i}"], name=f"exp{i}", queue=True)
+
+    results = dvc.experiments.run(exp_stage.addressing, params=[f"foo={queue_length}"],name=f"exp{queue_length}")
+    ref_info = first(exp_refs_by_rev(scm, first(results)))
+
+    removed = sorted(dvc.experiments.remove(all_commits=True, queue=True))
+
+    assert len(removed) == queue_length + 1
+    assert removed == [f"exp{i}" for i in range(queue_length)] + [ref_info.name]
+    assert len(dvc.experiments.stash_revs) == 0
+    assert scm.get_ref(str(ref_info)) is None
 
 def test_remove_special_queued_experiments(tmp_dir, scm, dvc, exp_stage):
     dvc.experiments.run(

--- a/tests/func/experiments/test_remove.py
+++ b/tests/func/experiments/test_remove.py
@@ -42,12 +42,17 @@ def test_remove_all_queued_experiments(tmp_dir, scm, dvc, exp_stage):
     assert len(dvc.experiments.stash_revs) == 0
     assert scm.get_ref(str(ref_info)) is not None
 
+
 def test_remove_all_experiments_queued_and_commits(tmp_dir, scm, dvc, exp_stage):
     queue_length = 3
     for i in range(queue_length):
-        dvc.experiments.run(exp_stage.addressing, params=[f"foo={i}"], name=f"exp{i}", queue=True)
+        dvc.experiments.run(
+            exp_stage.addressing, params=[f"foo={i}"], name=f"exp{i}", queue=True
+        )
 
-    results = dvc.experiments.run(exp_stage.addressing, params=[f"foo={queue_length}"],name=f"exp{queue_length}")
+    results = dvc.experiments.run(
+        exp_stage.addressing, params=[f"foo={queue_length}"], name=f"exp{queue_length}"
+    )
     ref_info = first(exp_refs_by_rev(scm, first(results)))
 
     removed = sorted(dvc.experiments.remove(all_commits=True, queue=True))
@@ -56,6 +61,7 @@ def test_remove_all_experiments_queued_and_commits(tmp_dir, scm, dvc, exp_stage)
     assert removed == [f"exp{i}" for i in range(queue_length)] + [ref_info.name]
     assert len(dvc.experiments.stash_revs) == 0
     assert scm.get_ref(str(ref_info)) is None
+
 
 def test_remove_special_queued_experiments(tmp_dir, scm, dvc, exp_stage):
     dvc.experiments.run(

--- a/tests/func/experiments/test_remove.py
+++ b/tests/func/experiments/test_remove.py
@@ -43,7 +43,7 @@ def test_remove_all_queued_experiments(tmp_dir, scm, dvc, exp_stage):
     assert scm.get_ref(str(ref_info)) is not None
 
 
-def test_remove_all_experiments_queued_and_commits(tmp_dir, scm, dvc, exp_stage):
+def test_remove_all_experiments_queued_and_completed(tmp_dir, scm, dvc, exp_stage):
     queue_length = 3
     for i in range(queue_length):
         dvc.experiments.run(


### PR DESCRIPTION
# Description

This PR addresses issue [#10638](https://github.com/iterative/dvc/issues/10638), by providing a minimal code fix that makes the `--all-commits`(aka. `-A` flag) append to the existing `removed` list instead of replacing it with a new value. 

When `--queue` is used, it might already contain the names of experiments removed from the queue. In all other cases, the list should exist but be empty, so appending still makes the job correctly.

# Checklist 
* [X] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [N/A] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
