### PR TITLE
Remove pytest-test-utils from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,6 @@ tests = [
     "pytest-cov>=4.1.0",
     "pytest-docker>=1,<4",
     "pytest-mock",
-    "pytest-test-utils",
     "pytest-timeout>=2",
     "pytest-xdist>=3.2",
     'pywin32>=225; sys_platform == "win32"', # optional test dependency


### PR DESCRIPTION
Removed 'pytest-test-utils' from the dependencies.

Forgot to remove in https://github.com/treeverse/dvc/pull/10934.

* [ ] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/treeverse/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
