### PR TITLE
fix(dvcfs): rename argument `url` to `repo`

### DIFF
--- a/dvc/dependency/repo.py
+++ b/dvc/dependency/repo.py
@@ -154,7 +154,7 @@ class RepoDependency(Dependency):
         config["cache"]["dir"] = self.repo.cache.local_cache_dir
 
         return DVCFileSystem(
-            url=self.def_repo[self.PARAM_URL],
+            repo=self.def_repo[self.PARAM_URL],
             rev=rev or self._get_rev(locked=locked),
             subrepos=True,
             config=config,

--- a/dvc/fs/dvc.py
+++ b/dvc/fs/dvc.py
@@ -83,11 +83,10 @@ class _DVCFileSystem(AbstractFileSystem):
     cachable = False
     root_marker = "/"
 
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
-        url: Optional[str] = None,
+        repo: Union["Repo", os.PathLike[str], str, None] = None,
         rev: Optional[str] = None,
-        repo: Optional["Repo"] = None,
         subrepos: bool = False,
         repo_factory: Optional[RepoFactory] = None,
         fo: Optional[str] = None,
@@ -101,7 +100,8 @@ class _DVCFileSystem(AbstractFileSystem):
         """DVC + git-tracked files fs.
 
         Args:
-            path (str, optional): URL or path to a DVC/Git repository.
+            repo (str | os.PathLike[str] | Repo, optional): A url or a path to a DVC/Git
+                repository, or a `Repo` instance.
                 Defaults to a DVC repository in the current working directory.
                 Both HTTP and SSH protocols are supported for remote Git repos
                 (e.g. [user@]server:project.git).
@@ -111,7 +111,6 @@ class _DVCFileSystem(AbstractFileSystem):
                 In case of a local repository, if rev is unspecified, it will
                 default to the working directory.
                 If the repo is not a Git repo, this option is ignored.
-            repo (:obj:`Repo`, optional): `Repo` instance.
             subrepos (bool): traverse to subrepos.
                 By default, it ignores subrepos.
             repo_factory (callable): A function to initialize subrepo with.
@@ -136,13 +135,23 @@ class _DVCFileSystem(AbstractFileSystem):
             ...    rev="main",
             ... )
         """
+        from dvc.repo import Repo
+
+        # kwargs.get("url") is for maintaining backward compatibility
+        repo = repo or fo or kwargs.get("url")
+        if isinstance(repo, Repo):
+            self._repo: Optional[Repo] = repo
+            url = None
+        else:
+            self._repo = None
+            url = os.fspath(repo) if repo else None
+
         super().__init__()
-        self._repo = repo
         self._repo_factory = repo_factory
         self._traverse_subrepos = subrepos
         self._repo_stack = ExitStack()
         self._repo_kwargs = {
-            "url": url if url is not None else fo,
+            "url": url,
             "rev": rev,
             "subrepos": subrepos,
             "config": config,

--- a/dvc/testing/api_tests.py
+++ b/dvc/testing/api_tests.py
@@ -32,12 +32,13 @@ class TestAPI:
         "fs_kwargs",
         [
             {},
-            {"url": "{path}"},
-            {"url": "{path}", "rev": "{default_branch}"},
-            {"url": "file://{posixpath}"},
-            {"url": "file://{posixpath}", "rev": "{default_branch}"},
+            {"repo": "{path}"},
+            {"repo": "{path}", "rev": "{default_branch}"},
+            {"repo": "file://{posixpath}"},
+            {"repo": "file://{posixpath}", "rev": "{default_branch}"},
+            {"url": "{path}"},  # test for backward compatibility
         ],
-        ids=["current", "local", "local_rev", "git", "git_rev"],
+        ids=["current", "local", "local_rev", "git", "git_rev", "local_url"],
     )
     def test_filesystem(
         self,
@@ -59,6 +60,8 @@ class TestAPI:
         if clear_cache:
             remove(dvc.cache.repo.path)
 
+        if repo := fs_kwargs.get("repo"):
+            fs_kwargs["repo"] = repo.format(path=tmp_dir, posixpath=tmp_dir.as_posix())
         if url := fs_kwargs.get("url"):
             fs_kwargs["url"] = url.format(path=tmp_dir, posixpath=tmp_dir.as_posix())
         if rev := fs_kwargs.get("rev"):

--- a/tests/unit/fs/test_dvc.py
+++ b/tests/unit/fs/test_dvc.py
@@ -696,3 +696,20 @@ def test_fsid_url(erepo_dir):
         fs = DVCFileSystem(repo=dvc)
         assert fs.fsid != old_fsid
         assert fs.fsid == "dvcfs_" + tokenize(url, erepo_dir.scm.get_rev())
+
+
+@pytest.mark.parametrize(
+    "fs_kwargs",
+    [
+        lambda tmp_dir, dvc: {},  # noqa: ARG005
+        lambda tmp_dir, dvc: {"repo": tmp_dir},  # noqa: ARG005
+        lambda tmp_dir, dvc: {"repo": os.fspath(tmp_dir)},  # noqa: ARG005
+        lambda tmp_dir, dvc: {"url": tmp_dir},  # noqa: ARG005
+        lambda tmp_dir, dvc: {"url": os.fspath(tmp_dir)},  # noqa: ARG005
+        lambda tmp_dir, dvc: {"repo": dvc},  # noqa: ARG005
+    ],
+)
+def test_init_arg(tmp_dir, dvc, fs_kwargs):
+    fs = DVCFileSystem(**fs_kwargs(tmp_dir, dvc))
+
+    assert fs.repo.root_dir == dvc.root_dir

--- a/tests/unit/fs/test_dvcfs.py
+++ b/tests/unit/fs/test_dvcfs.py
@@ -779,7 +779,7 @@ def test_maxdepth(tmp_dir, dvc, scm):
         commit="add dir",
     )
 
-    fs = DVCFileSystem(url=tmp_dir)
+    fs = DVCFileSystem(tmp_dir)
     fs.get("dir", "dir1", recursive=True, maxdepth=1)
     assert (tmp_dir / "dir1").read_text() == {"file1": "file1"}
 
@@ -803,3 +803,25 @@ def test_maxdepth(tmp_dir, dvc, scm):
             "subdir2": {"file3": "file3", "subdir3": {"file4": "file4"}},
         },
     }
+
+
+@pytest.mark.parametrize(
+    "fs_args",
+    [
+        lambda tmp_dir, dvc: ((), {}),  # noqa: ARG005
+        lambda tmp_dir, dvc: ((dvc,), {}),  # noqa: ARG005
+        lambda tmp_dir, dvc: ((tmp_dir,), {}),  # noqa: ARG005
+        lambda tmp_dir, dvc: ((str(tmp_dir),), {}),  # noqa: ARG005
+        lambda tmp_dir, dvc: ((), {"repo": tmp_dir}),  # noqa: ARG005
+        lambda tmp_dir, dvc: ((), {"repo": os.fspath(tmp_dir)}),  # noqa: ARG005
+        # url= is deprecated, but is still supported for backward compatibility
+        lambda tmp_dir, dvc: ((), {"url": tmp_dir}),  # noqa: ARG005
+        lambda tmp_dir, dvc: ((), {"url": os.fspath(tmp_dir)}),  # noqa: ARG005
+        lambda tmp_dir, dvc: ((), {"repo": dvc}),  # noqa: ARG005
+    ],
+)
+def test_init_arg(tmp_dir, dvc, fs_args):
+    args, kwargs = fs_args(tmp_dir, dvc)
+    fs = DVCFileSystem(*args, **kwargs)
+
+    assert fs.repo.root_dir == dvc.root_dir


### PR DESCRIPTION
See #10700 for the motivation.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.



We need to rename the `url` to something else for [`fsspec.core.url_to_fs`][1] to work for dvc urls with `storage_options`.

We have two options to consider:
1. Repurpose the existing `repo=` argument to accept both `str` and `Repo` instances, or
2. Rename `url=` to something else (preferably `repo`), and introduce a new argument for accepting `Repo` instances.

Most of the API in `dvc.api` already uses `repo=` (as a `str` path to the DVC/Git repository, eg: [`dvc.api.open`][2] and [`dvc.api.read`][3]. So, I prefer the 1st option, as it will be a good opportunity to align naming and use `repo=` consistently.

But I am happy with either of the options.

Also note that accepting `Repo` instance is part of an internal API, and is done for avoiding cost of opening another DVC/Git repository.

[1]: https://github.com/fsspec/filesystem_spec/blob/66340a15ef6a11aa89b4f23a4370c53316d85362/fsspec/core.py#L369
[2]: https://dvc.org/doc/api-reference/open
[3]: https://dvc.org/doc/api-reference/read


Related:
- #10700
- https://github.com/fsspec/filesystem_spec/pull/1802
- https://github.com/huggingface/datasets/issues/7421