### PR TITLE
cli: status: return integer instead of bool on --quiet

### DIFF
--- a/dvc/commands/status.py
+++ b/dvc/commands/status.py
@@ -71,7 +71,7 @@ class CmdDataStatus(CmdDataBase):
                 return 0
 
             if self.args.quiet:
-                return bool(st)
+                return int(bool(st))
 
             if st:
                 self._show(st, indent)


### PR DESCRIPTION
This does not have any effect on the user, as booleans are integers in Python.
