### PR TITLE
feat(cli): support initializing DVC repository in an arbitrary directory

### DIFF
--- a/dvc/commands/init.py
+++ b/dvc/commands/init.py
@@ -42,7 +42,7 @@ class CmdInit(CmdBaseNoRepo):
 
         try:
             with Repo.init(
-                ".",
+                self.args.directory,
                 no_scm=self.args.no_scm,
                 force=self.args.force,
                 subdir=self.args.subdir,
@@ -57,10 +57,11 @@ class CmdInit(CmdBaseNoRepo):
 
 def add_parser(subparsers, parent_parser):
     """Setup parser for `dvc init`."""
-    INIT_HELP = "Initialize DVC in the current directory."
+    INIT_HELP = "Initialize DVC repository."
     INIT_DESCRIPTION = (
-        "Initialize DVC in the current directory. Expects directory\n"
-        "to be a Git repository unless --no-scm option is specified."
+        "Initialize DVC repository in the given directory (defaults to the current "
+        "working directory).\n"
+        "Expects directory to be a Git repository unless --no-scm option is specified."
     )
 
     init_parser = subparsers.add_parser(
@@ -69,6 +70,14 @@ def add_parser(subparsers, parent_parser):
         description=append_doc_link(INIT_DESCRIPTION, "init"),
         help=INIT_HELP,
         formatter_class=formatter.RawDescriptionHelpFormatter,
+    )
+    init_parser.add_argument(
+        "directory",
+        nargs="?",
+        default=".",
+        help=(
+            "Directory to initialize DVC in. Defaults to the current working directory."
+        ),
     )
     init_parser.add_argument(
         "--no-scm",

--- a/dvc/repo/init.py
+++ b/dvc/repo/init.py
@@ -63,7 +63,7 @@ def init(root_dir=os.curdir, no_scm=False, force=False, subdir=False):  # noqa: 
 
         remove(dvc_dir)
 
-    os.mkdir(dvc_dir)
+    os.makedirs(dvc_dir, exist_ok=True)
 
     config = Config.init(dvc_dir)
 


### PR DESCRIPTION
Previously, it could be only initialized in the current working directory.

* [ ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
