### PR TITLE
Support pathspec v1

### DIFF
--- a/dvc/ignore.py
+++ b/dvc/ignore.py
@@ -5,7 +5,15 @@ from collections.abc import Iterable, Iterator
 from itertools import chain, groupby, takewhile
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Optional, Union, overload
 
-from pathspec.patterns.gitignore.spec import GitIgnoreSpecPattern
+try:
+    from pathspec.patterns.gitignore.spec import (  # type: ignore[import-not-found]
+        GitIgnoreSpecPattern,
+    )
+except ImportError:  # pathspec<1
+    from pathspec.patterns import (
+        GitWildMatchPattern as GitIgnoreSpecPattern,
+    )
+
 from pathspec.util import normalize_file
 from pygtrie import Trie
 
@@ -34,7 +42,14 @@ class DvcIgnorePatterns(DvcIgnore):
     def __init__(
         self, pattern_list: Iterable[Union[PatternInfo, str]], dirname: str, sep: str
     ) -> None:
-        from pathspec.patterns.gitignore.spec import _DIR_MARK
+        try:
+            from pathspec.patterns.gitignore.spec import (  # type: ignore[import-not-found]
+                _DIR_MARK,
+            )
+        except ImportError:  # pathspec<1
+            from pathspec.patterns.gitwildmatch import (  # type: ignore[attr-defined, no-redef]
+                _DIR_MARK,
+            )
 
         pattern_infos = [
             pattern if isinstance(pattern, PatternInfo) else PatternInfo(pattern, "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
     "networkx>=2.5",
     "omegaconf",
     "packaging>=19",
-    "pathspec>=1.0.1,<2",
+    "pathspec>=0.10.3,<2",
     "platformdirs<5,>=3.1.1",
     "psutil>=5.8",
     "pydot>=1.2.4",


### PR DESCRIPTION
Hi, I'm the author of pathspec and released v1 yesterday. It was reported to me in [#99](https://github.com/cpburnz/python-pathspec/issues/99) that this broke *dvc*, and you pinned to `pathspec<1` in #10948. The changes required to support v1 are minimal:

- *pathspec.patterns.GitWildMatchPattern* is now a deprecated alias for *pathspec.patterns.gitignore.spec.GitIgnoreSpecPattern*.
- *pathspec.patterns.gitwildmatch._DIR_MARK* was moved to *pathspec.patterns.gitignore.spec._DIR_MARK*.

---

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/treeverse/dvc.org) and linked it here.

Here's the pytest summary:

```
============================================= short test summary info ==============================================
SKIPPED [2] tests/func/metrics/test_show.py:260: no longer raising graph errors
SKIPPED [1] tests/func/test_add.py:483: Windows specific
SKIPPED [4] tests/func/utils/test_hydra.py:103: TOML dumper breaks when overriding a list/dict with other type or when handling `null` values.
SKIPPED [1] tests/unit/utils/test_fs.py:74: Windows specific
SKIPPED [1] tests/unit/utils/test_fs.py:133: Windows specific
SKIPPED [1] tests/unit/utils/test_utils.py:43: Windows specific
XPASS tests/func/test_data_cloud.py::TestRemote::test_pull_00_prefix
XPASS tests/func/test_data_cloud.py::TestRemote::test_pull_no_00_prefix
====================== 3047 passed, 10 skipped, 2 xpassed, 899 warnings in 248.52s (0:04:08) =======================
```