### PR TITLE
cache: use configured cache directory for fs cache path

### DIFF
--- a/dvc/cachemgr.py
+++ b/dvc/cachemgr.py
@@ -83,10 +83,11 @@ class CacheManager:
         """
         from dvc_data.index import FileStorage
 
+        cache_dir = self.config.get("dir") or self.default_local_cache_dir
         return FileStorage(
             key=(),
             fs=self.local.fs,
-            path=self.local.fs.join(self.default_local_cache_dir, self.FS_DIR),
+            path=self.local.fs.join(cache_dir, self.FS_DIR),
         )
 
     def _init_odb(self, schemes):

--- a/dvc/cachemgr.py
+++ b/dvc/cachemgr.py
@@ -83,11 +83,10 @@ class CacheManager:
         """
         from dvc_data.index import FileStorage
 
-        cache_dir = self.config.get("dir") or self.default_local_cache_dir
         return FileStorage(
             key=(),
             fs=self.local.fs,
-            path=self.local.fs.join(cache_dir, self.FS_DIR),
+            path=self.local.fs.join(self.local_cache_dir, self.FS_DIR),
         )
 
     def _init_odb(self, schemes):


### PR DESCRIPTION
Instead of using the default cache directory, use the the configured one. This helps with importing large datasets.

Fixes #10794
