### PR TITLE
pyproject: update license to PEP 639 format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=61", "setuptools_scm[toml]>=7"]
+requires = ["setuptools>=77", "setuptools_scm[toml]>=7"]
 
 [project]
 name = "dvc"
@@ -16,7 +16,8 @@ keywords = [
     "machine-learning",
     "reproducibility",
 ]
-license = { text = "Apache License 2.0" }
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 maintainers = [{ name = "Iterative", email = "support@dvc.org" }]
 authors = [{ name = "Dmitry Petrov", email = "dmitry@dvc.org" }]
 requires-python = ">=3.9"
@@ -148,9 +149,6 @@ dvc = "dvc.fs.dvc_path:DVCPath"
 [project.entry-points."pyinstaller40"]
 hook-dirs = "dvc.__pyinstaller:get_hook_dirs"
 tests = "dvc.__pyinstaller:get_PyInstaller_tests"
-
-[tool.setuptools]
-license-files = ["LICENSE"]
 
 [tool.setuptools.packages.find]
 exclude = ["tests", "tests.*"]


### PR DESCRIPTION
Requires bumping `setuptools` to 77.0.0 or later.

See:
- [PEP 639](https://peps.python.org/pep-0639)
- [Writing pyproject.toml - license](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license)

