### PR TITLE
fix(data status): show committed changes in a new Git repository

### DIFF
--- a/dvc/repo/data.py
+++ b/dvc/repo/data.py
@@ -4,10 +4,10 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING, Optional, TypedDict, Union
 
 from dvc.fs.callbacks import DEFAULT_CALLBACK
+from dvc.log import logger
 from dvc.scm import RevError
 from dvc.ui import ui
 from dvc_data.index.view import DataIndexView
-from dvc.log import logger
 
 if TYPE_CHECKING:
     from dvc.fs.callbacks import Callback

--- a/dvc/repo/data.py
+++ b/dvc/repo/data.py
@@ -4,8 +4,10 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING, Optional, TypedDict, Union
 
 from dvc.fs.callbacks import DEFAULT_CALLBACK
+from dvc.scm import RevError
 from dvc.ui import ui
 from dvc_data.index.view import DataIndexView
+from dvc.log import logger
 
 if TYPE_CHECKING:
     from dvc.fs.callbacks import Callback
@@ -13,6 +15,8 @@ if TYPE_CHECKING:
     from dvc.scm import Git, NoSCM
     from dvc_data.index import BaseDataIndex, DataIndex, DataIndexKey
     from dvc_data.index.diff import Change
+
+logger = logger.getChild(__name__)
 
 
 def posixpath_to_os_path(path: str) -> str:
@@ -220,12 +224,18 @@ def _diff_head_to_index(
     filter_keys: Optional[list["DataIndexKey"]] = None,
     granular: bool = False,
 ) -> dict[str, list[str]]:
+    from dvc_data.index import DataIndex
+
     index = repo.index.data["repo"]
     index_view = filter_index(index, filter_keys=filter_keys)
 
-    with repo.switch(head):
-        head_index = repo.index.data["repo"]
-        head_view = filter_index(head_index, filter_keys=filter_keys)
+    try:
+        with repo.switch(head):
+            head_index = repo.index.data["repo"]
+            head_view = filter_index(head_index, filter_keys=filter_keys)
+    except RevError:
+        logger.debug("failed to switch to '%s'", head)
+        head_view = DataIndex()
 
     with ui.progress(desc="Calculating diff between head/index", unit="entry") as pb:
         return _diff(

--- a/tests/func/test_data_status.py
+++ b/tests/func/test_data_status.py
@@ -144,9 +144,19 @@ def test_new_empty_git_repo(M, tmp_dir, scm):
         "git": M.dict(is_empty=True, is_dirty=True),
     }
 
+    tmp_dir.gen("foo", "foo")
+    dvc.add(["foo"])
+    assert dvc.data_status() == {
+        **EMPTY_STATUS,
+        "git": M.dict(is_empty=True, is_dirty=True),
+        "committed": {"added": ["foo"]},
+    }
 
-def test_noscm_repo(dvc):
+
+def test_noscm_repo(tmp_dir, dvc):
     assert dvc.data_status() == EMPTY_STATUS
+    tmp_dir.dvc_gen("foo", "foo")
+    assert dvc.data_status() == {**EMPTY_STATUS, "unchanged": ["foo"]}
 
 
 def test_unchanged(M, tmp_dir, dvc, scm):


### PR DESCRIPTION
In a freshly initialized Git repo with no commits, there is no `HEAD`, which caused `dvc data status` to skip showing committed changes.

We now provide empty `DataIndex` in place of Git's `HEAD` to `diff` and `coTests have been updated to cover this case.mpare`.

Tests have been updated to cover this case.

