### PR TITLE
Forward args to _get_remote_config() and honour core/no_scm if present

### DIFF
--- a/dvc/dependency/repo.py
+++ b/dvc/dependency/repo.py
@@ -146,6 +146,10 @@ class RepoDependency(Dependency):
         else:
             config = Config.load_file(conf)
 
+        # Setup config to the new DVCFileSystem to use the remote repo, but rely on the
+        # local cache instead of the remote's cache. This avoids re-streaming of data,
+        # but messes up the call to `_get_remote_config()` downstream, which will need
+        # to ignore cache parameters.
         config["cache"] = self.repo.config["cache"]
         config["cache"]["dir"] = self.repo.cache.local_cache_dir
 

--- a/dvc/repo/open_repo.py
+++ b/dvc/repo/open_repo.py
@@ -100,7 +100,7 @@ def clean_repos():
 
 def _get_remote_config(url, *args, **kwargs):
     try:
-        # Copy to avoid modifying the original config dictionary
+        # Deepcopy to prevent modifying the original `kwargs['config']`
         config = copy.deepcopy(kwargs.get("config"))
 
         # Import operations will use this function to get the remote's cache. However,
@@ -111,8 +111,9 @@ def _get_remote_config(url, *args, **kwargs):
         # This breaks this function, since we'd be instructing `Repo()` to use the wrong
         # cache to being with. We need to remove the cache info from `kwargs["config"]`
         # to read the actual remote repo data.
-        if isinstance(config, dict):
+        if config:
             _ = config.pop("cache", None)
+
         repo = Repo(url, config=config)
 
     except NotDvcRepoError:

--- a/dvc/repo/open_repo.py
+++ b/dvc/repo/open_repo.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import tempfile
 import threading
@@ -99,7 +100,8 @@ def clean_repos():
 
 def _get_remote_config(url, *args, **kwargs):
     try:
-        config = kwargs.get("config", {})
+        # Copy to avoid modifying the original config dictionary
+        config = copy.deepcopy(kwargs.get("config"))
 
         # Import operations will use this function to get the remote's cache. However,
         # while the `url` sent will point to the external repo, the cache information

--- a/dvc/repo/open_repo.py
+++ b/dvc/repo/open_repo.py
@@ -112,7 +112,7 @@ def _get_remote_config(url, *args, **kwargs):
         # cache to being with. We need to remove the cache info from `kwargs["config"]`
         # to read the actual remote repo data.
         if config:
-            _ = config.pop("cache", None)
+            config.pop("cache", None)
 
         repo = Repo(url, config=config)
 

--- a/tests/func/api/test_data.py
+++ b/tests/func/api/test_data.py
@@ -5,6 +5,7 @@ from funcy import first, get_in
 
 from dvc import api
 from dvc.exceptions import OutputNotFoundError, PathMissingError
+from dvc.scm import CloneError, SCMError
 from dvc.testing.api_tests import TestAPI  # noqa: F401
 from dvc.testing.tmp_dir import make_subrepo
 from dvc.utils.fs import remove
@@ -63,6 +64,38 @@ def test_get_url_from_remote(tmp_dir, erepo_dir, cloud, local_cloud):
         api.get_url("foo", repo=repo_url, remote_config={"url": cloud.url})
         == (cloud / expected_rel_path).url
     )
+
+
+def test_get_url_ignore_scm(tmp_dir, dvc, cloud, scm):
+    tmp_dir.add_remote(config=cloud.config)
+    tmp_dir.dvc_gen("foo", "foo", commit="add foo")
+
+    repo_posix = tmp_dir.as_posix()
+    expected_url = (cloud / "files" / "md5" / "ac/bd18db4cc2f85cedef654fccc4a4d8").url
+
+    # Test baseline with scm
+    assert api.get_url("foo", repo=repo_posix) == expected_url
+
+    # Simulate gitless environment (e.g. deployed container)
+    (tmp_dir / ".git").rename(tmp_dir / "gitless_environment")
+
+    # Test failure mode when trying to access with git
+    with pytest.raises(SCMError, match=f"{repo_posix} is not a git repository"):
+        api.get_url("foo", repo=repo_posix)
+
+    # Test successful access by ignoring git
+    assert (
+        api.get_url("foo", repo=repo_posix, config={"core": {"no_scm": True}})
+        == expected_url
+    )
+
+    # Addressing repos with `file://` triggers git, so it fails in a gitless environment
+    repo_url = f"file://{repo_posix}"
+    with pytest.raises(
+        CloneError,
+        match="SCM error",
+    ):
+        api.get_url("foo", repo=repo_url, config={"core": {"no_scm": True}})
 
 
 def test_open_external(tmp_dir, erepo_dir, cloud):

--- a/tests/func/api/test_data.py
+++ b/tests/func/api/test_data.py
@@ -80,7 +80,7 @@ def test_get_url_ignore_scm(tmp_dir, dvc, cloud, scm):
     (tmp_dir / ".git").rename(tmp_dir / "gitless_environment")
 
     # Test failure mode when trying to access with git
-    with pytest.raises(SCMError, match=f"{repo_posix} is not a git repository"):
+    with pytest.raises(SCMError, match="is not a git repository"):
         api.get_url("foo", repo=repo_posix)
 
     # Test successful access by ignoring git


### PR DESCRIPTION
This is a proposed fix for #10608, the code here makes steps 9 and 10 described in the issue work.

**Summary:**

This change allows a user to access the dvc information in an environment that is disconnected from the original Git backend (e.g. in a deployed container, see #10608), by using something like:
```python
dvc.api.get_url(path,
                repo,
                config={"core": {"no_scm": True}}
                )
```


**Description:**

Mainly, a call to `dvc/repo/open_repo.py:open_repo(url, *args, **kwargs)` may contain a parameter `config` in `**kwargs`. With this `config` a user might indicate they do not want to access the repo with Git support, by using `config={"core": {"no_scm": True}}`. 

During the execution of `dvc/repo/open_repo.py:open_repo()`, there is a call to a function `dvc/repo/open_repo.py:_get_remote_config()` that returns the remote configuration(`{"core": {"remote"}}`. This is then merged to the user provided `config` parameter before calling `Repo(url, *args, **kwargs)`.

`dvc/repo/open_repo.py:_get_remote_config()`, in turn, does a quick `Repo()` call to get the remote configuration. However, it does not use any of the parameters requested via `dvc/repo/open_repo.py:open_repo()` and thus relies entirely on the contents of `.dvc/config`. This means that even if the user requested no SCM support, it will try to look for a Git repo if `.dvc/config` says so, and fail if it does not find it.

This PR modifies `dvc/repo/open_repo.py:_get_remote_config()` to receive `*args, **kwargs` and honour the request to use or ignore Git support when accessing the dvc repo.


* [X] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
