### PR TITLE
(fix) `DVC_SITE_CACHE_DIR` environment variable should override `core.site_cache_dir`

### DIFF
--- a/dvc/dirs.py
+++ b/dvc/dirs.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 import platformdirs
 
@@ -20,7 +21,7 @@ def global_config_dir():
     )
 
 
-def site_cache_dir(config_site_cache_dir: str | None = None):
+def site_cache_dir(config_site_cache_dir: Optional[str]):
     from platformdirs import PlatformDirs
     from platformdirs.unix import Unix
 

--- a/dvc/dirs.py
+++ b/dvc/dirs.py
@@ -20,12 +20,15 @@ def global_config_dir():
     )
 
 
-def site_cache_dir():
+def site_cache_dir(config_site_cache_dir: str | None = None):
     from platformdirs import PlatformDirs
     from platformdirs.unix import Unix
 
     if dvc_site_cache_dir := os.getenv(env.DVC_SITE_CACHE_DIR):
         return dvc_site_cache_dir
+
+    if config_site_cache_dir is not None:
+        return config_site_cache_dir
 
     if issubclass(Unix, PlatformDirs):
         # Return the cache directory shared by users, e.g. `/var/tmp/$appname`

--- a/dvc/dirs.py
+++ b/dvc/dirs.py
@@ -21,7 +21,7 @@ def global_config_dir():
     )
 
 
-def site_cache_dir(config_site_cache_dir: Optional[str]):
+def site_cache_dir(config_site_cache_dir: Optional[str] = None):
     from platformdirs import PlatformDirs
     from platformdirs.unix import Unix
 

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -609,7 +609,8 @@ class Repo:
         from dvc.fs import GitFileSystem
         from dvc.version import version_tuple
 
-        cache_dir = self.config["core"].get("site_cache_dir") or site_cache_dir()
+        # DVC_SITE_CACHE_DIR might override our config, let site_cache_dir() decide
+        cache_dir = site_cache_dir(self.config["core"].get("site_cache_dir"))
 
         subdir = None
         if isinstance(self.fs, GitFileSystem):

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -609,7 +609,6 @@ class Repo:
         from dvc.fs import GitFileSystem
         from dvc.version import version_tuple
 
-        # DVC_SITE_CACHE_DIR might override our config, let site_cache_dir() decide
         cache_dir = site_cache_dir(self.config["core"].get("site_cache_dir"))
 
         subdir = None

--- a/tests/unit/test_dirs.py
+++ b/tests/unit/test_dirs.py
@@ -21,3 +21,13 @@ def test_site_cache_dir_on_unix(monkeypatch):
 def test_site_cache_dir_env_var(monkeypatch):
     monkeypatch.setenv(DVC_SITE_CACHE_DIR, "foo_bar")
     assert site_cache_dir() == "foo_bar"
+
+
+def test_site_cache_dir_with_config_parameter(monkeypatch):
+    monkeypatch.delenv(DVC_SITE_CACHE_DIR)
+    assert site_cache_dir(config_site_cache_dir="foo_bar") == "foo_bar"
+
+
+def test_site_cache_dir_env_var_precedence(monkeypatch):
+    monkeypatch.setenv(DVC_SITE_CACHE_DIR, "foo")
+    assert site_cache_dir(config_site_cache_dir="bar") == "foo"


### PR DESCRIPTION
Fixes #10777

Currently: `Repo.site_cache_dir()` in `dvc/repo/__init__.py` selects first the configuration read in the config file, and if it does not exist it relies on `dirs.site_cache_dir()` to pick a value.

The documentation states that `DVC_DITE_CACHE_DIR` should override this configuration, therefore the order of priority for selecting the `site_cache_dir` is:
1. `DVC_SITE_CACHE_DIR`
2. `core.site_cache_dir`
3. `platformdirs` selection

For this, `dirs.site_cache_dir()` needs to know the three options.

This PR:
- enables `dirs.site_cache_dir()` to receive a configuration option so it can make the right choice between the three values;
- modifies `Repo.site_cache_dir()` to send `core.site_cache_dir` instead of picking itself; and
- enables tests for the proper return values.


----

* [X] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
