### PR TITLE
hashing: Add usedforsecurity=False on hashlib calls

### DIFF
--- a/dvc/lock.py
+++ b/dvc/lock.py
@@ -212,7 +212,7 @@ class HardlinkLock(flufl.lock.Lock, LockBase):
 
         if self._tmp_dir is not None:
             # Under Windows file path length is limited so we hash it
-            hasher = hashlib.md5(self._claimfile.encode())  # noqa: S324
+            hasher = hashlib.md5(self._claimfile.encode(), usedforsecurity=False)
             filename = hasher.hexdigest()
             self._claimfile = os.path.join(self._tmp_dir, filename + ".lock")
 

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -641,10 +641,11 @@ class Repo:
         # that just happened to be at the same path as old deleted ones.
         btime = self._btime or getattr(os.stat(root_dir), "st_birthtime", None)
 
-        md5 = hashlib.md5(  # noqa: S324
+        md5 = hashlib.md5(
             str(
                 (root_dir, subdir, btime, getpass.getuser(), version_tuple[0], salt)
-            ).encode()
+            ).encode(),
+            usedforsecurity=False,
         )
         repo_token = md5.hexdigest()
         return os.path.join(repos_dir, repo_token)

--- a/dvc/repo/experiments/queue/celery.py
+++ b/dvc/repo/experiments/queue/celery.py
@@ -127,7 +127,9 @@ class LocalCeleryQueue(BaseStashQueue):
         from dvc_task.proc.process import ManagedProcess
 
         logger.debug("Spawning exp queue worker")
-        wdir_hash = hashlib.sha256(self.wdir.encode("utf-8")).hexdigest()[:6]
+        wdir_hash = hashlib.sha256(
+            self.wdir.encode("utf-8"), usedforsecurity=False
+        ).hexdigest()[:6]
         node_name = f"dvc-exp-{wdir_hash}-{num}@localhost"
         cmd = ["exp", "queue-worker", node_name]
         if num == 1:
@@ -158,7 +160,9 @@ class LocalCeleryQueue(BaseStashQueue):
 
         started = 0
         for num in range(1, 1 + count):
-            wdir_hash = hashlib.sha256(self.wdir.encode("utf-8")).hexdigest()[:6]
+            wdir_hash = hashlib.sha256(
+                self.wdir.encode("utf-8"), usedforsecurity=False
+            ).hexdigest()[:6]
             node_name = f"dvc-exp-{wdir_hash}-{num}@localhost"
             if node_name in active_worker:
                 logger.debug("Exp queue worker %s already exist", node_name)

--- a/dvc/repo/experiments/queue/celery.py
+++ b/dvc/repo/experiments/queue/celery.py
@@ -127,9 +127,7 @@ class LocalCeleryQueue(BaseStashQueue):
         from dvc_task.proc.process import ManagedProcess
 
         logger.debug("Spawning exp queue worker")
-        wdir_hash = hashlib.sha256(
-            self.wdir.encode("utf-8"), usedforsecurity=False
-        ).hexdigest()[:6]
+        wdir_hash = hashlib.sha256(self.wdir.encode("utf-8")).hexdigest()[:6]
         node_name = f"dvc-exp-{wdir_hash}-{num}@localhost"
         cmd = ["exp", "queue-worker", node_name]
         if num == 1:
@@ -160,9 +158,7 @@ class LocalCeleryQueue(BaseStashQueue):
 
         started = 0
         for num in range(1, 1 + count):
-            wdir_hash = hashlib.sha256(
-                self.wdir.encode("utf-8"), usedforsecurity=False
-            ).hexdigest()[:6]
+            wdir_hash = hashlib.sha256(self.wdir.encode("utf-8")).hexdigest()[:6]
             node_name = f"dvc-exp-{wdir_hash}-{num}@localhost"
             if node_name in active_worker:
                 logger.debug("Exp queue worker %s already exist", node_name)

--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -18,7 +18,7 @@ TARGET_REGEX = re.compile(r"(?P<path>.*?)(:(?P<name>[^\\/:]*))??$")
 
 
 def bytes_hash(byts, typ):
-    hasher = getattr(hashlib, typ)()
+    hasher = getattr(hashlib, typ)(usedforsecurity=False)
     hasher.update(byts)
     return hasher.hexdigest()
 

--- a/tests/func/test_diff.py
+++ b/tests/func/test_diff.py
@@ -9,7 +9,7 @@ from dvc.utils.fs import remove
 
 
 def digest(text):
-    return hashlib.md5(bytes(text, "utf-8")).hexdigest()
+    return hashlib.md5(bytes(text, "utf-8"), usedforsecurity=False).hexdigest()
 
 
 def test_no_scm(tmp_dir, dvc):

--- a/tests/unit/fs/test_dvcfs.py
+++ b/tests/unit/fs/test_dvcfs.py
@@ -67,7 +67,9 @@ class DVCFixtures:
         └── 📄 {hashed([0-9])}.txt
         """
         dir_contents = {
-            md5(str(i).encode("utf-8")).hexdigest() + ".txt": str(i) for i in range(10)
+            md5(str(i).encode("utf-8"), usedforsecurity=False).hexdigest()
+            + ".txt": str(i)
+            for i in range(10)
         }
         tmp_dir.dvc_gen({"source": dir_contents}, commit="add source")
         tmp_dir.scm_gen(".gitignore", "/source", commit="add .gitignore")
@@ -751,7 +753,7 @@ class TestDVCFileSystemGet(DVCFixtures):
         source_files = []
         destination_files = []
         for i in range(10):
-            hashed_i = md5(str(i).encode("utf-8")).hexdigest()
+            hashed_i = md5(str(i).encode("utf-8"), usedforsecurity=False).hexdigest()
             source_files.append(fs_join(source, f"{hashed_i}.txt"))
             destination_files.append(
                 make_path_posix(local_join(target, f"{hashed_i}.txt"))

--- a/tests/unit/test_analytics.py
+++ b/tests/unit/test_analytics.py
@@ -176,7 +176,7 @@ def test_system_info():
 )
 def test_git_remote_hash(mocker, git_remote):
     m = mocker.patch("dvc.analytics._git_remote_url", return_value=git_remote)
-    expected = hashlib.md5(b"iterative/dvc.git").hexdigest()
+    expected = hashlib.md5(b"iterative/dvc.git", usedforsecurity=False).hexdigest()
 
     assert analytics._git_remote_path_hash(None) == expected
     m.assert_called_once_with(None)
@@ -194,6 +194,8 @@ def test_git_remote_hash(mocker, git_remote):
 def test_git_remote_hash_local(mocker, git_remote):
     m = mocker.patch("dvc.analytics._git_remote_url", return_value=git_remote)
 
-    expected = hashlib.md5(git_remote.encode("utf-8")).hexdigest()
+    expected = hashlib.md5(
+        git_remote.encode("utf-8"), usedforsecurity=False
+    ).hexdigest()
     assert analytics._git_remote_path_hash(None) == expected
     m.assert_called_once_with(None)


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Communicates to OpenSSL that these function calls should be allowed in "secure" builds, since they do not function as a security layer for anything. This API was added to hashlib in Python 3.9, and so is available in all Python versions that dvc supports.