### PR TITLE
deps: bump minver version for dvc-gs to 3.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ all = ["dvc[azure,gdrive,gs,hdfs,oss,s3,ssh,webdav,webhdfs]"]
 azure = ["dvc-azure>=3.1.0,<4"]
 dev = ["dvc[azure,gdrive,gs,hdfs,lint,oss,s3,ssh,tests,webdav,webhdfs]"]
 gdrive = ["dvc-gdrive>=3,<4"]
-gs = ["dvc-gs>=3,<4"]
+gs = ["dvc-gs>=3.0.2,<4"]
 hdfs = ["dvc-hdfs>=3,<4"]
 lint = [
     "mypy==1.15.0",


### PR DESCRIPTION
To support `allow_anonymous_login` that was added in dvc-gs 3.0.2.

Related:
- https://github.com/iterative/dvc-gs/pull/115
- https://github.com/iterative/dvc/pull/10756
- https://github.com/iterative/dvc/issues/5797

