### PR TITLE
feat: matrix map rows

### DIFF
--- a/dvc/schema.py
+++ b/dvc/schema.py
@@ -80,7 +80,7 @@ PARAM_PSTAGE_NON_DEFAULT_SCHEMA = {str: [str]}
 VARS_SCHEMA = [str, dict]
 
 STAGE_DEFINITION = {
-    MATRIX_KWD: {str: vol.Any(str, list)},
+    MATRIX_KWD: {str: vol.Any(str, list, dict)},
     vol.Required(StageParams.PARAM_CMD): vol.Any(str, list),
     vol.Optional(StageParams.PARAM_WDIR): str,
     vol.Optional(StageParams.PARAM_DEPS): [str],

--- a/tests/func/parsing/test_matrix.py
+++ b/tests/func/parsing/test_matrix.py
@@ -1,6 +1,7 @@
 import pytest
 
-from dvc.parsing import DataResolver, MatrixDefinition
+from dvc.parsing import DataResolver, MatrixDefinition, ResolveError
+from dvc.schema import COMPILED_MULTI_STAGE_SCHEMA
 
 MATRIX_DATA = {
     "os": ["win", "linux"],
@@ -91,3 +92,90 @@ def test_matrix_key_present(tmp_dir, dvc, matrix):
         "build@linux-3.8-dict1-list0": {"cmd": "echo linux-3.8-dict1-list0"},
         "build@linux-3.8-dict1-list1": {"cmd": "echo linux-3.8-dict1-list1"},
     }
+
+
+def test_matrix_schema_allows_mapping():
+    data = {
+        "stages": {
+            "build": {
+                "matrix": {"models": {"goo": {"val": 1}, "baz": {"val": 2}}},
+                "cmd": "echo ${item.models.val}",
+            }
+        }
+    }
+    COMPILED_MULTI_STAGE_SCHEMA(data)
+
+
+MAPPING_MATRIX_DATA = {"goo": {"val": 1}, "baz": {"val": 2}}
+
+
+@pytest.mark.parametrize(
+    "matrix",
+    [
+        {"models": MAPPING_MATRIX_DATA},
+        {"models": "${map_param}"},
+    ],
+)
+def test_matrix_with_mapping(tmp_dir, dvc, matrix):
+    (tmp_dir / "params.yaml").dump({"map_param": MAPPING_MATRIX_DATA})
+    resolver = DataResolver(dvc, tmp_dir.fs_path, {})
+    data = {"matrix": matrix, "cmd": "echo ${item.models.val}"}
+    definition = MatrixDefinition(resolver, resolver.context, "build", data)
+
+    assert definition.resolve_all() == {
+        "build@goo": {"cmd": "echo 1"},
+        "build@baz": {"cmd": "echo 2"},
+    }
+
+
+@pytest.mark.parametrize(
+    "matrix",
+    [
+        {"models": MAPPING_MATRIX_DATA, "ver": [1, 2]},
+        {"models": "${map_param}", "ver": "${ver}"},
+    ],
+)
+def test_matrix_mixed_mapping_and_list(tmp_dir, dvc, matrix):
+    (tmp_dir / "params.yaml").dump({"map_param": MAPPING_MATRIX_DATA, "ver": [1, 2]})
+    resolver = DataResolver(dvc, tmp_dir.fs_path, {})
+    data = {"matrix": matrix, "cmd": "echo ${item.models.val} ${item.ver}"}
+    definition = MatrixDefinition(resolver, resolver.context, "build", data)
+
+    assert definition.resolve_all() == {
+        "build@goo-1": {"cmd": "echo 1 1"},
+        "build@goo-2": {"cmd": "echo 1 2"},
+        "build@baz-1": {"cmd": "echo 2 1"},
+        "build@baz-2": {"cmd": "echo 2 2"},
+    }
+
+
+@pytest.mark.parametrize(
+    "matrix",
+    [
+        {"models": MAPPING_MATRIX_DATA},
+        {"models": "${map_param}"},
+    ],
+)
+def test_matrix_mapping_key_present(tmp_dir, dvc, matrix):
+    (tmp_dir / "params.yaml").dump({"map_param": MAPPING_MATRIX_DATA})
+    resolver = DataResolver(dvc, tmp_dir.fs_path, {})
+    data = {"matrix": matrix, "cmd": "echo ${key}"}
+    definition = MatrixDefinition(resolver, resolver.context, "build", data)
+
+    assert definition.resolve_all() == {
+        "build@goo": {"cmd": "echo goo"},
+        "build@baz": {"cmd": "echo baz"},
+    }
+
+
+@pytest.mark.parametrize("matrix_value", ["${foo}", "${dct.model1}", "foobar"])
+def test_matrix_expects_list_or_dict(tmp_dir, dvc, matrix_value):
+    (tmp_dir / "params.yaml").dump({"foo": "bar", "dct": {"model1": "a-out"}})
+    resolver = DataResolver(dvc, tmp_dir.fs_path, {})
+    data = {"matrix": {"dim": matrix_value}, "cmd": "echo ${item.dim}"}
+    definition = MatrixDefinition(resolver, resolver.context, "build", data)
+
+    with pytest.raises(ResolveError) as exc_info:
+        definition.resolve_all()
+    assert "expected list/dictionary, got str" in str(exc_info.value)
+    assert "stages.build.matrix.dim" in str(exc_info.value)


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/treeverse/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

Adds support for maps in `matrix` rows, e.g. the `foo` in

```yaml
# dvc.yaml
stages:
  foobar:
    matrix:
      foo:
        goo: 1
        baz: 2
      bar: [1, 2, 3]
    cmd: python foobar.py --foo ${item.foo} --bar ${item.bar}