### PR TITLE
checkout/pull: report granular summary of changes

### DIFF
--- a/dvc/commands/checkout.py
+++ b/dvc/commands/checkout.py
@@ -1,5 +1,3 @@
-import operator
-
 from dvc.cli import completion, formatter
 from dvc.cli.command import CmdBase
 from dvc.cli.utils import append_doc_link
@@ -30,7 +28,7 @@ class CmdCheckout(CmdBase):
 
         stats, exc = None, None
         try:
-            stats = self.repo.checkout(
+            result = self.repo.checkout(
                 targets=self.args.targets,
                 with_deps=self.args.with_deps,
                 force=self.args.force,
@@ -40,14 +38,17 @@ class CmdCheckout(CmdBase):
             )
         except CheckoutError as _exc:
             exc = _exc
-            stats = exc.stats
+            result = exc.result
 
         if self.args.summary:
             default_message = "No changes."
-            msg = get_summary(sorted(stats.items(), key=operator.itemgetter(0)))
+            stats = result["stats"]
+            assert isinstance(stats, dict)
+            msg = get_summary(stats.items())
             ui.write(msg or default_message)
         else:
-            log_changes(stats)
+            result.pop("stats", {})
+            log_changes(result)
 
         if exc:
             raise exc

--- a/dvc/commands/data_sync.py
+++ b/dvc/commands/data_sync.py
@@ -22,17 +22,18 @@ class CmdDataBase(CmdBase):
 
 
 class CmdDataPull(CmdDataBase):
-    def log_summary(self, stats):
+    def log_summary(self, result):
         from dvc.commands.checkout import log_changes
 
-        log_changes(stats)
+        stats = result.pop("stats", {})
+        log_changes(result)
         super().log_summary(stats)
 
     def run(self):
         from dvc.exceptions import CheckoutError, DvcException
 
         try:
-            stats = self.repo.pull(
+            result = self.repo.pull(
                 targets=self.args.targets,
                 jobs=self.args.jobs,
                 remote=self.args.remote,
@@ -46,10 +47,10 @@ class CmdDataPull(CmdDataBase):
                 glob=self.args.glob,
                 allow_missing=self.args.allow_missing,
             )
-            self.log_summary(stats)
+            self.log_summary(result)
         except (CheckoutError, DvcException) as exc:
-            if stats := getattr(exc, "stats", {}):
-                self.log_summary(stats)
+            if result := getattr(exc, "result", {}):
+                self.log_summary(result)
             logger.exception("failed to pull data from the cloud")
             return 1
 

--- a/dvc/exceptions.py
+++ b/dvc/exceptions.py
@@ -242,11 +242,11 @@ class UploadError(FileTransferError):
 
 
 class CheckoutError(DvcException):
-    def __init__(self, target_infos: list[str], stats: dict[str, list[str]]):
+    def __init__(self, target_infos: list[str], result: dict):
         from dvc.utils import error_link
 
         self.target_infos = target_infos
-        self.stats = stats
+        self.result = result
         targets = [str(t) for t in target_infos]
         m = (
             "Checkout failed for following targets:\n{}\nIs your "

--- a/dvc/repo/pull.py
+++ b/dvc/repo/pull.py
@@ -39,7 +39,7 @@ def pull(  # noqa: PLR0913
         run_cache=run_cache,
     )
     try:
-        stats = self.checkout(
+        result = self.checkout(
             targets=expanded_targets,
             with_deps=with_deps,
             force=force,
@@ -47,8 +47,10 @@ def pull(  # noqa: PLR0913
             allow_missing=allow_missing,
         )
     except CheckoutError as exc:
-        exc.stats["fetched"] = processed_files_count
+        # put fetched counts first
+        exc.result["stats"] = {"fetched": processed_files_count} | exc.result["stats"]
         raise
-
-    stats["fetched"] = processed_files_count
-    return stats
+    else:
+        # put fetched counts first
+        result["stats"] = {"fetched": processed_files_count} | result["stats"]
+    return result

--- a/dvc/testing/remote_tests.py
+++ b/dvc/testing/remote_tests.py
@@ -137,8 +137,12 @@ class TestRemote:
         remove(tmp_dir / "bar")
 
         stats = dvc.pull()
-        assert stats["fetched"] == 2
-        assert set(stats["added"]) == {"foo", "bar"}
+        assert stats == {
+            "added": ["bar", "foo"],
+            "deleted": [],
+            "modified": [],
+            "stats": {"fetched": 2, "added": 2, "deleted": 0, "modified": 0},
+        }
 
     @pytest.mark.xfail(raises=NotImplementedError, strict=False)
     def test_pull_no_00_prefix(self, tmp_dir, dvc, remote, monkeypatch):
@@ -163,8 +167,12 @@ class TestRemote:
         remove(tmp_dir / "bar")
 
         stats = dvc.pull()
-        assert stats["fetched"] == 2
-        assert set(stats["added"]) == {"foo", "bar"}
+        assert stats == {
+            "added": ["bar", "foo"],
+            "deleted": [],
+            "modified": [],
+            "stats": {"fetched": 2, "added": 2, "deleted": 0, "modified": 0},
+        }
 
 
 class TestRemoteVersionAware:

--- a/dvc/testing/workspace_tests.py
+++ b/dvc/testing/workspace_tests.py
@@ -163,7 +163,12 @@ class TestImportURLVersionAware:
 
         (remote_version_aware / "data_dir" / "foo").write_text("foo")
         dvc.update(no_download=True)
-        assert dvc.pull()["fetched"] == 2
+        assert dvc.pull() == {
+            "modified": [],
+            "added": ["data_dir" + os.sep],
+            "deleted": [],
+            "stats": {"fetched": 2, "modified": 0, "added": 2, "deleted": 0},
+        }
         assert (tmp_dir / "data_dir").read_text() == {
             "foo": "foo",
             "subdir": {"file": "file"},
@@ -174,7 +179,12 @@ class TestImportURLVersionAware:
         scm.checkout("v1")
         dvc.cache.local.clear()
         remove(tmp_dir / "data_dir")
-        assert dvc.pull()["fetched"] == 1
+        assert dvc.pull() == {
+            "modified": [],
+            "added": ["data_dir" + os.sep],
+            "deleted": [],
+            "stats": {"fetched": 1, "modified": 0, "added": 1, "deleted": 0},
+        }
         assert (tmp_dir / "data_dir").read_text() == {"subdir": {"file": "file"}}
 
         dvc.commit(force=True)

--- a/tests/func/test_run_cache.py
+++ b/tests/func/test_run_cache.py
@@ -20,7 +20,12 @@ def test_push_pull(tmp_dir, dvc, erepo_dir, run_copy, local_remote):
     erepo_dir.add_remote(config=local_remote.config)
     with erepo_dir.chdir():
         assert not os.path.exists(erepo_dir.dvc.stage_cache.cache_dir)
-        assert erepo_dir.dvc.pull(run_cache=True)["fetched"] == 0
+        assert erepo_dir.dvc.pull(run_cache=True) == {
+            "added": [],
+            "deleted": [],
+            "modified": [],
+            "stats": {"fetched": 0, "added": 0, "deleted": 0, "modified": 0},
+        }
         assert os.listdir(erepo_dir.dvc.stage_cache.cache_dir)
 
 

--- a/tests/func/test_virtual_directory.py
+++ b/tests/func/test_virtual_directory.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 from os.path import join
 
@@ -180,7 +181,12 @@ def test_partial_checkout_and_update(M, tmp_dir, dvc, remote):
     dvc.cache.local.clear()
     shutil.rmtree("dir")
 
-    assert dvc.pull("dir/subdir") == M.dict(added=[join("dir", "")], fetched=11)
+    assert dvc.pull("dir/subdir") == {
+        "added": ["dir" + os.sep],
+        "deleted": [],
+        "modified": [],
+        "stats": {"added": 10, "deleted": 0, "fetched": 11, "modified": 0},
+    }
     assert (tmp_dir / "dir").read_text() == {"subdir": dir1}
 
     tmp_dir.gen({"dir": {"subdir": {"file": "file"}}})


### PR DESCRIPTION
Closes #9831.

Note that no. of deleted files are not reported granularly if those files are no longer being tracked by DVC. In that case, they are reported as one single change in the summary.