### PR TITLE
repro: parallel execution of stages

### DIFF
--- a/dvc/commands/repro.py
+++ b/dvc/commands/repro.py
@@ -40,6 +40,7 @@ class CmdRepro(CmdBase):
             "run_cache": not self.args.no_run_cache,
             "no_commit": self.args.no_commit,
             "glob": self.args.glob,
+            "jobs": self.args.jobs,
         }
 
 
@@ -187,5 +188,13 @@ def add_parser(subparsers, parent_parser):
             "Execute stage commands even if they have already been run with "
             "the same command/dependencies/outputs/etc before."
         ),
+    )
+    repro_parser.add_argument(
+        "-j",
+        "--jobs",
+        type=int,
+        default=1,
+        help="Run (at most) specified number of stages at a time in parallel.",
+        metavar="<number>",
     )
     repro_parser.set_defaults(func=CmdRepro)

--- a/dvc/stage/decorators.py
+++ b/dvc/stage/decorators.py
@@ -1,3 +1,4 @@
+import threading
 from functools import wraps
 
 from funcy import decorator
@@ -47,6 +48,8 @@ def rwlocked(call, read=None, write=None):
 def unlocked_repo(f):
     @wraps(f)
     def wrapper(stage, *args, **kwargs):
+        if threading.current_thread() is not threading.main_thread():
+            return f(stage, *args, **kwargs)
         stage.repo.lock.unlock()
         stage.repo._reset()
         try:

--- a/tests/unit/command/test_repro.py
+++ b/tests/unit/command/test_repro.py
@@ -1,3 +1,5 @@
+import pytest
+
 from dvc.cli import parse_args
 from dvc.commands.repro import CmdRepro
 
@@ -20,6 +22,7 @@ repro_arguments = {
     "run_cache": True,
     "no_commit": False,
     "glob": False,
+    "jobs": 1,
 }
 
 
@@ -30,11 +33,18 @@ def test_default_arguments(dvc, mocker):
     cmd.repo.reproduce.assert_called_with(**common_arguments, **repro_arguments)
 
 
-def test_downstream(dvc, mocker):
-    cmd = CmdRepro(parse_args(["repro", "--downstream"]))
+@pytest.mark.parametrize(
+    "cli_arguments, expected_arguments",
+    [
+        (["--downstream"], {"downstream": True}),
+        (["-j", "2"], {"jobs": 2}),
+    ],
+)
+def test_calls(dvc, mocker, cli_arguments, expected_arguments):
+    cmd = CmdRepro(parse_args(["repro", *cli_arguments]))
     mocker.patch.object(cmd.repo, "reproduce")
     cmd.run()
     arguments = common_arguments.copy()
     arguments.update(repro_arguments)
-    arguments.update({"downstream": True})
+    arguments.update(expected_arguments)
     cmd.repo.reproduce.assert_called_with(**arguments)


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/treeverse/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

## TODO
* [x] Tests
* [x] Add `--jobs` argument to CLI

## OTHER THOUGHTS
Obviously, when adding a feature like parallel execution, one of the first objections will be something like "but what if two stages can't run in parallel?". The quick answer is: then don't run in parallel!

But I think it would also be pretty easy to accommodate this in a fairly generic way. For example:
```yaml
stages:
  foo:
    cmd: python blah.py
    mutex: [foobar]
    # other stage properties

  bar:
    cmd: python other_thing.py
    mutex: [foobar, also_another_one]
```
Probably self-explanatory, but the idea behind this is:
* No two stages that belong to the same mutex group should be run concurrently
* A stage can belong to arbitrarily many mutex groups
* You can call the mutex groups whatever you want, so that they make sense to you

I'd be happy to contribute a follow-up PR with the `mutex` feature, if you like the idea