### PR TITLE
feat: dvc stage list --json

### DIFF
--- a/tests/func/test_stage_list_json.py
+++ b/tests/func/test_stage_list_json.py
@@ -1,0 +1,143 @@
+import json
+
+import pytest
+
+from dvc.cli import main
+
+
+@pytest.fixture
+def simple_stage(tmp_dir, dvc):
+    tmp_dir.gen("train.py", "print('training')")
+    tmp_dir.gen("data.csv", "a,b,c")
+    (tmp_dir / "dvc.yaml").dump(
+        {
+            "stages": {
+                "train": {
+                    "cmd": "python train.py",
+                    "deps": ["data.csv"],
+                    "outs": ["model.pkl"],
+                    "metrics": [{"metrics.json": {"cache": False}}],
+                    "desc": "Train the model",
+                }
+            }
+        }
+    )
+    return dvc
+
+
+def test_stage_list_json_simple(simple_stage, tmp_dir, capsys):
+    assert main(["stage", "list", "--json"]) == 0
+
+    out, _ = capsys.readouterr()
+    result = json.loads(out)
+
+    assert "train" in result
+    assert result["train"]["cmd"] == "python train.py"
+    assert "data.csv" in result["train"]["deps"]
+    assert "model.pkl" in result["train"]["outs"]
+    assert "metrics.json" in result["train"]["metrics"]
+    assert result["train"]["desc"] == "Train the model"
+
+
+@pytest.fixture
+def interpolated_stage(tmp_dir, dvc):
+    tmp_dir.gen("train.py", "print('training')")
+    (tmp_dir / "params.yaml").dump({"train": {"lr": 0.001, "epochs": 100}})
+    (tmp_dir / "dvc.yaml").dump(
+        {
+            "stages": {
+                "train": {
+                    "cmd": "python train.py --lr ${train.lr} --epochs ${train.epochs}",
+                    "params": ["train.lr", "train.epochs"],
+                }
+            }
+        }
+    )
+    return dvc
+
+
+def test_stage_list_json_interpolated_params(interpolated_stage, tmp_dir, capsys):
+    assert main(["stage", "list", "--json"]) == 0
+
+    out, _ = capsys.readouterr()
+    result = json.loads(out)
+
+    assert "train" in result
+    assert result["train"]["cmd"] == "python train.py --lr 0.001 --epochs 100"
+
+
+@pytest.fixture
+def matrix_stage(tmp_dir, dvc):
+    tmp_dir.gen("train.py", "print('training')")
+    (tmp_dir / "dvc.yaml").dump(
+        {
+            "stages": {
+                "train": {
+                    "matrix": {"lr": [0.001, 0.01], "epochs": [10, 100]},
+                    "cmd": "python train.py --lr ${item.lr} --epochs ${item.epochs}",
+                }
+            }
+        }
+    )
+    return dvc
+
+
+def test_stage_list_json_matrix_stage(matrix_stage, tmp_dir, capsys):
+    assert main(["stage", "list", "--json"]) == 0
+
+    out, _ = capsys.readouterr()
+    result = json.loads(out)
+
+    assert len(result) == 4
+    for stage_name, stage_data in result.items():
+        assert stage_name.startswith("train@")
+        assert "python train.py" in stage_data["cmd"]
+        assert "--lr" in stage_data["cmd"]
+        assert "--epochs" in stage_data["cmd"]
+
+
+@pytest.fixture
+def foreach_stage(tmp_dir, dvc):
+    tmp_dir.gen("process.py", "print('processing')")
+    (tmp_dir / "dvc.yaml").dump(
+        {
+            "stages": {
+                "process": {
+                    "foreach": ["a", "b", "c"],
+                    "do": {"cmd": "python process.py --file ${item}"},
+                }
+            }
+        }
+    )
+    return dvc
+
+
+def test_stage_list_json_foreach_stage(foreach_stage, tmp_dir, capsys):
+    assert main(["stage", "list", "--json"]) == 0
+
+    out, _ = capsys.readouterr()
+    result = json.loads(out)
+
+    expected_stages = ["process@a", "process@b", "process@c"]
+    for stage_name in expected_stages:
+        assert stage_name in result
+        assert "python process.py" in result[stage_name]["cmd"]
+
+
+def test_stage_list_json_with_target(simple_stage, tmp_dir, capsys):
+    assert main(["stage", "list", "--json", "train"]) == 0
+
+    out, _ = capsys.readouterr()
+    result = json.loads(out)
+
+    assert "train" in result
+    assert len(result) == 1
+
+
+def test_stage_list_json_all_flag(simple_stage, tmp_dir, capsys):
+    assert main(["stage", "list", "--json", "--all"]) == 0
+
+    out, _ = capsys.readouterr()
+    result = json.loads(out)
+
+    assert "train" in result

--- a/tests/unit/command/test_stage_list_json.py
+++ b/tests/unit/command/test_stage_list_json.py
@@ -1,0 +1,187 @@
+import json
+
+import pytest
+
+from dvc.cli import parse_args
+from dvc.commands.stage import CmdStageList
+from dvc.dependency import ParamsDependency
+from dvc.output import Output
+from dvc.stage import PipelineStage
+from dvc_data.hashfile.hash_info import HashInfo
+
+
+def _add_deps(stage, deps):
+    from dvc.dependency import Dependency
+
+    for dep_path in deps:
+        stage.deps.append(Dependency(stage, dep_path))
+
+
+def _add_params(stage, params):
+    for param_file, param_values in params.items():
+        param_dep = ParamsDependency(
+            stage, param_file, params=list(param_values.keys())
+        )
+        param_dep.hash_info = HashInfo("params", param_values)
+        stage.deps.append(param_dep)
+
+
+def _add_outs(stage, outs, metric=False, plot=False):
+    for out_path in outs:
+        stage.outs.append(Output(stage, out_path, metric=metric, plot=plot))
+
+
+def _create_mock_stage(
+    dvc,
+    name,
+    cmd,
+    deps=None,
+    outs=None,
+    metrics=None,
+    plots=None,
+    params=None,
+    desc=None,
+):
+    stage = PipelineStage(dvc, "dvc.yaml", cmd=cmd, name=name)
+    stage.desc = desc
+    _add_deps(stage, deps or [])
+    _add_params(stage, params or {})
+    _add_outs(stage, outs or [])
+    _add_outs(stage, metrics or [], metric=True)
+    _add_outs(stage, plots or [], plot=True)
+    return stage
+
+
+@pytest.mark.parametrize(
+    "stages_data, expected_json",
+    [
+        pytest.param(
+            [
+                {
+                    "name": "train",
+                    "cmd": "python train.py --lr 0.001",
+                    "deps": ["data/train.csv", "src/train.py"],
+                    "outs": ["model.pkl"],
+                    "metrics": ["metrics.json"],
+                    "desc": "Train the model",
+                }
+            ],
+            {
+                "train": {
+                    "cmd": "python train.py --lr 0.001",
+                    "deps": ["data/train.csv", "src/train.py"],
+                    "outs": ["model.pkl"],
+                    "metrics": ["metrics.json"],
+                    "plots": [],
+                    "params": {},
+                    "desc": "Train the model",
+                }
+            },
+            id="simple_stage",
+        ),
+        pytest.param(
+            [
+                {
+                    "name": "preprocess",
+                    "cmd": "python preprocess.py",
+                    "deps": ["raw_data.csv"],
+                    "outs": ["processed_data.csv"],
+                    "params": {"params.yaml": {"preprocess.threshold": 0.5}},
+                }
+            ],
+            {
+                "preprocess": {
+                    "cmd": "python preprocess.py",
+                    "deps": ["raw_data.csv"],
+                    "outs": ["processed_data.csv"],
+                    "metrics": [],
+                    "plots": [],
+                    "params": {"params.yaml": {"preprocess.threshold": 0.5}},
+                    "desc": None,
+                }
+            },
+            id="stage_with_params",
+        ),
+        pytest.param(
+            [
+                {
+                    "name": "evaluate",
+                    "cmd": "python evaluate.py",
+                    "plots": ["plots/confusion.png", "plots/roc.png"],
+                }
+            ],
+            {
+                "evaluate": {
+                    "cmd": "python evaluate.py",
+                    "deps": [],
+                    "outs": [],
+                    "metrics": [],
+                    "plots": ["plots/confusion.png", "plots/roc.png"],
+                    "params": {},
+                    "desc": None,
+                }
+            },
+            id="stage_with_plots",
+        ),
+    ],
+)
+def test_stage_list_json(dvc, mocker, capsys, stages_data, expected_json):
+    cli_args = parse_args(["stage", "list", "--json"])
+    assert cli_args.func == CmdStageList
+
+    cmd = cli_args.func(cli_args)
+
+    mock_stages = [_create_mock_stage(dvc, **data) for data in stages_data]
+    mocker.patch.object(cmd, "_get_stages", return_value=mock_stages)
+
+    assert cmd.run() == 0
+
+    out, _ = capsys.readouterr()
+    result = json.loads(out)
+    assert result == expected_json
+
+
+def test_stage_list_json_multiple_stages(dvc, mocker, capsys):
+    cli_args = parse_args(["stage", "list", "--json"])
+    cmd = cli_args.func(cli_args)
+
+    mock_stages = [
+        _create_mock_stage(dvc, "prepare", "python prepare.py", deps=["raw.csv"]),
+        _create_mock_stage(dvc, "train", "python train.py", outs=["model.pkl"]),
+    ]
+    mocker.patch.object(cmd, "_get_stages", return_value=mock_stages)
+
+    assert cmd.run() == 0
+
+    out, _ = capsys.readouterr()
+    result = json.loads(out)
+
+    assert "prepare" in result
+    assert "train" in result
+    assert result["prepare"]["cmd"] == "python prepare.py"
+    assert result["train"]["cmd"] == "python train.py"
+
+
+def test_stage_list_json_empty(dvc, mocker, capsys):
+    cli_args = parse_args(["stage", "list", "--json"])
+    cmd = cli_args.func(cli_args)
+
+    mocker.patch.object(cmd, "_get_stages", return_value=[])
+
+    assert cmd.run() == 0
+
+    out, _ = capsys.readouterr()
+    result = json.loads(out)
+    assert result == {}
+
+
+def test_stage_list_json_flag_parsing(dvc):
+    cli_args = parse_args(["stage", "list", "--json"])
+    assert cli_args.func == CmdStageList
+    assert cli_args.json is True
+
+
+def test_stage_list_without_json_flag(dvc):
+    cli_args = parse_args(["stage", "list"])
+    assert cli_args.func == CmdStageList
+    assert cli_args.json is False


### PR DESCRIPTION
Adds a `dvc stage list --json` flag, for machine-readable output. I'd like to use this as a replacement for the `dvc repro --dry` hack that I implemented in the [VS Code extension](https://github.com/treeverse/vscode-dvc/pull/6059)

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/treeverse/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
