### PR TITLE
fix(benchmarks): pin dulwich<1.0.0 for DVC versions before 3.44.0

### DIFF
--- a/dvc/testing/benchmarks/fixtures.py
+++ b/dvc/testing/benchmarks/fixtures.py
@@ -9,7 +9,7 @@ from typing import Optional
 import pytest
 from dulwich.porcelain import clone
 from funcy import first
-from packaging import version, specifiers
+from packaging import specifiers, version
 
 from dvc.types import StrPath
 


### PR DESCRIPTION
Dulwich 1.0.0 removed deprecated methods including `Repo.stage()`, which breaks scmrepo versions before 3.5.4. Since DVC only requires scmrepo>=3 starting from version 3.44.0, older DVC versions cannot use the fixed scmrepo and need to be pinned to dulwich<1.0.0.

This fixes dvc-bench CI failures when testing older DVC versions:

    ERROR: unexpected error - 'Repo' object has no attribute 'stage'

Failure: https://github.com/treeverse/dvc-bench/actions/runs/21269812297/job/61217395932

Refs:
- https://github.com/jelmer/dulwich/pull/2068
- https://github.com/treeverse/scmrepo/pull/447