### PR TITLE
ignore: simplify and reuse same implementation across check-ignore and is_ignored API

### DIFF
--- a/dvc/ignore.py
+++ b/dvc/ignore.py
@@ -1,7 +1,8 @@
+import functools
 import os
 import re
 from collections.abc import Iterable, Iterator
-from itertools import chain, groupby, takewhile
+from itertools import chain, takewhile
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Optional, Union, overload
 
 from pathspec.patterns import GitWildMatchPattern
@@ -41,20 +42,25 @@ class DvcIgnorePatterns(DvcIgnore):
         ]
 
         self.sep = sep
-        self.pattern_list: list[PatternInfo] = pattern_infos
+        self.pattern_list: list[PatternInfo] = []
         self.dirname = dirname
+        self.find_matching_pattern = functools.cache(self._find_matching_pattern)
 
-        self.regex_pattern_list: list[tuple[str, bool]] = []
-        for count, pattern in enumerate(pattern_infos):
-            regex, ignore = GitWildMatchPattern.pattern_to_regex(pattern.patterns)
+        self.regex_pattern_list: list[tuple[re.Pattern, bool, bool]] = []
+        for count, pattern_info in enumerate(pattern_infos):
+            regex, ignore = GitWildMatchPattern.pattern_to_regex(pattern_info.patterns)
             if regex is not None and ignore is not None:
+                self.pattern_list.append(pattern_info)
                 regex = regex.replace(f"<{_DIR_MARK}>", f"<{_DIR_MARK}{count}>")
-                self.regex_pattern_list.append((regex, ignore))
+                self.regex_pattern_list.append(
+                    (re.compile(regex), pattern_info.patterns.endswith("/"), ignore)
+                )
 
         self.ignore_spec = [
-            (ignore, re.compile("|".join(regex for regex, _ in group)))
-            for ignore, group in groupby(self.regex_pattern_list, lambda x: x[1])
-            if ignore is not None
+            (pattern, dir_only_pattern, ignore, pattern_info)
+            for (pattern, dir_only_pattern, ignore), pattern_info in zip(
+                reversed(self.regex_pattern_list), reversed(self.pattern_list)
+            )
         ]
 
     @classmethod
@@ -113,60 +119,61 @@ class DvcIgnorePatterns(DvcIgnore):
         basename: str,
         is_dir: bool = False,
         details: Literal[True] = ...,
-    ) -> tuple[bool, list[str]]: ...
+    ) -> tuple[bool, list[PatternInfo]]: ...
 
     @overload
     def matches(
-        self, dirname: str, basename: str, is_dir: bool = False, details: bool = False
-    ) -> Union[bool, tuple[bool, list[str]]]: ...
+        self,
+        dirname: str,
+        basename: str,
+        is_dir: bool = False,
+        details: bool = False,
+    ) -> Union[bool, tuple[bool, list[PatternInfo]]]: ...
 
     def matches(
-        self, dirname: str, basename: str, is_dir: bool = False, details: bool = False
-    ) -> Union[bool, tuple[bool, list[str]]]:
+        self,
+        dirname: str,
+        basename: str,
+        is_dir: bool = False,
+        details: bool = False,
+    ) -> Union[bool, tuple[bool, list[PatternInfo]]]:
         path = self._get_normalize_path(dirname, basename)
-        if not path:
-            return (False, []) if details else False
-        if details:
-            return self._ignore_details(path, is_dir)
-        return self.ignore(path, is_dir)
-
-    def ignore(self, path: str, is_dir: bool) -> bool:
-        def matches(pattern, path, is_dir) -> bool:
-            matches_ = bool(pattern.match(path))
-
-            if is_dir:
-                matches_ |= bool(pattern.match(f"{path}/"))
-
-            return matches_
-
         result = False
+        _match: list[PatternInfo] = []
+        if path:
+            result, _match = self._ignore(path, is_dir)
+        return (result, _match) if details else result
 
-        for ignore, pattern in self.ignore_spec[::-1]:
-            if matches(pattern, path, is_dir):
-                result = ignore
-                break
-        return result
+    def _find_matching_pattern(
+        self, path: str, is_dir: bool
+    ) -> tuple[bool, list[PatternInfo]]:
+        paths = [path]
+        if is_dir and not path.endswith("/"):
+            paths.append(f"{path}/")
 
-    def _ignore_details(self, path: str, is_dir: bool) -> tuple[bool, list[str]]:
-        result = False
-        matched_patterns = []
-        for (regex, ignore), pattern_info in list(
-            zip(self.regex_pattern_list, self.pattern_list)
-        ):
-            # skip system pattern
-            if not pattern_info.file_info:
+        for pattern, dir_only_pattern, ignore, pattern_info in self.ignore_spec:
+            if dir_only_pattern and not is_dir:
                 continue
+            for p in paths:
+                if pattern.match(p):
+                    return ignore, [pattern_info]
+        return False, []
 
-            pattern = re.compile(regex)
-
-            matches = bool(pattern.match(path))
-            if is_dir:
-                matches |= bool(pattern.match(f"{path}/"))
-
-            if matches:
-                matched_patterns.append(pattern_info.file_info)
-                result = ignore
-        return result, matched_patterns
+    def _ignore(self, path: str, is_dir: bool) -> tuple[bool, list[PatternInfo]]:
+        parts = path.split("/")
+        result = False
+        matches: list[PatternInfo] = []
+        for i in range(1, len(parts) + 1):
+            rel_path = "/".join(parts[:i])
+            result, _matches = self.find_matching_pattern(
+                rel_path, is_dir or i < len(parts)
+            )
+            if i < len(parts) and not result:
+                continue
+            matches.extend(_matches)
+            if result:
+                break
+        return result, matches
 
     def __hash__(self) -> int:
         return hash(self.dirname + ":" + str(self.pattern_list))
@@ -186,7 +193,7 @@ class DvcIgnorePatterns(DvcIgnore):
 class CheckIgnoreResult(NamedTuple):
     file: str
     match: bool
-    patterns: list[str]
+    pattern_infos: list[PatternInfo]
 
 
 class DvcIgnoreFilter:
@@ -454,14 +461,14 @@ class DvcIgnoreFilter:
         # NOTE: can only be used in `dvc check-ignore`, see
         # https://github.com/iterative/dvc/issues/5046
         full_target = self.fs.abspath(target)
-        matched_patterns: list[str] = []
+        matched_patterns: list[PatternInfo] = []
         ignore = False
         if not self._outside_repo(full_target):
             dirname, basename = self.fs.split(self.fs.normpath(full_target))
             pattern = self._get_trie_pattern(dirname)
             if pattern:
                 ignore, matched_patterns = pattern.matches(
-                    dirname, basename, self.fs.isdir(full_target), True
+                    dirname, basename, self.fs.isdir(full_target), details=True
                 )
         return CheckIgnoreResult(target, ignore, matched_patterns)
 

--- a/dvc/pathspec_math.py
+++ b/dvc/pathspec_math.py
@@ -13,6 +13,9 @@ class PatternInfo(NamedTuple):
     patterns: str
     file_info: str
 
+    def __str__(self) -> str:
+        return self.file_info or f":{self.patterns}"
+
 
 def _not_ignore(rule):
     return (True, rule[1:]) if rule.startswith("!") else (False, rule)

--- a/tests/func/test_check_ignore.py
+++ b/tests/func/test_check_ignore.py
@@ -78,7 +78,7 @@ def test_check_ignore_dir(tmp_dir, dvc, path, ret):
 
 
 def test_check_ignore_default_dir(tmp_dir, dvc):
-    assert main(["check-ignore", "-q", ".dvc"]) == 1
+    assert main(["check-ignore", "-q", ".dvc"]) == 0
 
 
 def test_check_ignore_out_side_repo(tmp_dir, dvc):
@@ -125,7 +125,6 @@ def test_check_ignore_details_all(tmp_dir, dvc, capsys):
 
     assert main(["check-ignore", "-d", "-a", "foo"]) == 0
     out, _ = capsys.readouterr()
-    assert f"{DvcIgnore.DVCIGNORE_FILE}:1:f*\tfoo\n" in out
     assert f"{DvcIgnore.DVCIGNORE_FILE}:2:!foo\tfoo\n" in out
 
 


### PR DESCRIPTION
~~This does slowdown `walk()` by almost 5x, as we were using union of regexes
before and now we are iterating over all patterns. That also means this
will be slower as the number of patterns increase.~~

EDIT: Changed the implementation to combine regexes for excluded lists.


Notable changes:
- The `check-ignore` command will also show default ignore patterns
(eg: `.dvc` / `.git` / `.hg` ), similar to how `is_ignored()` worked.

- `--all` is now hidden and deprecated, and dvc will stop matching all patterns
after the first match.



Closes #10722.
Closes #10122.