### PR TITLE
Fix: Properly propagate git authentication errors in fetch/import operations

### DIFF
--- a/dvc/repo/open_repo.py
+++ b/dvc/repo/open_repo.py
@@ -221,9 +221,9 @@ def _pull(git: "Git", unshallow: bool = False):
         git.fetch(unshallow=unshallow)
     except AuthError as exc:
         raise GitAuthError(str(exc)) from exc
-    
+
     _merge_upstream(git)
-    
+
     try:
         fetch_all_exps(git, "origin")
     except AuthError as exc:

--- a/dvc/scm.py
+++ b/dvc/scm.py
@@ -144,7 +144,8 @@ class TqdmGit(Tqdm):
 
 
 def clone(url: str, to_path: str, **kwargs):
-    from scmrepo.exceptions import AuthError, CloneError as InternalCloneError
+    from scmrepo.exceptions import AuthError
+    from scmrepo.exceptions import CloneError as InternalCloneError
 
     from dvc.repo.experiments.utils import fetch_all_exps
 

--- a/test_auth_error_fix.py
+++ b/test_auth_error_fix.py
@@ -3,8 +3,6 @@
 Test that git authentication errors are properly reported in DVC fetch/import operations.
 """
 
-import tempfile
-import unittest.mock
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -18,25 +16,29 @@ def test_pull_auth_error_propagation():
     """Test that _pull properly converts AuthError to GitAuthError."""
     mock_git = MagicMock()
     mock_git.fetch.side_effect = AuthError("Authentication failed")
-    
+
     with pytest.raises(GitAuthError) as exc_info:
         _pull(mock_git)
-    
+
     assert "Authentication failed" in str(exc_info.value)
-    assert "See https://dvc.org/doc/user-guide/troubleshooting#git-auth" in str(exc_info.value)
+    assert "See https://dvc.org/doc/user-guide/troubleshooting#git-auth" in str(
+        exc_info.value
+    )
 
 
 def test_pull_fetch_all_exps_auth_error():
     """Test that _pull handles AuthError from fetch_all_exps."""
     mock_git = MagicMock()
     mock_git.fetch.return_value = None  # fetch succeeds
-    
+
     with patch("dvc.repo.open_repo.fetch_all_exps") as mock_fetch_all_exps:
-        mock_fetch_all_exps.side_effect = AuthError("Authentication failed for experiments")
-        
+        mock_fetch_all_exps.side_effect = AuthError(
+            "Authentication failed for experiments"
+        )
+
         with pytest.raises(GitAuthError) as exc_info:
             _pull(mock_git)
-        
+
         assert "Authentication failed for experiments" in str(exc_info.value)
 
 
@@ -44,32 +46,34 @@ def test_clone_auth_error_propagation():
     """Test that clone properly converts AuthError to GitAuthError."""
     with patch("dvc.scm.Git.clone") as mock_git_clone:
         mock_git_clone.side_effect = AuthError("Bad PAT token")
-        
+
         with pytest.raises(GitAuthError) as exc_info:
             clone("https://github.com/test/repo.git", "/tmp/test")
-        
+
         assert "Bad PAT token" in str(exc_info.value)
-        assert "See https://dvc.org/doc/user-guide/troubleshooting#git-auth" in str(exc_info.value)
+        assert "See https://dvc.org/doc/user-guide/troubleshooting#git-auth" in str(
+            exc_info.value
+        )
 
 
 def test_clone_fetch_all_exps_auth_error():
     """Test that clone handles AuthError from fetch_all_exps."""
     mock_git = MagicMock()
-    
+
     with patch("dvc.scm.Git.clone", return_value=mock_git):
         with patch("dvc.repo.experiments.utils.fetch_all_exps") as mock_fetch_all_exps:
             mock_fetch_all_exps.side_effect = AuthError("Experiments fetch auth failed")
-            
+
             with pytest.raises(GitAuthError) as exc_info:
                 clone("https://github.com/test/repo.git", "/tmp/test")
-            
+
             assert "Experiments fetch auth failed" in str(exc_info.value)
 
 
 if __name__ == "__main__":
     # Run basic tests
     test_pull_auth_error_propagation()
-    test_pull_fetch_all_exps_auth_error() 
+    test_pull_fetch_all_exps_auth_error()
     test_clone_auth_error_propagation()
     test_clone_fetch_all_exps_auth_error()
     print("✅ All tests passed!")


### PR DESCRIPTION
Fixes #10992

## Problem
When git authentication fails during DVC fetch or import operations (e.g., with incorrect PAT tokens), authentication errors were being silently converted to generic SCM errors or not propagated at all. This caused DVC to report misleading messages like 'Everything is up to date' instead of the actual authentication failure.

## Root Cause
1. In `_pull()` function: `git.fetch()` and `fetch_all_exps()` calls could raise `AuthError` but these weren't being caught and converted to DVC's `GitAuthError`
2. In `clone()` function: `AuthError` from git operations was being caught as generic `InternalCloneError` and converted to a generic `CloneError('SCM error')`, losing authentication context

## Solution
- Enhanced `_pull()` function to catch `AuthError` from both `git.fetch()` and `fetch_all_exps()` calls and convert them to `GitAuthError`
- Updated `clone()` function to specifically catch `AuthError` before generic `InternalCloneError` and preserve authentication error details
- Added proper error chaining with `from exc` for better debugging and error traceability

## Testing
- Added comprehensive test suite covering all authentication failure scenarios
- Tests verify that `AuthError` is properly converted to `GitAuthError` with correct error messages
- Tests cover both clone and pull operations, including experiment fetching

## Impact
- Users will now receive clear, actionable error messages when authentication fails
- No more misleading 'Everything is up to date' messages when credentials are wrong
- Better developer experience with proper error context and troubleshooting links

This is a critical fix for production DVC workflows where authentication failures need to be clearly reported rather than silently ignored.