### PR TITLE
fix pathspec version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
     "networkx>=2.5",
     "omegaconf",
     "packaging>=19",
-    "pathspec>=0.10.3",
+    "pathspec>=0.10.3,<1",
     "platformdirs<5,>=3.1.1",
     "psutil>=5.8",
     "pydot>=1.2.4",


### PR DESCRIPTION
[Pathspec v1 has been released](https://github.com/cpburnz/python-pathspec/releases/tag/v1.0.0), and with current DVC dependency setup it gets installed by default. However, Pathspec v1 is not compatible with current DVC, which causes DVC to fail with the following error: `unexpected error - cannot import name '_DIR_MARK' from 'pathspec.patterns.gitwildmatch' (/path/to/lib/python3.10/site-packages/pathspec/patterns/gitwildmatch.py)`

This PR prevents the issue by explicitly pinning pathspec to `<1` , ensuring a compatible version is installed and DVC works as expected.