### PR TITLE
commit: batch dump stages, do not re-read on save from the workspace

### DIFF
--- a/tests/unit/test_dvcfile.py
+++ b/tests/unit/test_dvcfile.py
@@ -90,6 +90,10 @@ def test_dump_stage(tmp_dir, dvc):
     assert list(dvcfile.stages.values()) == [stage]
 
 
+def test_dump_multiple_stages(tmp_dir, dvc):
+    pass
+
+
 @pytest.mark.parametrize("file", ["stage.dvc", "dvc.yaml"])
 def test_stage_load_file_exists_but_dvcignored(tmp_dir, dvc, scm, file):
     (tmp_dir / file).write_text("")

--- a/tests/unit/test_dvcfile.py
+++ b/tests/unit/test_dvcfile.py
@@ -90,8 +90,37 @@ def test_dump_stage(tmp_dir, dvc):
     assert list(dvcfile.stages.values()) == [stage]
 
 
-def test_dump_multiple_stages(tmp_dir, dvc):
-    pass
+def test_dump_multiple_pipeline_stages(tmp_dir, dvc):
+    stage1 = PipelineStage(dvc, cmd="cmd1", name="stage1", path="dvc.yaml")
+    stage2 = PipelineStage(dvc, cmd="cmd2", name="stage2", path="dvc.yaml")
+    dvcfile = load_file(dvc, "dvc.yaml")
+
+    dvcfile.dump_stages([stage1, stage2], update_lock=False, update_pipeline=False)
+    assert not (tmp_dir / LOCK_FILE).exists()
+    assert not (tmp_dir / PROJECT_FILE).exists()
+
+    dvcfile.dump_stages([stage1, stage2], update_pipeline=False)
+    assert not (tmp_dir / PROJECT_FILE).exists()
+    assert (tmp_dir / LOCK_FILE).parse() == {
+        "schema": "2.0",
+        "stages": {"stage1": {"cmd": "cmd1"}, "stage2": {"cmd": "cmd2"}},
+    }
+
+    dvcfile.dump_stages([stage1, stage2], update_lock=False)
+    assert (tmp_dir / PROJECT_FILE).parse() == {
+        "stages": {"stage1": {"cmd": "cmd1"}, "stage2": {"cmd": "cmd2"}}
+    }
+
+
+def test_dump_stages_single_stage(tmp_dir, dvc):
+    stage = dvc.stage.create(
+        fname="foo.dvc", outs=["out"], deps=["dep"], single_stage=True
+    )
+    stage.dvcfile.dump_stages([stage])
+    assert (tmp_dir / "foo.dvc").parse() == {
+        "deps": [{"hash": "md5", "path": "dep"}],
+        "outs": [{"hash": "md5", "path": "out"}],
+    }
 
 
 @pytest.mark.parametrize("file", ["stage.dvc", "dvc.yaml"])


### PR DESCRIPTION
Fixes #10629.


Using reproducible script from #10629 description,
```bash
#! /bin/sh

cd "$(mktemp -d)"
git init -q
dvc init -q
echo 'stages:
  stepA:
    matrix:
      x: [1,2,3,4,5,6,7]
      y: [1,2,3,4,5,6,7]
      z: [1,2,3,4,5,6,7]
    cmd: echo "substep${item.x}-${item.y}-${item.z}" > data/substep${item.x}-${item.y}-${item.z}.txt
    outs:
      - data/substep${item.x}-${item.y}-${item.z}.txt' > dvc.yaml
mkdir data
dvc repro --no-commit
time -v dvc commit -f
```

### Before

```console
Command being timed: "dvc commit -f"
        User time (seconds): 65.71
        System time (seconds): 0.87
        Percent of CPU this job got: 99%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 1:06.69
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 239632
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 17661
        Voluntary context switches: 1049
        Involuntary context switches: 1780
        Swaps: 0
        File system inputs: 0
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 16384
        Exit status: 0
```

### After

```console
Command being timed: "dvc commit -f"
        User time (seconds): 1.14
        System time (seconds): 0.49
        Percent of CPU this job got: 98%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:01.66
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 63232
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 6621
        Voluntary context switches: 1046
        Involuntary context switches: 423
        Swaps: 0
        File system inputs: 0
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 16384
        Exit status: 0
```

## TODO

- [x] Add tests.