### PR TITLE
drop inputs passed to codecov-action

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -143,9 +143,6 @@ jobs:
         --cov --cov-report=xml --cov-report=term  --durations-path=./.github/.test_durations
     - name: upload coverage report
       uses: codecov/codecov-action@v5
-      with:
-        file: ./coverage.xml
-        fail_ci_if_error: false
   check:
     if: always()
     needs: [tests]


### PR DESCRIPTION
It can already search and find these coverage files. On `v5`, they also deprecated the `file` option and renamed to `files`, which adds noisy warnings in CI.