### PR TITLE
tests: fix flaky test in test_get_used_objs

### DIFF
--- a/tests/unit/output/test_output.py
+++ b/tests/unit/output/test_output.py
@@ -101,6 +101,7 @@ def test_get_used_objs(exists, expected_message, mocker, caplog):
         Output, "exists", new_callable=mocker.PropertyMock
     ).return_value = exists
 
+    caplog.clear()
     with caplog.at_level(logging.WARNING, logger="dvc"):
         assert output.get_used_objs() == {}
     assert first(caplog.messages) == expected_message


### PR DESCRIPTION
Clear logs before assertions so that logs from other tests do not interfere with the test. Some destructors may also run in between due to GC, so hopefully this will fix that issue too, or reduce the chances of it happening.

See
https://github.com/iterative/dvc/actions/runs/14873217814/job/41775314725#step:6:97.

```console
>       assert first(caplog.messages) == expected_message
E       assert 'RC: discarding all clients' == "Output 'path... 'stage.dvc'."
E
E         + RC: discarding all clients
E         - Output 'path'(stage: 'stage.dvc') is missing version info. Cache for it will not be collected. Use `dvc repro` to get your pipeline up to date.
E         - You can also use `dvc commit stage.dvc` to associate existing 'path' with stage: 'stage.dvc'.
```

* [ ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
