### PR TITLE
docs: clarify Hydra composition support in dvc repro vs dvc exp run (#10750)

### DIFF
--- a/dvc/commands/repro.py
+++ b/dvc/commands/repro.py
@@ -156,7 +156,13 @@ and then the stage name name.
 
 
 def add_parser(subparsers, parent_parser):
-    REPRO_HELP = "Reproduce complete or partial pipelines by executing their stages."
+    REPRO_HELP = """Reproduce complete or partial pipelines by executing their stages.
+
+    Note: This command is intended for production and CI/CD workflows. For
+    experimentation with Hydra configuration composition, use `dvc exp run`
+    instead. Hydra composition (automatic `params.yaml` generation from Hydra
+    configs) is only supported with `dvc exp run`, not with `dvc repro`.
+    """
     repro_parser = subparsers.add_parser(
         "repro",
         parents=[parent_parser],

--- a/dvc/repo/experiments/run.py
+++ b/dvc/repo/experiments/run.py
@@ -31,6 +31,12 @@ def run(  # noqa: C901, PLR0912
 
     Returns a dict mapping new experiment SHAs to the results
     of `repro` for that experiment.
+
+    Note: Unlike `dvc repro`, this command supports Hydra configuration
+    composition. When Hydra is enabled in the DVC config, `params.yaml` will
+    be automatically composed from Hydra configs before running the pipeline.
+    This feature is only available with `dvc exp run` and not with `dvc repro`,
+    which is intended for production and CI/CD workflows.
     """
     if kwargs.get("dry"):
         tmp_dir = True

--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -219,6 +219,17 @@ def reproduce(
     on_error: Optional[str] = "fail",
     **kwargs,
 ):
+    """Reproduce complete or partial pipelines by executing their stages.
+
+    This is the core reproduction logic used by `dvc repro`. It is intended
+    for production and CI/CD workflows where you want to reproduce pipelines
+    with stable, committed parameters.
+
+    Note: This function does not support Hydra configuration composition.
+    For experimentation with Hydra configs, use `dvc exp run` instead, which
+    automatically composes `params.yaml` from Hydra configurations before
+    running the pipeline.
+    """
     from dvc.dvcfile import PROJECT_FILE
 
     if all_pipelines or pipeline:


### PR DESCRIPTION
## Summary
This PR adds documentation clarifying that Hydra configuration composition is only supported with `dvc exp run` and not with `dvc repro`. This addresses a documentation gap where users were confused about why Hydra composition works with `dvc exp run` but not with `dvc repro`.

## Changes
- Updated `dvc repro` help text to mention that Hydra composition is only supported with `dvc exp run`
- Added docstring to `reproduce()` function explaining the design decision
- Enhanced `experiments.run()` docstring to clarify Hydra support and differentiate from `dvc repro`

## Rationale
This is by design - `dvc exp run` is for experimentation and parameter tuning, while `dvc repro` is for production and CI/CD workflows where you want to reproduce pipelines with stable, committed parameters.

## Related
Addresses #10750

This PR adds documentation to clarify the design decision and recommended workflow. 
The original issue requested Hydra composition support in `dvc repro`, but this 
documents why it's intentionally only available in `dvc exp run` and provides 
guidance on the recommended workflow.

## Testing
- [x] Help text displays correctly (`dvc repro --help`)
- [x] Docstrings are properly formatted
- [x] No linting errors