### PR TITLE
fix(status): treat target as a dataset path for cloud instead of search path for dvcfiles

### DIFF
--- a/dvc/repo/status.py
+++ b/dvc/repo/status.py
@@ -130,7 +130,7 @@ def status(  # noqa: PLR0913
             remote=remote,
             all_tags=all_tags,
             all_commits=all_commits,
-            recursive=True,
+            recursive=recursive,
         )
 
     ignored = list(


### PR DESCRIPTION
Previously, `recursive=True` was the default for cloud status, causing the target to be interpreted as a search path for DVC files. This meant scanning all DVC files in the target directory and subdirectories, then checking cloud status for tracked datasets found in those files.

This change sets the default to `recursive=False`, so the target is treated as a dataset path and cloud status is checked only for the dataset tracked at that path.

The old behavior can be restored with the `--recursive` flag.

Closes https://github.com/iterative/dvc/issues/9336. 

This flag was introduced in https://github.com/iterative/dvc/pull/3726, with what appears to be a bug where for the cloud status it was set to `True`.