### PR TITLE
fix(diff): do not show missing cache entries on diff result

### DIFF
--- a/dvc/repo/diff.py
+++ b/dvc/repo/diff.py
@@ -45,9 +45,11 @@ def _diff(old, new, data_keys, with_missing=False):
         with_renames=True,
         meta_cmp_key=meta_cmp_key,
         roots=data_keys,
-        # we need to get unknown and unchanged entries to tell whether
-        # the object is missing from the cache or not.
-        with_unknown=with_missing,
+        # Include unknown entries from missing dir entry, so that they don't
+        # get reported as added/modified/deleted.
+        # Also return unchanged entries so that we can check if they are missing
+        # from cache.
+        with_unknown=True,
         with_unchanged=with_missing,
     ):
         if (change.old and change.old.isdir and not change.old.hash_info) or (


### PR DESCRIPTION
The directory entry might show up in "Not in cache" when the second rev is a workspace revision.

But files inside missing cache entries won't be shown in any of the state, unless we know the oid of the entries from the index on both side of the `diff`.

On top of #10844.
Closes #7661.


