### PR TITLE
ci(build): use envvar override to omit local version for Test PyPI upload

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,22 +28,24 @@ jobs:
         python-version: 3.13
 
     - uses: astral-sh/setup-uv@v5
-    - run: uv pip install --upgrade setuptools_scm twine --system
 
-    - name: Force version for Test PyPI upload
-      if: ${{ !startsWith(github.ref, 'refs/tags') }}
-      run: echo version=$(python -m setuptools_scm | awk -F+ '{print $1}' | tail -1) >> $GITHUB_ENV
+    - name: Omit local version for Test PyPI upload
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      run: echo SETUPTOOLS_SCM_OVERRIDES_FOR_DVC='{local_scheme="no-local-version"}' >> $GITHUB_ENV
 
-    - run: echo 'PKG = "pip"'>dvc/_build.py
-    - run: uv build
-      env:
-        SETUPTOOLS_SCM_PRETEND_VERSION_FOR_DVC: ${{ env.version }}
-    - run: twine check --strict dist/*
+    - name: Build Python Package
+      run: |
+        echo 'PKG = "pip"'>dvc/_build.py
+        uv build
+
+    - name: Check dist
+      run: uv tool run twine check --strict dist/*
 
     - uses: actions/upload-artifact@v4
       with:
         name: Packages
         path: dist/
+        if-no-files-found: error
 
   test-pypi-publish:
     name: Publish dev package to test.pypi.org

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=77", "setuptools_scm[toml]>=7"]
+requires = ["setuptools>=77", "setuptools_scm[toml]>=8"]
 
 [project]
 name = "dvc"


### PR DESCRIPTION
Uses `SETUPTOOLS_SCM_OVERRIDES_FOR_DVC` to omit the local version when uploading to Test PyPI. This is needed because (Test) PyPI does not support local version.

This requires bumping minimum version of `setuptools_scm` to `8.0.0`.

The envvar is documented here: https://setuptools-scm.readthedocs.io/en/latest/overrides/.

Also see:
https://github.com/pypa/setuptools-scm/issues/455#issuecomment-2791301186.