### PR TITLE
exp: add support for --no-hydra flag

### DIFF
--- a/dvc/commands/experiments/run.py
+++ b/dvc/commands/experiments/run.py
@@ -20,6 +20,7 @@ class CmdExperimentsRun(CmdRepro):
             tmp_dir=self.args.tmp_dir,
             copy_paths=self.args.copy_paths,
             message=self.args.message,
+            no_hydra=self.args.no_hydra,
             **self._common_kwargs,
         )
 
@@ -106,5 +107,15 @@ def _add_run_common(parser):
         type=str,
         default=None,
         help="Custom commit message to use when committing the experiment.",
+    )
+    parser.add_argument(
+        "--no-hydra",
+        action="store_true",
+        default=False,
+        help=(
+            "Disables automatically updating `params.yaml` with Hydra configuration. "
+            " You can still use `--set-param` to update individual params if needed."
+            " Default is False."
+        ),
     )
     parser.add_argument("-M", dest="message", help=argparse.SUPPRESS)  # obsolete

--- a/dvc/repo/experiments/run.py
+++ b/dvc/repo/experiments/run.py
@@ -22,6 +22,7 @@ def run(  # noqa: C901, PLR0912
     queue: bool = False,
     copy_paths: Optional[Iterable[str]] = None,
     message: Optional[str] = None,
+    no_hydra: bool = False,
     **kwargs,
 ) -> dict[str, str]:
     """Reproduce the specified targets as an experiment.
@@ -67,7 +68,7 @@ def run(  # noqa: C901, PLR0912
     else:
         path_overrides = {}
 
-    hydra_enabled = repo.config.get("hydra", {}).get("enabled", False)
+    hydra_enabled = repo.config.get("hydra", {}).get("enabled", False) and not no_hydra
     hydra_output_file = ParamsDependency.DEFAULT_PARAMS_FILE
     if hydra_enabled and hydra_output_file not in path_overrides:
         # Force `_update_params` even if `--set-param` was not used
@@ -80,6 +81,7 @@ def run(  # noqa: C901, PLR0912
             tmp_dir=tmp_dir,
             copy_paths=copy_paths,
             message=message,
+            no_hydra=no_hydra,
             **kwargs,
         )
 
@@ -100,6 +102,7 @@ def run(  # noqa: C901, PLR0912
             params=sweep_overrides,
             copy_paths=copy_paths,
             message=message,
+            no_hydra=no_hydra,
             **kwargs,
         )
         if sweep_overrides:

--- a/tests/unit/command/test_experiments.py
+++ b/tests/unit/command/test_experiments.py
@@ -130,6 +130,7 @@ def test_experiments_run(dvc, scm, mocker):
         "tmp_dir": False,
         "copy_paths": [],
         "message": None,
+        "no_hydra": False,
     }
     default_arguments.update(repro_arguments)
 
@@ -151,6 +152,7 @@ def test_experiments_run_message(dvc, scm, mocker, flag):
         "tmp_dir": False,
         "copy_paths": [],
         "message": "mymessage",
+        "no_hydra": False,
     }
     default_arguments.update(repro_arguments)
 


### PR DESCRIPTION
Introduces --no-hydra in the CLI of dvc exp run, which disables automatically inserting Hydra config into params.yaml.

Fixes #10863

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/iterative/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
