### PR TITLE
fix: don't unprotect outs if not cached

### DIFF
--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -385,7 +385,8 @@ class Stage(params.StageParams):
 
     def unprotect_outs(self) -> None:
         for out in self.outs:
-            out.unprotect()
+            if out.use_cache:
+                out.unprotect()
 
     def ignore_remove_outs(self) -> None:
         for out in self.outs:


### PR DESCRIPTION
Only unprotect outputs that have use_cache set to True. This prevents unnecessary unprotection of non-cached outputs.