### PR TITLE
remote: show default when run "dvc remote list"

### DIFF
--- a/dvc/commands/remote.py
+++ b/dvc/commands/remote.py
@@ -130,8 +130,13 @@ class CmdRemoteList(CmdRemote):
             )
             del remotes[default_remote]
 
+            # to align all other remotes with the default remote
+            prefix = "  "
+        else:
+            prefix = ""
+
         for name, remote_conf in remotes.items():
-            ui.write(name, remote_conf["url"], sep="\t")
+            ui.write(f"{prefix}{name}", remote_conf["url"], sep="\t")
         return 0
 
 

--- a/dvc/commands/remote.py
+++ b/dvc/commands/remote.py
@@ -108,9 +108,29 @@ class CmdRemoteDefault(CmdRemote):
 
 
 class CmdRemoteList(CmdRemote):
+    @staticmethod
+    def _default_remote(conf):
+        try:
+            return conf["core"]["remote"]
+        except KeyError:
+            return None
+
     def run(self):
         conf = self.config.read(self.args.level)
-        for name, remote_conf in conf["remote"].items():
+        default_remote = self._default_remote(conf)
+        remotes = conf["remote"]
+
+        # use "git branch" style to indicate default remote
+        if default_remote:
+            ui.write(
+                f"* {default_remote}",
+                remotes[default_remote]["url"],
+                sep="\t",
+                style="success",
+            )
+            del remotes[default_remote]
+
+        for name, remote_conf in remotes.items():
             ui.write(name, remote_conf["url"], sep="\t")
         return 0
 

--- a/dvc/commands/remote.py
+++ b/dvc/commands/remote.py
@@ -108,35 +108,18 @@ class CmdRemoteDefault(CmdRemote):
 
 
 class CmdRemoteList(CmdRemote):
-    @staticmethod
-    def _default_remote(conf):
-        try:
-            return conf["core"]["remote"]
-        except KeyError:
-            return None
-
     def run(self):
         conf = self.config.read(self.args.level)
-        default_remote = self._default_remote(conf)
-        remotes = conf["remote"]
+        default_remote = conf["core"].get("remote")
 
-        # use "git branch" style to indicate default remote
-        if default_remote:
-            ui.write(
-                f"* {default_remote}",
-                remotes[default_remote]["url"],
-                sep="\t",
-                style="success",
-            )
-            del remotes[default_remote]
-
-            # to align all other remotes with the default remote
-            prefix = "  "
-        else:
-            prefix = ""
-
-        for name, remote_conf in remotes.items():
-            ui.write(f"{prefix}{name}", remote_conf["url"], sep="\t")
+        for name, remote_conf in conf["remote"].items():
+            if name == default_remote:
+                text = f"{name}\t{remote_conf['url']}\t(default)"
+                color = "green"
+            else:
+                text = f"{name}\t{remote_conf['url']}"
+                color = ""
+            ui.write(ui.rich_text(text, style=color), styled=True)
         return 0
 
 

--- a/tests/func/test_remote.py
+++ b/tests/func/test_remote.py
@@ -10,7 +10,6 @@ from dvc.cli import main
 from dvc.config import Config
 from dvc.exceptions import DownloadError, UploadError
 from dvc.utils.fs import remove
-from tests.func.parsing.test_errors import escape_ansi
 
 
 def test_remote(dvc):
@@ -119,15 +118,15 @@ def test_show_default(dvc, capsys):
 def test_list_shows_default(dvc, capsys):
     default_remote = "foo"
     other_remote = "bar"
-    assert main(["remote", "add", default_remote, "s3://bucket/name"]) == 0
-    assert main(["remote", "add", other_remote, "s3://bucket/name"]) == 0
+    bucket_url = "s3://bucket/name"
+    assert main(["remote", "add", default_remote, bucket_url]) == 0
+    assert main(["remote", "add", other_remote, bucket_url]) == 0
     assert main(["remote", "default", default_remote]) == 0
     assert main(["remote", "list"]) == 0
     out, _ = capsys.readouterr()
-    out_texts = escape_ansi(out).splitlines()
-
-    assert out_texts[0] == f"* {default_remote}\ts3://bucket/name"
-    assert out_texts[1] == f"  {other_remote}\ts3://bucket/name"
+    out_lines = out.splitlines()
+    assert out_lines[0].split() == [default_remote, bucket_url, "(default)"]
+    assert out_lines[1].split() == [other_remote, bucket_url]
 
 
 def test_upper_case_remote(tmp_dir, dvc, local_cloud):

--- a/tests/func/test_remote.py
+++ b/tests/func/test_remote.py
@@ -115,6 +115,18 @@ def test_show_default(dvc, capsys):
     assert out == "foo\n"
 
 
+def test_list_shows_default(dvc, capsys):
+    default_remote = "foo"
+    other_remote = "bar"
+    assert main(["remote", "add", default_remote, "s3://bucket/name"]) == 0
+    assert main(["remote", "add", other_remote, "s3://bucket/name"]) == 0
+    assert main(["remote", "default", default_remote]) == 0
+    assert main(["remote", "list"]) == 0
+    out, _ = capsys.readouterr()
+    assert "* foo" in out
+    assert "\nbar" in out
+
+
 def test_upper_case_remote(tmp_dir, dvc, local_cloud):
     remote_name = "UPPERCASEREMOTE"
 

--- a/tests/func/test_remote.py
+++ b/tests/func/test_remote.py
@@ -10,6 +10,7 @@ from dvc.cli import main
 from dvc.config import Config
 from dvc.exceptions import DownloadError, UploadError
 from dvc.utils.fs import remove
+from tests.func.parsing.test_errors import escape_ansi
 
 
 def test_remote(dvc):
@@ -123,8 +124,10 @@ def test_list_shows_default(dvc, capsys):
     assert main(["remote", "default", default_remote]) == 0
     assert main(["remote", "list"]) == 0
     out, _ = capsys.readouterr()
-    assert "* foo" in out
-    assert "\nbar" in out
+    out_texts = escape_ansi(out).splitlines()
+
+    assert out_texts[0] == f"* {default_remote}\ts3://bucket/name"
+    assert out_texts[1] == f"  {other_remote}\ts3://bucket/name"
 
 
 def test_upper_case_remote(tmp_dir, dvc, local_cloud):


### PR DESCRIPTION
Fixes #10708

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Hello, I'm new to DVC and this is my first contribution to this repo. Please feel free to make suggestions or edits of course. 

I'd also be more than happy to make a documentation PR but I first wanted to check you're happy with the formatting choice I have gone for to show the default remote, as that would affect the documentation. 

I have configured it so that the default remote is shown in a similar way to how `git branch` does it:
 
![Screenshot from 2025-03-26 17-13-24](https://github.com/user-attachments/assets/c908e408-f724-41b0-a8cd-e47042d23812)

Thanks! 